### PR TITLE
🎨 Palette: Human-readable sizes and sorted metrics in CLI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - CLI Data Visualization
+**Learning:** Users struggle to interpret raw byte counts (e.g., "8345710592 bytes") in CLI output. Sorted metrics (alphabetical) are significantly easier to scan than arbitrary hash map order.
+**Action:** Always implement a `format_size` helper for file/memory sizes and sort metric keys before display in CLI tools.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -1,15 +1,14 @@
 //! Command-line interface for HL7 v2 processing.
 
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use hl7v2_core::{parse, to_json, write};
+use hl7v2_gen::{AckCode as GenAckCode, Template, ack, generate};
+use hl7v2_prof::{load_profile, validate};
 use std::fs;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process;
-use hl7v2_core::{parse, to_json, write};
-use hl7v2_prof::{load_profile, validate};
-use hl7v2_gen::{ack, AckCode as GenAckCode, Template, generate};
 mod monitor;
-use monitor::{PerformanceMonitor, get_memory_info, get_cpu_info};
 
 #[derive(Parser)]
 #[command(name = "hl7v2", about = "HL7 v2 parser, validator, and generator")]
@@ -24,121 +23,121 @@ enum Commands {
     Parse {
         /// Input HL7 file
         input: PathBuf,
-        
+
         /// Output JSON format
         #[arg(long)]
         json: bool,
-        
+
         /// Include envelope information in JSON output
         #[arg(long)]
         envelope: Option<PathBuf>,
-        
+
         /// Input is MLLP framed
         #[arg(long)]
         mllp: bool,
-        
+
         /// Show summary statistics
         #[arg(long)]
         summary: bool,
     },
-    
+
     /// Normalize HL7 v2 message
     Norm {
         /// Input HL7 file
         input: PathBuf,
-        
+
         /// Use canonical delimiters (|^~\&)
         #[arg(long)]
         canonical_delims: bool,
-        
+
         /// Output file
         #[arg(short, long)]
         output: Option<PathBuf>,
-        
+
         /// Input is MLLP framed
         #[arg(long)]
         mllp_in: bool,
-        
+
         /// Output should be MLLP framed
         #[arg(long)]
         mllp_out: bool,
-        
+
         /// Show summary statistics
         #[arg(long)]
         summary: bool,
     },
-    
+
     /// Validate HL7 v2 message against profile
     Val {
         /// Input HL7 file
         input: PathBuf,
-        
+
         /// Profile YAML file
         #[arg(long)]
         profile: PathBuf,
-        
+
         /// Input is MLLP framed
         #[arg(long)]
         mllp: bool,
-        
+
         /// Show detailed validation results
         #[arg(long)]
         detailed: bool,
-        
+
         /// Show summary statistics
         #[arg(long)]
         summary: bool,
     },
-    
+
     /// Generate ACK for HL7 v2 message
     Ack {
         /// Input HL7 file
         input: PathBuf,
-        
+
         /// ACK mode (original or enhanced)
         #[arg(long)]
         mode: AckMode,
-        
+
         /// ACK code
         #[arg(long)]
         code: AckCode,
-        
+
         /// Input is MLLP framed
         #[arg(long)]
         mllp_in: bool,
-        
+
         /// Output should be MLLP framed
         #[arg(long)]
         mllp_out: bool,
-        
+
         /// Show summary statistics
         #[arg(long)]
         summary: bool,
     },
-    
+
     /// Generate synthetic messages
     Gen {
         /// Profile YAML file
         #[arg(long)]
         profile: PathBuf,
-        
+
         /// Random seed
         #[arg(long)]
         seed: u64,
-        
+
         /// Number of messages to generate
         #[arg(long)]
         count: usize,
-        
+
         /// Output directory
         #[arg(long)]
         out: PathBuf,
-        
+
         /// Show generation statistics
         #[arg(long)]
         stats: bool,
     },
-    
+
     /// Interactive mode
     Interactive,
 }
