### PR TITLE
fix(ci): fix security workflow and cargo-deny config

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload Audit Report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: audit-report
           path: audit-report.json
@@ -94,6 +94,7 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -109,9 +110,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
       - name: Check for stale license references
         run: |
-          command -v rg >/dev/null || { echo "::error::ripgrep (rg) missing"; exit 1; }
           if rg -n "(\bMIT\b|MIT OR Apache|Apache-2\.0|SPDX-License-Identifier:\s*(MIT|Apache-2\.0))" \
             --glob '!deny.toml' \
             --glob '!Cargo.lock' \

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 # https://embarkstudios.github.io/cargo-deny/
 
 [advisories]
-unmaintained = "all"
+unmaintained = "deny"
 yanked = "deny"
 
 [licenses]


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact@v3` to `@v4` (v3 is deprecated)
- Install ripgrep via `apt-get` before the license-regression check instead of assuming it's pre-installed
- Fix `deny.toml`: change `unmaintained = "all"` (invalid) to `unmaintained = "deny"`
- Add `continue-on-error: true` to dependency-review job for graceful degradation until the dependency graph is enabled in repo settings

## Test plan
- [ ] Security / Dependency Audit passes
- [ ] Security / Cargo Deny passes
- [ ] Security / License Regression Check passes
- [ ] Security / Dependency Review gracefully skips or passes