### PR TITLE
🛡️ Sentinel: [CRITICAL] Enforce API key authentication on /hl7 endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-01-29 - Missing Authentication Middleware Application
+**Vulnerability:** The `auth_middleware` was defined in `middleware.rs` but not applied to any routes in `routes.rs`. The API endpoints `/hl7/parse` and `/hl7/validate` were completely exposed and accessible without an API key.
+**Learning:** Defining middleware is not enough; it must be explicitly layered onto the router using `.layer()`. Integration tests that rely on `create_test_router` were not verifying the authentication failure case.
+**Prevention:** Always verify middleware application with a dedicated negative test case that specifically targets the protected endpoint *without* credentials and asserts a 401/403 response. Configure the application to "Fail Secure" (panic) if the API key is not provided at startup.

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,12 +5,12 @@ allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 
 # Warn on pedantic lints
-warn-on-all-pedantic = true
+# warn-on-all-pedantic = true
 
 # Specific lints to allow
-allowed-lints = [
-    "clippy::module-name-repetitions",
-    "clippy::must-use-candidate",
-    "clippy::missing-errors-doc",
-    "clippy::missing-panics-doc",
-]
+# allowed-lints = [
+#     "clippy::module-name-repetitions",
+#     "clippy::must-use-candidate",
+#     "clippy::missing-errors-doc",
+#     "clippy::missing-panics-doc",
+# ]

--- a/crates/hl7v2-core/src/lib.rs
+++ b/crates/hl7v2-core/src/lib.rs
@@ -8,8 +8,6 @@
 //! - JSON serialization
 //! - Batch message handling (FHS/BHS/BTS/FTS)
 
-use serde_json;
-
 #[cfg(feature = "network")]
 pub mod network;
 

--- a/crates/hl7v2-server/src/middleware.rs
+++ b/crates/hl7v2-server/src/middleware.rs
@@ -8,13 +8,16 @@
 //! - Request ID generation
 
 use axum::{
-    extract::Request,
+    extract::{Request, State},
     http::StatusCode,
     middleware::Next,
     response::Response,
 };
+use std::sync::Arc;
 use tower::limit::ConcurrencyLimitLayer;
 use tracing::info;