@@ -161,28 +160,55 @@ enum AckCode {
 
 fn main() {
     let cli = Cli::parse();
-    
+
     let result = match &cli.command {
-        Commands::Parse { input, json, envelope, mllp, summary } => {
-            parse_command(input, *json, envelope, *mllp, *summary)
-        }
-        Commands::Norm { input, canonical_delims, output, mllp_in, mllp_out, summary } => {
-            norm_command(input, *canonical_delims, output, *mllp_in, *mllp_out, *summary)
-        }
-        Commands::Val { input, profile, mllp, detailed, summary } => {
-            val_command(input, profile, *mllp, *detailed, *summary)
-        }
-        Commands::Ack { input, mode, code, mllp_in, mllp_out, summary } => {
-            ack_command(input, mode, code, *mllp_in, *mllp_out, *summary)
-        }
-        Commands::Gen { profile, seed, count, out, stats } => {
-            gen_command(profile, *seed, *count, out, *stats)
-        }
-        Commands::Interactive => {
-            interactive_mode()
-        }
+        Commands::Parse {
+            input,
+            json,
+            envelope,
+            mllp,
+            summary,
+        } => parse_command(input, *json, envelope, *mllp, *summary),
+        Commands::Norm {
+            input,
+            canonical_delims,
+            output,
+            mllp_in,
+            mllp_out,
+            summary,
+        } => norm_command(
+            input,
+            *canonical_delims,
+            output,
+            *mllp_in,
+            *mllp_out,
+            *summary,
+        ),
+        Commands::Val {
+            input,
+            profile,
+            mllp,
+            detailed,
+            summary,
+        } => val_command(input, profile, *mllp, *detailed, *summary),
+        Commands::Ack {
+            input,
+            mode,
+            code,
+            mllp_in,
+            mllp_out,
+            summary,
+        } => ack_command(input, mode, code, *mllp_in, *mllp_out, *summary),
+        Commands::Gen {
+            profile,
+            seed,
+            count,
+            out,
+            stats,
+        } => gen_command(profile, *seed, *count, out, *stats),
+        Commands::Interactive => interactive_mode(),
     };
-    
+
     if let Err(e) = result {
         eprintln!("Error: {}", e);
         process::exit(1);
@@ -210,7 +236,7 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     println!();
     println!("Performance Statistics:");
     println!("  Total execution time: {:?}", monitor.elapsed());
-    
+
     let metrics = monitor.get_metrics();
     if !metrics.is_empty() {
         println!("  Detailed metrics:");
@@ -221,14 +247,17 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
             println!("    {}: {:?}", name, duration);
         }
     }
-    
+
     // System information
     let system_info = monitor::get_system_info();
     println!("  System information:");
     if let Some(cpu_usage) = system_info.cpu.cpu_usage_percent {
         println!("    CPU usage: {:.2}%", cpu_usage);
     }
-    println!("    Total memory: {}", format_size(system_info.total_memory));
+    println!(
+        "    Total memory: {}",
+        format_size(system_info.total_memory)
+    );
     println!("    Used memory: {}", format_size(system_info.used_memory));
     if let Some(rss) = system_info.memory.resident_set_size {
         println!("    Process memory (RSS): {}", format_size(rss));
@@ -238,51 +267,57 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     }
 }
 
-fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: bool, summary: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn parse_command(
+    input: &PathBuf,
+    json: bool,
+    envelope: &Option<PathBuf>,
+    mllp: bool,
+    summary: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut monitor = monitor::PerformanceMonitor::new();
-    
+
     // Read the input file
     let contents = fs::read(input)?;
     let file_size = contents.len();
-    
+
     let read_time = monitor.elapsed();
     monitor.record_metric("File read", read_time);
-    
+
     // Parse the HL7 message
     let message = if mllp {
         hl7v2_core::parse_mllp(&contents)?
     } else {
         parse(&contents)?
     };
-    
+
     let parse_time = monitor.elapsed() - read_time;
     monitor.record_metric("Message parsing", parse_time);
-    
+
     // Count segments
     let segment_count = message.segments.len();
-    
+
     // Convert to JSON
     let json_value = to_json(&message);
-    
+
     let json_conversion_time = monitor.elapsed() - read_time - parse_time;
     monitor.record_metric("JSON conversion", json_conversion_time);
-    
+
     // Output JSON
     if json {
         println!("{}", serde_json::to_string_pretty(&json_value)?);
     } else {
         println!("{}", serde_json::to_string(&json_value)?);
     }
-    
+
     let output_time = monitor.elapsed() - read_time - parse_time - json_conversion_time;
     monitor.record_metric("Output", output_time);
-    
+
     // Handle envelope if specified
     if let Some(envelope_path) = envelope {
         // For now, we'll just print a message
         println!("Envelope would be written to: {:?}", envelope_path);
     }
-    
+
     // Show summary if requested
     if summary {
         println!();
@@ -290,38 +325,50 @@ fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: 
         println!("  Input file: {:?}", input);
         println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", segment_count);
-        println!("  Delimiters: |^~\\& (field={} comp={} rep={} esc={} sub={})", 
-                 message.delims.field, message.delims.comp, message.delims.rep, 
-                 message.delims.esc, message.delims.sub);
+        println!(
+            "  Delimiters: |^~\\& (field={} comp={} rep={} esc={} sub={})",
+            message.delims.field,
+            message.delims.comp,
+            message.delims.rep,
+            message.delims.esc,
+            message.delims.sub
+        );
         display_performance_stats(&monitor);
     }
-    
+
     Ok(())
 }
 
-fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf>, mllp_in: bool, mllp_out: bool, summary: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn norm_command(
+    input: &PathBuf,
+    canonical_delims: bool,
+    output: &Option<PathBuf>,
+    mllp_in: bool,
+    mllp_out: bool,
+    summary: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut monitor = monitor::PerformanceMonitor::new();
-    
+
     // Read the input file
     let contents = fs::read(input)?;
     let input_file_size = contents.len();
-    
+
     let read_time = monitor.elapsed();
     monitor.record_metric("File read", read_time);
-    
+
     // Parse the HL7 message
     let message = if mllp_in {
         hl7v2_core::parse_mllp(&contents)?
     } else {
         parse(&contents)?
     };
-    
+
     let parse_time = monitor.elapsed() - read_time;
     monitor.record_metric("Message parsing", parse_time);
-    
+
     // Count segments before normalization
     let segment_count = message.segments.len();
-    
+
     // Normalize the message
     let normalized_bytes = if canonical_delims {
         // We need to implement normalization with canonical delimiters
@@ -330,27 +377,28 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
     } else {
         write(&message)
     };
-    
+
     let normalize_time = monitor.elapsed() - read_time - parse_time;
     monitor.record_metric("Message normalization", normalize_time);
-    
+
     // Add MLLP framing if requested
     let output_bytes = if mllp_out {
         hl7v2_core::wrap_mllp(&normalized_bytes)
     } else {
         normalized_bytes
     };
-    
+
     let mllp_time = monitor.elapsed() - read_time - parse_time - normalize_time;
     monitor.record_metric("MLLP processing", mllp_time);
-    
+
     // Write to output file or stdout
     if let Some(output_path) = output {
         fs::write(output_path, &output_bytes)?;
         if summary {
-            let write_time = monitor.elapsed() - read_time - parse_time - normalize_time - mllp_time;
+            let write_time =
+                monitor.elapsed() - read_time - parse_time - normalize_time - mllp_time;
             monitor.record_metric("File write", write_time);
-            
+
             println!();
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
@@ -365,9 +413,10 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
     } else {
         std::io::stdout().write_all(&output_bytes)?;
         if summary {
-            let write_time = monitor.elapsed() - read_time - parse_time - normalize_time - mllp_time;
+            let write_time =
+                monitor.elapsed() - read_time - parse_time - normalize_time - mllp_time;
             monitor.record_metric("Output write", write_time);
-            
+
             println!();
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
@@ -380,48 +429,55 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             display_performance_stats(&monitor);
         }
     }
-    
+
     Ok(())
 }
 
-fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, summary: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn val_command(
+    input: &PathBuf,
+    profile: &PathBuf,
+    mllp: bool,
+    detailed: bool,
+    summary: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut monitor = monitor::PerformanceMonitor::new();
-    
+
     // Read the HL7 message file
     let contents = fs::read(input)?;
     let file_size = contents.len();
-    
+
     let read_time = monitor.elapsed();
     monitor.record_metric("File read", read_time);
-    
+
     // Parse the HL7 message
     let message = if mllp {
         hl7v2_core::parse_mllp(&contents)?
     } else {
         parse(&contents)?
     };
-    
+
     let parse_time = monitor.elapsed() - read_time;
     monitor.record_metric("Message parsing", parse_time);
-    
+
     // Read the profile YAML file
     let profile_yaml = fs::read_to_string(profile)?;
-    
+
     let read_profile_time = monitor.elapsed() - read_time - parse_time;
     monitor.record_metric("Profile read", read_profile_time);
-    
+
     // Load the profile
     let profile = load_profile(&profile_yaml)?;
-    
+
     let load_profile_time = monitor.elapsed() - read_time - parse_time - read_profile_time;
     monitor.record_metric("Profile loading", load_profile_time);
-    
+
     // Validate the message
     let results = validate(&message, &profile);
-    
-    let validation_time = monitor.elapsed() - read_time - parse_time - read_profile_time - load_profile_time;
+
+    let validation_time =
+        monitor.elapsed() - read_time - parse_time - read_profile_time - load_profile_time;
     monitor.record_metric("Message validation", validation_time);
-    
+
     // Print validation results
     if results.is_empty() {
         println!("Validation passed: No issues found");
@@ -436,7 +492,7 @@ fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, s
         }
         std::process::exit(1);
     }
-    
+
     // Show summary if requested
     if summary {
         println!();
@@ -448,30 +504,37 @@ fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, s
         println!("  Issues found: 0");
         display_performance_stats(&monitor);
     }
-    
+
     Ok(())
 }
 
-fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, mllp_out: bool, summary: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn ack_command(
+    input: &PathBuf,
+    mode: &AckMode,
+    code: &AckCode,
+    mllp_in: bool,
+    mllp_out: bool,
+    summary: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut monitor = monitor::PerformanceMonitor::new();
-    
+
     // Read the HL7 message file
     let contents = fs::read(input)?;
     let input_file_size = contents.len();
-    
+
     let read_time = monitor.elapsed();
     monitor.record_metric("File read", read_time);
-    
+
     // Parse the HL7 message
     let message = if mllp_in {
         hl7v2_core::parse_mllp(&contents)?
     } else {
         parse(&contents)?
     };
-    
+
     let parse_time = monitor.elapsed() - read_time;
     monitor.record_metric("Message parsing", parse_time);
-    
+
     // Convert ACK code
     let ack_code = match code {
         AckCode::AA => GenAckCode::AA,
@@ -481,30 +544,31 @@ fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, m
         AckCode::CE => GenAckCode::CE,
         AckCode::CR => GenAckCode::CR,
     };
-    
+
     // Generate ACK
     let ack_message = ack(&message, ack_code)?; // Remove the extra parameter
-    
+
     let ack_generation_time = monitor.elapsed() - read_time - parse_time;
     monitor.record_metric("ACK generation", ack_generation_time);
-    
+
     // Write ACK message
     let ack_bytes = if mllp_out {
         hl7v2_core::write_mllp(&ack_message)
     } else {
         write(&ack_message)
     };
-    
+
     let mllp_processing_time = monitor.elapsed() - read_time - parse_time - ack_generation_time;
     monitor.record_metric("MLLP processing", mllp_processing_time);
-    
+
     std::io::stdout().write_all(&ack_bytes)?;
-    
+
     // Show summary if requested
     if summary {
-        let write_time = monitor.elapsed() - read_time - parse_time - ack_generation_time - mllp_processing_time;
+        let write_time =
+            monitor.elapsed() - read_time - parse_time - ack_generation_time - mllp_processing_time;
         monitor.record_metric("Output write", write_time);
-        
+
         println!();
         println!("ACK Generation Summary:");
         println!("  Input file: {:?}", input);
@@ -518,7 +582,7 @@ fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, m
         println!("  MLLP output: {}", mllp_out);
         display_performance_stats(&monitor);
     }
-    
+
     Ok(())
 }
 
@@ -527,15 +591,15 @@ fn interactive_mode() -> Result<(), Box<dyn std::error::Error>> {
     println!("HL7 v2 Toolkit - Interactive Mode");
     println!("Type 'help' for available commands or 'exit' to quit.");
     println!();
-    
+
     loop {
         print!("hl7v2> ");
         std::io::stdout().flush()?;
-        
+
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
         let input = input.trim();
-        
+
         match input {
             "exit" | "quit" => {
                 println!("Goodbye!");
@@ -569,7 +633,7 @@ fn interactive_mode() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    
+
     Ok(())
 }
 
@@ -580,12 +644,12 @@ fn handle_parse_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         println!("Usage: parse <file> [--json] [--mllp] [--summary]");
         return Ok(());
     }
-    
+
     let file_path = PathBuf::from(parts[1]);
     let mut json = false;
     let mut mllp = false;
     let mut summary = false;
-    
+
     for part in &parts[2..] {
         match *part {
             "--json" => json = true,
@@ -594,7 +658,7 @@ fn handle_parse_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
             _ => println!("Unknown option: {}", part),
         }
     }
-    
+
     parse_command(&file_path, json, &None, mllp, summary)
 }
 
@@ -605,13 +669,13 @@ fn handle_norm_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         println!("Usage: norm <file> [--canonical-delims] [--mllp-in] [--mllp-out] [--summary]");
         return Ok(());
     }
-    
+
     let file_path = PathBuf::from(parts[1]);
     let mut canonical_delims = false;
     let mut mllp_in = false;
     let mut mllp_out = false;
     let mut summary = false;
-    
+
     for part in &parts[2..] {
         match *part {
             "--canonical-delims" => canonical_delims = true,
@@ -621,8 +685,15 @@ fn handle_norm_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
             _ => println!("Unknown option: {}", part),
         }
     }
-    
-    norm_command(&file_path, canonical_delims, &None, mllp_in, mllp_out, summary)
+
+    norm_command(
+        &file_path,
+        canonical_delims,
+        &None,
+        mllp_in,
+        mllp_out,
+        summary,
+    )
 }
 
 /// Handle val command in interactive mode
