### PR TITLE
🛡️ Sentinel: [HIGH] Restrict CORS methods

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-05-21 - [Missing Authentication Implementation]
+**Vulnerability:** The `hl7v2-server` codebase contains artifacts (`auth_middleware` in `middleware.rs`) suggesting API Key authentication is implemented, but the middleware is not applied to the router in `routes.rs`. Furthermore, `ServerConfig` and `AppState` lack the fields to store the API key, rendering the `auth_middleware` (which relies on checking env vars directly) disconnected from the application state pattern intended by the design.
+**Learning:** Code presence != Code execution. Dead code or unwired middleware can create a dangerous illusion of security. The discrepancy between "what is implemented" (middleware exists) and "what runs" (router config) is a classic gap.
+**Prevention:**
+1. Security controls must have positive verification tests (ensure they block unauthorized access).
+2. Use "secure by default" frameworks where middleware is applied globally or via type-safe builders that enforce auth.
+3. Regularly audit router configurations against security requirements.

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -1,6 +1,7 @@
 //! HTTP route definitions.
 
 use axum::{
+    http::Method,
     middleware,
     routing::{get, post},
     Router,
@@ -49,8 +50,8 @@ async fn ready_handler() -> &'static str {
 /// Build CORS layer
 fn build_cors_layer() -> CorsLayer {
     CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
+        .allow_origin(Any) // TODO: Restrict this in production!
+        .allow_methods([Method::GET, Method::POST])
         .allow_headers(Any)
 }
 


### PR DESCRIPTION
This PR improves the security of the `hl7v2-server` by restricting the allowed CORS methods to only `GET` and `POST`, which are the only methods currently supported by the API. This reduces the attack surface by preventing potential misuse of other HTTP methods if the server were to be exposed.

Additionally, a critical security gap regarding the unimplemented/unwired `auth_middleware` was discovered and documented in `.jules/sentinel.md` for future remediation.


---
*PR created automatically by Jules for task [7085923463791627358](https://jules.google.com/task/7085923463791627358) started by @EffortlessSteven*