+
+use crate::server::AppState;
 
 /// Request logging middleware
 pub async fn logging_middleware(request: Request, next: Next) -> Response {
@@ -40,7 +43,7 @@ pub async fn logging_middleware(request: Request, next: Next) -> Response {
 
 /// API key authentication middleware
 ///
-/// Validates requests against the HL7V2_API_KEY environment variable.
+/// Validates requests against the configured API key.
 /// Uses X-API-Key header for authentication.
 ///
 /// # Security Note
@@ -49,23 +52,13 @@ pub async fn logging_middleware(request: Request, next: Next) -> Response {
 /// - OAuth 2.0 / OIDC
 /// - mTLS
 /// - More sophisticated key management (HashiCorp Vault, AWS Secrets Manager)
-pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, StatusCode> {
+pub async fn auth_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
     const API_KEY_HEADER: &str = "X-API-Key";
-
-    // Load expected API key from environment
-    let expected_key = match std::env::var("HL7V2_API_KEY") {
-        Ok(key) if !key.is_empty() => key,
-        Ok(_) => {
-            // Empty key configured - fail closed
-            tracing::error!("HL7V2_API_KEY environment variable is empty");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-        Err(_) => {
-            // No key configured - fail closed
-            tracing::error!("HL7V2_API_KEY environment variable not set");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-    };
+    let expected_key = &state.api_key;
 
     // Get provided API key from request
     let provided_key = request
@@ -74,7 +67,7 @@ pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, S
         .and_then(|h| h.to_str().ok());
 
     match provided_key {
-        Some(key) if key == expected_key => {
+        Some(key) if constant_time_eq(key, expected_key) => {
             // Valid key - allow request
             Ok(next.run(request).await)
         }
@@ -89,6 +82,23 @@ pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, S
             Err(StatusCode::UNAUTHORIZED)
         }
     }
+}
+
+/// Constant-time string comparison to prevent timing attacks
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+    let mut result = 0;
+
+    for i in 0..a.len() {
+        result |= a_bytes[i] ^ b_bytes[i];
+    }
+
+    result == 0
 }
 
 /// Create a concurrency limiting layer
@@ -158,5 +168,15 @@ mod tests {
         // Test that we can create a custom concurrency limit layer
         let _layer = create_custom_concurrency_limit_layer(50);
         // No panic means success
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("secret", "secret"));
+        assert!(!constant_time_eq("secret", "secreT"));
+        assert!(!constant_time_eq("secret", "secret1"));
+        assert!(!constant_time_eq("secret", "short"));
+        assert!(!constant_time_eq("", "secret"));
+        assert!(constant_time_eq("", ""));
     }
 }

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -14,7 +14,7 @@ use tower_http::{
 
 use crate::handlers::{health_handler, parse_handler, validate_handler};
 use crate::metrics::{metrics_handler, middleware::metrics_middleware};
-use crate::middleware::create_concurrency_limit_layer;
+use crate::middleware::{auth_middleware, create_concurrency_limit_layer};
 use crate::server::AppState;
 
 /// Build the application router
@@ -22,7 +22,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // Create API routes
     let api_routes = Router::new()
         .route("/parse", post(parse_handler))
-        .route("/validate", post(validate_handler));
+        .route("/validate", post(validate_handler))
+        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
 
     // Main router
     Router::new()
@@ -72,6 +73,7 @@ mod tests {
         let state = Arc::new(AppState {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
+            api_key: "test-key".to_string(),
         });
 
         let app = build_router(state);
@@ -95,6 +97,7 @@ mod tests {
         let state = Arc::new(AppState {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
+            api_key: "test-key".to_string(),
         });
 
         let app = build_router(state);

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -17,6 +17,8 @@ pub struct AppState {
     pub start_time: Instant,
     /// Prometheus metrics handle
     pub metrics_handle: Arc<PrometheusHandle>,
+    /// API key for authentication
+    pub api_key: String,
 }
 
 /// HTTP server configuration
@@ -26,6 +28,8 @@ pub struct ServerConfig {
     pub bind_address: String,
     /// Maximum request body size in bytes
     pub max_body_size: usize,
+    /// API key for authentication (optional, overrides HL7V2_API_KEY env var)
+    pub api_key: Option<String>,
 }
 
 impl Default for ServerConfig {
@@ -33,6 +37,7 @@ impl Default for ServerConfig {
         Self {
             bind_address: "0.0.0.0:8080".to_string(),
             max_body_size: 10 * 1024 * 1024, // 10MB
+            api_key: None,
         }
     }
 }
@@ -49,9 +54,27 @@ impl Server {
         // Initialize Prometheus metrics recorder
         let metrics_handle = crate::metrics::init_metrics_recorder();
 
+        // Determine API key
+        // 1. Check config
+        // 2. Check environment variable
+        // 3. Panic if neither is set
+        let api_key = if let Some(key) = &config.api_key {
+            if key.is_empty() {
+                panic!("API key cannot be empty");
+            }
+            key.clone()
+        } else {
+            match std::env::var("HL7V2_API_KEY") {
+                Ok(key) if !key.is_empty() => key,
+                Ok(_) => panic!("HL7V2_API_KEY environment variable is empty"),
+                Err(_) => panic!("API key must be provided via config or HL7V2_API_KEY environment variable"),
+            }
+        };
+
         let state = Arc::new(AppState {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
+            api_key,
         });
 
         Self { config, state }
@@ -110,6 +133,12 @@ impl ServerBuilder {
         self
     }
 
+    /// Set the API key
+    pub fn api_key(mut self, key: impl Into<String>) -> Self {
+        self.config.api_key = Some(key.into());
+        self
+    }
+
     /// Build the server
     pub fn build(self) -> Server {
         Server::new(self.config)
@@ -127,14 +156,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_server_builder() {
+    #[should_panic(expected = "API key must be provided")]
+    fn test_server_builder_panics_without_key() {
+        // Should panic because no API key is set
+        Server::builder()
+            .bind("127.0.0.1:8080")
+            .build();
+    }
+
+    #[test]
+    fn test_server_builder_with_key() {
         let server = Server::builder()
             .bind("127.0.0.1:8080")
             .max_body_size(1024 * 1024)
+            .api_key("test-key")
             .build();
 
         assert_eq!(server.config.bind_address, "127.0.0.1:8080");
         assert_eq!(server.config.max_body_size, 1024 * 1024);
+        assert_eq!(server.config.api_key, Some("test-key".to_string()));
     }
 
     #[test]
@@ -142,5 +182,6 @@ mod tests {
         let config = ServerConfig::default();
         assert_eq!(config.bind_address, "0.0.0.0:8080");
         assert_eq!(config.max_body_size, 10 * 1024 * 1024);
+        assert!(config.api_key.is_none());
     }
 }

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -10,6 +10,7 @@ pub fn create_test_server() -> Server {
     let config = ServerConfig {
         bind_address: "127.0.0.1:0".to_string(), // Use random port for tests
         max_body_size: 1024 * 1024, // 1MB
+        api_key: Some("test-key".to_string()),
     };
     Server::new(config)
 }
@@ -20,6 +21,7 @@ pub fn create_test_router() -> Router {
     let state = Arc::new(AppState {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
+        api_key: "test-key".to_string(),
     });
     hl7v2_server::routes::build_router(state)
 }

--- a/crates/hl7v2-server/tests/error_handling_test.rs
+++ b/crates/hl7v2-server/tests/error_handling_test.rs
@@ -63,6 +63,7 @@ async fn test_content_type_validation() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "text/plain")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("some text"))
                 .unwrap(),
         )
@@ -101,6 +102,7 @@ async fn test_large_request_handling() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -123,6 +125,7 @@ async fn test_missing_content_type_header() {
             Request::builder()
                 .uri("/hl7/parse")
                 .method("POST")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("{}"))
                 .unwrap(),
         )

--- a/crates/hl7v2-server/tests/parse_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/parse_endpoint_test.rs
@@ -29,6 +29,7 @@ async fn test_parse_valid_adt_a01_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -57,6 +58,7 @@ async fn test_parse_valid_adt_a04_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -85,6 +87,7 @@ async fn test_parse_valid_oru_r01_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -113,6 +116,7 @@ async fn test_parse_minimal_valid_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -141,6 +145,7 @@ async fn test_parse_malformed_message_returns_error() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -176,6 +181,7 @@ async fn test_parse_invalid_encoding_may_succeed_if_has_msh() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -201,6 +207,7 @@ async fn test_parse_empty_request_body_returns_400() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("{}"))
                 .unwrap(),
         )
@@ -225,6 +232,7 @@ async fn test_parse_invalid_json_returns_400() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("not valid json"))
                 .unwrap(),
         )
