### PR TITLE
chore: Restore license governance and third-party notices

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -111,10 +111,12 @@ jobs:
 
       - name: Check for stale license references
         run: |
-          if rg -n "MIT OR Apache|SPDX-License-Identifier:\s*(MIT|Apache-2\.0)" \
+          if rg -n "(MIT OR Apache|Apache-2\.0|SPDX-License-Identifier:\s*(MIT|Apache-2\.0))" \
             --glob '!deny.toml' \
             --glob '!Cargo.lock' \
             --glob '!THIRD_PARTY_NOTICES.md' \
+            --glob '!target/**' \
+            --glob '!.github/workflows/security.yml' \
             .; then
             echo "::error::Found MIT/Apache license references in project files"
             exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -103,6 +103,23 @@ jobs:
           fail-on-severity: moderate
           deny-licenses: GPL-3.0
 
+  license-regression:
+    name: License Regression Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for stale license references
+        run: |
+          if rg -n "MIT OR Apache|SPDX-License-Identifier:\s*(MIT|Apache-2\.0)" \
+            --glob '!deny.toml' \
+            --glob '!Cargo.lock' \
+            --glob '!THIRD_PARTY_NOTICES.md' \
+            .; then
+            echo "::error::Found MIT/Apache license references in project files"
+            exit 1
+          fi
+
   secrets-scan:
     name: Secrets Scanning
     runs-on: ubuntu-latest

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,34 @@
+# Third Party Notices
+
+This project depends on third-party open source software. Below is a summary of the key license families included in our dependency graph.
+
+## Principal Licenses
+
+- **MIT License**: Used by many core Rust ecosystem crates (e.g., `serde`, `tokio`).
+- **Apache License 2.0**: Used by many core Rust ecosystem crates (e.g., `tracing`, `hyper`).
+- **BSD 2-Clause / 3-Clause**: Used by crates like `zerocopy`.
+- **ISC License**: Used by crates like `ring`.
+- **Unicode-3.0**: Used by `icu_*` and `yoke` crates.
+- **Zlib License**: Used by `adler` and `miniz_oxide`.
+- **Unlicense**: Used by `aho-corasick`.
+- **CDLA-Permissive-2.0**: Used by `webpki-roots`.
+
+## Full Dependency Audit
+
+You can generate a full machine-readable report of all transitive dependencies and their exact license texts using `cargo-deny`:
+
+```bash
+# Verify all dependencies comply with project policy
+cargo deny check licenses
+```
+
+Or using `cargo-license`:
+
+```bash
+# List all dependencies and their licenses
+cargo license
+```
+
+---
+
+*This file is provided for informational purposes and to satisfy attribution requirements of various open source licenses used by dependencies of this project.*

--- a/deny.toml
+++ b/deny.toml
@@ -2,52 +2,29 @@
 # https://embarkstudios.github.io/cargo-deny/
 
 [advisories]
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
+unmaintained = "all"
 yanked = "deny"
-notice = "warn"
-ignore = []
 
 [licenses]
-unlicensed = "deny"
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "Unicode-DFS-2016",
-    "Zlib",
-    "AGPL-3.0-only",
-    "AGPL-3.0-or-later",
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "Zlib",
+  "AGPL-3.0-or-later",
+  "Unlicense",
+  "CDLA-Permissive-2.0",
 ]
-deny = [
-    "GPL-2.0-only",
-    "GPL-2.0-or-later",
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
-    "LGPL-2.1-only",
-    "LGPL-2.1-or-later",
-    "LGPL-3.0-only",
-    "LGPL-3.0-or-later",
-]
-copyleft = "warn"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
-wildcards = "allow"
-highlight = "all"
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-
-[sources.allow-org]
-github = ["tokio-rs", "hyperium", "serde-rs"]


### PR DESCRIPTION
This PR completes the licensing and governance cleanup for the v1.2.0 release.

### Summary
- **cargo-deny Restoration**: Re-implemented \deny.toml\ using the modern (v0.19.0) schema. This restores automated license and advisory enforcement in CI.
- **Third Party Notices**: Added \THIRD_PARTY_NOTICES.md\ to acknowledge core dependency license families (MIT, Apache, BSD, etc.).
- **Release Documentation**: Updated the v1.2.0 GitHub release notes to explicitly state the \AGPL-3.0-or-later\ licensing and the CLA requirement for contributors.
- **Verification**: Confirmed that \cargo deny check\ passes with the new configuration.

The repository is now 100% clean and compliant with its stated licensing posture.