### PR TITLE
🎨 Palette: Categorize interactive mode help output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Interactive mode command help
+**Learning:** The interactive mode help display doesn't have headers dividing the commands into categories, which could make it less readable if more commands are added. The prompt instructions requested categorical help for the interactive mode.
+**Action:** Add categories to the 'help' command output in interactive mode (Processing, Validation, Generation, System).

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -527,11 +527,19 @@ fn interactive_mode() -> Result<(), Box<dyn std::error::Error>> {
             }
             "help" => {
                 println!("Available commands:");
+                println!();
+                println!("Processing:");
                 println!("  parse <file> [options]  - Parse an HL7 message");
                 println!("  norm <file> [options]   - Normalize an HL7 message");
+                println!();
+                println!("Validation:");
                 println!("  val <file> <profile>    - Validate an HL7 message");
+                println!();
+                println!("Generation:");
                 println!("  ack <file> [options]    - Generate an ACK for an HL7 message");
                 println!("  gen <profile> [options] - Generate synthetic messages");
+                println!();
+                println!("System:");
                 println!("  help                    - Show this help message");
                 println!("  exit|quit               - Exit interactive mode");
                 println!();


### PR DESCRIPTION
🎨 Palette: Categorize interactive mode help output

💡 **What:** Added category headers ("Processing", "Validation", "Generation", "System") and extra whitespace to the `help` command output in the interactive mode of the `hl7v2-cli`. Also added an entry to `.Jules/palette.md` to record the UX learning.

🎯 **Why:** The previous `help` command dumped all available commands in a single, unorganized list. As the number of commands grows, this becomes difficult to parse at a glance. Categorizing them improves readability and makes the interface significantly more intuitive and pleasant to use, solving a small but impactful discoverability problem.

📸 **Before:**
```
Available commands:
  parse <file> [options]  - Parse an HL7 message
  norm <file> [options]   - Normalize an HL7 message
  val <file> <profile>    - Validate an HL7 message
  ack <file> [options]    - Generate an ACK for an HL7 message
  gen <profile> [options] - Generate synthetic messages
  help                    - Show this help message
  exit|quit               - Exit interactive mode
```

📸 **After:**
```
Available commands:

Processing:
  parse <file> [options]  - Parse an HL7 message
  norm <file> [options]   - Normalize an HL7 message

Validation:
  val <file> <profile>    - Validate an HL7 message

Generation:
  ack <file> [options]    - Generate an ACK for an HL7 message
  gen <profile> [options] - Generate synthetic messages

System:
  help                    - Show this help message
  exit|quit               - Exit interactive mode
```

♿ **Accessibility:** While not a WCAG-specific change, visual grouping and increased whitespace significantly reduce cognitive load and improve scanability for all users, including those with cognitive or visual impairments.

---
*PR created automatically by Jules for task [4660411028264948259](https://jules.google.com/task/4660411028264948259) started by @EffortlessSteven*