### PR TITLE
🎨 Palette: Human-readable file sizes and sorted metrics in CLI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-28 - CLI Output Readability
+**Learning:** Developers often print raw data (bytes, unsorted maps) which creates cognitive load. Simple formatting (human-readable units, sorted keys) transforms debug output into a polished user interface.
+**Action:** Always check if numerical data (especially bytes/time) can be formatted for humans, and ensure list/map outputs are sorted for consistency.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -189,13 +189,36 @@ fn main() {
     }
 }
 
+/// Format bytes into human-readable string
+#[allow(clippy::cast_precision_loss)]
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    const TB: u64 = GB * 1024;
+
+    if bytes < KB {
+        format!("{} B", bytes)
+    } else if bytes < MB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else if bytes < GB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes < TB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else {
+        format!("{:.2} TB", bytes as f64 / TB as f64)
+    }
+}
+
 /// Display performance statistics
 fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     println!();
     println!("Performance Statistics:");
     println!("  Total execution time: {:?}", monitor.elapsed());
     
-    let metrics = monitor.get_metrics();
+    let mut metrics: Vec<_> = monitor.get_metrics().iter().collect();
+    metrics.sort_by_key(|k| k.0);
+
     if !metrics.is_empty() {
         println!("  Detailed metrics:");
         for (name, duration) in metrics {
@@ -209,13 +232,13 @@ fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
     if let Some(cpu_usage) = system_info.cpu.cpu_usage_percent {
         println!("    CPU usage: {:.2}%", cpu_usage);
     }
-    println!("    Total memory: {} bytes", system_info.total_memory);
-    println!("    Used memory: {} bytes", system_info.used_memory);
+    println!("    Total memory: {}", format_size(system_info.total_memory));
+    println!("    Used memory: {}", format_size(system_info.used_memory));
     if let Some(rss) = system_info.memory.resident_set_size {
-        println!("    Process memory (RSS): {} bytes", rss);
+        println!("    Process memory (RSS): {}", format_size(rss));
     }
     if let Some(vms) = system_info.memory.virtual_memory_size {
-        println!("    Process memory (VMS): {} bytes", vms);
+        println!("    Process memory (VMS): {}", format_size(vms));
     }
 }
 
@@ -269,7 +292,7 @@ fn parse_command(input: &PathBuf, json: bool, envelope: &Option<PathBuf>, mllp: 
         println!();
         println!("Parse Summary:");
         println!("  Input file: {:?}", input);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", segment_count);
         println!("  Delimiters: |^~\\& (field={} comp={} rep={} esc={} sub={})", 
                  message.delims.field, message.delims.comp, message.delims.rep, 
@@ -336,8 +359,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output file: {:?}", output_path);
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_size(input_file_size as u64));
+            println!("  Output size: {}", format_size(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -353,8 +376,8 @@ fn norm_command(input: &PathBuf, canonical_delims: bool, output: &Option<PathBuf
             println!("Normalize Summary:");
             println!("  Input file: {:?}", input);
             println!("  Output: stdout");
-            println!("  Input size: {} bytes", input_file_size);
-            println!("  Output size: {} bytes", output_bytes.len());
+            println!("  Input size: {}", format_size(input_file_size as u64));
+            println!("  Output size: {}", format_size(output_bytes.len() as u64));
             println!("  Segments: {}", segment_count);
             println!("  Canonical delimiters: {}", canonical_delims);
             println!("  MLLP output: {}", mllp_out);
@@ -424,7 +447,7 @@ fn val_command(input: &PathBuf, profile: &PathBuf, mllp: bool, detailed: bool, s
         println!("Validation Summary:");
         println!("  Input file: {:?}", input);
         println!("  Profile file: {:?}", profile);
-        println!("  File size: {} bytes", file_size);
+        println!("  File size: {}", format_size(file_size as u64));
         println!("  Segments: {}", message.segments.len());
         println!("  Issues found: 0");
         display_performance_stats(&monitor);
@@ -491,8 +514,8 @@ fn ack_command(input: &PathBuf, mode: &AckMode, code: &AckCode, mllp_in: bool, m
         println!("  Input file: {:?}", input);
         println!("  Mode: {:?}", mode);
         println!("  Code: {:?}", code);
-        println!("  Input size: {} bytes", input_file_size);
-        println!("  Output size: {} bytes", ack_bytes.len());
+        println!("  Input size: {}", format_size(input_file_size as u64));
+        println!("  Output size: {}", format_size(ack_bytes.len() as u64));
         println!("  Segments in original: {}", message.segments.len());
         println!("  Segments in ACK: {}", ack_message.segments.len());
         println!("  MLLP input: {}", mllp_in);


### PR DESCRIPTION
This PR introduces a small UX improvement to the CLI by formatting file sizes and memory statistics in a human-readable format (B, KB, MB, GB, TB) instead of raw bytes. It also sorts the performance metrics alphabetically to ensure the output order is consistent, making it easier for users to scan the information.

### Changes
- Added `format_size` helper function in `crates/hl7v2-cli/src/main.rs`.
- Applied `format_size` to all summary outputs where file sizes or memory stats are displayed.
- Refactored `display_performance_stats` to sort metrics before printing.

### Verification
- Verified by running `cargo run -p hl7v2-cli -- parse test.hl7 --summary`.
- Output confirms sizes are formatted (e.g., `138 B` for small files, `7.77 GB` for memory) and metrics are sorted.
- Ran `cargo check -p hl7v2-cli` to ensure no compilation errors.

---
*PR created automatically by Jules for task [6664439087932828167](https://jules.google.com/task/6664439087932828167) started by @EffortlessSteven*