### PR TITLE
chore(repo): pre-publish cleanup for public release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Secrets and credentials safety net
+.env
+*.pem
+*.key
+*.p12

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+The hl7v2-rs project uses this Code of Conduct to help create a welcoming
+environment for all contributors, users, and maintainers.
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for
+everyone, regardless of age, body size, disability, ethnicity, gender
+identity or expression, level of experience, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+We do not tolerate harassment of participants in any form.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Being respectful and considerate in all communications.
+- Being welcoming of newcomers and different perspectives.
+- Offering constructive, specific, and kind feedback.
+- Focusing on ideas and data, not personal attacks.
+- Showing empathy for people working in a complex, healthcare-focused project.
+
+Examples of unacceptable behavior include:
+
+- Trolling, insulting comments, and personal or political attacks.
+- Sexualized or otherwise offensive language and imagery.
+- Public or private harassment.
+- Repeatedly disrupting discussions or spaces.
+- Publishing others' private information without permission.
+- Other conduct that creates an unsafe or unwelcoming environment.
+
+## Scope
+
+This Code of Conduct applies to all project spaces and community venues,
+including:
+
+- GitHub issues, pull requests, and discussions.
+- Public and private communication channels used by the project.
+- Community events and any place where an individual represents hl7v2-rs.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing this Code of
+Conduct. They may take actions they deem appropriate, including warnings,
+removal of comments, temporary or permanent bans from community spaces, and
+limiting contribution access.
+
+## Reporting
+
+If you are experiencing or witness a behavior that violates this code, report it
+to `security@effortlessmetrics.com` with:
+
+- The names of those involved, if known.
+- Links, logs, or screenshots of the incident.
+- A short description of what happened and when.
+
+We will review each report and protect the confidentiality of the reporter where
+possible.
+
+## Enforcement Process
+
+1. The reporter submits concerns to the contact above.
+2. Maintainers investigate the report and may request additional context.
+3. Appropriate action is taken based on impact, pattern, and intent.
+4. The reporter receives a brief outcome update when possible.
+
+## Attribution
+
+This policy is based on the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for considering contributing to hl7v2-rs! This project is actively dev
 
 ## Code of Conduct
 
-Be respectful, inclusive, and constructive in all interactions. We're building healthcare infrastructure—let's do it right.
+Please follow the project [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions.
 
 ## License + CLA
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ license = "AGPL-3.0-or-later"
 repository = "https://github.com/EffortlessMetrics/hl7v2-rs"
 keywords = ["hl7", "healthcare", "parser", "validator"]
 categories = ["parser-implementations", "encoding"]
+homepage = "https://github.com/EffortlessMetrics/hl7v2-rs"
+documentation = "https://docs.rs/hl7v2-core"
 
 [workspace.dependencies]
 serde = { version = "1.0.228", features = ["derive"] }

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -121,7 +121,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-changeme}
     depends_on:
       - prometheus
 


### PR DESCRIPTION
## Summary
- **`.gitignore`**: Add safety-net entries for `.env`, `*.pem`, `*.key`, `*.p12` to prevent accidental secret commits
- **`Cargo.toml`**: Add `homepage` and `documentation` workspace metadata for crates.io
- **`DEPLOYMENT.md`**: Replace hardcoded Grafana `admin` password with `${GRAFANA_PASSWORD:-changeme}` env var

## Context
Final hygiene PR before flipping the repository public. Phase A (deleting 108 stale remote branches) was completed prior to this PR.

## Test plan
- [x] `cargo build --workspace --all-features` passes
- [x] `git check-ignore -v .env test.pem test.key test.p12` matches all four patterns