### PR TITLE
fix(ci): repair nightly property test job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -166,7 +166,7 @@ jobs:
           PROPTEST_CASES: 10000
           PROPTEST_MAX_DEFAULT_SIZE: 1000
         run: |
-          cargo test --workspace --features proptest property \
+          cargo test --workspace --test property_tests \
             -- --nocapture
         timeout-minutes: 25
 

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -193,7 +193,7 @@ The following jobs use `continue-on-error: true`:
 
 3. **Check property tests locally (limited):**
    ```bash
-   PROPTEST_CASES=100 cargo test --workspace --features proptest property
+   PROPTEST_CASES=100 cargo test --workspace --test property_tests -- --nocapture
    ```
 
 ### For Maintainers

--- a/docs/TESTING_ARCHITECTURE.md
+++ b/docs/TESTING_ARCHITECTURE.md
@@ -789,7 +789,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       
       - name: Property tests (limited cases)
-        run: PROPTEST_CASES=100 cargo test --features proptest
+        run: PROPTEST_CASES=100 cargo test --workspace --test property_tests -- --nocapture
 
   coverage:
     name: Coverage Report
@@ -1118,7 +1118,7 @@ cargo test --test '*' -p hl7v2-parser
 cargo test --test bdd_tests -p hl7v2-core
 
 # Run property tests with more cases
-PROPTEST_CASES=1000 cargo test --features proptest
+PROPTEST_CASES=1000 cargo test --workspace --test property_tests -- --nocapture
 
 # Run benchmarks
 cargo bench


### PR DESCRIPTION
## Summary
- replace the broken nightly property-test invocation with the real property_tests test target
- update maintainer docs so local instructions match the workflow again

## Validation
- cargo test --workspace --test property_tests -- --nocapture