### PR TITLE
fix(writer): exclude MSH from random segment IDs in property tests

### DIFF
--- a/crates/hl7v2-writer/tests/property_tests.proptest-regressions
+++ b/crates/hl7v2-writer/tests/property_tests.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a961865418be740ec5342371c08cec6163abc97e4369e6ce0cf7e4a0f1c3f60b # shrinks to messages = [Message { delims: Delims { field: '|', comp: '^', rep: '~', esc: '\\', sub: '&' }, segments: [Segment { id: [77, 83, 72], fields: [Field { reps: [Rep { comps: [Comp { subs: [Text("^~\\&")] }] }] }, Field { reps: [Rep { comps: [Comp { subs: [Text("APP")] }] }] }, Field { reps: [Rep { comps: [Comp { subs: [Text("FAC")] }] }] }] }, Segment { id: [77, 83, 72], fields: [Field { reps: [Rep { comps: [Comp { subs: [Text(" ")] }] }] }] }], charsets: [] }]

--- a/crates/hl7v2-writer/tests/property_tests.rs
+++ b/crates/hl7v2-writer/tests/property_tests.rs
@@ -33,9 +33,17 @@ fn text_with_delimiters() -> impl Strategy<Value = String> {
     proptest::string::string_regex("[A-Za-z0-9 |^~\\\\&]{0,50}").unwrap()
 }
 
-/// Generate a segment ID (3 uppercase letters)
+/// Generate a segment ID (3 uppercase letters, excluding MSH which is special)
 fn segment_id() -> impl Strategy<Value = [u8; 3]> {
-    (0u8..26, 0u8..26, 0u8..26).prop_map(|(a, b, c)| [b'A' + a, b'A' + b, b'A' + c])
+    (0u8..26, 0u8..26, 0u8..26).prop_map(|(a, b, c)| {
+        let id = [b'A' + a, b'A' + b, b'A' + c];
+        // Exclude MSH since it's a special segment that should only appear at message start
+        if &id == b"MSH" {
+            [b'M', b'S', b'I'] // Use MSI as a substitute
+        } else {
+            id
+        }
+    })
 }
 
 /// Generate a simple field


### PR DESCRIPTION
- Fix property test failure caused by duplicate MSH segments in generated messages
- Add proptest regression case
- Modify `segment_id()` strategy to substitute MSH with MSI when randomly generated

2 files changed, +17 -2