@@ -632,13 +703,13 @@ fn handle_val_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         println!("Usage: val <file> <profile> [--mllp] [--detailed] [--summary]");
         return Ok(());
     }
-    
+
     let file_path = PathBuf::from(parts[1]);
     let profile_path = PathBuf::from(parts[2]);
     let mut mllp = false;
     let mut detailed = false;
     let mut summary = false;
-    
+
     for part in &parts[3..] {
         match *part {
             "--mllp" => mllp = true,
@@ -647,7 +718,7 @@ fn handle_val_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
             _ => println!("Unknown option: {}", part),
         }
     }
-    
+
     val_command(&file_path, &profile_path, mllp, detailed, summary)
 }
 
@@ -655,17 +726,19 @@ fn handle_val_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
 fn handle_ack_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
     let parts: Vec<&str> = input.split_whitespace().collect();
     if parts.len() < 2 {
-        println!("Usage: ack <file> [--mode <original|enhanced>] [--code <AA|AE|AR|CA|CE|CR>] [--mllp-in] [--mllp-out] [--summary]");
+        println!(
+            "Usage: ack <file> [--mode <original|enhanced>] [--code <AA|AE|AR|CA|CE|CR>] [--mllp-in] [--mllp-out] [--summary]"
+        );
         return Ok(());
     }
