### PR TITLE
🎨 Palette: Improve CLI output readability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-27 - CLI Output Readability
+**Learning:** Users find raw byte counts (e.g., 8345710592) difficult to parse. Converting to human-readable units (e.g., 7.77 GB) is a high-impact, low-effort micro-UX win.
+**Action:** When working on CLI tools, always look for raw numbers (bytes, milliseconds) and format them for human readability using helper functions.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -189,6 +189,21 @@ fn main() {
     }
 }
 
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes as f64;
+    let mut unit_index = 0;
+    while value >= 1024.0 && unit_index < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit_index += 1;
+    }
+    if unit_index == 0 {
+        format!("{} {}", bytes, UNITS[unit_index])
+    } else {
+        format!("{:.2} {}", value, UNITS[unit_index])
+    }
+}
+
 /// Display performance statistics
 fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     println!();
@@ -198,7 +213,9 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     let metrics = monitor.get_metrics();
     if !metrics.is_empty() {
         println!("  Detailed metrics:");
-        for (name, duration) in metrics {
+        let mut sorted_metrics: Vec<_> = metrics.iter().collect();
+        sorted_metrics.sort_by_key(|a| a.0);
+        for (name, duration) in sorted_metrics {
             println!("    {}: {:?}", name, duration);
         }
     }
@@ -209,13 +226,13 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     if let Some(cpu_usage) = system_info.cpu.cpu_usage_percent {
         println!("    CPU usage: {:.2}%", cpu_usage);
     }
-    println!("    Total memory: {} bytes", system_info.total_memory);
-    println!("    Used memory: {} bytes", system_info.used_memory);
+    println!("    Total memory: {}", format_bytes(system_info.total_memory));
+    println!("    Used memory: {}", format_bytes(system_info.used_memory));
     if let Some(rss) = system_info.memory.resident_set_size {
-        println!("    Process memory (RSS): {} bytes", rss);
+        println!("    Process memory (RSS): {}", format_bytes(rss));
     }
     if let Some(vms) = system_info.memory.virtual_memory_size {
-        println!("    Process memory (VMS): {} bytes", vms);
+        println!("    Process memory (VMS): {}", format_bytes(vms));
     }
 }
 
@@ -269,7 +286,7 @@ fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: 
         println!();
         println!("Parse Summary:");
         println!("  Input file: {:?}", input);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_bytes(file_size as u64));
         println!("  Segments: {}", segment_count);
         println!("  Delimiters: |^~\\& (field={} comp={} rep={} esc={} sub={})", 
                  message.delims.field, message.delims.comp, message.delims.rep, 
@@ -278,6 +295,23 @@ fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: 
     }
     
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(100), "100 B");
+        assert_eq!(format_bytes(1023), "1023 B");
+        assert_eq!(format_bytes(1024), "1.00 KB");
+        assert_eq!(format_bytes(1536), "1.50 KB");
+        assert_eq!(format_bytes(1024 * 1024), "1.00 MB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00 GB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024 * 1024), "1.00 TB");
+    }
 }
 
 fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf>, mllp_in: bool, mllp_out: bool, summary: bool) -> Result<(), Box<dyn std::error::Error>> {
@@ -336,8 +370,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output file: {:?}", output_path);
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_bytes(input_file_size as u64));
+            println!("  Output size: {}", format_bytes(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -353,8 +387,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output: stdout");
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_bytes(input_file_size as u64));
+            println!("  Output size: {}", format_bytes(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -424,7 +458,7 @@ fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, s
         println!("Validation Summary:");
         println!("  Input file: {:?}", input);
         println!("  Profile file: {:?}", profile);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_bytes(file_size as u64));
         println!("  Segments: {}", message.segments.len());
         println!("  Issues found: 0");
         display_performance_stats(&monitor);
@@ -491,8 +525,8 @@ fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, m
         println!("  Input file: {:?}", input);
         println!("  Mode: {:?}", mode);
         println!("  Code: {:?}", code);
-        println!("  Input size: {} bytes", input_file_size);
-        println!("  Output size: {} bytes", ack_bytes.len());
+        println!("  Input size: {}", format_bytes(input_file_size as u64));
+        println!("  Output size: {}", format_bytes(ack_bytes.len() as u64));
         println!("  Segments in original: {}", message.segments.len());
         println!("  Segments in ACK: {}", ack_message.segments.len());
         println!("  MLLP input: {}", mllp_in);


### PR DESCRIPTION
💡 What: Added `format_bytes` helper to display file sizes and memory stats in human-readable units (B, KB, MB, GB, TB). Sorted performance metrics alphabetically.
🎯 Why: Raw byte counts are hard to read. Sorted metrics are easier to scan.
📸 Before: "File size: 1048576 bytes", metrics in random order.
   After: "File size: 1.00 MB", metrics sorted alphabetically.
♿ Accessibility: Improved cognitive load by reducing the need to count digits.

---
*PR created automatically by Jules for task [6296269057335605729](https://jules.google.com/task/6296269057335605729) started by @EffortlessSteven*