### PR TITLE
fix(release): remove unpublished test-utils versions

### DIFF
--- a/crates/hl7v2-ack/Cargo.toml
+++ b/crates/hl7v2-ack/Cargo.toml
@@ -17,7 +17,7 @@ hl7v2-core = { version = "1.2.0", path = "../hl7v2-core" }
 chrono = { version = "0.4.44", features = ["serde", "std", "clock"], default-features = false }
 
 [dev-dependencies]
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 hl7v2-writer = { version = "1.2.0", path = "../hl7v2-writer" }
 proptest = "1.6"
 

--- a/crates/hl7v2-batch/Cargo.toml
+++ b/crates/hl7v2-batch/Cargo.toml
@@ -18,5 +18,5 @@ hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
 hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
 
 [dev-dependencies]
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -31,7 +31,7 @@ hl7v2-stream = { version = "1.2.0", path = "../hl7v2-stream" }
 assert_cmd = "2.0"
 predicates = "3.1"
 tempfile = "3.19"
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 cucumber = { version = "0.22", default-features = false, features = ["macros"] }
 futures = "0.3"
 

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -44,7 +44,7 @@ tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
 cucumber = "0.22.1"
 serde_json = { workspace = true }
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 
 [[test]]
 name = "bdd_tests"

--- a/crates/hl7v2-validation/Cargo.toml
+++ b/crates/hl7v2-validation/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4.44", features = ["serde", "std", "clock"], default-fea
 
 [dev-dependencies]
 # Test utilities from workspace
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
+hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
 
 # Property-based testing


### PR DESCRIPTION
## Summary
- drop the version field from hl7v2-test-utils dev-dependencies in publishable crates
- keep those dev-dependencies workspace-local so crates.io packaging does not require an unpublished crate

## Validation
- cargo package -p hl7v2-batch --locked --allow-dirty
- cargo check -p hl7v2-batch --tests