-    
+
     let file_path = PathBuf::from(parts[1]);
     let mut mode = AckMode::Original;
     let mut code = AckCode::AA;
     let mut mllp_in = false;
     let mut mllp_out = false;
     let mut summary = false;
-    
+
     let mut i = 2;
     while i < parts.len() {
         match parts[i] {
@@ -723,7 +796,7 @@ fn handle_ack_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    
+
     ack_command(&file_path, &mode, &code, mllp_in, mllp_out, summary)
 }
 
@@ -731,16 +804,18 @@ fn handle_ack_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
 fn handle_gen_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
     let parts: Vec<&str> = input.split_whitespace().collect();
     if parts.len() < 2 {
-        println!("Usage: gen <profile> [--seed <number>] [--count <number>] [--out <directory>] [--stats]");
+        println!(
+            "Usage: gen <profile> [--seed <number>] [--count <number>] [--out <directory>] [--stats]"
+        );
         return Ok(());
     }
-    
+
     let profile_path = PathBuf::from(parts[1]);
     let mut seed = 42;
     let mut count = 1;
     let mut out = PathBuf::from("output");
     let mut stats = false;
-    
+
     let mut i = 2;
     while i < parts.len() {
         match parts[i] {
@@ -781,37 +856,44 @@ fn handle_gen_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    
+
     gen_command(&profile_path, seed, count, &out, stats)
 }
 
-fn gen_command(profile: &PathBuf, seed: u64, count: usize, out: &PathBuf, stats: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn gen_command(
+    profile: &PathBuf,
+    seed: u64,
+    count: usize,
+    out: &PathBuf,
+    stats: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut monitor = monitor::PerformanceMonitor::new();
-    
+
     // Read the template YAML file
     let template_yaml = fs::read_to_string(profile)?;
-    
+
     let read_template_time = monitor.elapsed();
     monitor.record_metric("Template read", read_template_time);
-    
+
     // Parse the template from YAML
     let template: Template = serde_yaml::from_str(&template_yaml)?;
-    
+
     let parse_template_time = monitor.elapsed() - read_template_time;
     monitor.record_metric("Template parsing", parse_template_time);
-    
+
     // Generate messages
     let messages = generate(&template, seed, count)?;
-    
+
     let generation_time = monitor.elapsed() - read_template_time - parse_template_time;
     monitor.record_metric("Message generation", generation_time);
-    
+
     // Create output directory if it doesn't exist
     fs::create_dir_all(out)?;
-    
-    let create_dir_time = monitor.elapsed() - read_template_time - parse_template_time - generation_time;
+
+    let create_dir_time =
+        monitor.elapsed() - read_template_time - parse_template_time - generation_time;
     monitor.record_metric("Directory creation", create_dir_time);
-    
+
     // Write each message to a separate file
     let mut written_files = 0;
     for (i, message) in messages.iter().enumerate() {
@@ -823,14 +905,18 @@ fn gen_command(profile: &PathBuf, seed: u64, count: usize, out: &PathBuf, stats:
         }
         written_files += 1;
     }
-    
-    let write_time = monitor.elapsed() - read_template_time - parse_template_time - generation_time - create_dir_time;
+
+    let write_time = monitor.elapsed()
+        - read_template_time
+        - parse_template_time
+        - generation_time
+        - create_dir_time;
     monitor.record_metric("File writing", write_time);
-    
+
     if stats {
         println!("Successfully generated {} messages", messages.len());
     }
-    
+
     // Show stats if requested
     if stats {
         println!();
@@ -843,6 +929,6 @@ fn gen_command(profile: &PathBuf, seed: u64, count: usize, out: &PathBuf, stats:
         println!("  Files written: {}", written_files);
         display_performance_stats(&monitor);
     }
-    
+
     Ok(())
 }

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -189,6 +189,22 @@ fn main() {
     }
 }
 
+fn format_size(bytes: u64) -> String {
+    const UNITS: [&str; 9] = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+    if bytes == 0 {
+        return "0 B".to_string();
+    }
+    let i = (bytes as f64).log(1024.0).floor() as usize;
+    let i = std::cmp::min(i, UNITS.len() - 1);
+    let size = bytes as f64 / 1024.0_f64.powi(i as i32);
+
+    if i == 0 {
+        format!("{} {}", bytes, UNITS[0])
+    } else {
+        format!("{:.2} {}", size, UNITS[i])
+    }
+}
+
 /// Display performance statistics
 fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     println!();
@@ -198,7 +214,10 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     let metrics = monitor.get_metrics();
     if !metrics.is_empty() {
         println!("  Detailed metrics:");
-        for (name, duration) in metrics {
+        let mut sorted_metrics: Vec<_> = metrics.iter().collect();
+        sorted_metrics.sort_by_key(|(name, _)| *name);
+
+        for (name, duration) in sorted_metrics {
             println!("    {}: {:?}", name, duration);
         }
     }
@@ -209,13 +228,13 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     if let Some(cpu_usage) = system_info.cpu.cpu_usage_percent {
         println!("    CPU usage: {:.2}%", cpu_usage);
     }
-    println!("    Total memory: {} bytes", system_info.total_memory);
-    println!("    Used memory: {} bytes", system_info.used_memory);
+    println!("    Total memory: {}", format_size(system_info.total_memory));
+    println!("    Used memory: {}", format_size(system_info.used_memory));
     if let Some(rss) = system_info.memory.resident_set_size {
-        println!("    Process memory (RSS): {} bytes", rss);
+        println!("    Process memory (RSS): {}", format_size(rss));
     }
     if let Some(vms) = system_info.memory.virtual_memory_size {
-        println!("    Process memory (VMS): {} bytes", vms);
+        println!("    Process memory (VMS): {}", format_size(vms));
     }
 }
 
@@ -269,7 +288,7 @@ fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: 
         println!();
         println!("Parse Summary:");
         println!("  Input file: {:?}", input);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", segment_count);
         println!("  Delimiters: |^~\\& (field={} comp={} rep={} esc={} sub={})", 
                  message.delims.field, message.delims.comp, message.delims.rep, 
@@ -336,8 +355,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output file: {:?}", output_path);
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_size(input_file_size as u64));
+            println!("  Output size: {}", format_size(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -353,8 +372,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output: stdout");
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_size(input_file_size as u64));
+            println!("  Output size: {}", format_size(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -424,7 +443,7 @@ fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, s
         println!("Validation Summary:");
         println!("  Input file: {:?}", input);
         println!("  Profile file: {:?}", profile);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", message.segments.len());
         println!("  Issues found: 0");
         display_performance_stats(&monitor);
@@ -491,8 +510,8 @@ fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, m
         println!("  Input file: {:?}", input);
         println!("  Mode: {:?}", mode);
         println!("  Code: {:?}", code);
-        println!("  Input size: {} bytes", input_file_size);
-        println!("  Output size: {} bytes", ack_bytes.len());
+        println!("  Input size: {}", format_size(input_file_size as u64));
+        println!("  Output size: {}", format_size(ack_bytes.len() as u64));
         println!("  Segments in original: {}", message.segments.len());
         println!("  Segments in ACK: {}", ack_message.segments.len());
         println!("  MLLP input: {}", mllp_in);

--- a/crates/hl7v2-cli/src/monitor.rs
+++ b/crates/hl7v2-cli/src/monitor.rs
@@ -1,8 +1,8 @@
 //! Performance monitoring utilities for the CLI
 
-use std::time::Instant;
 use std::collections::HashMap;
-use sysinfo::{System, CpuExt, ProcessExt, SystemExt};
+use std::time::Instant;
+use sysinfo::{CpuExt, ProcessExt, System, SystemExt};
 
 /// Performance metrics collector
 #[derive(Debug, Clone)]
@@ -19,22 +19,17 @@ impl PerformanceMonitor {
             metrics: HashMap::new(),
         }
     }
-    
+
     /// Record a metric
     pub fn record_metric(&mut self, name: &str, duration: std::time::Duration) {
         self.metrics.insert(name.to_string(), duration);
     }
-    
+
     /// Get elapsed time since creation
     pub fn elapsed(&self) -> std::time::Duration {
         self.start_time.elapsed()
     }
-    
-    /// Get a specific metric
-    pub fn get_metric(&self, name: &str) -> Option<std::time::Duration> {
-        self.metrics.get(name).copied()
-    }
-    
+
     /// Get all metrics
     pub fn get_metrics(&self) -> &HashMap<String, std::time::Duration> {
         &self.metrics
@@ -63,7 +58,7 @@ pub struct MemoryInfo {
 pub fn get_memory_info() -> MemoryInfo {
     let mut sys = System::new_all();
     sys.refresh_all();
-    
+
     if let Some(process) = sys.process(sysinfo::get_current_pid().unwrap()) {
         MemoryInfo {
             resident_set_size: Some(process.memory()),
@@ -87,9 +82,10 @@ pub struct CpuInfo {
 pub fn get_cpu_info() -> CpuInfo {
     let mut sys = System::new_all();
     sys.refresh_all();
-    
-    let cpu_usage: f64 = sys.cpus().iter().map(|cpu| cpu.cpu_usage()).sum::<f32>() as f64 / sys.cpus().len() as f64;
-    
+
+    let cpu_usage: f64 =
+        sys.cpus().iter().map(|cpu| cpu.cpu_usage()).sum::<f32>() as f64 / sys.cpus().len() as f64;
+
     CpuInfo {
         cpu_usage_percent: Some(cpu_usage),
     }
@@ -108,10 +104,10 @@ pub struct SystemInfo {
 pub fn get_system_info() -> SystemInfo {
     let mut sys = System::new_all();
     sys.refresh_all();
-    
+
     let memory_info = get_memory_info();
     let cpu_info = get_cpu_info();
-    
+
     SystemInfo {
         memory: memory_info,
         cpu: cpu_info,


### PR DESCRIPTION
Improved CLI UX by converting raw byte counts to human-readable strings (e.g., "1.50 MB") and sorting performance metrics alphabetically. This makes the output much easier to scan and understand.

Changes:
- Added `format_size` helper function in `crates/hl7v2-cli/src/main.rs`
- Updated `display_performance_stats` to sort metrics and use formatted sizes
- Updated `parse`, `norm`, `val`, and `ack` commands to use formatted sizes for file/data reporting

---
*PR created automatically by Jules for task [13703919202474653507](https://jules.google.com/task/13703919202474653507) started by @EffortlessSteven*