### PR TITLE
fix(security): green workflow under current repo settings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,18 +95,27 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    # Requires the dependency graph to be enabled in repo settings
-    # (Settings → Code security and analysis → Dependency graph)
-    # TODO: remove continue-on-error once dependency graph is enabled in repo settings
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check dependency graph status
+        id: dependency-graph
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          status=$(gh api "repos/${{ github.repository }}" --jq '.security_and_analysis.dependency_graph.status // "disabled"')
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
       - name: Dependency Review
+        if: steps.dependency-graph.outputs.status == 'enabled'
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
           deny-licenses: GPL-3.0
+
+      - name: Skip Dependency Review
+        if: steps.dependency-graph.outputs.status != 'enabled'
+        run: echo "Dependency graph is disabled; skipping dependency review."
 
   license-regression:
     name: License Regression Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,28 +202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,8 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -495,15 +471,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -894,12 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,12 +1001,6 @@ dependencies = [
  "nonempty",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1892,7 +1847,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2211,16 +2165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,14 +2286,12 @@ dependencies = [
  "base64",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "rustls",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3255,26 +3197,12 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3289,11 +3217,10 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/crates/hl7v2-network/Cargo.toml
+++ b/crates/hl7v2-network/Cargo.toml
@@ -24,8 +24,8 @@ bytes = "1.11.1"
 futures = "0.3.32"
 
 # Optional TLS support
-rustls = { version = "0.23.36", optional = true }
-tokio-rustls = { version = "0.26.4", optional = true }
+rustls = { version = "0.23.37", optional = true, default-features = false, features = ["ring"] }
+tokio-rustls = { version = "0.26.4", optional = true, default-features = false, features = ["ring"] }
 
 [features]
 default = []

--- a/crates/hl7v2-prof/Cargo.toml
+++ b/crates/hl7v2-prof/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "time", "fs"] }
 
 # HTTP client for remote profile loading
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "http2"] }
 
 # LRU cache for profile caching
 lru = "0.16"

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 metrics = { workspace = true }
-metrics-exporter-prometheus = { workspace = true }
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false, features = ["http-listener"] }
 tower_governor = { workspace = true }
 governor = "0.8"
 serde_yaml = { workspace = true }


### PR DESCRIPTION
## Summary
- skip dependency review automatically when the repository dependency graph is disabled
- move the TLS dependency path off aws-lc so cargo-audit and cargo-deny stop failing on the current advisories
- update the lockfile to remove the vulnerable aws-lc / rustls-webpki chain

## Validation
- cargo test -p hl7v2-server --all-features
- cargo audit --deny warnings
- cargo deny check advisories bans licenses sources
- cargo fmt --all -- --check