@@ -256,6 +264,7 @@ async fn test_parse_response_contains_segments() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -283,6 +292,7 @@ async fn test_parse_get_method_not_allowed() {
             Request::builder()
                 .uri("/hl7/parse")
                 .method("GET")
+                .header("X-API-Key", "test-key")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/hl7v2-server/tests/security_test.rs
+++ b/crates/hl7v2-server/tests/security_test.rs
@@ -1,0 +1,84 @@
+//! Security reproduction tests.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+mod common;
+
+#[tokio::test]
+async fn test_parse_endpoint_security() {
+    let app = common::create_test_router();
+
+    let request_body = json!({
+        "message": common::fixtures::ADT_A01_VALID,
+        "mllp_framed": false,
+        "options": {
+            "include_json": true,
+            "validate_structure": false
+        }
+    });
+
+    // Test 1: Request WITHOUT key -> Should fail (401)
+    let response_no_key = app.clone()
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response_no_key.status(),
+        StatusCode::UNAUTHORIZED,
+        "Endpoint should be protected and return 401 without API Key"
+    );
+
+    // Test 2: Request with INVALID key -> Should fail (401)
+    let response_bad_key = app.clone()
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .header("X-API-Key", "wrong-key")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response_bad_key.status(),
+        StatusCode::UNAUTHORIZED,
+        "Endpoint should return 401 with invalid API Key"
+    );
+
+    // Test 3: Request with VALID key -> Should pass (200)
+    let response_valid_key = app
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response_valid_key.status(),
+        StatusCode::OK,
+        "Endpoint should return 200 with valid API Key"
+    );
+}

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -26,6 +26,7 @@ async fn test_validate_with_minimal_profile() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -55,6 +56,7 @@ async fn test_validate_adt_a01_with_matching_profile() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -93,6 +95,7 @@ async fn test_validate_malformed_message_returns_error() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -122,6 +125,7 @@ async fn test_validate_invalid_profile_yaml_returns_error() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -151,6 +155,7 @@ async fn test_validate_missing_message_field_returns_400() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -179,6 +184,7 @@ async fn test_validate_missing_profile_field_returns_400() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -203,6 +209,7 @@ async fn test_validate_empty_request_body_returns_400() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("{}"))
                 .unwrap(),
         )
@@ -226,6 +233,7 @@ async fn test_validate_get_method_not_allowed() {
             Request::builder()
                 .uri("/hl7/validate")
                 .method("GET")
+                .header("X-API-Key", "test-key")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -255,6 +263,7 @@ async fn test_validate_returns_json_response() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )


### PR DESCRIPTION
This PR addresses a critical security vulnerability where the `auth_middleware` was defined but not applied to the API routes, leaving `/hl7/parse` and `/hl7/validate` exposed.

Changes include:
- **Authentication Enforcement:** Explicitly applied `auth_middleware` to the `/hl7` nested router.
- **Timing Attack Mitigation:** Implemented constant-time string comparison for API key validation.
- **Fail Secure Configuration:** Updated `Server` to panic at startup if no API key is provided via config or environment variable.
- **Test Coverage:** Added comprehensive security tests verifying that requests without keys or with invalid keys are rejected (401), while valid keys are accepted (200).
- **Maintenance:** Fixed broken `clippy.toml` configuration to re-enable linting and cleaned up minor code issues.

---
*PR created automatically by Jules for task [16877456384681834656](https://jules.google.com/task/16877456384681834656) started by @EffortlessSteven*