### PR TITLE
🎨 Palette: Improved CLI output readability

### DIFF
--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -9,7 +9,7 @@ use hl7v2_core::{parse, to_json, write};
 use hl7v2_prof::{load_profile, validate};
 use hl7v2_gen::{ack, AckCode as GenAckCode, Template, generate};
 mod monitor;
-use monitor::{PerformanceMonitor, get_memory_info, get_cpu_info};
+use monitor::PerformanceMonitor;
 
 #[derive(Parser)]
 #[command(name = "hl7v2", about = "HL7 v2 parser, validator, and generator")]
@@ -189,13 +189,26 @@ fn main() {
     }
 }
 
+/// Format bytes into human-readable size
+fn format_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    if bytes == 0 {
+        return "0 B".to_string();
+    }
+    let i = (bytes as f64).log(1024.0).floor() as usize;
+    let i = i.min(UNITS.len() - 1);
+    let size = bytes as f64 / 1024.0_f64.powi(i as i32);
+    format!("{:.2} {}", size, UNITS[i])
+}
+
 /// Display performance statistics
-fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
+fn display_performance_stats(monitor: &PerformanceMonitor) {
     println!();
     println!("Performance Statistics:");
     println!("  Total execution time: {:?}", monitor.elapsed());
     
-    let metrics = monitor.get_metrics();
+    let mut metrics: Vec<_> = monitor.get_metrics().iter().collect();
+    metrics.sort_by_key(|(name, _)| *name);
     if !metrics.is_empty() {
         println!("  Detailed metrics:");
         for (name, duration) in metrics {
@@ -209,13 +222,13 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     if let Some(cpu_usage) = system_info.cpu.cpu_usage_percent {
         println!("    CPU usage: {:.2}%", cpu_usage);
     }
-    println!("    Total memory: {} bytes", system_info.total_memory);
-    println!("    Used memory: {} bytes", system_info.used_memory);
+    println!("    Total memory: {}", format_size(system_info.total_memory));
+    println!("    Used memory: {}", format_size(system_info.used_memory));
     if let Some(rss) = system_info.memory.resident_set_size {
-        println!("    Process memory (RSS): {} bytes", rss);
+        println!("    Process memory (RSS): {}", format_size(rss));
     }
     if let Some(vms) = system_info.memory.virtual_memory_size {
-        println!("    Process memory (VMS): {} bytes", vms);
+        println!("    Process memory (VMS): {}", format_size(vms));
     }
 }
 
@@ -269,7 +282,7 @@ fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: 
         println!();
         println!("Parse Summary:");
         println!("  Input file: {:?}", input);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", segment_count);
         println!("  Delimiters: |^~\\& (field={} comp={} rep={} esc={} sub={})", 
                  message.delims.field, message.delims.comp, message.delims.rep, 
@@ -336,8 +349,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output file: {:?}", output_path);
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_size(input_file_size as u64));
+            println!("  Output size: {}", format_size(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -353,8 +366,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output: stdout");
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_size(input_file_size as u64));
+            println!("  Output size: {}", format_size(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -424,7 +437,7 @@ fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, s
         println!("Validation Summary:");
         println!("  Input file: {:?}", input);
         println!("  Profile file: {:?}", profile);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", message.segments.len());
         println!("  Issues found: 0");
         display_performance_stats(&monitor);
@@ -491,8 +504,8 @@ fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, m
         println!("  Input file: {:?}", input);
         println!("  Mode: {:?}", mode);
         println!("  Code: {:?}", code);
-        println!("  Input size: {} bytes", input_file_size);
-        println!("  Output size: {} bytes", ack_bytes.len());
+        println!("  Input size: {}", format_size(input_file_size as u64));
+        println!("  Output size: {}", format_size(ack_bytes.len() as u64));
         println!("  Segments in original: {}", message.segments.len());
         println!("  Segments in ACK: {}", ack_message.segments.len());
         println!("  MLLP input: {}", mllp_in);


### PR DESCRIPTION
Implemented a micro-UX improvement for the CLI tool. 

Key changes:
1.  **Human-Readable Sizes**: Replaced raw byte counts with formatted strings (e.g., "1.23 MB") in command summaries and performance stats. This makes it easier for users to understand file and memory sizes at a glance.
2.  **Sorted Metrics**: Performance metrics are now sorted alphabetically. This ensures the output order is deterministic, which improves readability and is better for testing/diffing.
3.  **Code Cleanup**: Removed unused imports in `main.rs`.

Verified by running `cargo run -p hl7v2-cli -- parse test.hl7 --summary` and observing the improved output.

---
*PR created automatically by Jules for task [331088163422915400](https://jules.google.com/task/331088163422915400) started by @EffortlessSteven*