### PR TITLE
🛡️ Sentinel: Fix missing auth middleware and timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Unused Middleware and Timing Attacks
+**Vulnerability:** The authentication middleware was defined but not attached to the API routes, leaving sensitive endpoints exposed. Additionally, it used standard string comparison for API keys, vulnerable to timing attacks.
+**Learning:** Defining middleware is not enough; it must be explicitly applied to routes. Dead code in security components is a risk as it gives a false sense of security.
+**Prevention:** Use integration tests that specifically target the *absence* of credentials to verify that protection is active. Use constant-time comparison for all secrets.

--- a/crates/hl7v2-server/src/middleware.rs
+++ b/crates/hl7v2-server/src/middleware.rs
@@ -74,7 +74,7 @@ pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, S
         .and_then(|h| h.to_str().ok());
 
     match provided_key {
-        Some(key) if key == expected_key => {
+        Some(key) if constant_time_eq(key, &expected_key) => {
             // Valid key - allow request
             Ok(next.run(request).await)
         }
@@ -89,6 +89,19 @@ pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, S
             Err(StatusCode::UNAUTHORIZED)
         }
     }
+}
+
+/// Constant-time string comparison to prevent timing attacks
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let mut result = 0;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        result |= x ^ y;
+    }
+    result == 0
 }
 
 /// Create a concurrency limiting layer
@@ -158,5 +171,16 @@ mod tests {
         // Test that we can create a custom concurrency limit layer
         let _layer = create_custom_concurrency_limit_layer(50);
         // No panic means success
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("secret", "secret"));
+        assert!(!constant_time_eq("secret", "wrong"));
+        assert!(!constant_time_eq("secret", "secret1"));
+        assert!(!constant_time_eq("secret", "secre"));
+        assert!(!constant_time_eq("", "secret"));
+        assert!(!constant_time_eq("secret", ""));
+        assert!(constant_time_eq("", ""));
     }
 }

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -22,7 +22,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // Create API routes
     let api_routes = Router::new()
         .route("/parse", post(parse_handler))
-        .route("/validate", post(validate_handler));
+        .route("/validate", post(validate_handler))
+        .layer(middleware::from_fn(crate::middleware::auth_middleware));
 
     // Main router
     Router::new()

--- a/crates/hl7v2-server/tests/auth_test.rs
+++ b/crates/hl7v2-server/tests/auth_test.rs
@@ -1,0 +1,120 @@
+//! Integration tests for API authentication.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+mod common;
+
+#[tokio::test]
+async fn test_auth_missing_api_key() {
+    let app = common::create_test_router();
+
+    let request_body = json!({
+        "message": common::fixtures::MINIMAL_VALID,
+        "mllp_framed": false
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                // No X-API-Key header
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Request without API key should be unauthorized"
+    );
+}
+
+#[tokio::test]
+async fn test_auth_invalid_api_key() {
+    let app = common::create_test_router();
+
+    let request_body = json!({
+        "message": common::fixtures::MINIMAL_VALID,
+        "mllp_framed": false
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                .header("X-API-Key", "invalid-key")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Request with invalid API key should be unauthorized"
+    );
+}
+
+#[tokio::test]
+async fn test_auth_valid_api_key() {
+    let app = common::create_test_router();
+
+    let request_body = json!({
+        "message": common::fixtures::MINIMAL_VALID,
+        "mllp_framed": false
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                .header("X-API-Key", "test-key")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Request with valid API key should be authorized"
+    );
+}
+
+#[tokio::test]
+async fn test_health_endpoint_public() {
+    let app = common::create_test_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Health endpoint should be public"
+    );
+}

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -16,6 +16,11 @@ pub fn create_test_server() -> Server {
 
 /// Create a test router for integration testing
 pub fn create_test_router() -> Router {
+    // Set API key for authentication in tests
+    // SAFETY: This is safe in tests as long as we don't have race conditions with other tests
+    // relying on the env var being unset or different.
+    unsafe { std::env::set_var("HL7V2_API_KEY", "test-key") };
+
     let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
     let state = Arc::new(AppState {
         start_time: Instant::now(),

--- a/crates/hl7v2-server/tests/parse_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/parse_endpoint_test.rs
@@ -27,7 +27,7 @@ async fn test_parse_valid_adt_a01_message() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -55,7 +55,7 @@ async fn test_parse_valid_adt_a04_message() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -83,7 +83,7 @@ async fn test_parse_valid_oru_r01_message() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -111,7 +111,7 @@ async fn test_parse_minimal_valid_message() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -139,7 +139,7 @@ async fn test_parse_malformed_message_returns_error() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -174,7 +174,7 @@ async fn test_parse_invalid_encoding_may_succeed_if_has_msh() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -199,7 +199,7 @@ async fn test_parse_empty_request_body_returns_400() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -223,7 +223,7 @@ async fn test_parse_invalid_json_returns_400() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from("not valid json"))
                 .unwrap(),
@@ -254,7 +254,7 @@ async fn test_parse_response_contains_segments() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -282,7 +282,7 @@ async fn test_parse_get_method_not_allowed() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/parse")
-                .method("GET")
+                .method("GET").header("X-API-Key", "test-key")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -24,7 +24,7 @@ async fn test_validate_with_minimal_profile() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -53,7 +53,7 @@ async fn test_validate_adt_a01_with_matching_profile() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -91,7 +91,7 @@ async fn test_validate_malformed_message_returns_error() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -120,7 +120,7 @@ async fn test_validate_invalid_profile_yaml_returns_error() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -149,7 +149,7 @@ async fn test_validate_missing_message_field_returns_400() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -177,7 +177,7 @@ async fn test_validate_missing_profile_field_returns_400() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
@@ -201,7 +201,7 @@ async fn test_validate_empty_request_body_returns_400() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from("{}"))
                 .unwrap(),
@@ -225,7 +225,7 @@ async fn test_validate_get_method_not_allowed() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("GET")
+                .method("GET").header("X-API-Key", "test-key")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -253,7 +253,7 @@ async fn test_validate_returns_json_response() {
         .oneshot(
             Request::builder()
                 .uri("/hl7/validate")
-                .method("POST")
+                .method("POST").header("X-API-Key", "test-key")
                 .header("Content-Type", "application/json")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix missing authentication and timing attack

**Severity:** CRITICAL / HIGH

**Vulnerability:** 
1.  **Missing Authentication:** The `auth_middleware` was defined but not applied to the API routes, leaving `/hl7/parse` and `/hl7/validate` exposed without authentication.
2.  **Timing Attack:** The `auth_middleware` used standard string equality (`==`) to compare API keys, which is vulnerable to timing side-channel attacks.

**Impact:**
1.  Unauthenticated users could access sensitive HL7 parsing and validation endpoints.
2.  Attackers could potentially deduce valid API keys by measuring response times.

**Fix:**
1.  Applied `auth_middleware` to the `api_routes` in `routes.rs`.
2.  Implemented a `constant_time_eq` function in `middleware.rs` and used it for key comparison.
3.  Updated all integration tests to provide a valid API key.
4.  Added specific tests to verify unauthorized access is blocked (401).

**Verification:**
- Run `cargo test -p hl7v2-server` to verify all tests pass, including the new `tests/auth_test.rs`.

---
*PR created automatically by Jules for task [16455458944044961803](https://jules.google.com/task/16455458944044961803) started by @EffortlessSteven*