### PR TITLE
🛡️ Sentinel: [CRITICAL] Enforce API Key Auth & Constant-Time Comparison

### DIFF
--- a/crates/hl7v2-server/src/middleware.rs
+++ b/crates/hl7v2-server/src/middleware.rs
@@ -8,13 +8,16 @@
 //! - Request ID generation
 
 use axum::{
-    extract::Request,
+    extract::{Request, State},
     http::StatusCode,
     middleware::Next,
     response::Response,
 };
+use std::sync::Arc;
 use tower::limit::ConcurrencyLimitLayer;
 use tracing::info;
+
+use crate::server::AppState;
 
 /// Request logging middleware
 pub async fn logging_middleware(request: Request, next: Next) -> Response {
@@ -38,31 +41,34 @@ pub async fn logging_middleware(request: Request, next: Next) -> Response {
     response
 }
 
+/// Constant-time string comparison to prevent timing attacks
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.bytes()
+        .zip(b.bytes())
+        .fold(0, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
 /// API key authentication middleware
 ///
-/// Validates requests against the HL7V2_API_KEY environment variable.
+/// Validates requests against the configured API key in AppState.
 /// Uses X-API-Key header for authentication.
-///
-/// # Security Note
-/// This is a basic API key implementation suitable for internal services
-/// or development environments. For production use, consider:
-/// - OAuth 2.0 / OIDC
-/// - mTLS
-/// - More sophisticated key management (HashiCorp Vault, AWS Secrets Manager)
-pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, StatusCode> {
+pub async fn auth_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
     const API_KEY_HEADER: &str = "X-API-Key";
 
-    // Load expected API key from environment
-    let expected_key = match std::env::var("HL7V2_API_KEY") {
-        Ok(key) if !key.is_empty() => key,
-        Ok(_) => {
-            // Empty key configured - fail closed
-            tracing::error!("HL7V2_API_KEY environment variable is empty");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-        Err(_) => {
+    // Get configured key from state
+    let expected_key = match &state.api_key {
+        Some(key) => key,
+        None => {
             // No key configured - fail closed
-            tracing::error!("HL7V2_API_KEY environment variable not set");
+            tracing::error!("Server configuration error: No API key configured");
             return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
     };
@@ -74,7 +80,7 @@ pub async fn auth_middleware(request: Request, next: Next) -> Result<Response, S
         .and_then(|h| h.to_str().ok());
 
     match provided_key {
-        Some(key) if key == expected_key => {
+        Some(key) if constant_time_eq(key, expected_key) => {
             // Valid key - allow request
             Ok(next.run(request).await)
         }
@@ -158,5 +164,13 @@ mod tests {
         // Test that we can create a custom concurrency limit layer
         let _layer = create_custom_concurrency_limit_layer(50);
         // No panic means success
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("secret", "secret"));
+        assert!(!constant_time_eq("secret", "secreT"));
+        assert!(!constant_time_eq("secret", "public"));
+        assert!(!constant_time_eq("short", "longstring"));
     }
 }

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -14,7 +14,7 @@ use tower_http::{
 
 use crate::handlers::{health_handler, parse_handler, validate_handler};
 use crate::metrics::{metrics_handler, middleware::metrics_middleware};
-use crate::middleware::create_concurrency_limit_layer;
+use crate::middleware::{auth_middleware, create_concurrency_limit_layer};
 use crate::server::AppState;
 
 /// Build the application router
@@ -22,7 +22,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // Create API routes
     let api_routes = Router::new()
         .route("/parse", post(parse_handler))
-        .route("/validate", post(validate_handler));
+        .route("/validate", post(validate_handler))
+        // Apply authentication middleware only to API routes
+        // We use from_fn_with_state because the middleware needs access to AppState
+        .layer(middleware::from_fn_with_state(state.clone(), auth_middleware));
 
     // Main router
     Router::new()
@@ -72,6 +75,7 @@ mod tests {
         let state = Arc::new(AppState {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
+            api_key: None,
         });
 
         let app = build_router(state);
@@ -95,6 +99,7 @@ mod tests {
         let state = Arc::new(AppState {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
+            api_key: Some("test-key".to_string()),
         });
 
         let app = build_router(state);
@@ -117,6 +122,7 @@ mod tests {
                     .uri("/hl7/parse")
                     .method("POST")
                     .header("Content-Type", "application/json")
+                    .header("X-API-Key", "test-key")
                     .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                     .unwrap(),
             )

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -17,6 +17,8 @@ pub struct AppState {
     pub start_time: Instant,
     /// Prometheus metrics handle
     pub metrics_handle: Arc<PrometheusHandle>,
+    /// API key for authentication
+    pub api_key: Option<String>,
 }
 
 /// HTTP server configuration
@@ -26,6 +28,8 @@ pub struct ServerConfig {
     pub bind_address: String,
     /// Maximum request body size in bytes
     pub max_body_size: usize,
+    /// API key for authentication (overrides environment variable)
+    pub api_key: Option<String>,
 }
 
 impl Default for ServerConfig {
@@ -33,6 +37,7 @@ impl Default for ServerConfig {
         Self {
             bind_address: "0.0.0.0:8080".to_string(),
             max_body_size: 10 * 1024 * 1024, // 10MB
+            api_key: None,
         }
     }
 }
@@ -49,9 +54,17 @@ impl Server {
         // Initialize Prometheus metrics recorder
         let metrics_handle = crate::metrics::init_metrics_recorder();
 
+        // Determine API key: explicit config > environment variable
+        let api_key = config
+            .api_key
+            .clone()
+            .or_else(|| std::env::var("HL7V2_API_KEY").ok())
+            .filter(|k| !k.is_empty());
+
         let state = Arc::new(AppState {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
+            api_key,
         });
 
         Self { config, state }
@@ -107,6 +120,12 @@ impl ServerBuilder {
     /// Set the maximum request body size
     pub fn max_body_size(mut self, size: usize) -> Self {
         self.config.max_body_size = size;
+        self
+    }
+
+    /// Set the API key
+    pub fn api_key(mut self, key: impl Into<String>) -> Self {
+        self.config.api_key = Some(key.into());
         self
     }
 

--- a/crates/hl7v2-server/tests/auth_test.rs
+++ b/crates/hl7v2-server/tests/auth_test.rs
@@ -1,0 +1,42 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+mod common;
+
+#[tokio::test]
+async fn test_access_without_api_key_is_denied() {
+    // This test confirms that accessing protected endpoints without an API key
+    // returns 401 Unauthorized.
+
+    let app = common::create_test_router();
+
+    let request_body = json!({
+        "message": common::fixtures::MINIMAL_VALID,
+        "mllp_framed": false
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/hl7/parse")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                // No X-API-Key header
+                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Expect 401 Unauthorized now that auth middleware is applied
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Endpoint should NOT be accessible without API Key"
+    );
+}

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -10,6 +10,7 @@ pub fn create_test_server() -> Server {
     let config = ServerConfig {
         bind_address: "127.0.0.1:0".to_string(), // Use random port for tests
         max_body_size: 1024 * 1024, // 1MB
+        api_key: Some("test-key".to_string()),
     };
     Server::new(config)
 }
@@ -20,6 +21,7 @@ pub fn create_test_router() -> Router {
     let state = Arc::new(AppState {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
+        api_key: Some("test-key".to_string()),
     });
     hl7v2_server::routes::build_router(state)
 }

--- a/crates/hl7v2-server/tests/parse_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/parse_endpoint_test.rs
@@ -29,6 +29,7 @@ async fn test_parse_valid_adt_a01_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -57,6 +58,7 @@ async fn test_parse_valid_adt_a04_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -85,6 +87,7 @@ async fn test_parse_valid_oru_r01_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -113,6 +116,7 @@ async fn test_parse_minimal_valid_message() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -141,6 +145,7 @@ async fn test_parse_malformed_message_returns_error() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -176,6 +181,7 @@ async fn test_parse_invalid_encoding_may_succeed_if_has_msh() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -201,6 +207,7 @@ async fn test_parse_empty_request_body_returns_400() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("{}"))
                 .unwrap(),
         )
@@ -225,6 +232,7 @@ async fn test_parse_invalid_json_returns_400() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("not valid json"))
                 .unwrap(),
         )
@@ -256,6 +264,7 @@ async fn test_parse_response_contains_segments() {
                 .uri("/hl7/parse")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -283,6 +292,7 @@ async fn test_parse_get_method_not_allowed() {
             Request::builder()
                 .uri("/hl7/parse")
                 .method("GET")
+                .header("X-API-Key", "test-key")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -26,6 +26,7 @@ async fn test_validate_with_minimal_profile() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -55,6 +56,7 @@ async fn test_validate_adt_a01_with_matching_profile() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -93,6 +95,7 @@ async fn test_validate_malformed_message_returns_error() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -122,6 +125,7 @@ async fn test_validate_invalid_profile_yaml_returns_error() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -151,6 +155,7 @@ async fn test_validate_missing_message_field_returns_400() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -179,6 +184,7 @@ async fn test_validate_missing_profile_field_returns_400() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )
@@ -203,6 +209,7 @@ async fn test_validate_empty_request_body_returns_400() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from("{}"))
                 .unwrap(),
         )
@@ -226,6 +233,7 @@ async fn test_validate_get_method_not_allowed() {
             Request::builder()
                 .uri("/hl7/validate")
                 .method("GET")
+                .header("X-API-Key", "test-key")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -255,6 +263,7 @@ async fn test_validate_returns_json_response() {
                 .uri("/hl7/validate")
                 .method("POST")
                 .header("Content-Type", "application/json")
+                .header("X-API-Key", "test-key")
                 .body(Body::from(serde_json::to_string(&request_body).unwrap()))
                 .unwrap(),
         )


### PR DESCRIPTION
This PR addresses a critical security vulnerability where the `/hl7/parse` and `/hl7/validate` endpoints were accessible without authentication. It also hardens the authentication mechanism against timing attacks.

**Changes:**
1.  **Configuration:** `ServerConfig` and `AppState` now include an `api_key` field. This allows the key to be injected programmatically (e.g., in tests) and prioritizes explicit config over the `HL7V2_API_KEY` environment variable.
2.  **Middleware:** The `auth_middleware` was rewritten to:
    *   Extract the API key from `AppState` (via `State<Arc<AppState>>`) instead of reading `std::env` on every request.
    *   Use a constant-time string comparison (`constant_time_eq`) to prevent timing side-channel attacks.
    *   Return `500 Internal Server Error` if no API key is configured (Fail Secure principle), rather than failing silently or insecurely.
3.  **Routing:** The middleware is now explicitly layered onto the `/hl7` route scope using `.layer(middleware::from_fn_with_state(...))`, ensuring it runs for all API endpoints.
4.  **Tests:**
    *   Added `crates/hl7v2-server/tests/auth_test.rs` to verify that requests without a key return `401 Unauthorized`.
    *   Updated `parse_endpoint_test.rs` and `validate_endpoint_test.rs` to include the `X-API-Key` header with a test key.
    *   Updated `common/mod.rs` to configure the test server with a known key.

**Verification:**
*   `cargo test -p hl7v2-server` passes.
*   `auth_test.rs` explicitly confirms that unauthorized requests are rejected.

---
*PR created automatically by Jules for task [7595384774868311715](https://jules.google.com/task/7595384774868311715) started by @EffortlessSteven*