### PR TITLE
fix(ci): green publish automation follow-up checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -63,7 +63,8 @@ jobs:
             --skip-clean \
             --exclude-files '*/tests/*' \
             --exclude-files '*/examples/*' \
-            --exclude-files '*/benches/*'
+            --exclude-files '*/benches/*' \
+            --exclude-files 'xtask/**'
         timeout-minutes: 20
 
       - name: Upload coverage artifact
@@ -132,7 +133,7 @@ jobs:
             --all-features \
             --lcov \
             --output-path coverage/llvm/lcov.info \
-            --ignore-filename-regex='(tests|examples|benches)/'
+            --ignore-filename-regex='(tests|examples|benches|xtask)/'
         timeout-minutes: 15
 
       - name: Generate HTML report
@@ -142,7 +143,7 @@ jobs:
             --all-features \
             --html \
             --output-dir coverage/llvm/html/ \
-            --ignore-filename-regex='(tests|examples|benches)/'
+            --ignore-filename-regex='(tests|examples|benches|xtask)/'
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
@@ -207,7 +208,7 @@ jobs:
             --all-features \
             --lcov \
             --output-path coverage/pr/lcov.info \
-            --ignore-filename-regex='(tests|examples|benches)/'
+            --ignore-filename-regex='(tests|examples|benches|xtask)/'
 
       - name: Checkout base branch
         run: |
@@ -221,7 +222,7 @@ jobs:
             --all-features \
             --lcov \
             --output-path coverage/base/lcov.info \
-            --ignore-filename-regex='(tests|examples|benches)/'
+            --ignore-filename-regex='(tests|examples|benches|xtask)/'
 
       - name: Compare coverage
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,11 @@ jobs:
           shared-key: publish-crates-io
 
       - name: Show publish plan
+        env:
+          PUBLISH_FROM: ${{ github.event.inputs.from }}
         run: |
-          if [ -n "${{ github.event.inputs.from }}" ]; then
-            cargo run -p xtask -- publish-plan --from "${{ github.event.inputs.from }}"
+          if [ -n "$PUBLISH_FROM" ]; then
+            cargo run -p xtask -- publish-plan --from "$PUBLISH_FROM"
           else
             cargo run -p xtask -- publish-plan
           fi
@@ -62,9 +64,10 @@ jobs:
         if: github.event.inputs.execute == 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          PUBLISH_FROM: ${{ github.event.inputs.from }}
         run: |
-          if [ -n "${{ github.event.inputs.from }}" ]; then
-            cargo run -p xtask -- publish --yes --from "${{ github.event.inputs.from }}"
+          if [ -n "$PUBLISH_FROM" ]; then
+            cargo run -p xtask -- publish --yes --from "$PUBLISH_FROM"
           else
             cargo run -p xtask -- publish --yes
           fi

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -780,3 +780,51 @@ fn get_changed_scope() -> Result<ChangedScope> {
 
     Ok(ChangedScope::Crates(changed_crates.into_iter().collect()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_order_uses_workspace_dependency_order() {
+        let ordered = publish_order(None).expect("workspace publish order should resolve");
+
+        assert!(ordered.contains(&"hl7v2-core".to_string()));
+        assert!(ordered.contains(&"hl7v2".to_string()));
+        assert!(ordered.contains(&"hl7v2-template-values".to_string()));
+        assert!(!ordered.contains(&"xtask".to_string()));
+
+        assert_dependency_precedes(&ordered, "hl7v2-datatype", "hl7v2-core");
+        assert_dependency_precedes(&ordered, "hl7v2-core", "hl7v2");
+        assert_dependency_precedes(&ordered, "hl7v2-template-values", "hl7v2-template");
+    }
+
+    #[test]
+    fn publish_order_can_resume_from_a_named_crate() {
+        let ordered = publish_order(None).expect("workspace publish order should resolve");
+        let resumed =
+            publish_order(Some("hl7v2-core")).expect("resume point should exist in workspace");
+        let start = ordered
+            .iter()
+            .position(|crate_name| crate_name == "hl7v2-core")
+            .expect("hl7v2-core should be publishable");
+
+        assert_eq!(resumed, ordered[start..].to_vec());
+    }
+
+    fn assert_dependency_precedes(ordered: &[String], dependency: &str, dependent: &str) {
+        let dependency_index = ordered
+            .iter()
+            .position(|crate_name| crate_name == dependency)
+            .unwrap_or_else(|| panic!("{dependency} should be present in publish order"));
+        let dependent_index = ordered
+            .iter()
+            .position(|crate_name| crate_name == dependent)
+            .unwrap_or_else(|| panic!("{dependent} should be present in publish order"));
+
+        assert!(
+            dependency_index < dependent_index,
+            "{dependency} should appear before {dependent}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- stop the publish workflow from interpolating untrusted GitHub input directly inside shell steps
- exclude xtask developer tooling from workspace coverage gating
- add xtask unit tests covering derived publish order and resume-from behavior

## Validation
- cargo fmt --all -- --check
- cargo test -p xtask
- cargo clippy -p xtask -- -D warnings