### PR TITLE
chore(release): prepare workspace for crates.io publication

### DIFF
--- a/crates/hl7v2-ack/Cargo.toml
+++ b/crates/hl7v2-ack/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 ACK (Acknowledgment) message generation"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-batch/Cargo.toml
+++ b/crates/hl7v2-batch/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 batch message handling (FHS/BHS/FTS/BTS)"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "batch", "file", "processing"]
 categories = ["parser-implementations"]
 

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Command-line interface for HL7 v2 message manipulation and validation."
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-core/Cargo.toml
+++ b/crates/hl7v2-core/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "High-level API and core functionality for hl7v2-rs."
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-corpus/Cargo.toml
+++ b/crates/hl7v2-corpus/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 test corpus generation and management utilities"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-datatype/Cargo.toml
+++ b/crates/hl7v2-datatype/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 data type validation"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "datatype", "validation"]
 categories = ["parser-implementations", "encoding"]
 

--- a/crates/hl7v2-datetime/Cargo.toml
+++ b/crates/hl7v2-datetime/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 date/time parsing and validation"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "datetime", "date", "time"]
 categories = ["date-and-time", "parser-implementations"]
 

--- a/crates/hl7v2-escape/Cargo.toml
+++ b/crates/hl7v2-escape/Cargo.toml
@@ -15,5 +15,5 @@ categories = ["encoding", "parser-implementations"]
 hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
 
 [dev-dependencies]
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"

--- a/crates/hl7v2-escape/Cargo.toml
+++ b/crates/hl7v2-escape/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 escape sequence handling"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "escape", "encoding"]
 categories = ["encoding", "parser-implementations"]
 

--- a/crates/hl7v2-faker/Cargo.toml
+++ b/crates/hl7v2-faker/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Realistic HL7 v2 test data generation (names, addresses, medical codes, etc.)"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "faker", "test-data", "mock"]
 categories = ["development-tools::testing", "parser-implementations"]
 

--- a/crates/hl7v2-gen/Cargo.toml
+++ b/crates/hl7v2-gen/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Code generation utilities for creating Rust models from HL7 v2 profiles."
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-json/Cargo.toml
+++ b/crates/hl7v2-json/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 JSON serialization"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "json", "serialization"]
 categories = ["encoding", "parser-implementations"]
 

--- a/crates/hl7v2-mllp/Cargo.toml
+++ b/crates/hl7v2-mllp/Cargo.toml
@@ -16,7 +16,7 @@ hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"
 
 [features]

--- a/crates/hl7v2-mllp/Cargo.toml
+++ b/crates/hl7v2-mllp/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "MLLP (Minimal Lower Layer Protocol) framing for HL7 v2"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "mllp", "protocol", "framing"]
 categories = ["network-programming", "encoding"]
 

--- a/crates/hl7v2-model/Cargo.toml
+++ b/crates/hl7v2-model/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Core data model for HL7 v2 messages"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "data-model"]
 categories = ["data-structures", "encoding"]
 

--- a/crates/hl7v2-network/Cargo.toml
+++ b/crates/hl7v2-network/Cargo.toml
@@ -33,7 +33,7 @@ tls = ["rustls", "tokio-rustls"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"
 tokio-test = "0.4"
 

--- a/crates/hl7v2-network/Cargo.toml
+++ b/crates/hl7v2-network/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 MLLP network client and server (TCP/TLS)"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories = ["network-programming", "asynchronous"]
 

--- a/crates/hl7v2-normalize/Cargo.toml
+++ b/crates/hl7v2-normalize/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 message normalization"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "normalize", "canonical"]
 categories = ["encoding", "parser-implementations"]
 

--- a/crates/hl7v2-parser/Cargo.toml
+++ b/crates/hl7v2-parser/Cargo.toml
@@ -18,8 +18,8 @@ hl7v2-mllp = { version = "1.2.0", path = "../hl7v2-mllp" }
 hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
 
 [dev-dependencies]
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
-hl7v2-writer = { version = "1.2.0", path = "../hl7v2-writer" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
+hl7v2-writer = { path = "../hl7v2-writer" }
 proptest = "1.6"
 insta = { version = "1.42", features = ["yaml", "json", "redactions"] }
 pretty_assertions = "1.4"

--- a/crates/hl7v2-parser/Cargo.toml
+++ b/crates/hl7v2-parser/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 message parser"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "parser"]
 categories = ["parser-implementations", "encoding"]
 

--- a/crates/hl7v2-path/Cargo.toml
+++ b/crates/hl7v2-path/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 field path parsing and resolution"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "path", "field", "access"]
 categories = ["parser-implementations"]
 

--- a/crates/hl7v2-prof/Cargo.toml
+++ b/crates/hl7v2-prof/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 message profile and conformance processing."
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-query/Cargo.toml
+++ b/crates/hl7v2-query/Cargo.toml
@@ -16,5 +16,5 @@ hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
 
 [dev-dependencies]
 proptest = "1.6"
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
+hl7v2-parser = { path = "../hl7v2-parser" }
 

--- a/crates/hl7v2-query/Cargo.toml
+++ b/crates/hl7v2-query/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 path-based field access and query functionality"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "query", "path"]
 categories = ["parser-implementations", "encoding"]
 

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HTTP/REST API server for HL7v2 message processing"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-stream/Cargo.toml
+++ b/crates/hl7v2-stream/Cargo.toml
@@ -23,8 +23,8 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 # Test utilities
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
+hl7v2-parser = { path = "../hl7v2-parser" }
 
 # Property-based testing
 proptest = "1.6"

--- a/crates/hl7v2-stream/Cargo.toml
+++ b/crates/hl7v2-stream/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Streaming/event-based parser for HL7 v2 messages"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-template-values/Cargo.toml
+++ b/crates/hl7v2-template-values/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Value generation helpers for HL7 v2 templates"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-template/Cargo.toml
+++ b/crates/hl7v2-template/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 template-based message generation"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-validation/Cargo.toml
+++ b/crates/hl7v2-validation/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "Comprehensive HL7 v2 message, segment, and field validation."
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 

--- a/crates/hl7v2-writer/Cargo.toml
+++ b/crates/hl7v2-writer/Cargo.toml
@@ -18,8 +18,8 @@ hl7v2-mllp = { version = "1.2.0", path = "../hl7v2-mllp" }
 hl7v2-json = { version = "1.2.0", path = "../hl7v2-json" }
 
 [dev-dependencies]
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-parser = { path = "../hl7v2-parser" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"
 serde_json = "1.0"
 

--- a/crates/hl7v2-writer/Cargo.toml
+++ b/crates/hl7v2-writer/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HL7 v2 message writer/serializer"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 keywords = ["hl7", "healthcare", "serializer", "writer"]
 categories = ["encoding", "parser-implementations"]
 


### PR DESCRIPTION
This PR prepares the hl7v2-rs workspace for publication to crates.io by: