### PR TITLE
feat(test): expand BDD coverage and apply clippy fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hl7v2"
+version = "1.2.0"
+dependencies = [
+ "hl7v2-core",
+]
+
+[[package]]
 name = "hl7v2-ack"
 version = "1.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,8 +1434,10 @@ name = "hl7v2-datetime"
 version = "1.2.0"
 dependencies = [
  "chrono",
+ "cucumber",
  "proptest",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1477,9 +1479,11 @@ dependencies = [
 name = "hl7v2-escape"
 version = "1.2.0"
 dependencies = [
+ "cucumber",
  "hl7v2-model",
  "hl7v2-test-utils",
  "proptest",
+ "tokio",
 ]
 
 [[package]]
@@ -1554,10 +1558,12 @@ dependencies = [
 name = "hl7v2-mllp"
 version = "1.2.0"
 dependencies = [
+ "cucumber",
  "hl7v2-model",
  "hl7v2-test-utils",
  "proptest",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1604,6 +1610,7 @@ name = "hl7v2-parser"
 version = "1.2.0"
 dependencies = [
  "assert_matches",
+ "cucumber",
  "hl7v2-escape",
  "hl7v2-mllp",
  "hl7v2-model",
@@ -1613,6 +1620,7 @@ dependencies = [
  "insta",
  "pretty_assertions",
  "proptest",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,10 +1423,12 @@ name = "hl7v2-datatype"
 version = "1.2.0"
 dependencies = [
  "chrono",
+ "cucumber",
  "hl7v2-datetime",
  "proptest",
  "regex",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1516,9 +1518,11 @@ name = "hl7v2-faker"
 version = "1.2.0"
 dependencies = [
  "chrono",
+ "cucumber",
  "proptest",
  "rand 0.10.0",
  "rand_distr",
+ "tokio",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    # Top-level name-claim crate
+    "crates/hl7v2",
     # Microcrates (SRP-focused)
     "crates/hl7v2-model",
     "crates/hl7v2-escape",

--- a/crates/hl7v2-ack/CLAUDE.md
+++ b/crates/hl7v2-ack/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-ack
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-ack
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-ack
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-ack -- -D warnings
-`
+```

--- a/crates/hl7v2-ack/tests/bdd_tests.rs
+++ b/crates/hl7v2-ack/tests/bdd_tests.rs
@@ -76,7 +76,7 @@ fn given_from_to_fac(world: &mut AckWorld) {
 // When Steps
 // ============================================================================
 
-#[when(regex = r#"I generate an ACK with code (AA|AE|AR|CA|CE|CR)"#)]
+#[when(regex = r"I generate an ACK with code (AA|AE|AR|CA|CE|CR)")]
 fn when_generate_ack(world: &mut AckWorld, code: String) {
     let ack_code = match code.as_str() {
         "AA" => AckCode::AA,

--- a/crates/hl7v2-batch/CLAUDE.md
+++ b/crates/hl7v2-batch/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-batch
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-batch
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-batch
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-batch -- -D warnings
-`
+```

--- a/crates/hl7v2-batch/src/tests.rs
+++ b/crates/hl7v2-batch/src/tests.rs
@@ -337,7 +337,7 @@ fn test_extract_batch_info_minimal() {
             || info
                 .encoding_characters
                 .as_ref()
-                .is_some_and(|s| s.is_empty())
+                .is_some_and(std::string::String::is_empty)
     );
 }
 
@@ -385,8 +385,8 @@ fn test_batch_error_display() {
         expected: 5,
         actual: 3,
     };
-    assert!(error.to_string().contains("5"));
-    assert!(error.to_string().contains("3"));
+    assert!(error.to_string().contains('5'));
+    assert!(error.to_string().contains('3'));
 }
 
 // ============================================================================

--- a/crates/hl7v2-batch/tests/bdd_tests.rs
+++ b/crates/hl7v2-batch/tests/bdd_tests.rs
@@ -186,7 +186,7 @@ BTS|1|End of batch\r";
     world.raw_bytes = batch.to_vec();
 }
 
-#[given(regex = r#"a batch containing ([A-Z]{3}\^[A-Z0-9]{2,3}) messages"#)]
+#[given(regex = r"a batch containing ([A-Z]{3}\^[A-Z0-9]{2,3}) messages")]
 fn given_batch_message_type(world: &mut BatchWorld, message_type: String) {
     let batch = format!(
         "BHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120000|||BATCH001|Test batch\r\
@@ -495,7 +495,7 @@ fn then_trailer_comment(world: &mut BatchWorld) {
     assert_eq!(info.trailer_comment, Some("End of batch".to_string()));
 }
 
-#[then(regex = r#"each message should be of type ([A-Z]{3}\^[A-Z0-9]{2,3})"#)]
+#[then(regex = r"each message should be of type ([A-Z]{3}\^[A-Z0-9]{2,3})")]
 fn then_each_message_type(world: &mut BatchWorld, _message_type: String) {
     then_parse_success(world);
 }

--- a/crates/hl7v2-bench/CLAUDE.md
+++ b/crates/hl7v2-bench/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-bench
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-bench
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-bench
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-bench -- -D warnings
-`
+```

--- a/crates/hl7v2-bench/benches/batch.rs
+++ b/crates/hl7v2-bench/benches/batch.rs
@@ -108,7 +108,7 @@ fn bench_parse_file_batch(c: &mut Criterion) {
 fn bench_batch_by_message_count(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_message_count");
 
-    for count in [10, 100, 1000].iter() {
+    for count in &[10, 100, 1000] {
         let batch = create_single_batch(*count);
         let bytes = batch.as_bytes();
 
@@ -209,7 +209,7 @@ fn bench_message_parsing_from_batch(c: &mut Criterion) {
                 let result = parse(full_msg.as_bytes());
                 let _ = black_box(result);
             }
-        })
+        });
     });
 }
 
@@ -228,7 +228,7 @@ fn bench_batch_iteration(c: &mut Criterion) {
                 }
             }
             black_box(count)
-        })
+        });
     });
 }
 
@@ -302,7 +302,7 @@ fn bench_batch_memory_efficiency(c: &mut Criterion) {
             let parsed = parse_batch(black_box(bytes)).expect("Failed to parse");
             let count = parsed.total_message_count();
             black_box(count)
-        })
+        });
     });
 
     // Parse and access first message
@@ -312,7 +312,7 @@ fn bench_batch_memory_efficiency(c: &mut Criterion) {
             let first_msg = parsed.iter_all_messages().next();
             let segment_count = first_msg.map(|m| m.segments.len()).unwrap_or(0);
             black_box(segment_count)
-        })
+        });
     });
 
     group.finish();

--- a/crates/hl7v2-bench/benches/escape.rs
+++ b/crates/hl7v2-bench/benches/escape.rs
@@ -24,7 +24,7 @@ fn bench_unescape_text(c: &mut Criterion) {
         b.iter(|| {
             let result = unescape_text(black_box(&text), black_box(&delims));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -37,7 +37,7 @@ fn bench_escape_text(c: &mut Criterion) {
         b.iter(|| {
             let result = escape_text(black_box(&text), black_box(&delims));
             black_box(result)
-        })
+        });
     });
 }
 

--- a/crates/hl7v2-bench/benches/json.rs
+++ b/crates/hl7v2-bench/benches/json.rs
@@ -37,7 +37,7 @@ fn bench_to_json_value(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -51,7 +51,7 @@ fn bench_to_json_string(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -65,7 +65,7 @@ fn bench_to_json_string_pretty(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string_pretty(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -81,14 +81,14 @@ fn bench_json_complex_message(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.bench_function("to_json_string", |b| {
         b.iter(|| {
             let result = to_json_string(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -104,7 +104,7 @@ fn bench_json_nested_message(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -116,7 +116,7 @@ fn bench_json_throughput(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("json_throughput");
 
-    for count in [1, 10, 100, 1000].iter() {
+    for count in &[1, 10, 100, 1000] {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::new("serialize", count), count, |b, _| {
             b.iter(|| {
@@ -124,7 +124,7 @@ fn bench_json_throughput(c: &mut Criterion) {
                     let result = to_json(black_box(&parsed));
                     black_box(result);
                 }
-            })
+            });
         });
     }
 
@@ -150,7 +150,7 @@ fn bench_json_size_comparison(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string(black_box(&simple_parsed));
             black_box(result)
-        })
+        });
     });
 
     // Complex message
@@ -160,7 +160,7 @@ fn bench_json_size_comparison(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string(black_box(&complex_parsed));
             black_box(result)
-        })
+        });
     });
 
     // Nested message
@@ -170,7 +170,7 @@ fn bench_json_size_comparison(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string(black_box(&nested_parsed));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -188,14 +188,14 @@ fn bench_json_vs_hl7_format(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.bench_function("hl7_serialize", |b| {
         b.iter(|| {
             let result = write(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -227,7 +227,7 @@ fn bench_json_value_access(c: &mut Criterion) {
                     }
                 }
             }
-        })
+        });
     });
 }
 
@@ -242,7 +242,7 @@ fn bench_json_by_segment_count(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json(black_box(&small_parsed));
             black_box(result)
-        })
+        });
     });
 
     // 13 segments (MSH, PID, PV1, 5x OBX, 2x AL1, 2x DG1)
@@ -252,7 +252,7 @@ fn bench_json_by_segment_count(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json(black_box(&medium_parsed));
             black_box(result)
-        })
+        });
     });
 
     // Create a larger message with more segments
@@ -269,7 +269,7 @@ fn bench_json_by_segment_count(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json(black_box(&large_parsed));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -289,7 +289,7 @@ fn bench_json_memory_allocation(c: &mut Criterion) {
             let json_value = to_json(black_box(&parsed));
             let string = serde_json::to_string(&json_value).unwrap();
             black_box(string)
-        })
+        });
     });
 
     // Direct to string
@@ -297,7 +297,7 @@ fn bench_json_memory_allocation(c: &mut Criterion) {
         b.iter(|| {
             let result = to_json_string(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.finish();

--- a/crates/hl7v2-bench/benches/memory.rs
+++ b/crates/hl7v2-bench/benches/memory.rs
@@ -33,7 +33,7 @@ fn bench_memory_parse(c: &mut Criterion) {
         b.iter(|| {
             let result = parse(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -46,7 +46,7 @@ fn bench_memory_parse_large(c: &mut Criterion) {
         b.iter(|| {
             let result = parse(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -59,7 +59,7 @@ fn bench_memory_write(c: &mut Criterion) {
         b.iter(|| {
             let result = write(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -72,7 +72,7 @@ fn bench_memory_parse_mllp(c: &mut Criterion) {
         b.iter(|| {
             let result = parse_mllp(black_box(&mllp_bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -85,7 +85,7 @@ fn bench_memory_write_mllp(c: &mut Criterion) {
         b.iter(|| {
             let result = write_mllp(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -98,7 +98,7 @@ fn bench_memory_normalize(c: &mut Criterion) {
         b.iter(|| {
             let result = normalize(black_box(bytes), false);
             black_box(result)
-        })
+        });
     });
 }
 

--- a/crates/hl7v2-bench/benches/mllp.rs
+++ b/crates/hl7v2-bench/benches/mllp.rs
@@ -20,7 +20,7 @@ fn bench_mllp_wrap(c: &mut Criterion) {
         b.iter(|| {
             let result = write_mllp(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -33,7 +33,7 @@ fn bench_mllp_unwrap_and_parse(c: &mut Criterion) {
         b.iter(|| {
             let result = parse_mllp(black_box(&mllp_bytes));
             black_box(result)
-        })
+        });
     });
 }
 

--- a/crates/hl7v2-bench/benches/network.rs
+++ b/crates/hl7v2-bench/benches/network.rs
@@ -43,7 +43,7 @@ fn bench_mllp_wrap(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -56,7 +56,7 @@ fn bench_mllp_wrap_large(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -67,7 +67,7 @@ fn bench_mllp_wrap_throughput(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("mllp_wrap_throughput");
 
-    for count in [1, 10, 100, 1000].iter() {
+    for count in &[1, 10, 100, 1000] {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, _| {
             b.iter(|| {
@@ -75,7 +75,7 @@ fn bench_mllp_wrap_throughput(c: &mut Criterion) {
                     let result = wrap_mllp(black_box(bytes));
                     black_box(result);
                 }
-            })
+            });
         });
     }
 
@@ -91,7 +91,7 @@ fn bench_mllp_write_message(c: &mut Criterion) {
         b.iter(|| {
             let result = write_mllp(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -104,7 +104,7 @@ fn bench_mllp_write_large_message(c: &mut Criterion) {
         b.iter(|| {
             let result = write_mllp(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -119,7 +119,7 @@ fn bench_codec_encoding(c: &mut Criterion) {
             // Simulate encoding for MLLP transmission
             let wrapped = wrap_mllp(black_box(bytes));
             black_box(wrapped)
-        })
+        });
     });
 }
 
@@ -139,7 +139,7 @@ fn bench_codec_decoding(c: &mut Criterion) {
                 let message_bytes = &wrapped[start + 1..end];
                 black_box(message_bytes);
             }
-        })
+        });
     });
 }
 
@@ -155,7 +155,7 @@ fn bench_frame_size_impact(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(small_bytes));
             black_box(result)
-        })
+        });
     });
 
     // Medium message (~1KB)
@@ -166,7 +166,7 @@ fn bench_frame_size_impact(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(medium_bytes));
             black_box(result)
-        })
+        });
     });
 
     // Large message (~10KB)
@@ -185,7 +185,7 @@ fn bench_frame_size_impact(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(large_bytes));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -199,7 +199,7 @@ fn bench_concurrent_frame_processing(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("concurrent_frames");
 
-    for concurrency in [1, 2, 4, 8].iter() {
+    for concurrency in &[1, 2, 4, 8] {
         group.bench_with_input(
             BenchmarkId::new("concurrent_wrap", concurrency),
             concurrency,
@@ -214,7 +214,7 @@ fn bench_concurrent_frame_processing(c: &mut Criterion) {
                     }
                     let results: Vec<_> = futures::future::join_all(handles).await;
                     black_box(results)
-                })
+                });
             },
         );
     }
@@ -236,7 +236,7 @@ fn bench_message_roundtrip(c: &mut Criterion) {
             // Wrap
             let wrapped = wrap_mllp(&mllp);
             black_box(wrapped)
-        })
+        });
     });
 }
 
@@ -247,7 +247,7 @@ fn bench_pipeline_throughput(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("pipeline_throughput");
 
-    for count in [1, 10, 100].iter() {
+    for count in &[1, 10, 100] {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &count| {
             b.iter(|| {
@@ -260,7 +260,7 @@ fn bench_pipeline_throughput(c: &mut Criterion) {
                     let wrapped = wrap_mllp(&mllp);
                     black_box(wrapped);
                 }
-            })
+            });
         });
     }
 
@@ -280,7 +280,7 @@ fn bench_async_overhead(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 
     // Async wrapping with tokio
@@ -288,7 +288,7 @@ fn bench_async_overhead(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             let result = wrap_mllp(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -306,7 +306,7 @@ fn bench_buffer_patterns(c: &mut Criterion) {
         b.iter(|| {
             let result = wrap_mllp(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 
     // Reuse pre-allocated buffer (simulated)
@@ -318,7 +318,7 @@ fn bench_buffer_patterns(c: &mut Criterion) {
             buffer.push(0x1C);
             buffer.push(0x0D);
             black_box(buffer)
-        })
+        });
     });
 
     group.finish();
@@ -336,7 +336,7 @@ fn bench_network_serialization(c: &mut Criterion) {
         b.iter(|| {
             let result = write_mllp(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     // MLLP write + wrap
@@ -345,7 +345,7 @@ fn bench_network_serialization(c: &mut Criterion) {
             let mllp = write_mllp(black_box(&parsed));
             let wrapped = wrap_mllp(&mllp);
             black_box(wrapped)
-        })
+        });
     });
 
     group.finish();

--- a/crates/hl7v2-bench/benches/parsing.rs
+++ b/crates/hl7v2-bench/benches/parsing.rs
@@ -31,7 +31,7 @@ fn bench_parse(c: &mut Criterion) {
         b.iter(|| {
             let result = parse(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -44,7 +44,7 @@ fn bench_parse_large(c: &mut Criterion) {
         b.iter(|| {
             let result = parse(black_box(bytes));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -57,7 +57,7 @@ fn bench_write(c: &mut Criterion) {
         b.iter(|| {
             let result = write(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -66,7 +66,7 @@ fn bench_parse_sizes(c: &mut Criterion) {
     let base_message = create_sample_message();
     let mut group = c.benchmark_group("parse_sizes");
 
-    for size in [1, 2, 5, 10, 20].iter() {
+    for size in &[1, 2, 5, 10, 20] {
         let mut message = String::new();
         for _ in 0..*size {
             message.push_str(&base_message);

--- a/crates/hl7v2-bench/benches/template.rs
+++ b/crates/hl7v2-bench/benches/template.rs
@@ -174,7 +174,7 @@ fn bench_simple_template_generation(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 1);
             black_box(result)
-        })
+        });
     });
 }
 
@@ -186,7 +186,7 @@ fn bench_template_with_values_generation(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 1);
             black_box(result)
-        })
+        });
     });
 }
 
@@ -198,7 +198,7 @@ fn bench_complex_template_generation(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 1);
             black_box(result)
-        })
+        });
     });
 }
 
@@ -208,13 +208,13 @@ fn bench_generation_throughput(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("generation_throughput");
 
-    for count in [1, 10, 100, 1000].iter() {
+    for count in &[1, 10, 100, 1000] {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::new("messages", count), count, |b, &count| {
             b.iter(|| {
                 let result = generate(black_box(&template), 42, count);
                 black_box(result)
-            })
+            });
         });
     }
 
@@ -233,7 +233,7 @@ fn bench_value_source_resolution(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&fixed), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // From list
@@ -246,7 +246,7 @@ fn bench_value_source_resolution(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&from_list), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Numeric
@@ -255,7 +255,7 @@ fn bench_value_source_resolution(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&numeric), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // UUID v4
@@ -264,7 +264,7 @@ fn bench_value_source_resolution(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&uuid), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Date
@@ -276,7 +276,7 @@ fn bench_value_source_resolution(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&date), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Gaussian
@@ -289,7 +289,7 @@ fn bench_value_source_resolution(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&gaussian), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -307,7 +307,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&name), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic address
@@ -316,7 +316,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&address), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic phone
@@ -325,7 +325,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&phone), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic SSN
@@ -334,7 +334,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&ssn), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic MRN
@@ -343,7 +343,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&mrn), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic ICD-10
@@ -352,7 +352,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&icd10), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic LOINC
@@ -361,7 +361,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&loinc), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic medication
@@ -370,7 +370,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&med), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     // Realistic allergen
@@ -379,7 +379,7 @@ fn bench_realistic_value_generators(c: &mut Criterion) {
         b.iter(|| {
             let result = generate_value(black_box(&allergen), &mut rng);
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -391,13 +391,13 @@ fn bench_corpus_generation(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("corpus_generation");
 
-    for count in [10, 100, 1000].iter() {
+    for count in &[10, 100, 1000] {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::new("corpus", count), count, |b, &count| {
             b.iter(|| {
                 let result = generate_corpus(black_box(&template), 42, count, 100);
                 black_box(result)
-            })
+            });
         });
     }
 
@@ -414,7 +414,7 @@ fn bench_template_complexity(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&simple), 42, 1);
             black_box(result)
-        })
+        });
     });
 
     // Medium template (2 segments, 8 value sources)
@@ -423,7 +423,7 @@ fn bench_template_complexity(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&medium), 42, 1);
             black_box(result)
-        })
+        });
     });
 
     // Complex template (12 segments, 15+ value sources)
@@ -432,7 +432,7 @@ fn bench_template_complexity(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&complex), 42, 1);
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -448,7 +448,7 @@ fn bench_deterministic_generation(c: &mut Criterion) {
             let result = generate(black_box(&template), iteration, 1);
             iteration += 1;
             black_box(result)
-        })
+        });
     });
 }
 
@@ -463,7 +463,7 @@ fn bench_batch_generation(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 10);
             black_box(result)
-        })
+        });
     });
 
     // Medium batch
@@ -471,7 +471,7 @@ fn bench_batch_generation(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 100);
             black_box(result)
-        })
+        });
     });
 
     // Large batch
@@ -479,7 +479,7 @@ fn bench_batch_generation(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 1000);
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -493,7 +493,7 @@ fn bench_numeric_template(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template), 42, 1);
             black_box(result)
-        })
+        });
     });
 }
 
@@ -508,14 +508,14 @@ fn bench_value_generation_overhead(c: &mut Criterion) {
         b.iter(|| {
             let result = generate(black_box(&template_no_values), 42, 1);
             black_box(result)
-        })
+        });
     });
 
     group.bench_function("with_values", |b| {
         b.iter(|| {
             let result = generate(black_box(&template_with_values), 42, 1);
             black_box(result)
-        })
+        });
     });
 
     group.finish();

--- a/crates/hl7v2-bench/benches/validation.rs
+++ b/crates/hl7v2-bench/benches/validation.rs
@@ -124,9 +124,7 @@ impl Validator for StrictValidator {
                     // MSH.3 - Sending Application (required)
                     if segment.fields.len() > 2 {
                         let sending_app = segment.fields[2].first_text();
-                        if sending_app.is_none()
-                            || sending_app.map(str::is_empty).unwrap_or(true)
-                        {
+                        if sending_app.is_none() || sending_app.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_SENDING_APP",
                                 Some("MSH.3".to_string()),
@@ -198,8 +196,7 @@ impl Validator for StrictValidator {
                         ));
                     } else {
                         let patient_id = segment.fields[2].first_text();
-                        if patient_id.is_none() || patient_id.map(str::is_empty).unwrap_or(true)
-                        {
+                        if patient_id.is_none() || patient_id.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_PATIENT_ID",
                                 Some("PID.3".to_string()),
@@ -288,8 +285,7 @@ impl Validator for StrictValidator {
                         ));
                     } else {
                         let value_type = segment.fields[1].first_text();
-                        if value_type.is_none() || value_type.map(str::is_empty).unwrap_or(true)
-                        {
+                        if value_type.is_none() || value_type.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_VALUE_TYPE",
                                 Some("OBX.2".to_string()),

--- a/crates/hl7v2-bench/benches/validation.rs
+++ b/crates/hl7v2-bench/benches/validation.rs
@@ -62,7 +62,7 @@ impl Validator for BasicValidator {
                 // Check PID.3 (Patient ID) - should be valid
                 if segment.fields.len() > 2 {
                     let patient_id = segment.fields[2].first_text();
-                    if patient_id.is_none() || patient_id.map(|s| s.is_empty()).unwrap_or(true) {
+                    if patient_id.is_none() || patient_id.map(str::is_empty).unwrap_or(true) {
                         issues.push(Issue::error(
                             "MISSING_PATIENT_ID",
                             Some("PID.3".to_string()),
@@ -125,7 +125,7 @@ impl Validator for StrictValidator {
                     if segment.fields.len() > 2 {
                         let sending_app = segment.fields[2].first_text();
                         if sending_app.is_none()
-                            || sending_app.map(|s| s.is_empty()).unwrap_or(true)
+                            || sending_app.map(str::is_empty).unwrap_or(true)
                         {
                             issues.push(Issue::error(
                                 "MISSING_SENDING_APP",
@@ -138,7 +138,7 @@ impl Validator for StrictValidator {
                     // MSH.7 - Date/Time (required, must be valid)
                     if segment.fields.len() > 6 {
                         let dt = segment.fields[6].first_text();
-                        if dt.is_none() || dt.map(|s| s.is_empty()).unwrap_or(true) {
+                        if dt.is_none() || dt.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_DATETIME",
                                 Some("MSH.7".to_string()),
@@ -158,7 +158,7 @@ impl Validator for StrictValidator {
                     // MSH.9 - Message Type (required)
                     if segment.fields.len() > 8 {
                         let msg_type = segment.fields[8].first_text();
-                        if msg_type.is_none() || msg_type.map(|s| s.is_empty()).unwrap_or(true) {
+                        if msg_type.is_none() || msg_type.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_MESSAGE_TYPE",
                                 Some("MSH.9".to_string()),
@@ -179,7 +179,7 @@ impl Validator for StrictValidator {
                     // MSH.12 - Version ID (required)
                     if segment.fields.len() > 11 {
                         let version = segment.fields[11].first_text();
-                        if version.is_none() || version.map(|s| s.is_empty()).unwrap_or(true) {
+                        if version.is_none() || version.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_VERSION",
                                 Some("MSH.12".to_string()),
@@ -198,7 +198,7 @@ impl Validator for StrictValidator {
                         ));
                     } else {
                         let patient_id = segment.fields[2].first_text();
-                        if patient_id.is_none() || patient_id.map(|s| s.is_empty()).unwrap_or(true)
+                        if patient_id.is_none() || patient_id.map(str::is_empty).unwrap_or(true)
                         {
                             issues.push(Issue::error(
                                 "MISSING_PATIENT_ID",
@@ -217,7 +217,7 @@ impl Validator for StrictValidator {
                         ));
                     } else {
                         let name = segment.fields[4].first_text();
-                        if name.is_none() || name.map(|s| s.is_empty()).unwrap_or(true) {
+                        if name.is_none() || name.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_PATIENT_NAME",
                                 Some("PID.5".to_string()),
@@ -248,7 +248,7 @@ impl Validator for StrictValidator {
                         ));
                     } else {
                         let sex = segment.fields[7].first_text();
-                        if sex.is_none() || sex.map(|s| s.is_empty()).unwrap_or(true) {
+                        if sex.is_none() || sex.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::error(
                                 "MISSING_SEX",
                                 Some("PID.8".to_string()),
@@ -268,7 +268,7 @@ impl Validator for StrictValidator {
                     } else {
                         let patient_class = segment.fields[1].first_text();
                         if patient_class.is_none()
-                            || patient_class.map(|s| s.is_empty()).unwrap_or(true)
+                            || patient_class.map(str::is_empty).unwrap_or(true)
                         {
                             issues.push(Issue::error(
                                 "MISSING_PATIENT_CLASS",
@@ -288,7 +288,7 @@ impl Validator for StrictValidator {
                         ));
                     } else {
                         let value_type = segment.fields[1].first_text();
-                        if value_type.is_none() || value_type.map(|s| s.is_empty()).unwrap_or(true)
+                        if value_type.is_none() || value_type.map(str::is_empty).unwrap_or(true)
                         {
                             issues.push(Issue::error(
                                 "MISSING_VALUE_TYPE",
@@ -301,7 +301,7 @@ impl Validator for StrictValidator {
                     // OBX.5 - Observation Value
                     if segment.fields.len() > 4 {
                         let obs_value = segment.fields[4].first_text();
-                        if obs_value.is_none() || obs_value.map(|s| s.is_empty()).unwrap_or(true) {
+                        if obs_value.is_none() || obs_value.map(str::is_empty).unwrap_or(true) {
                             issues.push(Issue::warning(
                                 "MISSING_OBSERVATION_VALUE",
                                 Some("OBX.5".to_string()),
@@ -359,7 +359,7 @@ fn bench_basic_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validator.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -374,7 +374,7 @@ fn bench_strict_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validator.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -389,7 +389,7 @@ fn bench_lenient_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validator.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -404,7 +404,7 @@ fn bench_complex_message_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validator.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -419,7 +419,7 @@ fn bench_validation_with_issues(c: &mut Criterion) {
         b.iter(|| {
             let result = validator.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 }
 
@@ -433,7 +433,7 @@ fn bench_data_type_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validate_data_type(black_box(date_value), black_box("DT"));
             black_box(result)
-        })
+        });
     });
 
     // Time validation
@@ -442,7 +442,7 @@ fn bench_data_type_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validate_data_type(black_box(time_value), black_box("TM"));
             black_box(result)
-        })
+        });
     });
 
     // Timestamp validation
@@ -451,7 +451,7 @@ fn bench_data_type_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validate_data_type(black_box(ts_value), black_box("TS"));
             black_box(result)
-        })
+        });
     });
 
     // Numeric validation
@@ -460,7 +460,7 @@ fn bench_data_type_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validate_data_type(black_box(nm_value), black_box("NM"));
             black_box(result)
-        })
+        });
     });
 
     // String validation
@@ -469,7 +469,7 @@ fn bench_data_type_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validate_data_type(black_box(st_value), black_box("ST"));
             black_box(result)
-        })
+        });
     });
 
     // Identifier validation
@@ -478,7 +478,7 @@ fn bench_data_type_validation(c: &mut Criterion) {
         b.iter(|| {
             let result = validate_data_type(black_box(id_value), black_box("ID"));
             black_box(result)
-        })
+        });
     });
 
     group.finish();
@@ -493,7 +493,7 @@ fn bench_validation_throughput(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("validation_throughput");
 
-    for count in [1, 10, 100, 1000].iter() {
+    for count in &[1, 10, 100, 1000] {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &count| {
             b.iter(|| {
@@ -501,7 +501,7 @@ fn bench_validation_throughput(c: &mut Criterion) {
                     let result = validator.validate(black_box(&parsed));
                     black_box(result);
                 }
-            })
+            });
         });
     }
 
@@ -522,14 +522,14 @@ fn bench_strict_vs_lenient_comparison(c: &mut Criterion) {
         b.iter(|| {
             let result = strict.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.bench_function("lenient", |b| {
         b.iter(|| {
             let result = lenient.validate(black_box(&parsed));
             black_box(result)
-        })
+        });
     });
 
     group.finish();

--- a/crates/hl7v2-cli/CLAUDE.md
+++ b/crates/hl7v2-cli/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-cli
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-cli
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-cli
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-cli -- -D warnings
-`
+```

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -412,7 +412,7 @@ fn parse_command(
                     ),
                     Event::Segment { id } => println!("Segment: {}", String::from_utf8_lossy(&id)),
                     Event::Field { num, raw } => {
-                        println!("  Field {}: {}", num, String::from_utf8_lossy(&raw))
+                        println!("  Field {}: {}", num, String::from_utf8_lossy(&raw));
                     }
                     Event::EndMessage => println!("--- Message End ---"),
                 }

--- a/crates/hl7v2-cli/src/monitor.rs
+++ b/crates/hl7v2-cli/src/monitor.rs
@@ -89,8 +89,8 @@ pub fn get_cpu_info() -> CpuInfo {
     let mut sys = System::new_all();
     sys.refresh_all();
 
-    let cpu_usage: f64 =
-        sys.cpus().iter().map(sysinfo::Cpu::cpu_usage).sum::<f32>() as f64 / sys.cpus().len() as f64;
+    let cpu_usage: f64 = sys.cpus().iter().map(sysinfo::Cpu::cpu_usage).sum::<f32>() as f64
+        / sys.cpus().len() as f64;
 
     CpuInfo {
         cpu_usage_percent: Some(cpu_usage),

--- a/crates/hl7v2-cli/src/monitor.rs
+++ b/crates/hl7v2-cli/src/monitor.rs
@@ -90,7 +90,7 @@ pub fn get_cpu_info() -> CpuInfo {
     sys.refresh_all();
 
     let cpu_usage: f64 =
-        sys.cpus().iter().map(|cpu| cpu.cpu_usage()).sum::<f32>() as f64 / sys.cpus().len() as f64;
+        sys.cpus().iter().map(sysinfo::Cpu::cpu_usage).sum::<f32>() as f64 / sys.cpus().len() as f64;
 
     CpuInfo {
         cpu_usage_percent: Some(cpu_usage),

--- a/crates/hl7v2-cli/tests/bdd_tests.rs
+++ b/crates/hl7v2-cli/tests/bdd_tests.rs
@@ -671,7 +671,7 @@ fn then_output_has_messages(world: &mut CliWorld) {
     assert!(output_dir.exists(), "Output directory should exist");
 
     let count = std::fs::read_dir(output_dir)
-        .map(|entries| entries.count())
+        .map(std::iter::Iterator::count)
         .unwrap_or(0);
     assert!(
         count > 0,
@@ -679,12 +679,12 @@ fn then_output_has_messages(world: &mut CliWorld) {
     );
 }
 
-#[then(regex = r#"^the output directory should contain (\d+) messages$"#)]
+#[then(regex = r"^the output directory should contain (\d+) messages$")]
 fn then_output_has_n_messages(world: &mut CliWorld, count: usize) {
     let output_dir = world.output_dir.as_ref().expect("Output dir should be set");
 
     let actual_count = std::fs::read_dir(output_dir)
-        .map(|entries| entries.count())
+        .map(std::iter::Iterator::count)
         .unwrap_or(0);
     assert!(
         actual_count >= count,

--- a/crates/hl7v2-cli/tests/common/mod.rs
+++ b/crates/hl7v2-cli/tests/common/mod.rs
@@ -75,14 +75,14 @@ constraints:
 
 /// Helper to create a template YAML for message generation
 pub fn simple_template() -> &'static str {
-    r#"
+    r"
 message:
   type: ADT
   trigger: A01
 segments:
   - MSH
   - PID
-"#
+"
 }
 
 /// Helper to create an invalid HL7 message

--- a/crates/hl7v2-core/CLAUDE.md
+++ b/crates/hl7v2-core/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-core
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-core
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-core
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-core -- -D warnings
-`
+```

--- a/crates/hl7v2-corpus/CLAUDE.md
+++ b/crates/hl7v2-corpus/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-corpus
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-corpus
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-corpus
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-corpus -- -D warnings
-`
+```

--- a/crates/hl7v2-datatype/CLAUDE.md
+++ b/crates/hl7v2-datatype/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-datatype
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-datatype
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-datatype
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-datatype -- -D warnings
-`
+```

--- a/crates/hl7v2-datatype/Cargo.toml
+++ b/crates/hl7v2-datatype/Cargo.toml
@@ -20,4 +20,10 @@ hl7v2-datetime = { version = "1.2.0", path = "../hl7v2-datetime" }
 
 [dev-dependencies]
 proptest = "1.6"
+cucumber = "0.22.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "bdd_tests"
+harness = false
 

--- a/crates/hl7v2-datatype/src/lib.rs
+++ b/crates/hl7v2-datatype/src/lib.rs
@@ -353,7 +353,7 @@ pub fn is_address(value: &str) -> bool {
 /// Check if value is a valid phone number (basic validation)
 pub fn is_phone_number(value: &str) -> bool {
     // Remove common phone number formatting characters
-    let cleaned: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    let cleaned: String = value.chars().filter(char::is_ascii_digit).collect();
 
     // Basic phone number validation (7-15 digits)
     cleaned.len() >= 7 && cleaned.len() <= 15 && cleaned.chars().all(|c| c.is_ascii_digit())
@@ -390,7 +390,7 @@ pub fn is_email(value: &str) -> bool {
 /// Check if value is a valid SSN (Social Security Number) format
 pub fn is_ssn(value: &str) -> bool {
     // Remove dashes and spaces
-    let cleaned: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    let cleaned: String = value.chars().filter(char::is_ascii_digit).collect();
 
     // SSN should be exactly 9 digits
     if cleaned.len() != 9 {
@@ -421,7 +421,7 @@ pub fn is_ssn(value: &str) -> bool {
 /// Validate Luhn checksum (used for credit cards, etc.)
 pub fn validate_luhn_checksum(value: &str) -> bool {
     // Remove any non-digit characters
-    let digits: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    let digits: String = value.chars().filter(char::is_ascii_digit).collect();
 
     if digits.len() < 2 {
         return false;

--- a/crates/hl7v2-datatype/src/tests.rs
+++ b/crates/hl7v2-datatype/src/tests.rs
@@ -674,12 +674,12 @@ mod error_tests {
         assert!(err.to_string().contains("Unknown type"));
 
         let err = DataTypeError::TooShort { length: 3, min: 5 };
-        assert!(err.to_string().contains("3"));
-        assert!(err.to_string().contains("5"));
+        assert!(err.to_string().contains('3'));
+        assert!(err.to_string().contains('5'));
 
         let err = DataTypeError::TooLong { length: 10, max: 5 };
         assert!(err.to_string().contains("10"));
-        assert!(err.to_string().contains("5"));
+        assert!(err.to_string().contains('5'));
 
         let err = DataTypeError::PatternMismatch {
             value: "abc".to_string(),
@@ -691,7 +691,7 @@ mod error_tests {
         let err = DataTypeError::NotInAllowedSet {
             value: "X".to_string(),
         };
-        assert!(err.to_string().contains("X"));
+        assert!(err.to_string().contains('X'));
 
         let err = DataTypeError::ChecksumFailed;
         assert!(err.to_string().contains("Checksum"));

--- a/crates/hl7v2-datatype/tests/bdd_tests.rs
+++ b/crates/hl7v2-datatype/tests/bdd_tests.rs
@@ -1,0 +1,312 @@
+//! BDD tests for hl7v2-datatype using Cucumber
+//!
+//! Run with: cargo test --test bdd_tests -p hl7v2-datatype
+
+use cucumber::{World, given, then, when};
+use hl7v2_datatype::{
+    ChecksumAlgorithm, DataType, DataTypeError, DataTypeValidator, is_email, is_ssn,
+    is_valid_age_range, is_valid_birth_date, is_within_range, matches_format, validate_datatype,
+    validate_luhn_checksum,
+};
+
+/// Test world for datatype BDD tests
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct DatatypeWorld {
+    /// The value under test
+    value: String,
+    /// The data type code
+    datatype_code: String,
+    /// The parsed data type result
+    parsed_datatype: Option<DataType>,
+    /// Whether the last validation succeeded
+    validation_valid: bool,
+    /// The validator builder
+    validator: Option<DataTypeValidator>,
+    /// Detailed validation error (if any)
+    validation_error: Option<DataTypeError>,
+    /// Birth date for age range tests
+    birth_date: String,
+    /// Reference date for age range tests
+    reference_date: String,
+    /// Numeric range min
+    range_min: String,
+    /// Numeric range max
+    range_max: String,
+}
+
+impl DatatypeWorld {
+    fn new() -> Self {
+        Self {
+            value: String::new(),
+            datatype_code: String::new(),
+            parsed_datatype: None,
+            validation_valid: false,
+            validator: None,
+            validation_error: None,
+            birth_date: String::new(),
+            reference_date: String::new(),
+            range_min: String::new(),
+            range_max: String::new(),
+        }
+    }
+}
+
+// ============================================================================
+// Given Steps
+// ============================================================================
+
+#[given(regex = r#"^a data type code "([^"]*)"$"#)]
+fn given_datatype_code(world: &mut DatatypeWorld, code: String) {
+    world.datatype_code = code;
+}
+
+#[given(regex = r#"^a value "([^"]*)"$"#)]
+fn given_value(world: &mut DatatypeWorld, value: String) {
+    world.value = value;
+}
+
+#[given(regex = r#"^a value with embedded newline "([^"]*)"$"#)]
+fn given_value_with_newline(world: &mut DatatypeWorld, raw: String) {
+    // The feature file uses literal \n in the string; convert it to an actual newline
+    world.value = raw.replace("\\n", "\n");
+}
+
+#[given("a birth date in the past")]
+fn given_birth_date_past(world: &mut DatatypeWorld) {
+    world.value = "19900101".to_string();
+}
+
+#[given("a birth date in the future")]
+fn given_birth_date_future(world: &mut DatatypeWorld) {
+    world.value = "30000101".to_string();
+}
+
+#[given(regex = r#"^a birth date "([^"]*)" and reference date "([^"]*)"$"#)]
+fn given_birth_and_reference(world: &mut DatatypeWorld, birth: String, reference: String) {
+    world.birth_date = birth;
+    world.reference_date = reference;
+}
+
+#[given(regex = r#"^a value "([^"]*)" with range "([^"]*)" to "([^"]*)"$"#)]
+fn given_value_with_range(world: &mut DatatypeWorld, value: String, min: String, max: String) {
+    world.value = value;
+    world.range_min = min;
+    world.range_max = max;
+}
+
+#[given(regex = r"^a validator with min length (\d+)$")]
+fn given_validator_min_length(world: &mut DatatypeWorld, min: usize) {
+    world.validator = Some(DataTypeValidator::new().with_min_length(min));
+}
+
+#[given(regex = r"^a validator with max length (\d+)$")]
+fn given_validator_max_length(world: &mut DatatypeWorld, max: usize) {
+    world.validator = Some(DataTypeValidator::new().with_max_length(max));
+}
+
+#[given(regex = r"^a validator with min length (\d+) and max length (\d+)$")]
+fn given_validator_min_max(world: &mut DatatypeWorld, min: usize, max: usize) {
+    world.validator = Some(
+        DataTypeValidator::new()
+            .with_min_length(min)
+            .with_max_length(max),
+    );
+}
+
+#[given(regex = r#"^a validator with pattern "([^"]*)"$"#)]
+fn given_validator_pattern(world: &mut DatatypeWorld, pattern: String) {
+    world.validator = Some(DataTypeValidator::new().with_pattern(&pattern));
+}
+
+#[given(regex = r#"^a validator with allowed values "([^"]*)"$"#)]
+fn given_validator_allowed_values(world: &mut DatatypeWorld, values_str: String) {
+    let values: Vec<String> = values_str.split(',').map(|s| s.to_string()).collect();
+    world.validator = Some(DataTypeValidator::new().with_allowed_values(values));
+}
+
+#[given("a validator with Luhn checksum")]
+fn given_validator_luhn(world: &mut DatatypeWorld) {
+    world.validator = Some(DataTypeValidator::new().with_checksum(ChecksumAlgorithm::Luhn));
+}
+
+#[given(regex = r"^a validator with min length (\d+) and max length (\d+) and Luhn checksum$")]
+fn given_validator_min_max_luhn(world: &mut DatatypeWorld, min: usize, max: usize) {
+    world.validator = Some(
+        DataTypeValidator::new()
+            .with_min_length(min)
+            .with_max_length(max)
+            .with_checksum(ChecksumAlgorithm::Luhn),
+    );
+}
+
+// ============================================================================
+// When Steps
+// ============================================================================
+
+#[when("I parse the data type code")]
+fn when_parse_datatype(world: &mut DatatypeWorld) {
+    world.parsed_datatype = DataType::parse(&world.datatype_code);
+}
+
+#[when(regex = r#"^I validate it as data type "([^"]*)"$"#)]
+fn when_validate_as_datatype(world: &mut DatatypeWorld, dtype: String) {
+    world.validation_valid = validate_datatype(&world.value, &dtype);
+}
+
+#[when("I validate it as an email")]
+fn when_validate_email(world: &mut DatatypeWorld) {
+    world.validation_valid = is_email(&world.value);
+}
+
+#[when("I validate it as an SSN")]
+fn when_validate_ssn(world: &mut DatatypeWorld) {
+    world.validation_valid = is_ssn(&world.value);
+}
+
+#[when("I validate it with Luhn checksum")]
+fn when_validate_luhn(world: &mut DatatypeWorld) {
+    world.validation_valid = validate_luhn_checksum(&world.value);
+}
+
+#[when(regex = r#"^I validate value "([^"]*)" with the validator$"#)]
+fn when_validate_with_validator(world: &mut DatatypeWorld, value: String) {
+    let validator = world.validator.as_ref().expect("Validator not set");
+    world.validation_valid = validator.validate(&value);
+}
+
+#[when(regex = r#"^I validate value "([^"]*)" with detailed errors$"#)]
+fn when_validate_detailed(world: &mut DatatypeWorld, value: String) {
+    let validator = world.validator.as_ref().expect("Validator not set");
+    match validator.validate_detailed(&value) {
+        Ok(()) => {
+            world.validation_valid = true;
+            world.validation_error = None;
+        }
+        Err(e) => {
+            world.validation_valid = false;
+            world.validation_error = Some(e);
+        }
+    }
+}
+
+#[when("I validate it as a birth date")]
+fn when_validate_birth_date(world: &mut DatatypeWorld) {
+    world.validation_valid = is_valid_birth_date(&world.value);
+}
+
+#[when("I validate the age range")]
+fn when_validate_age_range(world: &mut DatatypeWorld) {
+    world.validation_valid = is_valid_age_range(&world.birth_date, &world.reference_date);
+}
+
+#[when("I validate the numeric range")]
+fn when_validate_numeric_range(world: &mut DatatypeWorld) {
+    world.validation_valid = is_within_range(&world.value, &world.range_min, &world.range_max);
+}
+
+#[when(regex = r#"^I validate it matches format "([^"]*)" for data type "([^"]*)"$"#)]
+fn when_validate_format(world: &mut DatatypeWorld, format: String, dtype: String) {
+    world.validation_valid = matches_format(&world.value, &format, &dtype);
+}
+
+// ============================================================================
+// Then Steps
+// ============================================================================
+
+#[then(regex = r"^the parsed data type should be (\w+)$")]
+fn then_parsed_datatype(world: &mut DatatypeWorld, variant: String) {
+    if variant == "None" {
+        assert_eq!(
+            world.parsed_datatype, None,
+            "Expected None for code '{}', got {:?}",
+            world.datatype_code, world.parsed_datatype
+        );
+    } else {
+        let expected = DataType::parse(&variant);
+        assert_eq!(
+            world.parsed_datatype, expected,
+            "Expected parsed data type {:?} for code '{}', got {:?}",
+            expected, world.datatype_code, world.parsed_datatype
+        );
+    }
+}
+
+#[then("the validation result should be valid")]
+fn then_valid(world: &mut DatatypeWorld) {
+    assert!(
+        world.validation_valid,
+        "Expected validation to pass for value '{}'",
+        world.value
+    );
+}
+
+#[then("the validation result should be invalid")]
+fn then_invalid(world: &mut DatatypeWorld) {
+    assert!(
+        !world.validation_valid,
+        "Expected validation to fail for value '{}'",
+        world.value
+    );
+}
+
+#[then(regex = r"^the error should be TooShort with length (\d+) and min (\d+)$")]
+fn then_error_too_short(world: &mut DatatypeWorld, length: usize, min: usize) {
+    match &world.validation_error {
+        Some(DataTypeError::TooShort { length: l, min: m }) => {
+            assert_eq!(*l, length, "Expected length {}, got {}", length, l);
+            assert_eq!(*m, min, "Expected min {}, got {}", min, m);
+        }
+        other => panic!("Expected TooShort error, got {:?}", other),
+    }
+}
+
+#[then(regex = r"^the error should be TooLong with length (\d+) and max (\d+)$")]
+fn then_error_too_long(world: &mut DatatypeWorld, length: usize, max: usize) {
+    match &world.validation_error {
+        Some(DataTypeError::TooLong { length: l, max: m }) => {
+            assert_eq!(*l, length, "Expected length {}, got {}", length, l);
+            assert_eq!(*m, max, "Expected max {}, got {}", max, m);
+        }
+        other => panic!("Expected TooLong error, got {:?}", other),
+    }
+}
+
+#[then("the error should be PatternMismatch")]
+fn then_error_pattern_mismatch(world: &mut DatatypeWorld) {
+    match &world.validation_error {
+        Some(DataTypeError::PatternMismatch { .. }) => {}
+        other => panic!("Expected PatternMismatch error, got {:?}", other),
+    }
+}
+
+#[then(regex = r#"^the error should be NotInAllowedSet with value "([^"]*)"$"#)]
+fn then_error_not_in_allowed_set(world: &mut DatatypeWorld, expected_value: String) {
+    match &world.validation_error {
+        Some(DataTypeError::NotInAllowedSet { value }) => {
+            assert_eq!(
+                value, &expected_value,
+                "Expected value '{}', got '{}'",
+                expected_value, value
+            );
+        }
+        other => panic!("Expected NotInAllowedSet error, got {:?}", other),
+    }
+}
+
+#[then("the error should be ChecksumFailed")]
+fn then_error_checksum_failed(world: &mut DatatypeWorld) {
+    match &world.validation_error {
+        Some(DataTypeError::ChecksumFailed) => {}
+        other => panic!("Expected ChecksumFailed error, got {:?}", other),
+    }
+}
+
+// ============================================================================
+// Cucumber Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() {
+    DatatypeWorld::run("tests/features/datatype.feature").await;
+}

--- a/crates/hl7v2-datatype/tests/features/datatype.feature
+++ b/crates/hl7v2-datatype/tests/features/datatype.feature
@@ -1,0 +1,543 @@
+Feature: HL7 v2 Data Type Validation
+  As an HL7 message processor
+  I want to validate HL7 v2 data type values
+  So that I can ensure messages contain properly formatted data
+
+  # ===========================================================================
+  # DataType Enum Parsing
+  # ===========================================================================
+
+  Scenario Outline: Parse known data type codes
+    Given a data type code "<code>"
+    When I parse the data type code
+    Then the parsed data type should be <variant>
+
+    Examples:
+      | code | variant |
+      | ST   | ST      |
+      | ID   | ID      |
+      | IS   | IS      |
+      | DT   | DT      |
+      | TM   | TM      |
+      | TS   | TS      |
+      | NM   | NM      |
+      | SI   | SI      |
+      | TX   | TX      |
+      | FT   | FT      |
+      | PN   | PN      |
+      | CX   | CX      |
+      | HD   | HD      |
+      | AD   | AD      |
+      | XTN  | XTN     |
+
+  Scenario Outline: Reject unknown data type codes
+    Given a data type code "<code>"
+    When I parse the data type code
+    Then the parsed data type should be None
+
+    Examples:
+      | code    |
+      | INVALID |
+      |         |
+      | st      |
+      | XX      |
+
+  # ===========================================================================
+  # ST (String Data)
+  # ===========================================================================
+
+  Scenario Outline: Validate ST (String Data) values
+    Given a value "<value>"
+    When I validate it as data type "ST"
+    Then the validation result should be <result>
+
+    Examples:
+      | value       | result |
+      | any string  | valid  |
+      |             | valid  |
+      | test123!@#  | valid  |
+
+  # ===========================================================================
+  # ID (Identifier)
+  # ===========================================================================
+
+  Scenario Outline: Validate ID (Identifier) values
+    Given a value "<value>"
+    When I validate it as data type "ID"
+    Then the validation result should be <result>
+
+    Examples:
+      | value         | result  |
+      | ABC123        | valid   |
+      | test-value    | valid   |
+
+  Scenario: Reject ID with control characters
+    Given a value with embedded newline "test\nvalue"
+    When I validate it as data type "ID"
+    Then the validation result should be invalid
+
+  # ===========================================================================
+  # IS (Coded Value)
+  # ===========================================================================
+
+  Scenario Outline: Validate IS (Coded Value) values
+    Given a value "<value>"
+    When I validate it as data type "IS"
+    Then the validation result should be <result>
+
+    Examples:
+      | value | result |
+      | CODE1 | valid  |
+      | 123   | valid  |
+
+  # ===========================================================================
+  # DT (Date)
+  # ===========================================================================
+
+  Scenario Outline: Validate DT (Date) values
+    Given a value "<value>"
+    When I validate it as data type "DT"
+    Then the validation result should be <result>
+
+    Examples:
+      | value    | result  |
+      | 20250128 | valid   |
+      | 20251328 | invalid |
+      | invalid  | invalid |
+
+  # ===========================================================================
+  # TM (Time)
+  # ===========================================================================
+
+  Scenario Outline: Validate TM (Time) values
+    Given a value "<value>"
+    When I validate it as data type "TM"
+    Then the validation result should be <result>
+
+    Examples:
+      | value  | result  |
+      | 152312 | valid   |
+      | 1523   | valid   |
+      | 252300 | invalid |
+
+  # ===========================================================================
+  # TS (Timestamp)
+  # ===========================================================================
+
+  Scenario Outline: Validate TS (Timestamp) values
+    Given a value "<value>"
+    When I validate it as data type "TS"
+    Then the validation result should be <result>
+
+    Examples:
+      | value          | result  |
+      | 20250128152312 | valid   |
+      | 20250128       | valid   |
+      | invalid        | invalid |
+
+  # ===========================================================================
+  # NM (Numeric)
+  # ===========================================================================
+
+  Scenario Outline: Validate NM (Numeric) values
+    Given a value "<value>"
+    When I validate it as data type "NM"
+    Then the validation result should be <result>
+
+    Examples:
+      | value    | result  |
+      | 123      | valid   |
+      | 123.45   | valid   |
+      | -123     | valid   |
+      | 0        | valid   |
+      | -123.456 | valid   |
+      | abc      | invalid |
+      | 12.34.56 | invalid |
+
+  # ===========================================================================
+  # SI (Sequence ID)
+  # ===========================================================================
+
+  Scenario Outline: Validate SI (Sequence ID) values
+    Given a value "<value>"
+    When I validate it as data type "SI"
+    Then the validation result should be <result>
+
+    Examples:
+      | value | result  |
+      | 1     | valid   |
+      | 123   | valid   |
+      | 0     | invalid |
+      | -1    | invalid |
+      | abc   | invalid |
+
+  # ===========================================================================
+  # TX (Text Data)
+  # ===========================================================================
+
+  Scenario Outline: Validate TX (Text Data) values
+    Given a value "<value>"
+    When I validate it as data type "TX"
+    Then the validation result should be <result>
+
+    Examples:
+      | value    | result |
+      | any text | valid  |
+      |          | valid  |
+
+  # ===========================================================================
+  # FT (Formatted Text)
+  # ===========================================================================
+
+  Scenario Outline: Validate FT (Formatted Text) values
+    Given a value "<value>"
+    When I validate it as data type "FT"
+    Then the validation result should be <result>
+
+    Examples:
+      | value          | result |
+      | formatted text | valid  |
+      |                | valid  |
+
+  # ===========================================================================
+  # PN (Person Name)
+  # ===========================================================================
+
+  Scenario Outline: Validate PN (Person Name) values
+    Given a value "<value>"
+    When I validate it as data type "PN"
+    Then the validation result should be <result>
+
+    Examples:
+      | value      | result  |
+      | Smith^John | valid   |
+      | O'Brien^Mary | valid |
+      | Doe-Jane   | valid   |
+      | Dr. Smith  | valid   |
+      | Smith123   | invalid |
+
+  # ===========================================================================
+  # CX (Extended Composite ID)
+  # ===========================================================================
+
+  Scenario Outline: Validate CX (Extended Composite ID) values
+    Given a value "<value>"
+    When I validate it as data type "CX"
+    Then the validation result should be <result>
+
+    Examples:
+      | value   | result |
+      | 12345   | valid  |
+      | ABC-123 | valid  |
+
+  # ===========================================================================
+  # HD (Hierarchic Designator)
+  # ===========================================================================
+
+  Scenario Outline: Validate HD (Hierarchic Designator) values
+    Given a value "<value>"
+    When I validate it as data type "HD"
+    Then the validation result should be <result>
+
+    Examples:
+      | value      | result |
+      | HOSPITAL.1 | valid  |
+      | FACILITY   | valid  |
+
+  # ===========================================================================
+  # AD (Address)
+  # ===========================================================================
+
+  Scenario Outline: Validate AD (Address) values
+    Given a value "<value>"
+    When I validate it as data type "AD"
+    Then the validation result should be <result>
+
+    Examples:
+      | value                 | result |
+      | 123 Main St           | valid  |
+      | Apt 4B, 456 Oak Ave   | valid  |
+
+  Scenario: Reject AD with control characters
+    Given a value with embedded newline "Line\nBreak"
+    When I validate it as data type "AD"
+    Then the validation result should be invalid
+
+  # ===========================================================================
+  # XTN (Phone Number)
+  # ===========================================================================
+
+  Scenario Outline: Validate XTN (Phone Number) values
+    Given a value "<value>"
+    When I validate it as data type "XTN"
+    Then the validation result should be <result>
+
+    Examples:
+      | value            | result  |
+      | 1234567          | valid   |
+      | 1234567890       | valid   |
+      | (555) 123-4567   | valid   |
+      | 555-123-4567     | valid   |
+      | 123              | invalid |
+      | 1234567890123456 | invalid |
+
+  # ===========================================================================
+  # Unknown data types
+  # ===========================================================================
+
+  Scenario Outline: Accept any value for unknown data types
+    Given a value "<value>"
+    When I validate it as data type "<dtype>"
+    Then the validation result should be valid
+
+    Examples:
+      | value    | dtype   |
+      | anything | UNKNOWN |
+      |          | XX      |
+
+  # ===========================================================================
+  # Email validation
+  # ===========================================================================
+
+  Scenario Outline: Validate email addresses
+    Given a value "<value>"
+    When I validate it as an email
+    Then the validation result should be <result>
+
+    Examples:
+      | value                 | result  |
+      | test@example.com      | valid   |
+      | user.name@domain.org  | valid   |
+      | user+tag@example.com  | valid   |
+      | a@b.co                | valid   |
+      | invalid               | invalid |
+      | @example.com          | invalid |
+      | test@                 | invalid |
+      | test@example          | invalid |
+
+  # ===========================================================================
+  # SSN validation
+  # ===========================================================================
+
+  Scenario Outline: Validate SSN values
+    Given a value "<value>"
+    When I validate it as an SSN
+    Then the validation result should be <result>
+
+    Examples:
+      | value        | result  |
+      | 123-45-6789  | valid   |
+      | 123456789    | valid   |
+      | 123 45 6789  | valid   |
+      | 000-45-6789  | invalid |
+      | 666-45-6789  | invalid |
+      | 900-45-6789  | invalid |
+      | 123-00-6789  | invalid |
+      | 123-45-0000  | invalid |
+      | 123-45-678   | invalid |
+      | 123-45-67890 | invalid |
+
+  # ===========================================================================
+  # Luhn checksum validation
+  # ===========================================================================
+
+  Scenario Outline: Validate Luhn checksum
+    Given a value "<value>"
+    When I validate it with Luhn checksum
+    Then the validation result should be <result>
+
+    Examples:
+      | value                | result  |
+      | 4532015112830366     | valid   |
+      | 6011111111111117     | valid   |
+      | 378282246310005      | valid   |
+      | 4111111111111111     | valid   |
+      | 4532015112830367     | invalid |
+      | 1234567890123456     | invalid |
+      | 4532-0151-1283-0366  | valid   |
+      | 1                    | invalid |
+
+  # ===========================================================================
+  # DataTypeValidator builder
+  # ===========================================================================
+
+  Scenario: Validator with minimum length constraint
+    Given a validator with min length 5
+    When I validate value "abc" with the validator
+    Then the validation result should be invalid
+    When I validate value "abcde" with the validator
+    Then the validation result should be valid
+
+  Scenario: Validator with maximum length constraint
+    Given a validator with max length 10
+    When I validate value "abc" with the validator
+    Then the validation result should be valid
+    When I validate value "abcdeabcdef" with the validator
+    Then the validation result should be invalid
+
+  Scenario: Validator with min and max length constraints
+    Given a validator with min length 3 and max length 10
+    When I validate value "ab" with the validator
+    Then the validation result should be invalid
+    When I validate value "abcde" with the validator
+    Then the validation result should be valid
+    When I validate value "abcdeabcdef" with the validator
+    Then the validation result should be invalid
+
+  Scenario: Validator with regex pattern constraint
+    Given a validator with pattern "^\d{3}$"
+    When I validate value "123" with the validator
+    Then the validation result should be valid
+    When I validate value "abc" with the validator
+    Then the validation result should be invalid
+    When I validate value "1234" with the validator
+    Then the validation result should be invalid
+
+  Scenario: Validator with allowed values constraint
+    Given a validator with allowed values "M,F,U"
+    When I validate value "M" with the validator
+    Then the validation result should be valid
+    When I validate value "F" with the validator
+    Then the validation result should be valid
+    When I validate value "X" with the validator
+    Then the validation result should be invalid
+
+  Scenario: Validator with Luhn checksum constraint
+    Given a validator with Luhn checksum
+    When I validate value "4532015112830366" with the validator
+    Then the validation result should be valid
+    When I validate value "4532015112830367" with the validator
+    Then the validation result should be invalid
+
+  Scenario: Validator with combined constraints
+    Given a validator with min length 16 and max length 16 and Luhn checksum
+    When I validate value "4532015112830366" with the validator
+    Then the validation result should be valid
+    When I validate value "453201511283036" with the validator
+    Then the validation result should be invalid
+    When I validate value "4532015112830367" with the validator
+    Then the validation result should be invalid
+
+  # ===========================================================================
+  # Detailed validation errors
+  # ===========================================================================
+
+  Scenario: Detailed error for too short value
+    Given a validator with min length 5
+    When I validate value "abc" with detailed errors
+    Then the error should be TooShort with length 3 and min 5
+
+  Scenario: Detailed error for too long value
+    Given a validator with max length 5
+    When I validate value "abcdefgh" with detailed errors
+    Then the error should be TooLong with length 8 and max 5
+
+  Scenario: Detailed error for pattern mismatch
+    Given a validator with pattern "^\d+$"
+    When I validate value "abc123" with detailed errors
+    Then the error should be PatternMismatch
+
+  Scenario: Detailed error for not in allowed set
+    Given a validator with allowed values "A,B"
+    When I validate value "C" with detailed errors
+    Then the error should be NotInAllowedSet with value "C"
+
+  Scenario: Detailed error for checksum failure
+    Given a validator with Luhn checksum
+    When I validate value "1234567890123456" with detailed errors
+    Then the error should be ChecksumFailed
+
+  # ===========================================================================
+  # Birth date validation
+  # ===========================================================================
+
+  Scenario: Validate a past birth date
+    Given a birth date in the past
+    When I validate it as a birth date
+    Then the validation result should be valid
+
+  Scenario: Reject a future birth date
+    Given a birth date in the future
+    When I validate it as a birth date
+    Then the validation result should be invalid
+
+  Scenario: Reject an invalid birth date string
+    Given a value "invalid"
+    When I validate it as a birth date
+    Then the validation result should be invalid
+
+  # ===========================================================================
+  # Age range validation
+  # ===========================================================================
+
+  Scenario Outline: Validate age ranges
+    Given a birth date "<birth>" and reference date "<reference>"
+    When I validate the age range
+    Then the validation result should be <result>
+
+    Examples:
+      | birth    | reference | result  |
+      | 19900101 | 20250128  | valid   |
+      | 20250101 | 20250101  | valid   |
+      | 20250128 | 19900101  | invalid |
+
+  Scenario: Reject age range with invalid dates
+    Given a birth date "invalid" and reference date "20250128"
+    When I validate the age range
+    Then the validation result should be invalid
+
+  # ===========================================================================
+  # Numeric range validation
+  # ===========================================================================
+
+  Scenario Outline: Validate numeric ranges
+    Given a value "<value>" with range "<min>" to "<max>"
+    When I validate the numeric range
+    Then the validation result should be <result>
+
+    Examples:
+      | value | min | max | result  |
+      | 5     | 1   | 10  | valid   |
+      | 1     | 1   | 10  | valid   |
+      | 10    | 1   | 10  | valid   |
+      | 0     | 1   | 10  | invalid |
+      | 11    | 1   | 10  | invalid |
+      | abc   | 1   | 10  | invalid |
+
+  # ===========================================================================
+  # Format matching
+  # ===========================================================================
+
+  Scenario Outline: Validate date format YYYY-MM-DD
+    Given a value "<value>"
+    When I validate it matches format "YYYY-MM-DD" for data type "DT"
+    Then the validation result should be <result>
+
+    Examples:
+      | value      | result  |
+      | 2025-01-28 | valid   |
+      | 1900-12-31 | valid   |
+      | 2025-13-28 | invalid |
+      | 2025-01-32 | invalid |
+      | 2025/01/28 | invalid |
+      | 20250128   | invalid |
+
+  Scenario Outline: Validate time format HH:MM:SS
+    Given a value "<value>"
+    When I validate it matches format "HH:MM:SS" for data type "TM"
+    Then the validation result should be <result>
+
+    Examples:
+      | value    | result  |
+      | 15:23:12 | valid   |
+      | 00:00:00 | valid   |
+      | 23:59:59 | valid   |
+      | 24:00:00 | invalid |
+      | 23:60:00 | invalid |
+      | 23:59:60 | invalid |
+      | 152312   | invalid |
+
+  Scenario: Unknown format is accepted
+    Given a value "anything"
+    When I validate it matches format "UNKNOWN" for data type "ST"
+    Then the validation result should be valid

--- a/crates/hl7v2-datatype/tests/property_tests.rs
+++ b/crates/hl7v2-datatype/tests/property_tests.rs
@@ -108,7 +108,7 @@ proptest! {
     #[test]
     fn test_identifier_with_control_chars_invalid(s in ".*") {
         // If string contains control characters, it should be invalid
-        let has_control = s.chars().any(|c| c.is_control());
+        let has_control = s.chars().any(char::is_control);
         if has_control {
             prop_assert!(!is_identifier(&s));
         }

--- a/crates/hl7v2-datetime/CLAUDE.md
+++ b/crates/hl7v2-datetime/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-datetime
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-datetime
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-datetime
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-datetime -- -D warnings
-`
+```

--- a/crates/hl7v2-datetime/Cargo.toml
+++ b/crates/hl7v2-datetime/Cargo.toml
@@ -19,4 +19,10 @@ thiserror = { workspace = true }
 [dev-dependencies]
 proptest = "1.6"
 chrono = { version = "0.4", features = ["serde", "std", "clock"], default-features = false }
+cucumber = "0.22.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "bdd_tests"
+harness = false
 

--- a/crates/hl7v2-datetime/features/datetime.feature
+++ b/crates/hl7v2-datetime/features/datetime.feature
@@ -1,0 +1,208 @@
+Feature: HL7 v2 Date/Time Parsing and Validation
+  As an HL7 message processor
+  I want to parse and validate HL7 date, time, and timestamp fields
+  So that I can correctly handle temporal data in HL7 v2 messages
+
+  # ---------------------------------------------------------------------------
+  # Date (DT) Parsing
+  # ---------------------------------------------------------------------------
+
+  Scenario: Parse a valid HL7 date
+    Given the date string "20250128"
+    When I parse the date
+    Then the year should be 2025
+    And the month should be 1
+    And the day should be 28
+
+  Scenario: Parse a leap year date
+    Given the date string "20240229"
+    When I parse the date
+    Then the year should be 2024
+    And the month should be 2
+    And the day should be 29
+
+  Scenario: Reject an invalid date with bad month
+    Given the date string "20251301"
+    When I attempt to parse the date
+    Then date parsing should fail
+
+  Scenario: Reject a non-leap-year Feb 29
+    Given the date string "20250229"
+    When I attempt to parse the date
+    Then date parsing should fail
+
+  # ---------------------------------------------------------------------------
+  # Time (TM) Parsing
+  # ---------------------------------------------------------------------------
+
+  Scenario: Parse a time with hour and minute only
+    Given the time string "1523"
+    When I parse the time
+    Then the hour should be 15
+    And the minute should be 23
+    And the second should be 0
+    And the fractional seconds should be absent
+
+  Scenario: Parse a time with seconds
+    Given the time string "152312"
+    When I parse the time
+    Then the hour should be 15
+    And the minute should be 23
+    And the second should be 12
+    And the fractional seconds should be absent
+
+  Scenario: Parse a time with fractional seconds
+    Given the time string "152312.1234"
+    When I parse the time
+    Then the hour should be 15
+    And the minute should be 23
+    And the second should be 12
+    And the fractional seconds should be 123400
+
+  Scenario: Reject a time with invalid hour
+    Given the time string "2500"
+    When I attempt to parse the time
+    Then time parsing should fail
+
+  Scenario: Reject a time with invalid minute
+    Given the time string "2360"
+    When I attempt to parse the time
+    Then time parsing should fail
+
+  # ---------------------------------------------------------------------------
+  # Timestamp (TS) Parsing
+  # ---------------------------------------------------------------------------
+
+  Scenario: Parse a full timestamp with seconds
+    Given the timestamp string "20250128152312"
+    When I parse the timestamp
+    Then the parsed datetime year should be 2025
+    And the parsed datetime month should be 1
+    And the parsed datetime day should be 28
+    And the parsed datetime hour should be 15
+    And the parsed datetime minute should be 23
+    And the parsed datetime second should be 12
+
+  Scenario: Parse a date-only timestamp defaulting to midnight
+    Given the timestamp string "20250128"
+    When I parse the timestamp
+    Then the parsed datetime year should be 2025
+    And the parsed datetime hour should be 0
+    And the parsed datetime minute should be 0
+    And the parsed datetime second should be 0
+
+  Scenario: Reject a timestamp that is too short
+    Given the timestamp string "2025"
+    When I attempt to parse the timestamp
+    Then timestamp parsing should fail
+
+  # ---------------------------------------------------------------------------
+  # Timestamp Precision
+  # ---------------------------------------------------------------------------
+
+  Scenario Outline: Detect timestamp precision from input length
+    Given the timestamp string "<input>"
+    When I parse the timestamp with precision
+    Then the precision should be "<precision>"
+
+    Examples:
+      | input                   | precision        |
+      | 2025                    | Year             |
+      | 202501                  | Month            |
+      | 20250128                | Day              |
+      | 2025012815              | Hour             |
+      | 202501281523            | Minute           |
+      | 20250128152312          | Second           |
+      | 20250128152312.123456   | FractionalSecond |
+
+  # ---------------------------------------------------------------------------
+  # Timestamp Comparison
+  # ---------------------------------------------------------------------------
+
+  Scenario: An earlier timestamp is before a later one
+    Given a timestamp "20250128100000" as the first
+    And a timestamp "20250128120000" as the second
+    Then the first timestamp should be before the second
+    And the second timestamp should be after the first
+
+  Scenario: Two timestamps on the same date are on the same day
+    Given a timestamp "20250128" as the first
+    And a timestamp "20250128235959" as the second
+    Then the two timestamps should be on the same day
+
+  Scenario: Two timestamps on different dates are not on the same day
+    Given a timestamp "20250128" as the first
+    And a timestamp "20250129000000" as the second
+    Then the two timestamps should not be on the same day
+
+  # ---------------------------------------------------------------------------
+  # to_hl7_string Round-Trip
+  # ---------------------------------------------------------------------------
+
+  Scenario Outline: Round-trip a timestamp through to_hl7_string
+    Given the timestamp string "<input>"
+    When I parse the timestamp with precision
+    And I format the timestamp to an HL7 string
+    Then the HL7 string should be "<expected>"
+
+    Examples:
+      | input                   | expected                |
+      | 2025                    | 2025                    |
+      | 202501                  | 202501                  |
+      | 20250128                | 20250128                |
+      | 2025012815              | 2025012815              |
+      | 202501281523            | 202501281523            |
+      | 20250128152312          | 20250128152312          |
+
+  # ---------------------------------------------------------------------------
+  # Validation Boolean Helpers
+  # ---------------------------------------------------------------------------
+
+  Scenario Outline: Validate HL7 date strings
+    Given the date string "<input>"
+    Then the date validity should be <valid>
+
+    Examples:
+      | input      | valid |
+      | 20250128   | true  |
+      | 20240229   | true  |
+      | 20251301   | false |
+      | 2025       | false |
+      | abcdefgh   | false |
+
+  Scenario Outline: Validate HL7 time strings
+    Given the time string "<input>"
+    Then the time validity should be <valid>
+
+    Examples:
+      | input        | valid |
+      | 0000         | true  |
+      | 2359         | true  |
+      | 152312.123   | true  |
+      | 2400         | false |
+      | 12           | false |
+
+  Scenario Outline: Validate HL7 timestamp strings
+    Given the timestamp string "<input>"
+    Then the timestamp validity should be <valid>
+
+    Examples:
+      | input              | valid |
+      | 20250128           | true  |
+      | 20250128152312     | true  |
+      | 2025               | false |
+      | 20251328           | false |
+
+  # ---------------------------------------------------------------------------
+  # Current Date/Time Helpers
+  # ---------------------------------------------------------------------------
+
+  Scenario: now_hl7 returns a 14-digit valid timestamp
+    When I call now_hl7
+    Then the result should be 14 digits long
+    And the result should be a valid timestamp
+
+  Scenario: today_hl7 returns an 8-digit valid date
+    When I call today_hl7
+    Then the result should be 8 digits long
+    And the result should be a valid date

--- a/crates/hl7v2-datetime/tests/bdd_tests.rs
+++ b/crates/hl7v2-datetime/tests/bdd_tests.rs
@@ -9,6 +9,9 @@ use hl7v2_datetime::{
     parse_hl7_ts_with_precision, today_hl7,
 };
 
+/// Parsed time components: (hour, minute, second, optional fractional)
+type TimeComponents = (u32, u32, u32, Option<u32>);
+
 /// Test world for DateTime BDD tests
 #[derive(Debug, World)]
 #[world(init = Self::new)]
@@ -22,7 +25,7 @@ pub struct DateTimeWorld {
     date_result: Option<Result<chrono::NaiveDate, DateTimeError>>,
 
     // ---- time parse results ----
-    time_result: Option<Result<(u32, u32, u32, Option<u32>), DateTimeError>>,
+    time_result: Option<Result<TimeComponents, DateTimeError>>,
 
     // ---- timestamp parse results ----
     ts_result: Option<Result<chrono::NaiveDateTime, DateTimeError>>,

--- a/crates/hl7v2-datetime/tests/bdd_tests.rs
+++ b/crates/hl7v2-datetime/tests/bdd_tests.rs
@@ -192,11 +192,7 @@ fn then_day(world: &mut DateTimeWorld, expected: u32) {
 #[then("date parsing should fail")]
 fn then_date_parsing_fails(world: &mut DateTimeWorld) {
     assert!(
-        world
-            .date_result
-            .as_ref()
-            .expect("No date result")
-            .is_err(),
+        world.date_result.as_ref().expect("No date result").is_err(),
         "Expected date parsing to fail"
     );
 }
@@ -263,11 +259,7 @@ fn then_fractional_value(world: &mut DateTimeWorld, expected: u32) {
 #[then("time parsing should fail")]
 fn then_time_parsing_fails(world: &mut DateTimeWorld) {
     assert!(
-        world
-            .time_result
-            .as_ref()
-            .expect("No time result")
-            .is_err(),
+        world.time_result.as_ref().expect("No time result").is_err(),
         "Expected time parsing to fail"
     );
 }

--- a/crates/hl7v2-datetime/tests/bdd_tests.rs
+++ b/crates/hl7v2-datetime/tests/bdd_tests.rs
@@ -1,0 +1,526 @@
+//! BDD tests for hl7v2-datetime using Cucumber
+//!
+//! Run with: cargo test --test bdd_tests
+
+use cucumber::{World, given, then, when};
+use hl7v2_datetime::{
+    DateTimeError, ParsedTimestamp, TimestampPrecision, is_valid_hl7_date, is_valid_hl7_time,
+    is_valid_hl7_timestamp, now_hl7, parse_hl7_dt, parse_hl7_tm, parse_hl7_ts,
+    parse_hl7_ts_with_precision, today_hl7,
+};
+
+/// Test world for DateTime BDD tests
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct DateTimeWorld {
+    // ---- inputs ----
+    date_string: String,
+    time_string: String,
+    timestamp_string: String,
+
+    // ---- date parse results ----
+    date_result: Option<Result<chrono::NaiveDate, DateTimeError>>,
+
+    // ---- time parse results ----
+    time_result: Option<Result<(u32, u32, u32, Option<u32>), DateTimeError>>,
+
+    // ---- timestamp parse results ----
+    ts_result: Option<Result<chrono::NaiveDateTime, DateTimeError>>,
+
+    // ---- precision parse results ----
+    precision_result: Option<Result<ParsedTimestamp, DateTimeError>>,
+    parsed_ts: Option<ParsedTimestamp>,
+
+    // ---- comparison pair ----
+    first_ts: Option<ParsedTimestamp>,
+    second_ts: Option<ParsedTimestamp>,
+
+    // ---- formatted output ----
+    hl7_string: String,
+
+    // ---- helper output ----
+    helper_output: String,
+}
+
+impl DateTimeWorld {
+    fn new() -> Self {
+        Self {
+            date_string: String::new(),
+            time_string: String::new(),
+            timestamp_string: String::new(),
+            date_result: None,
+            time_result: None,
+            ts_result: None,
+            precision_result: None,
+            parsed_ts: None,
+            first_ts: None,
+            second_ts: None,
+            hl7_string: String::new(),
+            helper_output: String::new(),
+        }
+    }
+}
+
+// ============================================================================
+// Given Steps
+// ============================================================================
+
+#[given(regex = r#"^the date string "([^"]*)"$"#)]
+fn given_date_string(world: &mut DateTimeWorld, input: String) {
+    world.date_string = input;
+}
+
+#[given(regex = r#"^the time string "([^"]*)"$"#)]
+fn given_time_string(world: &mut DateTimeWorld, input: String) {
+    world.time_string = input;
+}
+
+#[given(regex = r#"^the timestamp string "([^"]*)"$"#)]
+fn given_timestamp_string(world: &mut DateTimeWorld, input: String) {
+    world.timestamp_string = input;
+}
+
+#[given(regex = r#"^a timestamp "([^"]*)" as the first$"#)]
+fn given_first_timestamp(world: &mut DateTimeWorld, input: String) {
+    world.first_ts = Some(parse_hl7_ts_with_precision(&input).expect("valid first timestamp"));
+}
+
+#[given(regex = r#"^a timestamp "([^"]*)" as the second$"#)]
+fn given_second_timestamp(world: &mut DateTimeWorld, input: String) {
+    world.second_ts = Some(parse_hl7_ts_with_precision(&input).expect("valid second timestamp"));
+}
+
+// ============================================================================
+// When Steps
+// ============================================================================
+
+#[when("I parse the date")]
+fn when_parse_date(world: &mut DateTimeWorld) {
+    world.date_result = Some(parse_hl7_dt(&world.date_string));
+}
+
+#[when("I attempt to parse the date")]
+fn when_attempt_parse_date(world: &mut DateTimeWorld) {
+    world.date_result = Some(parse_hl7_dt(&world.date_string));
+}
+
+#[when("I parse the time")]
+fn when_parse_time(world: &mut DateTimeWorld) {
+    world.time_result = Some(parse_hl7_tm(&world.time_string));
+}
+
+#[when("I attempt to parse the time")]
+fn when_attempt_parse_time(world: &mut DateTimeWorld) {
+    world.time_result = Some(parse_hl7_tm(&world.time_string));
+}
+
+#[when("I parse the timestamp")]
+fn when_parse_timestamp(world: &mut DateTimeWorld) {
+    world.ts_result = Some(parse_hl7_ts(&world.timestamp_string));
+}
+
+#[when("I attempt to parse the timestamp")]
+fn when_attempt_parse_timestamp(world: &mut DateTimeWorld) {
+    world.ts_result = Some(parse_hl7_ts(&world.timestamp_string));
+}
+
+#[when("I parse the timestamp with precision")]
+fn when_parse_timestamp_with_precision(world: &mut DateTimeWorld) {
+    let result = parse_hl7_ts_with_precision(&world.timestamp_string);
+    if let Ok(ref ts) = result {
+        world.parsed_ts = Some(ts.clone());
+    }
+    world.precision_result = Some(result);
+}
+
+#[when("I format the timestamp to an HL7 string")]
+fn when_format_hl7_string(world: &mut DateTimeWorld) {
+    let ts = world.parsed_ts.as_ref().expect("No parsed timestamp");
+    world.hl7_string = ts.to_hl7_string();
+}
+
+#[when("I call now_hl7")]
+fn when_call_now_hl7(world: &mut DateTimeWorld) {
+    world.helper_output = now_hl7();
+}
+
+#[when("I call today_hl7")]
+fn when_call_today_hl7(world: &mut DateTimeWorld) {
+    world.helper_output = today_hl7();
+}
+
+// ============================================================================
+// Then Steps — Date
+// ============================================================================
+
+#[then(regex = r"^the year should be (\d+)$")]
+fn then_year(world: &mut DateTimeWorld, expected: i32) {
+    use chrono::Datelike;
+    let date = world
+        .date_result
+        .as_ref()
+        .expect("No date result")
+        .as_ref()
+        .expect("Date parse failed");
+    assert_eq!(date.year(), expected);
+}
+
+#[then(regex = r"^the month should be (\d+)$")]
+fn then_month(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Datelike;
+    let date = world
+        .date_result
+        .as_ref()
+        .expect("No date result")
+        .as_ref()
+        .expect("Date parse failed");
+    assert_eq!(date.month(), expected);
+}
+
+#[then(regex = r"^the day should be (\d+)$")]
+fn then_day(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Datelike;
+    let date = world
+        .date_result
+        .as_ref()
+        .expect("No date result")
+        .as_ref()
+        .expect("Date parse failed");
+    assert_eq!(date.day(), expected);
+}
+
+#[then("date parsing should fail")]
+fn then_date_parsing_fails(world: &mut DateTimeWorld) {
+    assert!(
+        world
+            .date_result
+            .as_ref()
+            .expect("No date result")
+            .is_err(),
+        "Expected date parsing to fail"
+    );
+}
+
+// ============================================================================
+// Then Steps — Time
+// ============================================================================
+
+#[then(regex = r"^the hour should be (\d+)$")]
+fn then_hour(world: &mut DateTimeWorld, expected: u32) {
+    let (h, _, _, _) = world
+        .time_result
+        .as_ref()
+        .expect("No time result")
+        .as_ref()
+        .expect("Time parse failed");
+    assert_eq!(*h, expected);
+}
+
+#[then(regex = r"^the minute should be (\d+)$")]
+fn then_minute(world: &mut DateTimeWorld, expected: u32) {
+    let (_, m, _, _) = world
+        .time_result
+        .as_ref()
+        .expect("No time result")
+        .as_ref()
+        .expect("Time parse failed");
+    assert_eq!(*m, expected);
+}
+
+#[then(regex = r"^the second should be (\d+)$")]
+fn then_second(world: &mut DateTimeWorld, expected: u32) {
+    let (_, _, s, _) = world
+        .time_result
+        .as_ref()
+        .expect("No time result")
+        .as_ref()
+        .expect("Time parse failed");
+    assert_eq!(*s, expected);
+}
+
+#[then("the fractional seconds should be absent")]
+fn then_fractional_absent(world: &mut DateTimeWorld) {
+    let (_, _, _, f) = world
+        .time_result
+        .as_ref()
+        .expect("No time result")
+        .as_ref()
+        .expect("Time parse failed");
+    assert_eq!(*f, None);
+}
+
+#[then(regex = r"^the fractional seconds should be (\d+)$")]
+fn then_fractional_value(world: &mut DateTimeWorld, expected: u32) {
+    let (_, _, _, f) = world
+        .time_result
+        .as_ref()
+        .expect("No time result")
+        .as_ref()
+        .expect("Time parse failed");
+    assert_eq!(*f, Some(expected));
+}
+
+#[then("time parsing should fail")]
+fn then_time_parsing_fails(world: &mut DateTimeWorld) {
+    assert!(
+        world
+            .time_result
+            .as_ref()
+            .expect("No time result")
+            .is_err(),
+        "Expected time parsing to fail"
+    );
+}
+
+// ============================================================================
+// Then Steps — Timestamp
+// ============================================================================
+
+#[then(regex = r"^the parsed datetime year should be (\d+)$")]
+fn then_ts_year(world: &mut DateTimeWorld, expected: i32) {
+    use chrono::Datelike;
+    let dt = world
+        .ts_result
+        .as_ref()
+        .expect("No timestamp result")
+        .as_ref()
+        .expect("Timestamp parse failed");
+    assert_eq!(dt.year(), expected);
+}
+
+#[then(regex = r"^the parsed datetime month should be (\d+)$")]
+fn then_ts_month(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Datelike;
+    let dt = world
+        .ts_result
+        .as_ref()
+        .expect("No timestamp result")
+        .as_ref()
+        .expect("Timestamp parse failed");
+    assert_eq!(dt.month(), expected);
+}
+
+#[then(regex = r"^the parsed datetime day should be (\d+)$")]
+fn then_ts_day(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Datelike;
+    let dt = world
+        .ts_result
+        .as_ref()
+        .expect("No timestamp result")
+        .as_ref()
+        .expect("Timestamp parse failed");
+    assert_eq!(dt.day(), expected);
+}
+
+#[then(regex = r"^the parsed datetime hour should be (\d+)$")]
+fn then_ts_hour(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Timelike;
+    let dt = world
+        .ts_result
+        .as_ref()
+        .expect("No timestamp result")
+        .as_ref()
+        .expect("Timestamp parse failed");
+    assert_eq!(dt.hour(), expected);
+}
+
+#[then(regex = r"^the parsed datetime minute should be (\d+)$")]
+fn then_ts_minute(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Timelike;
+    let dt = world
+        .ts_result
+        .as_ref()
+        .expect("No timestamp result")
+        .as_ref()
+        .expect("Timestamp parse failed");
+    assert_eq!(dt.minute(), expected);
+}
+
+#[then(regex = r"^the parsed datetime second should be (\d+)$")]
+fn then_ts_second(world: &mut DateTimeWorld, expected: u32) {
+    use chrono::Timelike;
+    let dt = world
+        .ts_result
+        .as_ref()
+        .expect("No timestamp result")
+        .as_ref()
+        .expect("Timestamp parse failed");
+    assert_eq!(dt.second(), expected);
+}
+
+#[then("timestamp parsing should fail")]
+fn then_timestamp_parsing_fails(world: &mut DateTimeWorld) {
+    assert!(
+        world
+            .ts_result
+            .as_ref()
+            .expect("No timestamp result")
+            .is_err(),
+        "Expected timestamp parsing to fail"
+    );
+}
+
+// ============================================================================
+// Then Steps — Precision
+// ============================================================================
+
+#[then(regex = r#"^the precision should be "([^"]+)"$"#)]
+fn then_precision(world: &mut DateTimeWorld, expected: String) {
+    let ts = world.parsed_ts.as_ref().expect("No parsed timestamp");
+    let actual = match ts.precision {
+        TimestampPrecision::Year => "Year",
+        TimestampPrecision::Month => "Month",
+        TimestampPrecision::Day => "Day",
+        TimestampPrecision::Hour => "Hour",
+        TimestampPrecision::Minute => "Minute",
+        TimestampPrecision::Second => "Second",
+        TimestampPrecision::FractionalSecond => "FractionalSecond",
+    };
+    assert_eq!(actual, expected);
+}
+
+// ============================================================================
+// Then Steps — Comparison
+// ============================================================================
+
+#[then("the first timestamp should be before the second")]
+fn then_first_before_second(world: &mut DateTimeWorld) {
+    let first = world.first_ts.as_ref().expect("No first timestamp");
+    let second = world.second_ts.as_ref().expect("No second timestamp");
+    assert!(
+        first.is_before(second),
+        "Expected first ({:?}) to be before second ({:?})",
+        first,
+        second
+    );
+}
+
+#[then("the second timestamp should be after the first")]
+fn then_second_after_first(world: &mut DateTimeWorld) {
+    let first = world.first_ts.as_ref().expect("No first timestamp");
+    let second = world.second_ts.as_ref().expect("No second timestamp");
+    assert!(
+        second.is_after(first),
+        "Expected second ({:?}) to be after first ({:?})",
+        second,
+        first
+    );
+}
+
+#[then("the two timestamps should be on the same day")]
+fn then_same_day(world: &mut DateTimeWorld) {
+    let first = world.first_ts.as_ref().expect("No first timestamp");
+    let second = world.second_ts.as_ref().expect("No second timestamp");
+    assert!(
+        first.is_same_day(second),
+        "Expected same day: {:?} vs {:?}",
+        first,
+        second
+    );
+}
+
+#[then("the two timestamps should not be on the same day")]
+fn then_not_same_day(world: &mut DateTimeWorld) {
+    let first = world.first_ts.as_ref().expect("No first timestamp");
+    let second = world.second_ts.as_ref().expect("No second timestamp");
+    assert!(
+        !first.is_same_day(second),
+        "Expected different days: {:?} vs {:?}",
+        first,
+        second
+    );
+}
+
+// ============================================================================
+// Then Steps — to_hl7_string round-trip
+// ============================================================================
+
+#[then(regex = r#"^the HL7 string should be "([^"]*)"$"#)]
+fn then_hl7_string(world: &mut DateTimeWorld, expected: String) {
+    assert_eq!(world.hl7_string, expected);
+}
+
+// ============================================================================
+// Then Steps — Validation helpers
+// ============================================================================
+
+#[then(regex = r"^the date validity should be (true|false)$")]
+fn then_date_validity(world: &mut DateTimeWorld, expected: String) {
+    let valid = is_valid_hl7_date(&world.date_string);
+    let expected_bool = expected == "true";
+    assert_eq!(
+        valid, expected_bool,
+        "is_valid_hl7_date({:?}) = {}, expected {}",
+        world.date_string, valid, expected_bool
+    );
+}
+
+#[then(regex = r"^the time validity should be (true|false)$")]
+fn then_time_validity(world: &mut DateTimeWorld, expected: String) {
+    let valid = is_valid_hl7_time(&world.time_string);
+    let expected_bool = expected == "true";
+    assert_eq!(
+        valid, expected_bool,
+        "is_valid_hl7_time({:?}) = {}, expected {}",
+        world.time_string, valid, expected_bool
+    );
+}
+
+#[then(regex = r"^the timestamp validity should be (true|false)$")]
+fn then_timestamp_validity(world: &mut DateTimeWorld, expected: String) {
+    let valid = is_valid_hl7_timestamp(&world.timestamp_string);
+    let expected_bool = expected == "true";
+    assert_eq!(
+        valid, expected_bool,
+        "is_valid_hl7_timestamp({:?}) = {}, expected {}",
+        world.timestamp_string, valid, expected_bool
+    );
+}
+
+// ============================================================================
+// Then Steps — now_hl7 / today_hl7 helpers
+// ============================================================================
+
+#[then(regex = r"^the result should be (\d+) digits long$")]
+fn then_result_length(world: &mut DateTimeWorld, expected: usize) {
+    assert_eq!(
+        world.helper_output.len(),
+        expected,
+        "Expected length {}, got {} for {:?}",
+        expected,
+        world.helper_output.len(),
+        world.helper_output
+    );
+    assert!(
+        world.helper_output.chars().all(|c| c.is_ascii_digit()),
+        "Expected all digits, got {:?}",
+        world.helper_output
+    );
+}
+
+#[then("the result should be a valid timestamp")]
+fn then_result_valid_timestamp(world: &mut DateTimeWorld) {
+    assert!(
+        is_valid_hl7_timestamp(&world.helper_output),
+        "Expected valid timestamp, got {:?}",
+        world.helper_output
+    );
+}
+
+#[then("the result should be a valid date")]
+fn then_result_valid_date(world: &mut DateTimeWorld) {
+    assert!(
+        is_valid_hl7_date(&world.helper_output),
+        "Expected valid date, got {:?}",
+        world.helper_output
+    );
+}
+
+// ============================================================================
+// Cucumber Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() {
+    DateTimeWorld::run("features/datetime.feature").await;
+}

--- a/crates/hl7v2-e2e-tests/CLAUDE.md
+++ b/crates/hl7v2-e2e-tests/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-e2e-tests
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-e2e-tests
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-e2e-tests
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-e2e-tests -- -D warnings
-`
+```

--- a/crates/hl7v2-e2e-tests/tests/e2e/cli_integration_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/cli_integration_tests.rs
@@ -713,7 +713,7 @@ mod workflows {
 
         // Verify JSON output
         let output = String::from_utf8_lossy(&parse_result.get_output().stdout);
-        assert!(output.contains("{"));
+        assert!(output.contains('{'));
 
         // Step 2: Validate
         let mut cmd = cli();

--- a/crates/hl7v2-escape/CLAUDE.md
+++ b/crates/hl7v2-escape/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-escape
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-escape
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-escape
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-escape -- -D warnings
-`
+```

--- a/crates/hl7v2-escape/Cargo.toml
+++ b/crates/hl7v2-escape/Cargo.toml
@@ -18,3 +18,9 @@ hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
 [dev-dependencies]
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"
+cucumber = "0.22.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "bdd_tests"
+harness = false

--- a/crates/hl7v2-escape/features/escape.feature
+++ b/crates/hl7v2-escape/features/escape.feature
@@ -1,0 +1,240 @@
+Feature: HL7 v2 Escape Sequence Handling
+  As an HL7 message processor
+  I want to escape and unescape delimiter characters in HL7 text
+  So that delimiter characters can be safely embedded in field values
+
+  # =========================================================================
+  # Escaping individual delimiters
+  # =========================================================================
+
+  Scenario: Escape field separator
+    Given the text "before|after"
+    And default delimiters
+    When I escape the text
+    Then the result should be "before\F\after"
+
+  Scenario: Escape component separator
+    Given the text "before^after"
+    And default delimiters
+    When I escape the text
+    Then the result should be "before\S\after"
+
+  Scenario: Escape repetition separator
+    Given the text "before~after"
+    And default delimiters
+    When I escape the text
+    Then the result should be "before\R\after"
+
+  Scenario: Escape the escape character
+    Given the text "before\after"
+    And default delimiters
+    When I escape the text
+    Then the result should be "before\E\after"
+
+  Scenario: Escape subcomponent separator
+    Given the text "before&after"
+    And default delimiters
+    When I escape the text
+    Then the result should be "before\T\after"
+
+  # =========================================================================
+  # Unescaping individual sequences
+  # =========================================================================
+
+  Scenario: Unescape field separator sequence
+    Given the text "before\F\after"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "before|after"
+
+  Scenario: Unescape component separator sequence
+    Given the text "before\S\after"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "before^after"
+
+  Scenario: Unescape repetition separator sequence
+    Given the text "before\R\after"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "before~after"
+
+  Scenario: Unescape the escape character sequence
+    Given the text "before\E\after"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "before\after"
+
+  Scenario: Unescape subcomponent separator sequence
+    Given the text "before\T\after"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "before&after"
+
+  # =========================================================================
+  # Roundtrip: escape then unescape
+  # =========================================================================
+
+  Scenario: Roundtrip field separator
+    Given the text "val|ue"
+    And default delimiters
+    When I escape then unescape the text
+    Then the result should be "val|ue"
+
+  Scenario: Roundtrip component separator
+    Given the text "val^ue"
+    And default delimiters
+    When I escape then unescape the text
+    Then the result should be "val^ue"
+
+  Scenario: Roundtrip repetition separator
+    Given the text "val~ue"
+    And default delimiters
+    When I escape then unescape the text
+    Then the result should be "val~ue"
+
+  Scenario: Roundtrip escape character
+    Given the text "val\ue"
+    And default delimiters
+    When I escape then unescape the text
+    Then the result should be "val\ue"
+
+  Scenario: Roundtrip subcomponent separator
+    Given the text "val&ue"
+    And default delimiters
+    When I escape then unescape the text
+    Then the result should be "val&ue"
+
+  # =========================================================================
+  # Passthrough for plain text
+  # =========================================================================
+
+  Scenario: Text with no delimiters passes through escape unchanged
+    Given the text "Hello World 123"
+    And default delimiters
+    When I escape the text
+    Then the result should be "Hello World 123"
+
+  Scenario: Text with no escape sequences passes through unescape unchanged
+    Given the text "Hello World 123"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "Hello World 123"
+
+  # =========================================================================
+  # Custom delimiters
+  # =========================================================================
+
+  Scenario: Escape with custom delimiters
+    Given the text "a#b$c*d@e!f"
+    And custom delimiters "#$*@!"
+    When I escape the text
+    Then the result should be "a@F@b@S@c@R@d@E@e@T@f"
+
+  Scenario: Unescape with custom delimiters
+    Given the text "a@F@b@S@c@R@d@E@e@T@f"
+    And custom delimiters "#$*@!"
+    When I unescape the text
+    Then the result should be "a#b$c*d@e!f"
+
+  Scenario: Roundtrip with custom delimiters
+    Given the text "x#y$z"
+    And custom delimiters "#$*@!"
+    When I escape then unescape the text
+    Then the result should be "x#y$z"
+
+  # =========================================================================
+  # needs_escaping
+  # =========================================================================
+
+  Scenario: needs_escaping returns true for field separator
+    Given the text "has|pipe"
+    And default delimiters
+    Then needs_escaping should return true
+
+  Scenario: needs_escaping returns true for component separator
+    Given the text "has^caret"
+    And default delimiters
+    Then needs_escaping should return true
+
+  Scenario: needs_escaping returns true for repetition separator
+    Given the text "has~tilde"
+    And default delimiters
+    Then needs_escaping should return true
+
+  Scenario: needs_escaping returns true for escape character
+    Given the text "has\backslash"
+    And default delimiters
+    Then needs_escaping should return true
+
+  Scenario: needs_escaping returns true for subcomponent separator
+    Given the text "has&ampersand"
+    And default delimiters
+    Then needs_escaping should return true
+
+  Scenario: needs_escaping returns false for plain text
+    Given the text "plain text"
+    And default delimiters
+    Then needs_escaping should return false
+
+  # =========================================================================
+  # needs_unescaping
+  # =========================================================================
+
+  Scenario: needs_unescaping returns true when escape sequences present
+    Given the text "has\F\sequence"
+    And default delimiters
+    Then needs_unescaping should return true
+
+  Scenario: needs_unescaping returns false for plain text
+    Given the text "plain text"
+    And default delimiters
+    Then needs_unescaping should return false
+
+  # =========================================================================
+  # Empty string handling
+  # =========================================================================
+
+  Scenario: Escape empty string
+    Given the text ""
+    And default delimiters
+    When I escape the text
+    Then the result should be ""
+
+  Scenario: Unescape empty string
+    Given the text ""
+    And default delimiters
+    When I unescape the text
+    Then the result should be ""
+
+  Scenario: needs_escaping on empty string returns false
+    Given the text ""
+    And default delimiters
+    Then needs_escaping should return false
+
+  Scenario: needs_unescaping on empty string returns false
+    Given the text ""
+    And default delimiters
+    Then needs_unescaping should return false
+
+  # =========================================================================
+  # Multiple delimiters in one string
+  # =========================================================================
+
+  Scenario: Escape multiple different delimiters in one string
+    Given the text "a|b^c~d\e&f"
+    And default delimiters
+    When I escape the text
+    Then the result should be "a\F\b\S\c\R\d\E\e\T\f"
+
+  Scenario: Unescape multiple different sequences in one string
+    Given the text "a\F\b\S\c\R\d\E\e\T\f"
+    And default delimiters
+    When I unescape the text
+    Then the result should be "a|b^c~d\e&f"
+
+  Scenario: Roundtrip multiple delimiters in one string
+    Given the text "a|b^c~d\e&f"
+    And default delimiters
+    When I escape then unescape the text
+    Then the result should be "a|b^c~d\e&f"

--- a/crates/hl7v2-escape/tests/bdd_tests.rs
+++ b/crates/hl7v2-escape/tests/bdd_tests.rs
@@ -1,0 +1,138 @@
+//! BDD tests for hl7v2-escape using Cucumber
+//!
+//! Run with: cargo test --test bdd_tests -p hl7v2-escape
+
+use cucumber::{World, given, then, when};
+use hl7v2_escape::{escape_text, needs_escaping, needs_unescaping, unescape_text};
+use hl7v2_model::Delims;
+
+/// Test world for escape BDD tests
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct EscapeWorld {
+    /// The input text under test
+    text: String,
+    /// The delimiter configuration
+    delims: Delims,
+    /// The result of an escape or unescape operation
+    result: Option<String>,
+}
+
+impl EscapeWorld {
+    fn new() -> Self {
+        Self {
+            text: String::new(),
+            delims: Delims::default(),
+            result: None,
+        }
+    }
+}
+
+// ============================================================================
+// Given Steps
+// ============================================================================
+
+#[given(regex = r#"^the text "([^"]*)"$"#)]
+fn given_text(world: &mut EscapeWorld, text: String) {
+    world.text = text;
+}
+
+#[given("default delimiters")]
+fn given_default_delimiters(world: &mut EscapeWorld) {
+    world.delims = Delims::default();
+}
+
+#[given(regex = r#"^custom delimiters "([^"]+)"$"#)]
+fn given_custom_delimiters(world: &mut EscapeWorld, delim_str: String) {
+    let chars: Vec<char> = delim_str.chars().collect();
+    assert_eq!(
+        chars.len(),
+        5,
+        "Custom delimiters must be exactly 5 characters"
+    );
+    world.delims = Delims {
+        field: chars[0],
+        comp: chars[1],
+        rep: chars[2],
+        esc: chars[3],
+        sub: chars[4],
+    };
+}
+
+// ============================================================================
+// When Steps
+// ============================================================================
+
+#[when("I escape the text")]
+fn when_escape(world: &mut EscapeWorld) {
+    world.result = Some(escape_text(&world.text, &world.delims));
+}
+
+#[when("I unescape the text")]
+fn when_unescape(world: &mut EscapeWorld) {
+    world.result = Some(
+        unescape_text(&world.text, &world.delims).expect("unescape_text should not fail"),
+    );
+}
+
+#[when("I escape then unescape the text")]
+fn when_roundtrip(world: &mut EscapeWorld) {
+    let escaped = escape_text(&world.text, &world.delims);
+    let unescaped = unescape_text(&escaped, &world.delims).expect("unescape_text should not fail");
+    world.result = Some(unescaped);
+}
+
+// ============================================================================
+// Then Steps
+// ============================================================================
+
+#[then(regex = r#"^the result should be "([^"]*)"$"#)]
+fn then_result_should_be(world: &mut EscapeWorld, expected: String) {
+    let actual = world.result.as_ref().expect("No result produced");
+    assert_eq!(actual, &expected, "Expected '{}' but got '{}'", expected, actual);
+}
+
+#[then("needs_escaping should return true")]
+fn then_needs_escaping_true(world: &mut EscapeWorld) {
+    assert!(
+        needs_escaping(&world.text, &world.delims),
+        "Expected needs_escaping to return true for '{}'",
+        world.text
+    );
+}
+
+#[then("needs_escaping should return false")]
+fn then_needs_escaping_false(world: &mut EscapeWorld) {
+    assert!(
+        !needs_escaping(&world.text, &world.delims),
+        "Expected needs_escaping to return false for '{}'",
+        world.text
+    );
+}
+
+#[then("needs_unescaping should return true")]
+fn then_needs_unescaping_true(world: &mut EscapeWorld) {
+    assert!(
+        needs_unescaping(&world.text, &world.delims),
+        "Expected needs_unescaping to return true for '{}'",
+        world.text
+    );
+}
+
+#[then("needs_unescaping should return false")]
+fn then_needs_unescaping_false(world: &mut EscapeWorld) {
+    assert!(
+        !needs_unescaping(&world.text, &world.delims),
+        "Expected needs_unescaping to return false for '{}'",
+        world.text
+    );
+}
+
+// ============================================================================
+// Cucumber Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() {
+    EscapeWorld::run("features/escape.feature").await;
+}

--- a/crates/hl7v2-escape/tests/bdd_tests.rs
+++ b/crates/hl7v2-escape/tests/bdd_tests.rs
@@ -70,9 +70,8 @@ fn when_escape(world: &mut EscapeWorld) {
 
 #[when("I unescape the text")]
 fn when_unescape(world: &mut EscapeWorld) {
-    world.result = Some(
-        unescape_text(&world.text, &world.delims).expect("unescape_text should not fail"),
-    );
+    world.result =
+        Some(unescape_text(&world.text, &world.delims).expect("unescape_text should not fail"));
 }
 
 #[when("I escape then unescape the text")]
@@ -89,7 +88,11 @@ fn when_roundtrip(world: &mut EscapeWorld) {
 #[then(regex = r#"^the result should be "([^"]*)"$"#)]
 fn then_result_should_be(world: &mut EscapeWorld, expected: String) {
     let actual = world.result.as_ref().expect("No result produced");
-    assert_eq!(actual, &expected, "Expected '{}' but got '{}'", expected, actual);
+    assert_eq!(
+        actual, &expected,
+        "Expected '{}' but got '{}'",
+        expected, actual
+    );
 }
 
 #[then("needs_escaping should return true")]

--- a/crates/hl7v2-faker/CLAUDE.md
+++ b/crates/hl7v2-faker/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-faker
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-faker
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-faker
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-faker -- -D warnings
-`
+```

--- a/crates/hl7v2-faker/Cargo.toml
+++ b/crates/hl7v2-faker/Cargo.toml
@@ -20,4 +20,10 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 proptest = "1.6"
+cucumber = "0.22.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "bdd_tests"
+harness = false
 

--- a/crates/hl7v2-faker/src/tests.rs
+++ b/crates/hl7v2-faker/src/tests.rs
@@ -109,7 +109,7 @@ fn test_address_has_street_number() {
     let address = faker.address();
 
     // Should start with a street number (100-9999)
-    let street_number: String = address.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let street_number: String = address.chars().take_while(char::is_ascii_digit).collect();
     let num: i32 = street_number.parse().unwrap();
     assert!((100..=9999).contains(&num));
 }
@@ -177,7 +177,7 @@ fn test_ssn_all_digits() {
     let mut faker = Faker::new(&mut rng);
     let ssn = faker.ssn();
 
-    let digits_only: String = ssn.chars().filter(|c| c.is_ascii_digit()).collect();
+    let digits_only: String = ssn.chars().filter(char::is_ascii_digit).collect();
     assert_eq!(digits_only.len(), 9);
 }
 

--- a/crates/hl7v2-faker/tests/bdd_tests.rs
+++ b/crates/hl7v2-faker/tests/bdd_tests.rs
@@ -1,0 +1,1201 @@
+//! BDD tests for hl7v2-faker using Cucumber
+//!
+//! Run with: cargo test --test bdd_tests -p hl7v2-faker
+
+use std::collections::HashMap;
+
+use cucumber::{World, given, then, when};
+use hl7v2_faker::{Faker, FakerValue, GenerateError, StdRng};
+use rand::SeedableRng;
+
+/// Test world for faker BDD tests
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct FakerWorld {
+    /// The seeded RNG
+    rng: StdRng,
+    /// Generated name result
+    name: Option<String>,
+    /// Second name for comparison
+    name2: Option<String>,
+    /// Generated address result
+    address: Option<String>,
+    /// Generated phone result
+    phone: Option<String>,
+    /// Generated SSN result
+    ssn: Option<String>,
+    /// Generated MRN result
+    mrn: Option<String>,
+    /// Generated ICD-10 code result
+    icd10: Option<String>,
+    /// Generated LOINC code result
+    loinc: Option<String>,
+    /// Generated medication result
+    medication: Option<String>,
+    /// Generated allergen result
+    allergen: Option<String>,
+    /// Generated blood type result
+    blood_type: Option<String>,
+    /// Generated ethnicity result
+    ethnicity: Option<String>,
+    /// Generated race result
+    race: Option<String>,
+    /// Generated numeric string result
+    numeric_string: Option<String>,
+    /// Generated date result
+    date_result: Option<Result<String, hl7v2_faker::DateError>>,
+    /// Generated Gaussian value result
+    gaussian_value: Option<String>,
+    /// Generated UUID result
+    uuid: Option<String>,
+    /// Generated timestamp result
+    timestamp: Option<String>,
+    /// Selected value from list
+    selected_value: Option<Option<String>>,
+    /// Selected value from map
+    map_selected_value: Option<Option<String>>,
+    /// Generated FakerValue result
+    faker_value_result: Option<Result<String, GenerateError>>,
+    /// First set of all data types for determinism test
+    all_data_set1: Option<Vec<String>>,
+    /// Second set of all data types for determinism test
+    all_data_set2: Option<Vec<String>>,
+    /// Gaussian mean for validation
+    gaussian_mean: f64,
+    /// Gaussian stddev for validation
+    gaussian_sd: f64,
+}
+
+impl FakerWorld {
+    fn new() -> Self {
+        Self {
+            rng: StdRng::seed_from_u64(0),
+            name: None,
+            name2: None,
+            address: None,
+            phone: None,
+            ssn: None,
+            mrn: None,
+            icd10: None,
+            loinc: None,
+            medication: None,
+            allergen: None,
+            blood_type: None,
+            ethnicity: None,
+            race: None,
+            numeric_string: None,
+            date_result: None,
+            gaussian_value: None,
+            uuid: None,
+            timestamp: None,
+            selected_value: None,
+            map_selected_value: None,
+            faker_value_result: None,
+            all_data_set1: None,
+            all_data_set2: None,
+            gaussian_mean: 0.0,
+            gaussian_sd: 0.0,
+        }
+    }
+}
+
+/// Generate all deterministic data types and return as a Vec<String>.
+fn generate_all_data(rng: &mut StdRng) -> Vec<String> {
+    let mut faker = Faker::new(rng);
+    vec![
+        faker.name(Some("M")),
+        faker.name(Some("F")),
+        faker.name(None),
+        faker.address(),
+        faker.phone(),
+        faker.ssn(),
+        faker.mrn(),
+        faker.icd10(),
+        faker.loinc(),
+        faker.medication(),
+        faker.allergen(),
+        faker.blood_type(),
+        faker.ethnicity(),
+        faker.race(),
+        faker.numeric(8),
+        faker.date("20200101", "20201231").unwrap(),
+        faker.gaussian(100.0, 10.0, 2).unwrap(),
+    ]
+}
+
+// ============================================================================
+// Given Steps
+// ============================================================================
+
+#[given(regex = r"^a faker with seed (\d+)$")]
+fn given_faker_with_seed(world: &mut FakerWorld, seed: u64) {
+    world.rng = StdRng::seed_from_u64(seed);
+}
+
+// ============================================================================
+// When Steps — Name Generation
+// ============================================================================
+
+#[when(regex = r#"^I generate a name with gender "([^"]*)"$"#)]
+fn when_generate_name_with_gender(world: &mut FakerWorld, gender: String) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.name = Some(faker.name(Some(&gender)));
+}
+
+#[when("I generate a name with no gender")]
+fn when_generate_name_no_gender(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.name = Some(faker.name(None));
+}
+
+#[when(regex = r#"^I generate another name with gender "([^"]*)" using seed (\d+)$"#)]
+fn when_generate_another_name(world: &mut FakerWorld, gender: String, seed: u64) {
+    let mut rng2 = StdRng::seed_from_u64(seed);
+    let mut faker2 = Faker::new(&mut rng2);
+    world.name2 = Some(faker2.name(Some(&gender)));
+}
+
+// ============================================================================
+// When Steps — Address Generation
+// ============================================================================
+
+#[when("I generate an address")]
+fn when_generate_address(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.address = Some(faker.address());
+}
+
+// ============================================================================
+// When Steps — Phone Generation
+// ============================================================================
+
+#[when("I generate a phone number")]
+fn when_generate_phone(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.phone = Some(faker.phone());
+}
+
+// ============================================================================
+// When Steps — SSN Generation
+// ============================================================================
+
+#[when("I generate an SSN")]
+fn when_generate_ssn(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.ssn = Some(faker.ssn());
+}
+
+// ============================================================================
+// When Steps — MRN Generation
+// ============================================================================
+
+#[when("I generate an MRN")]
+fn when_generate_mrn(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.mrn = Some(faker.mrn());
+}
+
+// ============================================================================
+// When Steps — Medical Code Generation
+// ============================================================================
+
+#[when("I generate an ICD-10 code")]
+fn when_generate_icd10(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.icd10 = Some(faker.icd10());
+}
+
+#[when("I generate a LOINC code")]
+fn when_generate_loinc(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.loinc = Some(faker.loinc());
+}
+
+// ============================================================================
+// When Steps — Medication and Allergen Generation
+// ============================================================================
+
+#[when("I generate a medication name")]
+fn when_generate_medication(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.medication = Some(faker.medication());
+}
+
+#[when("I generate an allergen name")]
+fn when_generate_allergen(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.allergen = Some(faker.allergen());
+}
+
+// ============================================================================
+// When Steps — Patient Demographics
+// ============================================================================
+
+#[when("I generate a blood type")]
+fn when_generate_blood_type(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.blood_type = Some(faker.blood_type());
+}
+
+#[when("I generate an ethnicity")]
+fn when_generate_ethnicity(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.ethnicity = Some(faker.ethnicity());
+}
+
+#[when("I generate a race")]
+fn when_generate_race(world: &mut FakerWorld) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.race = Some(faker.race());
+}
+
+// ============================================================================
+// When Steps — Numeric Generation
+// ============================================================================
+
+#[when(regex = r"^I generate a numeric string of (\d+) digits$")]
+fn when_generate_numeric(world: &mut FakerWorld, digits: usize) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.numeric_string = Some(faker.numeric(digits));
+}
+
+// ============================================================================
+// When Steps — Date Generation
+// ============================================================================
+
+#[when(regex = r#"^I generate a date between "([^"]*)" and "([^"]*)"$"#)]
+fn when_generate_date(world: &mut FakerWorld, start: String, end: String) {
+    let mut faker = Faker::new(&mut world.rng);
+    world.date_result = Some(faker.date(&start, &end));
+}
+
+// ============================================================================
+// When Steps — Gaussian Generation
+// ============================================================================
+
+#[when(regex = r"^I generate a Gaussian value with mean ([^ ]+) stddev ([^ ]+) precision (\d+)$")]
+fn when_generate_gaussian(world: &mut FakerWorld, mean: f64, sd: f64, precision: usize) {
+    world.gaussian_mean = mean;
+    world.gaussian_sd = sd;
+    let mut faker = Faker::new(&mut world.rng);
+    world.gaussian_value = Some(faker.gaussian(mean, sd, precision).unwrap());
+}
+
+// ============================================================================
+// When Steps — UUID Generation
+// ============================================================================
+
+#[when("I generate a UUID v4")]
+fn when_generate_uuid(world: &mut FakerWorld) {
+    let faker = Faker::new(&mut world.rng);
+    world.uuid = Some(faker.uuid_v4());
+}
+
+// ============================================================================
+// When Steps — Timestamp Generation
+// ============================================================================
+
+#[when("I generate a UTC timestamp")]
+fn when_generate_timestamp(world: &mut FakerWorld) {
+    let faker = Faker::new(&mut world.rng);
+    world.timestamp = Some(faker.dtm_now_utc());
+}
+
+// ============================================================================
+// When Steps — Selection Functions
+// ============================================================================
+
+#[when(regex = r#"^I select from the list "([^"]*)"$"#)]
+fn when_select_from_list(world: &mut FakerWorld, items: String) {
+    let options: Vec<String> = items.split(',').map(|s| s.to_string()).collect();
+    let mut faker = Faker::new(&mut world.rng);
+    world.selected_value = Some(faker.select_from(&options));
+}
+
+#[when("I select from an empty list")]
+fn when_select_from_empty_list(world: &mut FakerWorld) {
+    let options: Vec<String> = vec![];
+    let mut faker = Faker::new(&mut world.rng);
+    world.selected_value = Some(faker.select_from(&options));
+}
+
+#[when(regex = r#"^I select from a map with entries "([^"]*)"$"#)]
+fn when_select_from_map(world: &mut FakerWorld, entries: String) {
+    let mut map = HashMap::new();
+    for entry in entries.split(',') {
+        let parts: Vec<&str> = entry.split('=').collect();
+        map.insert(parts[0].to_string(), parts[1].to_string());
+    }
+    let mut faker = Faker::new(&mut world.rng);
+    world.map_selected_value = Some(faker.select_from_map(&map));
+}
+
+#[when("I select from an empty map")]
+fn when_select_from_empty_map(world: &mut FakerWorld) {
+    let map: HashMap<String, String> = HashMap::new();
+    let mut faker = Faker::new(&mut world.rng);
+    world.map_selected_value = Some(faker.select_from_map(&map));
+}
+
+// ============================================================================
+// When Steps — FakerValue Enum Generation
+// ============================================================================
+
+#[when(regex = r#"^I generate a FakerValue::Fixed with value "([^"]*)"$"#)]
+fn when_faker_value_fixed(world: &mut FakerWorld, value: String) {
+    let fv = FakerValue::Fixed(value);
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when(regex = r#"^I generate a FakerValue::From with options "([^"]*)"$"#)]
+fn when_faker_value_from(world: &mut FakerWorld, options: String) {
+    let opts: Vec<String> = options.split(',').map(|s| s.to_string()).collect();
+    let fv = FakerValue::From(opts);
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::From with no options")]
+fn when_faker_value_from_empty(world: &mut FakerWorld) {
+    let fv = FakerValue::From(vec![]);
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when(regex = r"^I generate a FakerValue::Numeric with (\d+) digits$")]
+fn when_faker_value_numeric(world: &mut FakerWorld, digits: usize) {
+    let fv = FakerValue::Numeric { digits };
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when(regex = r#"^I generate a FakerValue::RealisticName for gender "([^"]*)"$"#)]
+fn when_faker_value_realistic_name(world: &mut FakerWorld, gender: String) {
+    let fv = FakerValue::RealisticName {
+        gender: Some(gender),
+    };
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::RealisticAddress")]
+fn when_faker_value_realistic_address(world: &mut FakerWorld) {
+    let fv = FakerValue::RealisticAddress;
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::RealisticPhone")]
+fn when_faker_value_realistic_phone(world: &mut FakerWorld) {
+    let fv = FakerValue::RealisticPhone;
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::RealisticSsn")]
+fn when_faker_value_realistic_ssn(world: &mut FakerWorld) {
+    let fv = FakerValue::RealisticSsn;
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::RealisticMrn")]
+fn when_faker_value_realistic_mrn(world: &mut FakerWorld) {
+    let fv = FakerValue::RealisticMrn;
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::RealisticBloodType")]
+fn when_faker_value_realistic_blood_type(world: &mut FakerWorld) {
+    let fv = FakerValue::RealisticBloodType;
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+#[when("I generate a FakerValue::Map with no entries")]
+fn when_faker_value_map_empty(world: &mut FakerWorld) {
+    let fv = FakerValue::Map(HashMap::new());
+    let mut faker = Faker::new(&mut world.rng);
+    world.faker_value_result = Some(fv.generate(&mut faker));
+}
+
+// ============================================================================
+// When Steps — Determinism
+// ============================================================================
+
+#[when("I generate all data types")]
+fn when_generate_all_data(world: &mut FakerWorld) {
+    world.all_data_set1 = Some(generate_all_data(&mut world.rng));
+}
+
+#[when(regex = r"^I generate all data types again with seed (\d+)$")]
+fn when_generate_all_data_again(world: &mut FakerWorld, seed: u64) {
+    let mut rng2 = StdRng::seed_from_u64(seed);
+    world.all_data_set2 = Some(generate_all_data(&mut rng2));
+}
+
+// ============================================================================
+// Then Steps — Name Generation
+// ============================================================================
+
+#[then(regex = r#"^the name should be in "LAST\^FIRST" format$"#)]
+fn then_name_in_hl7_format(world: &mut FakerWorld) {
+    let name = world.name.as_ref().expect("No name was generated");
+    assert!(name.contains('^'), "Name '{}' does not contain '^'", name);
+    let parts: Vec<&str> = name.split('^').collect();
+    assert_eq!(
+        parts.len(),
+        2,
+        "Name '{}' is not in LAST^FIRST format",
+        name
+    );
+    assert!(!parts[0].is_empty(), "Last name is empty");
+    assert!(!parts[1].is_empty(), "First name is empty");
+}
+
+#[then("the first name should be a known male name")]
+fn then_first_name_is_male(world: &mut FakerWorld) {
+    let name = world.name.as_ref().expect("No name was generated");
+    let first = name.split('^').nth(1).expect("No first name in result");
+    let male_names = [
+        "James", "John", "Robert", "Michael", "William", "David", "Richard", "Joseph", "Thomas",
+        "Charles",
+    ];
+    assert!(
+        male_names.contains(&first),
+        "First name '{}' is not a known male name",
+        first
+    );
+}
+
+#[then("the first name should be a known female name")]
+fn then_first_name_is_female(world: &mut FakerWorld) {
+    let name = world.name.as_ref().expect("No name was generated");
+    let first = name.split('^').nth(1).expect("No first name in result");
+    let female_names = [
+        "Mary",
+        "Patricia",
+        "Jennifer",
+        "Linda",
+        "Elizabeth",
+        "Barbara",
+        "Susan",
+        "Jessica",
+        "Sarah",
+        "Karen",
+    ];
+    assert!(
+        female_names.contains(&first),
+        "First name '{}' is not a known female name",
+        first
+    );
+}
+
+#[then("both names should be identical")]
+fn then_names_identical(world: &mut FakerWorld) {
+    let name1 = world.name.as_ref().expect("No first name was generated");
+    let name2 = world.name2.as_ref().expect("No second name was generated");
+    assert_eq!(name1, name2, "Names differ: '{}' vs '{}'", name1, name2);
+}
+
+// ============================================================================
+// Then Steps — Address Generation
+// ============================================================================
+
+#[then("the address should contain component separators")]
+fn then_address_has_separators(world: &mut FakerWorld) {
+    let address = world.address.as_ref().expect("No address was generated");
+    assert!(
+        address.contains('^'),
+        "Address '{}' has no component separators",
+        address
+    );
+}
+
+#[then(regex = r#"^the address should end with "([^"]*)"$"#)]
+fn then_address_ends_with(world: &mut FakerWorld, suffix: String) {
+    let address = world.address.as_ref().expect("No address was generated");
+    assert!(
+        address.ends_with(&suffix),
+        "Address '{}' does not end with '{}'",
+        address,
+        suffix
+    );
+}
+
+#[then(regex = r"^the address should have a street number between (\d+) and (\d+)$")]
+fn then_address_street_number_range(world: &mut FakerWorld, min: i32, max: i32) {
+    let address = world.address.as_ref().expect("No address was generated");
+    let street_number: String = address.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let num: i32 = street_number
+        .parse()
+        .expect("Could not parse street number");
+    assert!(
+        (min..=max).contains(&num),
+        "Street number {} is not between {} and {}",
+        num,
+        min,
+        max
+    );
+}
+
+// ============================================================================
+// Then Steps — Phone Generation
+// ============================================================================
+
+#[then(regex = r#"^the phone number should match the format "\(XXX\)XXX-XXXX"$"#)]
+fn then_phone_format(world: &mut FakerWorld) {
+    let phone = world.phone.as_ref().expect("No phone was generated");
+    assert!(
+        phone.starts_with('('),
+        "Phone '{}' doesn't start with '('",
+        phone
+    );
+    assert!(phone.contains(')'), "Phone '{}' doesn't contain ')'", phone);
+    assert!(phone.contains('-'), "Phone '{}' doesn't contain '-'", phone);
+}
+
+#[then(regex = r"^the phone number should be (\d+) characters long$")]
+fn then_phone_length(world: &mut FakerWorld, length: usize) {
+    let phone = world.phone.as_ref().expect("No phone was generated");
+    assert_eq!(
+        phone.len(),
+        length,
+        "Phone '{}' has length {} but expected {}",
+        phone,
+        phone.len(),
+        length
+    );
+}
+
+// ============================================================================
+// Then Steps — SSN Generation
+// ============================================================================
+
+#[then(regex = r#"^the SSN should match the format "XXX-XX-XXXX"$"#)]
+fn then_ssn_format(world: &mut FakerWorld) {
+    let ssn = world.ssn.as_ref().expect("No SSN was generated");
+    assert_eq!(ssn.len(), 11, "SSN '{}' is not 11 characters", ssn);
+    assert_eq!(&ssn[3..4], "-", "SSN '{}' missing dash at position 3", ssn);
+    assert_eq!(&ssn[6..7], "-", "SSN '{}' missing dash at position 6", ssn);
+}
+
+#[then(regex = r"^the SSN should contain exactly (\d+) digits$")]
+fn then_ssn_digit_count(world: &mut FakerWorld, count: usize) {
+    let ssn = world.ssn.as_ref().expect("No SSN was generated");
+    let digit_count = ssn.chars().filter(|c| c.is_ascii_digit()).count();
+    assert_eq!(
+        digit_count, count,
+        "SSN '{}' has {} digits but expected {}",
+        ssn, digit_count, count
+    );
+}
+
+// ============================================================================
+// Then Steps — MRN Generation
+// ============================================================================
+
+#[then(regex = r"^the MRN should be between (\d+) and (\d+) digits long$")]
+fn then_mrn_length_range(world: &mut FakerWorld, min: usize, max: usize) {
+    let mrn = world.mrn.as_ref().expect("No MRN was generated");
+    assert!(
+        (min..=max).contains(&mrn.len()),
+        "MRN '{}' has length {} but expected between {} and {}",
+        mrn,
+        mrn.len(),
+        min,
+        max
+    );
+}
+
+#[then("the MRN should contain only digits")]
+fn then_mrn_all_digits(world: &mut FakerWorld) {
+    let mrn = world.mrn.as_ref().expect("No MRN was generated");
+    assert!(
+        mrn.chars().all(|c| c.is_ascii_digit()),
+        "MRN '{}' contains non-digit characters",
+        mrn
+    );
+}
+
+// ============================================================================
+// Then Steps — ICD-10 Generation
+// ============================================================================
+
+#[then(regex = r#"^the ICD-10 code should match the format "LNN\.N"$"#)]
+fn then_icd10_format(world: &mut FakerWorld) {
+    let code = world.icd10.as_ref().expect("No ICD-10 code was generated");
+    assert!(code.contains('.'), "ICD-10 '{}' has no decimal point", code);
+    let parts: Vec<&str> = code.split('.').collect();
+    assert_eq!(parts.len(), 2, "ICD-10 '{}' format is wrong", code);
+    assert_eq!(
+        parts[0].len(),
+        3,
+        "ICD-10 category '{}' is not 3 chars",
+        parts[0]
+    );
+    assert_eq!(
+        parts[1].len(),
+        1,
+        "ICD-10 subcode '{}' is not 1 char",
+        parts[1]
+    );
+}
+
+#[then("the ICD-10 code should start with an uppercase letter")]
+fn then_icd10_starts_with_letter(world: &mut FakerWorld) {
+    let code = world.icd10.as_ref().expect("No ICD-10 code was generated");
+    let first = code.chars().next().expect("ICD-10 code is empty");
+    assert!(
+        first.is_ascii_uppercase(),
+        "ICD-10 '{}' does not start with an uppercase letter",
+        code
+    );
+}
+
+// ============================================================================
+// Then Steps — LOINC Generation
+// ============================================================================
+
+#[then(regex = r"^the LOINC code should be between (\d+) and (\d+) digits long$")]
+fn then_loinc_length_range(world: &mut FakerWorld, min: usize, max: usize) {
+    let code = world.loinc.as_ref().expect("No LOINC code was generated");
+    assert!(
+        (min..=max).contains(&code.len()),
+        "LOINC '{}' has length {} but expected between {} and {}",
+        code,
+        code.len(),
+        min,
+        max
+    );
+}
+
+#[then("the LOINC code should contain only digits")]
+fn then_loinc_all_digits(world: &mut FakerWorld) {
+    let code = world.loinc.as_ref().expect("No LOINC code was generated");
+    assert!(
+        code.chars().all(|c| c.is_ascii_digit()),
+        "LOINC '{}' contains non-digit characters",
+        code
+    );
+}
+
+// ============================================================================
+// Then Steps — Medication and Allergen Generation
+// ============================================================================
+
+#[then("the medication should be a known medication")]
+fn then_medication_known(world: &mut FakerWorld) {
+    let med = world
+        .medication
+        .as_ref()
+        .expect("No medication was generated");
+    let medications = [
+        "Atorvastatin",
+        "Levothyroxine",
+        "Lisinopril",
+        "Metformin",
+        "Amlodipine",
+        "Metoprolol",
+        "Omeprazole",
+        "Simvastatin",
+        "Losartan",
+        "Albuterol",
+    ];
+    assert!(
+        medications.contains(&med.as_str()),
+        "Medication '{}' is not in the known list",
+        med
+    );
+}
+
+#[then("the allergen should be a known allergen")]
+fn then_allergen_known(world: &mut FakerWorld) {
+    let allergen = world.allergen.as_ref().expect("No allergen was generated");
+    let allergens = [
+        "Penicillin",
+        "Latex",
+        "Peanuts",
+        "Shellfish",
+        "Eggs",
+        "Milk",
+        "Tree Nuts",
+        "Soy",
+        "Wheat",
+        "Bee Stings",
+    ];
+    assert!(
+        allergens.contains(&allergen.as_str()),
+        "Allergen '{}' is not in the known list",
+        allergen
+    );
+}
+
+// ============================================================================
+// Then Steps — Patient Demographics
+// ============================================================================
+
+#[then("the blood type should be a valid ABO/Rh type")]
+fn then_blood_type_valid(world: &mut FakerWorld) {
+    let bt = world
+        .blood_type
+        .as_ref()
+        .expect("No blood type was generated");
+    let valid = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+    assert!(
+        valid.contains(&bt.as_str()),
+        "Blood type '{}' is not valid",
+        bt
+    );
+}
+
+#[then("the ethnicity should be a recognized value")]
+fn then_ethnicity_recognized(world: &mut FakerWorld) {
+    let eth = world
+        .ethnicity
+        .as_ref()
+        .expect("No ethnicity was generated");
+    let valid = [
+        "Hispanic or Latino",
+        "Not Hispanic or Latino",
+        "Declined to Specify",
+    ];
+    assert!(
+        valid.contains(&eth.as_str()),
+        "Ethnicity '{}' is not recognized",
+        eth
+    );
+}
+
+#[then("the race should be a recognized value")]
+fn then_race_recognized(world: &mut FakerWorld) {
+    let race = world.race.as_ref().expect("No race was generated");
+    let valid = [
+        "American Indian or Alaska Native",
+        "Asian",
+        "Black or African American",
+        "Native Hawaiian or Other Pacific Islander",
+        "White",
+        "Declined to Specify",
+    ];
+    assert!(
+        valid.contains(&race.as_str()),
+        "Race '{}' is not recognized",
+        race
+    );
+}
+
+// ============================================================================
+// Then Steps — Numeric Generation
+// ============================================================================
+
+#[then(regex = r"^the numeric string should be exactly (\d+) characters long$")]
+fn then_numeric_length(world: &mut FakerWorld, length: usize) {
+    let num = world
+        .numeric_string
+        .as_ref()
+        .expect("No numeric string was generated");
+    assert_eq!(
+        num.len(),
+        length,
+        "Numeric string '{}' has length {} but expected {}",
+        num,
+        num.len(),
+        length
+    );
+}
+
+#[then("the numeric string should contain only digits")]
+fn then_numeric_all_digits(world: &mut FakerWorld) {
+    let num = world
+        .numeric_string
+        .as_ref()
+        .expect("No numeric string was generated");
+    assert!(
+        num.chars().all(|c| c.is_ascii_digit()),
+        "Numeric string '{}' contains non-digit characters",
+        num
+    );
+}
+
+// ============================================================================
+// Then Steps — Date Generation
+// ============================================================================
+
+#[then("the date should be 8 digits in YYYYMMDD format")]
+fn then_date_format(world: &mut FakerWorld) {
+    let date = world
+        .date_result
+        .as_ref()
+        .expect("No date result")
+        .as_ref()
+        .expect("Date generation failed unexpectedly");
+    assert_eq!(date.len(), 8, "Date '{}' is not 8 characters", date);
+    assert!(
+        date.chars().all(|c| c.is_ascii_digit()),
+        "Date '{}' is not all digits",
+        date
+    );
+}
+
+#[then(regex = r#"^the date should be between "([^"]*)" and "([^"]*)"$"#)]
+fn then_date_in_range(world: &mut FakerWorld, start: String, end: String) {
+    let date = world
+        .date_result
+        .as_ref()
+        .expect("No date result")
+        .as_ref()
+        .expect("Date generation failed unexpectedly");
+    assert!(
+        date.as_str() >= start.as_str() && date.as_str() <= end.as_str(),
+        "Date '{}' is not between '{}' and '{}'",
+        date,
+        start,
+        end
+    );
+}
+
+#[then(regex = r#"^the date should be "([^"]*)"$"#)]
+fn then_date_equals(world: &mut FakerWorld, expected: String) {
+    let date = world
+        .date_result
+        .as_ref()
+        .expect("No date result")
+        .as_ref()
+        .expect("Date generation failed unexpectedly");
+    assert_eq!(date, &expected, "Date '{}' != '{}'", date, expected);
+}
+
+#[then("the date generation should fail with an invalid format error")]
+fn then_date_invalid_error(world: &mut FakerWorld) {
+    let result = world.date_result.as_ref().expect("No date result");
+    assert!(result.is_err(), "Expected date generation to fail");
+    assert!(
+        matches!(
+            result.as_ref().unwrap_err(),
+            hl7v2_faker::DateError::InvalidDateFormat(_)
+        ),
+        "Expected InvalidDateFormat error"
+    );
+}
+
+// ============================================================================
+// Then Steps — Gaussian Generation
+// ============================================================================
+
+#[then("the Gaussian value should be a valid number")]
+fn then_gaussian_valid(world: &mut FakerWorld) {
+    let value = world
+        .gaussian_value
+        .as_ref()
+        .expect("No Gaussian value was generated");
+    let _: f64 = value
+        .parse()
+        .unwrap_or_else(|_| panic!("Gaussian value '{}' is not a valid number", value));
+}
+
+#[then("the Gaussian value should be within 5 standard deviations of the mean")]
+fn then_gaussian_within_range(world: &mut FakerWorld) {
+    let value = world
+        .gaussian_value
+        .as_ref()
+        .expect("No Gaussian value was generated");
+    let parsed: f64 = value.parse().expect("Not a valid number");
+    let low = world.gaussian_mean - 5.0 * world.gaussian_sd;
+    let high = world.gaussian_mean + 5.0 * world.gaussian_sd;
+    assert!(
+        (low..=high).contains(&parsed),
+        "Gaussian value {} is not within 5 SDs of mean {} (range {}-{})",
+        parsed,
+        world.gaussian_mean,
+        low,
+        high
+    );
+}
+
+// ============================================================================
+// Then Steps — UUID Generation
+// ============================================================================
+
+#[then(regex = r"^the UUID should be (\d+) characters long$")]
+fn then_uuid_length(world: &mut FakerWorld, length: usize) {
+    let uuid = world.uuid.as_ref().expect("No UUID was generated");
+    assert_eq!(
+        uuid.len(),
+        length,
+        "UUID '{}' has length {} but expected {}",
+        uuid,
+        uuid.len(),
+        length
+    );
+}
+
+#[then(regex = r"^the UUID should have dashes at positions (\d+), (\d+), (\d+), and (\d+)$")]
+fn then_uuid_dash_positions(world: &mut FakerWorld, p1: usize, p2: usize, p3: usize, p4: usize) {
+    let uuid = world.uuid.as_ref().expect("No UUID was generated");
+    let chars: Vec<char> = uuid.chars().collect();
+    assert_eq!(chars[p1], '-', "UUID '{}' no dash at position {}", uuid, p1);
+    assert_eq!(chars[p2], '-', "UUID '{}' no dash at position {}", uuid, p2);
+    assert_eq!(chars[p3], '-', "UUID '{}' no dash at position {}", uuid, p3);
+    assert_eq!(chars[p4], '-', "UUID '{}' no dash at position {}", uuid, p4);
+}
+
+// ============================================================================
+// Then Steps — Timestamp Generation
+// ============================================================================
+
+#[then("the timestamp should be 14 digits in YYYYMMDDHHMMSS format")]
+fn then_timestamp_format(world: &mut FakerWorld) {
+    let ts = world
+        .timestamp
+        .as_ref()
+        .expect("No timestamp was generated");
+    assert_eq!(ts.len(), 14, "Timestamp '{}' is not 14 characters", ts);
+    assert!(
+        ts.chars().all(|c| c.is_ascii_digit()),
+        "Timestamp '{}' is not all digits",
+        ts
+    );
+}
+
+#[then(regex = r#"^the timestamp should start with "([^"]*)"$"#)]
+fn then_timestamp_starts_with(world: &mut FakerWorld, prefix: String) {
+    let ts = world
+        .timestamp
+        .as_ref()
+        .expect("No timestamp was generated");
+    assert!(
+        ts.starts_with(&prefix),
+        "Timestamp '{}' does not start with '{}'",
+        ts,
+        prefix
+    );
+}
+
+// ============================================================================
+// Then Steps — Selection Functions
+// ============================================================================
+
+#[then(regex = r#"^the selected value should be one of "([^"]*)"$"#)]
+fn then_selected_value_one_of(world: &mut FakerWorld, options_str: String) {
+    let options: Vec<&str> = options_str.split(',').collect();
+    let value = world
+        .selected_value
+        .as_ref()
+        .expect("No selection was made")
+        .as_ref()
+        .expect("Selection returned None");
+    assert!(
+        options.contains(&value.as_str()),
+        "Selected value '{}' is not one of {:?}",
+        value,
+        options
+    );
+}
+
+#[then("the selection should return nothing")]
+fn then_selection_none(world: &mut FakerWorld) {
+    let result = world
+        .selected_value
+        .as_ref()
+        .expect("No selection was made");
+    assert!(result.is_none(), "Expected None but got {:?}", result);
+}
+
+#[then(regex = r#"^the selected value should be one of the map values "([^"]*)"$"#)]
+fn then_map_selected_value_one_of(world: &mut FakerWorld, values_str: String) {
+    let values: Vec<&str> = values_str.split(',').collect();
+    let value = world
+        .map_selected_value
+        .as_ref()
+        .expect("No map selection was made")
+        .as_ref()
+        .expect("Map selection returned None");
+    assert!(
+        values.contains(&value.as_str()),
+        "Selected map value '{}' is not one of {:?}",
+        value,
+        values
+    );
+}
+
+#[then("the map selection should return nothing")]
+fn then_map_selection_none(world: &mut FakerWorld) {
+    let result = world
+        .map_selected_value
+        .as_ref()
+        .expect("No map selection was made");
+    assert!(result.is_none(), "Expected None but got {:?}", result);
+}
+
+// ============================================================================
+// Then Steps — FakerValue Enum Generation
+// ============================================================================
+
+#[then(regex = r#"^the generated value should be "([^"]*)"$"#)]
+fn then_generated_value_equals(world: &mut FakerWorld, expected: String) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert_eq!(
+        value, &expected,
+        "Generated '{}' but expected '{}'",
+        value, expected
+    );
+}
+
+#[then(regex = r#"^the generated value should be one of "([^"]*)"$"#)]
+fn then_generated_value_one_of(world: &mut FakerWorld, options_str: String) {
+    let options: Vec<&str> = options_str.split(',').collect();
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert!(
+        options.contains(&value.as_str()),
+        "Generated value '{}' is not one of {:?}",
+        value,
+        options
+    );
+}
+
+#[then("the generation should fail with an empty options error")]
+fn then_generation_fails_empty_options(world: &mut FakerWorld) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    assert!(result.is_err(), "Expected error but got success");
+    assert!(
+        matches!(result.as_ref().unwrap_err(), GenerateError::EmptyOptions),
+        "Expected EmptyOptions error but got {:?}",
+        result
+    );
+}
+
+#[then(regex = r"^the generated value should be (\d+) characters long$")]
+fn then_generated_value_length(world: &mut FakerWorld, length: usize) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert_eq!(
+        value.len(),
+        length,
+        "Generated value '{}' has length {} but expected {}",
+        value,
+        value.len(),
+        length
+    );
+}
+
+#[then("the generated value should contain only digits")]
+fn then_generated_value_all_digits(world: &mut FakerWorld) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert!(
+        value.chars().all(|c| c.is_ascii_digit()),
+        "Generated value '{}' contains non-digit characters",
+        value
+    );
+}
+
+#[then(regex = r#"^the generated value should contain "([^"]*)"$"#)]
+fn then_generated_value_contains(world: &mut FakerWorld, substring: String) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert!(
+        value.contains(&substring),
+        "Generated value '{}' does not contain '{}'",
+        value,
+        substring
+    );
+}
+
+#[then(regex = r#"^the generated value should start with "([^"]*)"$"#)]
+fn then_generated_value_starts_with(world: &mut FakerWorld, prefix: String) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert!(
+        value.starts_with(&prefix),
+        "Generated value '{}' does not start with '{}'",
+        value,
+        prefix
+    );
+}
+
+#[then(regex = r"^the generated value length should be between (\d+) and (\d+)$")]
+fn then_generated_value_length_range(world: &mut FakerWorld, min: usize, max: usize) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    let value = result.as_ref().expect("FakerValue generation failed");
+    assert!(
+        (min..=max).contains(&value.len()),
+        "Generated value '{}' has length {} but expected between {} and {}",
+        value,
+        value.len(),
+        min,
+        max
+    );
+}
+
+#[then("the generation should fail with an empty map error")]
+fn then_generation_fails_empty_map(world: &mut FakerWorld) {
+    let result = world
+        .faker_value_result
+        .as_ref()
+        .expect("No FakerValue result");
+    assert!(result.is_err(), "Expected error but got success");
+    assert!(
+        matches!(result.as_ref().unwrap_err(), GenerateError::EmptyMap),
+        "Expected EmptyMap error but got {:?}",
+        result
+    );
+}
+
+// ============================================================================
+// Then Steps — Determinism
+// ============================================================================
+
+#[then("both sets of generated data should be identical")]
+fn then_both_data_sets_identical(world: &mut FakerWorld) {
+    let set1 = world
+        .all_data_set1
+        .as_ref()
+        .expect("No first data set generated");
+    let set2 = world
+        .all_data_set2
+        .as_ref()
+        .expect("No second data set generated");
+    assert_eq!(
+        set1, set2,
+        "Data sets differ:\nSet 1: {:?}\nSet 2: {:?}",
+        set1, set2
+    );
+}
+
+// ============================================================================
+// Cucumber Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() {
+    FakerWorld::run("tests/features/faker.feature").await;
+}

--- a/crates/hl7v2-faker/tests/features/faker.feature
+++ b/crates/hl7v2-faker/tests/features/faker.feature
@@ -1,0 +1,280 @@
+Feature: Realistic HL7 v2 Test Data Generation
+  As a test engineer
+  I want to generate realistic fake healthcare data
+  So that I can build representative HL7 test messages
+
+  # ============================================================================
+  # Name Generation
+  # ============================================================================
+
+  Scenario: Generate a male name in HL7 format
+    Given a faker with seed 42
+    When I generate a name with gender "M"
+    Then the name should be in "LAST^FIRST" format
+    And the first name should be a known male name
+
+  Scenario: Generate a female name in HL7 format
+    Given a faker with seed 42
+    When I generate a name with gender "F"
+    Then the name should be in "LAST^FIRST" format
+    And the first name should be a known female name
+
+  Scenario: Generate a name with no gender specified
+    Given a faker with seed 42
+    When I generate a name with no gender
+    Then the name should be in "LAST^FIRST" format
+
+  Scenario: Name generation is deterministic with same seed
+    Given a faker with seed 42
+    When I generate a name with gender "M"
+    And I generate another name with gender "M" using seed 42
+    Then both names should be identical
+
+  # ============================================================================
+  # Address Generation
+  # ============================================================================
+
+  Scenario: Generate an address in HL7 format
+    Given a faker with seed 42
+    When I generate an address
+    Then the address should contain component separators
+    And the address should end with "USA"
+    And the address should have a street number between 100 and 9999
+
+  # ============================================================================
+  # Phone Number Generation
+  # ============================================================================
+
+  Scenario: Generate a phone number
+    Given a faker with seed 42
+    When I generate a phone number
+    Then the phone number should match the format "(XXX)XXX-XXXX"
+    And the phone number should be 13 characters long
+
+  # ============================================================================
+  # SSN Generation
+  # ============================================================================
+
+  Scenario: Generate a Social Security Number
+    Given a faker with seed 42
+    When I generate an SSN
+    Then the SSN should match the format "XXX-XX-XXXX"
+    And the SSN should contain exactly 9 digits
+
+  # ============================================================================
+  # MRN Generation
+  # ============================================================================
+
+  Scenario: Generate a Medical Record Number
+    Given a faker with seed 42
+    When I generate an MRN
+    Then the MRN should be between 6 and 10 digits long
+    And the MRN should contain only digits
+
+  # ============================================================================
+  # Medical Code Generation
+  # ============================================================================
+
+  Scenario: Generate an ICD-10 code
+    Given a faker with seed 42
+    When I generate an ICD-10 code
+    Then the ICD-10 code should match the format "LNN.N"
+    And the ICD-10 code should start with an uppercase letter
+
+  Scenario: Generate a LOINC code
+    Given a faker with seed 42
+    When I generate a LOINC code
+    Then the LOINC code should be between 5 and 7 digits long
+    And the LOINC code should contain only digits
+
+  # ============================================================================
+  # Medication and Allergen Generation
+  # ============================================================================
+
+  Scenario: Generate a medication name
+    Given a faker with seed 42
+    When I generate a medication name
+    Then the medication should be a known medication
+
+  Scenario: Generate an allergen name
+    Given a faker with seed 42
+    When I generate an allergen name
+    Then the allergen should be a known allergen
+
+  # ============================================================================
+  # Patient Demographics
+  # ============================================================================
+
+  Scenario: Generate a blood type
+    Given a faker with seed 42
+    When I generate a blood type
+    Then the blood type should be a valid ABO/Rh type
+
+  Scenario: Generate an ethnicity
+    Given a faker with seed 42
+    When I generate an ethnicity
+    Then the ethnicity should be a recognized value
+
+  Scenario: Generate a race
+    Given a faker with seed 42
+    When I generate a race
+    Then the race should be a recognized value
+
+  # ============================================================================
+  # Numeric Generation
+  # ============================================================================
+
+  Scenario: Generate a numeric string of specified length
+    Given a faker with seed 42
+    When I generate a numeric string of 8 digits
+    Then the numeric string should be exactly 8 characters long
+    And the numeric string should contain only digits
+
+  Scenario: Generate a zero-length numeric string
+    Given a faker with seed 42
+    When I generate a numeric string of 0 digits
+    Then the numeric string should be exactly 0 characters long
+
+  # ============================================================================
+  # Date Generation
+  # ============================================================================
+
+  Scenario: Generate a date within a valid range
+    Given a faker with seed 42
+    When I generate a date between "20200101" and "20201231"
+    Then the date should be 8 digits in YYYYMMDD format
+    And the date should be between "20200101" and "20201231"
+
+  Scenario: Generate a date with identical start and end
+    Given a faker with seed 42
+    When I generate a date between "20200601" and "20200601"
+    Then the date should be "20200601"
+
+  Scenario: Generate a date with invalid start format
+    Given a faker with seed 42
+    When I generate a date between "invalid" and "20201231"
+    Then the date generation should fail with an invalid format error
+
+  # ============================================================================
+  # Gaussian Distribution
+  # ============================================================================
+
+  Scenario: Generate a Gaussian distributed value
+    Given a faker with seed 42
+    When I generate a Gaussian value with mean 100.0 stddev 10.0 precision 2
+    Then the Gaussian value should be a valid number
+    And the Gaussian value should be within 5 standard deviations of the mean
+
+  # ============================================================================
+  # UUID Generation
+  # ============================================================================
+
+  Scenario: Generate a UUID v4
+    Given a faker with seed 42
+    When I generate a UUID v4
+    Then the UUID should be 36 characters long
+    And the UUID should have dashes at positions 8, 13, 18, and 23
+
+  # ============================================================================
+  # Timestamp Generation
+  # ============================================================================
+
+  Scenario: Generate a current UTC timestamp
+    Given a faker with seed 42
+    When I generate a UTC timestamp
+    Then the timestamp should be 14 digits in YYYYMMDDHHMMSS format
+    And the timestamp should start with "202"
+
+  # ============================================================================
+  # Selection Functions
+  # ============================================================================
+
+  Scenario: Select from a list of options
+    Given a faker with seed 42
+    When I select from the list "apple,banana,cherry"
+    Then the selected value should be one of "apple,banana,cherry"
+
+  Scenario: Select from an empty list
+    Given a faker with seed 42
+    When I select from an empty list
+    Then the selection should return nothing
+
+  Scenario: Select from a key-value map
+    Given a faker with seed 42
+    When I select from a map with entries "k1=v1,k2=v2,k3=v3"
+    Then the selected value should be one of the map values "v1,v2,v3"
+
+  Scenario: Select from an empty map
+    Given a faker with seed 42
+    When I select from an empty map
+    Then the map selection should return nothing
+
+  # ============================================================================
+  # FakerValue Enum Generation
+  # ============================================================================
+
+  Scenario: FakerValue::Fixed returns the fixed string
+    Given a faker with seed 42
+    When I generate a FakerValue::Fixed with value "Hello HL7"
+    Then the generated value should be "Hello HL7"
+
+  Scenario: FakerValue::From selects from options
+    Given a faker with seed 42
+    When I generate a FakerValue::From with options "X,Y,Z"
+    Then the generated value should be one of "X,Y,Z"
+
+  Scenario: FakerValue::From with empty list returns error
+    Given a faker with seed 42
+    When I generate a FakerValue::From with no options
+    Then the generation should fail with an empty options error
+
+  Scenario: FakerValue::Numeric generates digits
+    Given a faker with seed 42
+    When I generate a FakerValue::Numeric with 5 digits
+    Then the generated value should be 5 characters long
+    And the generated value should contain only digits
+
+  Scenario: FakerValue::RealisticName generates HL7 name
+    Given a faker with seed 42
+    When I generate a FakerValue::RealisticName for gender "M"
+    Then the generated value should contain "^"
+
+  Scenario: FakerValue::RealisticAddress generates HL7 address
+    Given a faker with seed 42
+    When I generate a FakerValue::RealisticAddress
+    Then the generated value should contain "USA"
+
+  Scenario: FakerValue::RealisticPhone generates phone number
+    Given a faker with seed 42
+    When I generate a FakerValue::RealisticPhone
+    Then the generated value should start with "("
+
+  Scenario: FakerValue::RealisticSsn generates SSN
+    Given a faker with seed 42
+    When I generate a FakerValue::RealisticSsn
+    Then the generated value should be 11 characters long
+
+  Scenario: FakerValue::RealisticMrn generates MRN
+    Given a faker with seed 42
+    When I generate a FakerValue::RealisticMrn
+    Then the generated value length should be between 6 and 10
+
+  Scenario: FakerValue::RealisticBloodType generates valid blood type
+    Given a faker with seed 42
+    When I generate a FakerValue::RealisticBloodType
+    Then the generated value should be one of "A+,A-,B+,B-,AB+,AB-,O+,O-"
+
+  Scenario: FakerValue::Map with empty map returns error
+    Given a faker with seed 42
+    When I generate a FakerValue::Map with no entries
+    Then the generation should fail with an empty map error
+
+  # ============================================================================
+  # Determinism Across All Methods
+  # ============================================================================
+
+  Scenario: All faker methods are deterministic with the same seed
+    Given a faker with seed 42
+    When I generate all data types
+    And I generate all data types again with seed 42
+    Then both sets of generated data should be identical

--- a/crates/hl7v2-faker/tests/integration_tests.rs
+++ b/crates/hl7v2-faker/tests/integration_tests.rs
@@ -19,7 +19,7 @@ fn test_name_in_hl7_message_context() {
     // Should be usable in PID segment
     let pid_segment = format!("PID|1||{}^^^HOSP^MR||{}", faker.mrn(), name);
     assert!(pid_segment.contains("PID|"));
-    assert!(pid_segment.contains("^"));
+    assert!(pid_segment.contains('^'));
 }
 
 #[test]
@@ -71,11 +71,11 @@ fn test_clinical_codes_integration() {
 
     // Build DG1 segment (diagnosis)
     let dg1 = format!("DG1|1||{}|Diagnosis description", icd10);
-    assert!(dg1.contains("."));
+    assert!(dg1.contains('.'));
 
     // Build OBR segment (observation request)
     let obr = format!("OBR|1|||{}^Lab Test", loinc);
-    assert!(obr.contains("^"));
+    assert!(obr.contains('^'));
 
     // Build RXO segment (pharmacy order)
     let rxo = format!("RXO|{}^{}^TAB", medication, medication);

--- a/crates/hl7v2-gen/CLAUDE.md
+++ b/crates/hl7v2-gen/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-gen
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-gen
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-gen
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-gen -- -D warnings
-`
+```

--- a/crates/hl7v2-gen/src/tests.rs
+++ b/crates/hl7v2-gen/src/tests.rs
@@ -11,10 +11,10 @@ use std::collections::HashMap;
 fn test_generate_simple_message() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -32,10 +32,10 @@ fn test_generate_simple_message() {
 fn test_generate_multiple_messages() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -53,10 +53,10 @@ fn test_generate_multiple_messages() {
 fn test_generate_deterministic() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -79,10 +79,10 @@ fn test_generate_different_seeds() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -109,10 +109,10 @@ fn test_generate_with_uuid() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -134,10 +134,10 @@ fn test_generate_with_date() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John|||M||||"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John|||M||||".to_string(),
         ],
         values,
     };
@@ -160,10 +160,10 @@ fn test_generate_with_gaussian() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John|||M||||"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John|||M||||".to_string(),
         ],
         values,
     };
@@ -177,15 +177,15 @@ fn test_generate_with_fixed_value() {
     let mut values = HashMap::new();
     values.insert(
         "PID.5".to_string(),
-        vec![ValueSource::Fixed(r#"Smith^John"#.to_string())],
+        vec![ValueSource::Fixed(r"Smith^John".to_string())],
     );
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -200,18 +200,18 @@ fn test_generate_with_from_value() {
     values.insert(
         "PID.5".to_string(),
         vec![ValueSource::From(vec![
-            r#"Smith^John"#.to_string(),
-            r#"Doe^Jane"#.to_string(),
-            r#"Brown^Bob"#.to_string(),
+            r"Smith^John".to_string(),
+            r"Doe^Jane".to_string(),
+            r"Brown^Bob".to_string(),
         ])],
     );
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -230,10 +230,10 @@ fn test_generate_with_numeric() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -250,9 +250,9 @@ fn test_generate_with_numeric() {
 fn test_generate_invalid_segment_id() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"INVALID|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
+            r"INVALID|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -267,7 +267,7 @@ fn test_generate_invalid_delimiters() {
         name: "test".to_string(),
         delims: "^^".to_string(), // Too short
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -282,7 +282,7 @@ fn test_generate_duplicate_delimiters() {
         name: "test".to_string(),
         delims: "^^^^".to_string(), // Duplicate characters
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -389,7 +389,7 @@ fn test_faker_value_generation() {
 fn test_template_clone() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec!["MSH|...".to_string()],
         values: HashMap::new(),
     };
@@ -404,7 +404,7 @@ fn test_template_clone() {
 fn test_template_debug() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec!["MSH|...".to_string()],
         values: HashMap::new(),
     };
@@ -422,9 +422,9 @@ fn test_template_debug() {
 fn test_generate_zero_messages() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -441,10 +441,10 @@ fn test_generate_zero_messages() {
 fn test_generate_many_messages() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -464,16 +464,16 @@ fn test_generate_with_multiple_value_sources() {
         "PID.3".to_string(),
         vec![
             ValueSource::Numeric { digits: 3 },
-            ValueSource::Fixed(r#"^^^HOSP^MR"#.to_string()),
+            ValueSource::Fixed(r"^^^HOSP^MR".to_string()),
         ],
     );
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -490,10 +490,10 @@ fn test_generate_with_multiple_value_sources() {
 fn test_generate_adt_a04() {
     let template = Template {
         name: "adt_a04".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A04^ADT_A04|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A04^ADT_A04|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -510,12 +510,12 @@ fn test_generate_adt_a04() {
 fn test_generate_oru_r01() {
     let template = Template {
         name: "oru_r01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ORU^R01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
-            r#"OBR|1|||1234^Test"#.to_string(),
-            r#"OBX|1|NM|1234^Result||120|mg/dL"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ORU^R01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
+            r"OBR|1|||1234^Test".to_string(),
+            r"OBX|1|NM|1234^Result||120|mg/dL".to_string(),
         ],
         values: HashMap::new(),
     };

--- a/crates/hl7v2-gen/tests/bdd_tests.rs
+++ b/crates/hl7v2-gen/tests/bdd_tests.rs
@@ -69,8 +69,7 @@ fn given_dynamic_template(world: &mut GenWorld) {
         name: "dynamic".to_string(),
         delims: r"^~\&".to_string(),
         segments: vec![
-            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
-                .to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
             r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
@@ -85,8 +84,7 @@ fn given_template_fixed_pid5(world: &mut GenWorld, value: String) {
         name: "fixed".to_string(),
         delims: r"^~\&".to_string(),
         segments: vec![
-            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
-                .to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
             r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
@@ -95,15 +93,17 @@ fn given_template_fixed_pid5(world: &mut GenWorld, value: String) {
 
 #[given(regex = r#"a template with PID\.8 from list "([^"]+)""#)]
 fn given_template_from_list(world: &mut GenWorld, list: String) {
-    let items: Vec<String> = list.split(',').map(std::string::ToString::to_string).collect();
+    let items: Vec<String> = list
+        .split(',')
+        .map(std::string::ToString::to_string)
+        .collect();
     let mut values = HashMap::new();
     values.insert("PID.8".to_string(), vec![ValueSource::From(items)]);
     world.template = Some(Template {
         name: "from_list".to_string(),
         delims: r"^~\&".to_string(),
         segments: vec![
-            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
-                .to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
             r"PID|1||123456^^^HOSP^MR||Doe^John||19800101|M".to_string(),
         ],
         values,
@@ -118,8 +118,7 @@ fn given_template_uuid(world: &mut GenWorld) {
         name: "uuid".to_string(),
         delims: r"^~\&".to_string(),
         segments: vec![
-            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
-                .to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
             r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
@@ -137,8 +136,7 @@ fn given_template_numeric(world: &mut GenWorld) {
         name: "numeric".to_string(),
         delims: r"^~\&".to_string(),
         segments: vec![
-            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
-                .to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
             r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
@@ -153,8 +151,7 @@ fn given_template_date_range(world: &mut GenWorld, start: String, end: String) {
         name: "date".to_string(),
         delims: r"^~\&".to_string(),
         segments: vec![
-            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
-                .to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
             r"PID|1||123456^^^HOSP^MR||Doe^John|||M||||".to_string(),
         ],
         values,

--- a/crates/hl7v2-gen/tests/bdd_tests.rs
+++ b/crates/hl7v2-gen/tests/bdd_tests.rs
@@ -36,11 +36,11 @@ impl GenWorld {
     fn simple_adt_template() -> Template {
         Template {
             name: "adt_a01".to_string(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+                r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                     .to_string(),
-                r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+                r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
             ],
             values: HashMap::new(),
         }
@@ -67,11 +67,11 @@ fn given_dynamic_template(world: &mut GenWorld) {
     values.insert("PID.3".to_string(), vec![ValueSource::UuidV4]);
     world.template = Some(Template {
         name: "dynamic".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                 .to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     });
@@ -83,11 +83,11 @@ fn given_template_fixed_pid5(world: &mut GenWorld, value: String) {
     values.insert("PID.5".to_string(), vec![ValueSource::Fixed(value)]);
     world.template = Some(Template {
         name: "fixed".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                 .to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     });
@@ -95,16 +95,16 @@ fn given_template_fixed_pid5(world: &mut GenWorld, value: String) {
 
 #[given(regex = r#"a template with PID\.8 from list "([^"]+)""#)]
 fn given_template_from_list(world: &mut GenWorld, list: String) {
-    let items: Vec<String> = list.split(',').map(|s| s.to_string()).collect();
+    let items: Vec<String> = list.split(',').map(std::string::ToString::to_string).collect();
     let mut values = HashMap::new();
     values.insert("PID.8".to_string(), vec![ValueSource::From(items)]);
     world.template = Some(Template {
         name: "from_list".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                 .to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John||19800101|M"#.to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John||19800101|M".to_string(),
         ],
         values,
     });
@@ -116,11 +116,11 @@ fn given_template_uuid(world: &mut GenWorld) {
     values.insert("PID.3".to_string(), vec![ValueSource::UuidV4]);
     world.template = Some(Template {
         name: "uuid".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                 .to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     });
@@ -135,11 +135,11 @@ fn given_template_numeric(world: &mut GenWorld) {
     );
     world.template = Some(Template {
         name: "numeric".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                 .to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     });
@@ -151,11 +151,11 @@ fn given_template_date_range(world: &mut GenWorld, start: String, end: String) {
     values.insert("PID.7".to_string(), vec![ValueSource::Date { start, end }]);
     world.template = Some(Template {
         name: "date".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"
                 .to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John|||M||||"#.to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John|||M||||".to_string(),
         ],
         values,
     });
@@ -174,12 +174,12 @@ fn given_template_gaussian(world: &mut GenWorld) {
     );
     world.template = Some(Template {
         name: "gaussian".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ORU^R01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
-            r#"OBR|1|||1234^Test"#.to_string(),
-            r#"OBX|1|NM|1234^Result||120|mg/dL"#.to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ORU^R01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
+            r"OBR|1|||1234^Test".to_string(),
+            r"OBX|1|NM|1234^Result||120|mg/dL".to_string(),
         ],
         values,
     });
@@ -198,12 +198,12 @@ fn given_valid_message_for_ack(world: &mut GenWorld) {
 fn given_oru_template(world: &mut GenWorld) {
     world.template = Some(Template {
         name: "oru_r01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ORU^R01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
-            r#"OBR|1|||1234^Test"#.to_string(),
-            r#"OBX|1|NM|1234^Result||120|mg/dL"#.to_string(),
+            r"MSH|^~\&|App|Fac|Recv|Fac|20250128152312||ORU^R01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
+            r"OBR|1|||1234^Test".to_string(),
+            r"OBX|1|NM|1234^Result||120|mg/dL".to_string(),
         ],
         values: HashMap::new(),
     });

--- a/crates/hl7v2-gen/tests/integration_tests.rs
+++ b/crates/hl7v2-gen/tests/integration_tests.rs
@@ -11,12 +11,12 @@ use std::collections::HashMap;
 fn test_full_adt_a01_generation() {
     let template = Template {
         name: "adt_a01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"EVN|A01|20250128152312||"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John^Robert||19700101|M|||123 Main St^^Anytown^CA^12345^USA||(555)123-4567|||M|S|123456789||"#.to_string(),
-            r#"PV1|1|I|ICU^01^01||||123456^Smith^John^J^^MD||||||||ADM|A0||||||||||||||||||||||||||"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"EVN|A01|20250128152312||".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John^Robert||19700101|M|||123 Main St^^Anytown^CA^12345^USA||(555)123-4567|||M|S|123456789||".to_string(),
+            r"PV1|1|I|ICU^01^01||||123456^Smith^John^J^^MD||||||||ADM|A0||||||||||||||||||||||||||".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -57,10 +57,10 @@ fn test_generation_with_value_substitution() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John||19700101|M"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John||19700101|M".to_string(),
         ],
         values,
     };
@@ -81,9 +81,9 @@ fn test_generation_with_uuid() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
         ],
         values,
     };
@@ -206,10 +206,10 @@ fn test_faker_value_integration() {
 fn test_generate_parse_query() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -233,10 +233,10 @@ fn test_generate_parse_query() {
 fn test_generate_normalize() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -263,10 +263,10 @@ fn test_generate_normalize() {
 fn test_large_corpus_generation() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -288,14 +288,14 @@ fn test_large_corpus_generation() {
 fn test_oru_r01_generation() {
     let template = Template {
         name: "oru_r01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|LabSystem|Lab|HIS|Hospital|20250128152312||ORU^R01|LAB00001|P|2.5.1"#
+            r"MSH|^~\&|LabSystem|Lab|HIS|Hospital|20250128152312||ORU^R01|LAB00001|P|2.5.1"
                 .to_string(),
-            r#"PID|1||PATID123||Smith^Jane"#.to_string(),
-            r#"OBR|1||ORD001|CBC^Complete Blood Count^L"#.to_string(),
-            r#"OBX|1|NM|HB^Hemoglobin^L||13.2|g/dL|11.5-17.5||||F"#.to_string(),
-            r#"OBX|2|NM|WBC^White Blood Count^L||7.5|10^9/L|4.0-11.0||||F"#.to_string(),
+            r"PID|1||PATID123||Smith^Jane".to_string(),
+            r"OBR|1||ORD001|CBC^Complete Blood Count^L".to_string(),
+            r"OBX|1|NM|HB^Hemoglobin^L||13.2|g/dL|11.5-17.5||||F".to_string(),
+            r"OBX|2|NM|WBC^White Blood Count^L||7.5|10^9/L|4.0-11.0||||F".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -309,10 +309,10 @@ fn test_oru_r01_generation() {
 fn test_adt_a04_generation() {
     let template = Template {
         name: "adt_a04".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|ADT1|MCM|LABADT|MCM|198808181126||ADT^A04|MSG00001|P|2.5.1"#.to_string(),
-            r#"PID|1||PATID1234^5^M11^ADT1^MR^MCM~~~123456789||JONES^WILLIAM^A^III||19610615|M"#
+            r"MSH|^~\&|ADT1|MCM|LABADT|MCM|198808181126||ADT^A04|MSG00001|P|2.5.1".to_string(),
+            r"PID|1||PATID1234^5^M11^ADT1^MR^MCM~~~123456789||JONES^WILLIAM^A^III||19610615|M"
                 .to_string(),
         ],
         values: HashMap::new(),
@@ -336,7 +336,7 @@ fn test_invalid_template_handling() {
         name: "test".to_string(),
         delims: "^^".to_string(), // Invalid - too short
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -353,10 +353,10 @@ fn test_invalid_template_handling() {
 fn test_same_seed_same_output() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -381,10 +381,10 @@ fn test_different_seed_different_output() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };

--- a/crates/hl7v2-gen/tests/property_tests.rs
+++ b/crates/hl7v2-gen/tests/property_tests.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 fn test_template_creation() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|123|P|2.5"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|123|P|2.5".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -20,10 +20,10 @@ fn test_template_creation() {
 fn test_generate_simple_message() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|123|P|2.5"#.to_string(),
-            r#"PID|1||456|Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|123|P|2.5".to_string(),
+            r"PID|1||456|Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };

--- a/crates/hl7v2-json/CLAUDE.md
+++ b/crates/hl7v2-json/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-json
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-json
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-json
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-json -- -D warnings
-`
+```

--- a/crates/hl7v2-json/tests/bdd_tests.rs
+++ b/crates/hl7v2-json/tests/bdd_tests.rs
@@ -214,7 +214,7 @@ fn given_message_special_chars(world: &mut JsonWorld) {
     world.message = Some(message);
 }
 
-#[given(regex = r#"a ([A-Z]{3}\^[A-Z0-9]{2,3}) message"#)]
+#[given(regex = r"a ([A-Z]{3}\^[A-Z0-9]{2,3}) message")]
 fn given_message_type(world: &mut JsonWorld, message_type: String) {
     let delims = Delims::default();
     let mut msh = JsonWorld::create_msh_segment(&delims);

--- a/crates/hl7v2-mllp/CLAUDE.md
+++ b/crates/hl7v2-mllp/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-mllp
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-mllp
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-mllp
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-mllp -- -D warnings
-`
+```

--- a/crates/hl7v2-mllp/Cargo.toml
+++ b/crates/hl7v2-mllp/Cargo.toml
@@ -19,6 +19,12 @@ thiserror = { workspace = true }
 [dev-dependencies]
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"
+cucumber = "0.22.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "bdd_tests"
+harness = false
 
 [features]
 default = []

--- a/crates/hl7v2-mllp/features/mllp.feature
+++ b/crates/hl7v2-mllp/features/mllp.feature
@@ -1,0 +1,76 @@
+Feature: MLLP (Minimal Lower Layer Protocol) Framing
+  As an HL7 message transport layer
+  I want to frame and unframe HL7 messages using MLLP
+  So that messages can be reliably transmitted over TCP connections
+
+  Scenario: Wrap a simple HL7 message
+    Given an HL7 message "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128||ADT^A01|MSG001|P|2.5.1\r"
+    When I wrap it with MLLP framing
+    Then the first byte should be 0x0B
+    And the second-to-last byte should be 0x1C
+    And the last byte should be 0x0D
+    And the wrapped length should be the message length plus 3
+
+  Scenario: Unwrap a framed message
+    Given an HL7 message "MSH|^~\\&|TEST\r"
+    And the message is wrapped with MLLP framing
+    When I unwrap the MLLP frame
+    Then the unwrapped content should equal the original message
+
+  Scenario: Roundtrip wrap then unwrap
+    Given an HL7 message "MSH|^~\\&|App|Fac|Recv|RecvFac|20250128||ADT^A01|ABC123|P|2.5.1\rPID|1||12345\r"
+    When I wrap it with MLLP framing
+    And I unwrap the MLLP frame
+    Then the unwrapped content should equal the original message
+
+  Scenario: Detect MLLP framing on a framed message
+    Given an HL7 message "MSH|^~\\&|TEST\r"
+    And the message is wrapped with MLLP framing
+    When I check if the data is MLLP framed
+    Then the result should be true
+
+  Scenario: Detect non-MLLP data
+    Given raw bytes "MSH|^~\\&|TEST\r"
+    When I check if the data is MLLP framed
+    Then the result should be false
+
+  Scenario: Missing start block error
+    Given raw bytes "MSH|^~\\&|TEST\r"
+    When I try to unwrap the data with checked unwrap
+    Then the error should be MissingStartBlock
+
+  Scenario: Missing end block error
+    Given a byte sequence starting with 0x0B followed by "MSH|TEST"
+    When I try to unwrap the data with checked unwrap
+    Then the error should be MissingEndBlock
+
+  Scenario: Empty message wrapping
+    Given an empty message
+    When I wrap it with MLLP framing
+    Then the wrapped length should be 3
+    And the first byte should be 0x0B
+    And the second-to-last byte should be 0x1C
+    And the last byte should be 0x0D
+
+  Scenario: Find complete message length
+    Given an HL7 message "MSH|^~\\&|TEST\r"
+    And the message is wrapped with MLLP framing
+    When I search for a complete MLLP message
+    Then the found length should equal the wrapped data length
+
+  Scenario: Frame iterator with single message
+    Given an MLLP frame iterator
+    And an HL7 message "MSH|^~\\&|SINGLE\r" wrapped with MLLP framing is added to the iterator
+    When I extract the next message from the iterator
+    Then the extracted message should be "MSH|^~\\&|SINGLE\r"
+    And there should be no more messages in the iterator
+
+  Scenario: Frame iterator with multiple messages
+    Given an MLLP frame iterator
+    And an HL7 message "MSH|^~\\&|FIRST\r" wrapped with MLLP framing is added to the iterator
+    And an HL7 message "MSH|^~\\&|SECOND\r" wrapped with MLLP framing is added to the iterator
+    When I extract the next message from the iterator
+    Then the extracted message should be "MSH|^~\\&|FIRST\r"
+    When I extract the next message from the iterator
+    Then the extracted message should be "MSH|^~\\&|SECOND\r"
+    And there should be no more messages in the iterator

--- a/crates/hl7v2-mllp/src/lib.rs
+++ b/crates/hl7v2-mllp/src/lib.rs
@@ -201,7 +201,7 @@ pub fn unwrap_mllp_checked(bytes: &[u8]) -> Result<&[u8], MllpError> {
 ///
 /// The HL7 message bytes as an owned Vec, or an error if the framing is invalid
 pub fn unwrap_mllp_owned(bytes: &[u8]) -> Result<Vec<u8>, Error> {
-    unwrap_mllp(bytes).map(|s| s.to_vec())
+    unwrap_mllp(bytes).map(<[u8]>::to_vec)
 }
 
 /// Unwrap MLLP-framed bytes and return owned data with specific MLLP error types.
@@ -217,7 +217,7 @@ pub fn unwrap_mllp_owned(bytes: &[u8]) -> Result<Vec<u8>, Error> {
 ///
 /// The HL7 message bytes as an owned Vec, or a specific MllpError if the framing is invalid
 pub fn unwrap_mllp_owned_checked(bytes: &[u8]) -> Result<Vec<u8>, MllpError> {
-    unwrap_mllp_checked(bytes).map(|s| s.to_vec())
+    unwrap_mllp_checked(bytes).map(<[u8]>::to_vec)
 }
 
 /// Find the MLLP end sequence position.

--- a/crates/hl7v2-mllp/src/tests.rs
+++ b/crates/hl7v2-mllp/src/tests.rs
@@ -310,7 +310,7 @@ fn test_frame_iterator_byte_by_byte() {
     let framed = wrap_mllp(hl7);
 
     // Add byte by byte
-    for byte in framed.iter() {
+    for byte in &framed {
         iter.extend(&[*byte]);
         if iter.buffer_len() < framed.len() {
             assert!(iter.next_message().is_none());

--- a/crates/hl7v2-mllp/tests/bdd_tests.rs
+++ b/crates/hl7v2-mllp/tests/bdd_tests.rs
@@ -1,0 +1,293 @@
+//! BDD tests for hl7v2-mllp using Cucumber
+//!
+//! Run with: cargo test --test bdd_tests -p hl7v2-mllp
+
+use cucumber::{World, given, then, when};
+use hl7v2_mllp::{
+    MllpError, MllpFrameIterator, find_complete_mllp_message, is_mllp_framed, unwrap_mllp,
+    unwrap_mllp_checked, wrap_mllp,
+};
+
+/// Test world for MLLP BDD tests
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct MllpWorld {
+    /// Original HL7 message bytes
+    original_message: Vec<u8>,
+    /// MLLP-wrapped data
+    wrapped_data: Vec<u8>,
+    /// Unwrapped result (if successful)
+    unwrapped_data: Option<Vec<u8>>,
+    /// Boolean result from is_mllp_framed
+    framed_check_result: Option<bool>,
+    /// Error result from unwrap_mllp_checked
+    checked_error: Option<MllpError>,
+    /// Length found by find_complete_mllp_message
+    found_length: Option<usize>,
+    /// Frame iterator for streaming tests
+    frame_iterator: MllpFrameIterator,
+    /// Last extracted message from the iterator
+    extracted_message: Option<Vec<u8>>,
+    /// Raw bytes for direct manipulation
+    raw_bytes: Vec<u8>,
+}
+
+impl MllpWorld {
+    fn new() -> Self {
+        Self {
+            original_message: Vec::new(),
+            wrapped_data: Vec::new(),
+            unwrapped_data: None,
+            framed_check_result: None,
+            checked_error: None,
+            found_length: None,
+            frame_iterator: MllpFrameIterator::new(),
+            extracted_message: None,
+            raw_bytes: Vec::new(),
+        }
+    }
+}
+
+/// Interpret Gherkin string literals, converting `\r` escape to carriage return.
+fn parse_hl7_string(s: &str) -> Vec<u8> {
+    s.replace("\\r", "\r").into_bytes()
+}
+
+// ============================================================================
+// Given Steps
+// ============================================================================
+
+#[given(regex = r#"^an HL7 message "([^"]*)"$"#)]
+fn given_hl7_message(world: &mut MllpWorld, message: String) {
+    world.original_message = parse_hl7_string(&message);
+}
+
+#[given("the message is wrapped with MLLP framing")]
+fn given_message_is_wrapped(world: &mut MllpWorld) {
+    world.wrapped_data = wrap_mllp(&world.original_message);
+}
+
+#[given(regex = r#"^raw bytes "([^"]*)"$"#)]
+fn given_raw_bytes(world: &mut MllpWorld, data: String) {
+    let bytes = parse_hl7_string(&data);
+    world.raw_bytes = bytes.clone();
+    world.wrapped_data = bytes;
+}
+
+#[given(regex = r#"^a byte sequence starting with 0x0B followed by "([^"]*)"$"#)]
+fn given_byte_sequence_with_start(world: &mut MllpWorld, content: String) {
+    let mut bytes = vec![0x0B];
+    bytes.extend_from_slice(parse_hl7_string(&content).as_slice());
+    world.raw_bytes = bytes.clone();
+    world.wrapped_data = bytes;
+}
+
+#[given("an empty message")]
+fn given_empty_message(world: &mut MllpWorld) {
+    world.original_message = Vec::new();
+}
+
+#[given("an MLLP frame iterator")]
+fn given_frame_iterator(world: &mut MllpWorld) {
+    world.frame_iterator = MllpFrameIterator::new();
+}
+
+#[given(regex = r#"^an HL7 message "([^"]*)" wrapped with MLLP framing is added to the iterator$"#)]
+fn given_message_added_to_iterator(world: &mut MllpWorld, message: String) {
+    let msg_bytes = parse_hl7_string(&message);
+    let framed = wrap_mllp(&msg_bytes);
+    world.frame_iterator.extend(&framed);
+}
+
+// ============================================================================
+// When Steps
+// ============================================================================
+
+#[when("I wrap it with MLLP framing")]
+fn when_wrap_mllp(world: &mut MllpWorld) {
+    world.wrapped_data = wrap_mllp(&world.original_message);
+}
+
+#[when("I unwrap the MLLP frame")]
+fn when_unwrap_mllp(world: &mut MllpWorld) {
+    let result = unwrap_mllp(&world.wrapped_data).expect("Unwrap failed");
+    world.unwrapped_data = Some(result.to_vec());
+}
+
+#[when("I check if the data is MLLP framed")]
+fn when_check_mllp_framed(world: &mut MllpWorld) {
+    world.framed_check_result = Some(is_mllp_framed(&world.wrapped_data));
+}
+
+#[when("I try to unwrap the data with checked unwrap")]
+fn when_try_unwrap_checked(world: &mut MllpWorld) {
+    match unwrap_mllp_checked(&world.wrapped_data) {
+        Ok(data) => world.unwrapped_data = Some(data.to_vec()),
+        Err(e) => world.checked_error = Some(e),
+    }
+}
+
+#[when("I search for a complete MLLP message")]
+fn when_find_complete_message(world: &mut MllpWorld) {
+    world.found_length = find_complete_mllp_message(&world.wrapped_data);
+}
+
+#[when("I extract the next message from the iterator")]
+fn when_extract_next_message(world: &mut MllpWorld) {
+    match world.frame_iterator.next_message() {
+        Some(Ok(msg)) => world.extracted_message = Some(msg),
+        Some(Err(e)) => panic!("Iterator returned error: {}", e),
+        None => world.extracted_message = None,
+    }
+}
+
+// ============================================================================
+// Then Steps
+// ============================================================================
+
+#[then("the first byte should be 0x0B")]
+fn then_first_byte_is_start(world: &mut MllpWorld) {
+    assert_eq!(
+        world.wrapped_data[0], 0x0B,
+        "Expected first byte to be 0x0B (VT), got 0x{:02X}",
+        world.wrapped_data[0]
+    );
+}
+
+#[then("the second-to-last byte should be 0x1C")]
+fn then_second_to_last_byte(world: &mut MllpWorld) {
+    let len = world.wrapped_data.len();
+    assert_eq!(
+        world.wrapped_data[len - 2],
+        0x1C,
+        "Expected second-to-last byte to be 0x1C (FS), got 0x{:02X}",
+        world.wrapped_data[len - 2]
+    );
+}
+
+#[then("the last byte should be 0x0D")]
+fn then_last_byte(world: &mut MllpWorld) {
+    let len = world.wrapped_data.len();
+    assert_eq!(
+        world.wrapped_data[len - 1],
+        0x0D,
+        "Expected last byte to be 0x0D (CR), got 0x{:02X}",
+        world.wrapped_data[len - 1]
+    );
+}
+
+#[then("the wrapped length should be the message length plus 3")]
+fn then_wrapped_length_plus_3(world: &mut MllpWorld) {
+    assert_eq!(
+        world.wrapped_data.len(),
+        world.original_message.len() + 3,
+        "Expected wrapped length {} but got {}",
+        world.original_message.len() + 3,
+        world.wrapped_data.len()
+    );
+}
+
+#[then("the unwrapped content should equal the original message")]
+fn then_unwrapped_equals_original(world: &mut MllpWorld) {
+    let unwrapped = world
+        .unwrapped_data
+        .as_ref()
+        .expect("No unwrapped data available");
+    assert_eq!(
+        unwrapped.as_slice(),
+        world.original_message.as_slice(),
+        "Unwrapped content does not match original message"
+    );
+}
+
+#[then("the result should be true")]
+fn then_result_true(world: &mut MllpWorld) {
+    assert_eq!(
+        world.framed_check_result,
+        Some(true),
+        "Expected is_mllp_framed to return true"
+    );
+}
+
+#[then("the result should be false")]
+fn then_result_false(world: &mut MllpWorld) {
+    assert_eq!(
+        world.framed_check_result,
+        Some(false),
+        "Expected is_mllp_framed to return false"
+    );
+}
+
+#[then("the error should be MissingStartBlock")]
+fn then_error_missing_start_block(world: &mut MllpWorld) {
+    assert!(
+        matches!(world.checked_error, Some(MllpError::MissingStartBlock)),
+        "Expected MissingStartBlock error, got {:?}",
+        world.checked_error
+    );
+}
+
+#[then("the error should be MissingEndBlock")]
+fn then_error_missing_end_block(world: &mut MllpWorld) {
+    assert!(
+        matches!(world.checked_error, Some(MllpError::MissingEndBlock)),
+        "Expected MissingEndBlock error, got {:?}",
+        world.checked_error
+    );
+}
+
+#[then(regex = r"^the wrapped length should be (\d+)$")]
+fn then_wrapped_length_exact(world: &mut MllpWorld, expected: usize) {
+    assert_eq!(
+        world.wrapped_data.len(),
+        expected,
+        "Expected wrapped length {} but got {}",
+        expected,
+        world.wrapped_data.len()
+    );
+}
+
+#[then("the found length should equal the wrapped data length")]
+fn then_found_length_equals_wrapped(world: &mut MllpWorld) {
+    let found = world
+        .found_length
+        .expect("find_complete_mllp_message returned None");
+    assert_eq!(
+        found,
+        world.wrapped_data.len(),
+        "Expected found length {} but got {}",
+        world.wrapped_data.len(),
+        found
+    );
+}
+
+#[then(regex = r#"^the extracted message should be "([^"]*)"$"#)]
+fn then_extracted_message_equals(world: &mut MllpWorld, expected: String) {
+    let expected_bytes = parse_hl7_string(&expected);
+    let extracted = world
+        .extracted_message
+        .as_ref()
+        .expect("No extracted message available");
+    assert_eq!(
+        extracted.as_slice(),
+        expected_bytes.as_slice(),
+        "Extracted message does not match expected"
+    );
+}
+
+#[then("there should be no more messages in the iterator")]
+fn then_no_more_messages(world: &mut MllpWorld) {
+    assert!(
+        world.frame_iterator.next_message().is_none(),
+        "Expected no more messages but found one"
+    );
+}
+
+// ============================================================================
+// Cucumber Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() {
+    MllpWorld::run("features/mllp.feature").await;
+}

--- a/crates/hl7v2-mllp/tests/integration_tests.rs
+++ b/crates/hl7v2-mllp/tests/integration_tests.rs
@@ -105,7 +105,7 @@ fn test_fragmented_message_single_byte() {
     let framed = wrap_mllp(msg);
 
     // Add one byte at a time
-    for byte in framed.iter() {
+    for byte in &framed {
         iter.extend(&[*byte]);
     }
 

--- a/crates/hl7v2-model/CLAUDE.md
+++ b/crates/hl7v2-model/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-model
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-model
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-model
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-model -- -D warnings
-`
+```

--- a/crates/hl7v2-model/tests/integration_tests.rs
+++ b/crates/hl7v2-model/tests/integration_tests.rs
@@ -697,7 +697,7 @@ mod error_tests {
 
         let msg = err.to_string();
         assert!(msg.contains("PID"));
-        assert!(msg.contains("3"));
+        assert!(msg.contains('3'));
     }
 }
 

--- a/crates/hl7v2-network/CLAUDE.md
+++ b/crates/hl7v2-network/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-network
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-network
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-network
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-network -- -D warnings
-`
+```

--- a/crates/hl7v2-normalize/CLAUDE.md
+++ b/crates/hl7v2-normalize/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-normalize
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-normalize
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-normalize
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-normalize -- -D warnings
-`
+```

--- a/crates/hl7v2-normalize/src/tests.rs
+++ b/crates/hl7v2-normalize/src/tests.rs
@@ -138,9 +138,9 @@ fn normalize_converts_all_delimiter_types() {
     let normalized_str = String::from_utf8(normalized).unwrap();
 
     // Check canonical delimiters are used
-    assert!(normalized_str.contains("|"));
-    assert!(normalized_str.contains("^"));
-    assert!(normalized_str.contains("~"));
+    assert!(normalized_str.contains('|'));
+    assert!(normalized_str.contains('^'));
+    assert!(normalized_str.contains('~'));
 }
 
 #[test]

--- a/crates/hl7v2-normalize/tests/bdd_tests.rs
+++ b/crates/hl7v2-normalize/tests/bdd_tests.rs
@@ -109,7 +109,7 @@ fn given_malformed_delimiters(world: &mut NormalizeWorld) {
     world.raw_bytes = b"MSH||~\\&|SendingApp\r".to_vec();
 }
 
-#[given(regex = r#"a ([A-Z]{3}\^[A-Z0-9]{2,3}) message"#)]
+#[given(regex = r"a ([A-Z]{3}\^[A-Z0-9]{2,3}) message")]
 fn given_message_type(world: &mut NormalizeWorld, message_type: String) {
     let msg = format!(
         "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||{}|MSG001|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r",
@@ -212,17 +212,17 @@ fn then_preserve_escape(world: &mut NormalizeWorld) {
 
 #[then("the normalized message should preserve repetitions")]
 fn then_preserve_repetitions(world: &mut NormalizeWorld) {
-    assert!(world.normalized_str.contains("~"));
+    assert!(world.normalized_str.contains('~'));
 }
 
 #[then("the normalized message should preserve components")]
 fn then_preserve_components(world: &mut NormalizeWorld) {
-    assert!(world.normalized_str.contains("^"));
+    assert!(world.normalized_str.contains('^'));
 }
 
 #[then("the normalized message should preserve subcomponents")]
 fn then_preserve_subcomponents(world: &mut NormalizeWorld) {
-    assert!(world.normalized_str.contains("&"));
+    assert!(world.normalized_str.contains('&'));
 }
 
 #[then("the normalized message should preserve null values")]
@@ -257,7 +257,7 @@ fn then_normalized_contains(world: &mut NormalizeWorld, text: String) {
 
 #[then("the normalized message should preserve special characters")]
 fn then_preserve_special(world: &mut NormalizeWorld) {
-    assert!(world.normalized_str.contains(","));
+    assert!(world.normalized_str.contains(','));
 }
 
 #[then("the normalized message should preserve long values")]
@@ -277,7 +277,7 @@ fn then_field_separator(world: &mut NormalizeWorld) {
 
 #[then("the component separator should be \"^\"")]
 fn then_component_separator(world: &mut NormalizeWorld) {
-    assert!(world.normalized_str.contains("^"));
+    assert!(world.normalized_str.contains('^'));
 }
 
 #[then("the repetition separator should be \"~\"")]
@@ -288,7 +288,7 @@ fn then_repetition_separator(world: &mut NormalizeWorld) {
 
 #[then("the escape character should be \"\\\\\"")]
 fn then_escape_char(world: &mut NormalizeWorld) {
-    assert!(world.normalized_str.contains("\\"));
+    assert!(world.normalized_str.contains('\\'));
 }
 
 #[then("the subcomponent separator should be \"&\"")]

--- a/crates/hl7v2-parser/CLAUDE.md
+++ b/crates/hl7v2-parser/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-parser
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-parser
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-parser
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-parser -- -D warnings
-`
+```

--- a/crates/hl7v2-parser/Cargo.toml
+++ b/crates/hl7v2-parser/Cargo.toml
@@ -21,10 +21,17 @@ hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
 [dev-dependencies]
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 hl7v2-writer = { path = "../hl7v2-writer" }
+hl7v2-mllp = { path = "../hl7v2-mllp" }
 proptest = "1.6"
 insta = { version = "1.42", features = ["yaml", "json", "redactions"] }
 pretty_assertions = "1.4"
 assert_matches = "1.5"
+cucumber = "0.22.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "bdd_tests"
+harness = false
 
 [features]
 default = []

--- a/crates/hl7v2-parser/features/parser.feature
+++ b/crates/hl7v2-parser/features/parser.feature
@@ -1,0 +1,158 @@
+Feature: HL7 v2 Message Parsing
+  As an HL7 message processor
+  I want to parse HL7 v2 messages from raw bytes
+  So that I can extract structured healthcare data
+
+  # ---------- Basic parsing ----------
+
+  Scenario: Parse a simple ADT^A01 message
+    Given a valid ADT^A01 message with MSH and PID segments
+    When I parse the message
+    Then parsing should succeed
+    And the message should have 2 segments
+    And segment 1 should be "MSH"
+    And segment 2 should be "PID"
+
+  Scenario: Parse a message with multiple segments
+    Given a message with MSH, PID, PV1, and OBX segments
+    When I parse the message
+    Then parsing should succeed
+    And the message should have 4 segments
+    And segment 1 should be "MSH"
+    And segment 2 should be "PID"
+    And segment 3 should be "PV1"
+    And segment 4 should be "OBX"
+
+  # ---------- MSH field extraction ----------
+
+  Scenario: Extract MSH sending application
+    Given a valid ADT^A01 message with MSH and PID segments
+    When I parse the message
+    Then MSH.3 should be "SendingApp"
+
+  Scenario: Extract MSH sending and receiving facilities
+    Given a valid ADT^A01 message with MSH and PID segments
+    When I parse the message
+    Then MSH.4 should be "SendingFac"
+    And MSH.5 should be "ReceivingApp"
+    And MSH.6 should be "ReceivingFac"
+
+  Scenario: Extract MSH message type components
+    Given a valid ADT^A01 message with MSH and PID segments
+    When I parse the message
+    Then MSH.9.1 should be "ADT"
+    And MSH.9.2 should be "A01"
+
+  Scenario: Extract MSH control ID and processing ID
+    Given a valid ADT^A01 message with MSH and PID segments
+    When I parse the message
+    Then MSH.10 should be "ABC123"
+    And MSH.11 should be "P"
+
+  # ---------- Custom delimiters ----------
+
+  Scenario: Parse message with custom delimiters
+    Given a message with custom delimiters "#$*@!"
+    When I parse the message
+    Then parsing should succeed
+    And the field delimiter should be "#"
+    And the component delimiter should be "$"
+    And the repetition delimiter should be "*"
+    And the escape delimiter should be "@"
+    And the subcomponent delimiter should be "!"
+
+  # ---------- Field repetitions ----------
+
+  Scenario: Parse message with field repetitions
+    Given a message with repeated patient names "Doe^John~Smith^Jane"
+    When I parse the message
+    Then PID.5[1].1 should be "Doe"
+    And PID.5[1].2 should be "John"
+    And PID.5[2].1 should be "Smith"
+    And PID.5[2].2 should be "Jane"
+
+  # ---------- Components and subcomponents ----------
+
+  Scenario: Parse message with components
+    Given a message with patient ID "123456^^^HOSP^MR"
+    When I parse the message
+    Then PID.3.1 should be "123456"
+    And PID.3.4 should be "HOSP"
+    And PID.3.5 should be "MR"
+
+  Scenario: Parse message with subcomponents
+    Given a message with subcomponent value "MainId&SubId" in PID-3
+    When I parse the message
+    Then PID.3.1 should contain subcomponents "MainId" and "SubId"
+
+  # ---------- MLLP framing ----------
+
+  Scenario: Parse MLLP-framed message
+    Given an MLLP-framed ADT^A01 message
+    When I parse the MLLP message
+    Then parsing should succeed
+    And the message should have 2 segments
+    And MSH.9.1 should be "ADT"
+    And MSH.9.2 should be "A01"
+
+  # ---------- Error handling ----------
+
+  Scenario: Handle empty input
+    Given an empty byte input
+    When I attempt to parse the message
+    Then parsing should fail
+    And the error should indicate an invalid segment
+
+  Scenario: Handle missing MSH segment
+    Given a message starting with "PID" instead of MSH
+    When I attempt to parse the message
+    Then parsing should fail
+    And the error should indicate an invalid segment
+
+  Scenario: Handle non-UTF8 input
+    Given a byte sequence with invalid UTF-8
+    When I attempt to parse the message
+    Then parsing should fail
+    And the error should indicate an invalid charset
+
+  # ---------- Escape sequences ----------
+
+  Scenario: Parse message with escape sequences
+    Given a message with escape sequence "\F\" in a field value
+    When I parse the message
+    Then parsing should succeed
+    And the unescaped field value should contain "|"
+
+  # ---------- Segment count validation ----------
+
+  Scenario: Validate segment count for a large message
+    Given a message with 10 OBX segments
+    When I parse the message
+    Then parsing should succeed
+    And the message should have 12 segments
+
+  # ---------- HL7 version ----------
+
+  Scenario: Parse HL7 v2.5.1 message
+    Given a message with HL7 version "2.5.1"
+    When I parse the message
+    Then MSH.12 should be "2.5.1"
+
+  Scenario: Parse HL7 v2.3 message
+    Given a message with HL7 version "2.3"
+    When I parse the message
+    Then MSH.12 should be "2.3"
+
+  # ---------- Batch parsing ----------
+
+  Scenario: Parse batch with BHS header
+    Given a batch message with BHS, 2 MSH messages, and BTS
+    When I parse the batch
+    Then batch parsing should succeed
+    And the batch should contain 2 messages
+
+  Scenario: Parse file batch with FHS header
+    Given a file batch with FHS, BHS, 1 MSH message, BTS, and FTS
+    When I parse the file batch
+    Then file batch parsing should succeed
+    And the file batch should contain 1 batch

--- a/crates/hl7v2-parser/tests/bdd_tests.rs
+++ b/crates/hl7v2-parser/tests/bdd_tests.rs
@@ -68,7 +68,11 @@ fn given_custom_delimiters(world: &mut ParserWorld, delims: String) {
     // Build MSH with custom delimiters: MSH<field><comp><rep><esc><sub><field>...
     let msg = format!(
         "MSH{f}{c}{r}{e}{s}{f}SendingApp{f}SendingFac{f}ReceivingApp{f}ReceivingFac{f}20250128152312{f}{f}ADT{c}A01{f}MSG001{f}P{f}2.5.1\r",
-        f = field, c = comp, r = rep, e = esc, s = sub
+        f = field,
+        c = comp,
+        r = rep,
+        e = esc,
+        s = sub
     );
     world.raw_bytes = msg.into_bytes();
 }
@@ -114,10 +118,7 @@ fn given_empty_input(world: &mut ParserWorld) {
 
 #[given(regex = r#"^a message starting with "([^"]+)" instead of MSH$"#)]
 fn given_non_msh_start(world: &mut ParserWorld, segment: String) {
-    let msg = format!(
-        "{}|1||123456^^^HOSP^MR||Doe^John\r",
-        segment
-    );
+    let msg = format!("{}|1||123456^^^HOSP^MR||Doe^John\r", segment);
     world.raw_bytes = msg.into_bytes();
 }
 
@@ -137,7 +138,7 @@ fn given_escape_sequence(world: &mut ParserWorld, _esc: String) {
 #[given("a message with 10 OBX segments")]
 fn given_many_obx(world: &mut ParserWorld) {
     let mut msg = String::from(
-        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ORU^R01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r"
+        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ORU^R01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r",
     );
     for i in 1..=10 {
         msg.push_str(&format!("OBX|{}|NM|1234-{}^Test^LN||{}\r", i, i, i * 10));
@@ -439,10 +440,18 @@ fn then_pid3_comp5(world: &mut ParserWorld, expected: String) {
 fn then_pid3_comp1_subcomponents(world: &mut ParserWorld, sub1: String, sub2: String) {
     use hl7v2_model::Atom;
     let msg = world.message.as_ref().expect("No parsed message");
-    let pid = msg.segments.iter().find(|s| &s.id == b"PID").expect("PID not found");
+    let pid = msg
+        .segments
+        .iter()
+        .find(|s| &s.id == b"PID")
+        .expect("PID not found");
     // PID-3 is field index 2 (0-based)
     let comp = &pid.fields[2].reps[0].comps[0];
-    assert!(comp.subs.len() >= 2, "Expected at least 2 subcomponents, got {}", comp.subs.len());
+    assert!(
+        comp.subs.len() >= 2,
+        "Expected at least 2 subcomponents, got {}",
+        comp.subs.len()
+    );
     assert_eq!(comp.subs[0], Atom::Text(sub1));
     assert_eq!(comp.subs[1], Atom::Text(sub2));
 }

--- a/crates/hl7v2-parser/tests/bdd_tests.rs
+++ b/crates/hl7v2-parser/tests/bdd_tests.rs
@@ -1,0 +1,532 @@
+//! BDD tests for hl7v2-parser using Cucumber
+//!
+//! Run with: cargo test --test bdd_tests -p hl7v2-parser
+
+use cucumber::{World, given, then, when};
+use hl7v2_model::Error;
+use hl7v2_parser::{get, parse, parse_batch, parse_file_batch, parse_mllp};
+
+/// Test world for Parser BDD tests
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct ParserWorld {
+    /// Raw input bytes
+    raw_bytes: Vec<u8>,
+    /// Parsed message result
+    parse_result: Option<Result<hl7v2_model::Message, Error>>,
+    /// Parsed message (if successful)
+    message: Option<hl7v2_model::Message>,
+    /// Error (if parsing failed)
+    error: Option<Error>,
+    /// Parsed batch result
+    batch: Option<hl7v2_model::Batch>,
+    /// Parsed file batch result
+    file_batch: Option<hl7v2_model::FileBatch>,
+}
+
+impl ParserWorld {
+    fn new() -> Self {
+        Self {
+            raw_bytes: Vec::new(),
+            parse_result: None,
+            message: None,
+            error: None,
+            batch: None,
+            file_batch: None,
+        }
+    }
+}
+
+// ============================================================================
+// Given Steps
+// ============================================================================
+
+#[given("a valid ADT^A01 message with MSH and PID segments")]
+fn given_adt_a01(world: &mut ParserWorld) {
+    world.raw_bytes = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r".to_vec();
+}
+
+#[given("a message with MSH, PID, PV1, and OBX segments")]
+fn given_multi_segment(world: &mut ParserWorld) {
+    world.raw_bytes = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\r\
+PID|1||123456^^^HOSP^MR||Doe^John\r\
+PV1|1|I|ICU\r\
+OBX|1|NM|1234-5^Weight^LN||75|kg\r".to_vec();
+}
+
+#[given(regex = r#"^a message with custom delimiters "([^"]+)"$"#)]
+fn given_custom_delimiters(world: &mut ParserWorld, delims: String) {
+    // delims = "#$*@!"
+    let chars: Vec<char> = delims.chars().collect();
+    assert_eq!(chars.len(), 5, "Expected 5 delimiter characters");
+    let field = chars[0]; // #
+    let comp = chars[1]; // $
+    let rep = chars[2]; // *
+    let esc = chars[3]; // @
+    let sub = chars[4]; // !
+
+    // Build MSH with custom delimiters: MSH<field><comp><rep><esc><sub><field>...
+    let msg = format!(
+        "MSH{f}{c}{r}{e}{s}{f}SendingApp{f}SendingFac{f}ReceivingApp{f}ReceivingFac{f}20250128152312{f}{f}ADT{c}A01{f}MSG001{f}P{f}2.5.1\r",
+        f = field, c = comp, r = rep, e = esc, s = sub
+    );
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given(regex = r#"^a message with repeated patient names "([^"]+)"$"#)]
+fn given_repeated_names(world: &mut ParserWorld, names: String) {
+    // names = "Doe^John~Smith^Jane"
+    let msg = format!(
+        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||{}\r",
+        names
+    );
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given(regex = r#"^a message with patient ID "([^"]+)"$"#)]
+fn given_patient_id(world: &mut ParserWorld, pid: String) {
+    let msg = format!(
+        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||{}||Doe^John\r",
+        pid
+    );
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given(regex = r#"^a message with subcomponent value "([^"]+)" in PID-3$"#)]
+fn given_subcomponent(world: &mut ParserWorld, value: String) {
+    let msg = format!(
+        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||{}||Doe^John\r",
+        value
+    );
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given("an MLLP-framed ADT^A01 message")]
+fn given_mllp_message(world: &mut ParserWorld) {
+    let inner = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r";
+    world.raw_bytes = hl7v2_mllp::wrap_mllp(inner);
+}
+
+#[given("an empty byte input")]
+fn given_empty_input(world: &mut ParserWorld) {
+    world.raw_bytes = Vec::new();
+}
+
+#[given(regex = r#"^a message starting with "([^"]+)" instead of MSH$"#)]
+fn given_non_msh_start(world: &mut ParserWorld, segment: String) {
+    let msg = format!(
+        "{}|1||123456^^^HOSP^MR||Doe^John\r",
+        segment
+    );
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given("a byte sequence with invalid UTF-8")]
+fn given_invalid_utf8(world: &mut ParserWorld) {
+    // 0xFF 0xFE are not valid UTF-8 continuation bytes
+    world.raw_bytes = vec![0xFF, 0xFE, 0xFD, 0x0D];
+}
+
+#[given(regex = r#"^a message with escape sequence "([^"]*)" in a field value$"#)]
+fn given_escape_sequence(world: &mut ParserWorld, _esc: String) {
+    // Build a message with \F\ escape in OBX-5 (observation value)
+    let msg = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ORU^R01|ABC123|P|2.5.1\rOBX|1|ST|1234-5^Test^LN||Value\\F\\More\r";
+    world.raw_bytes = msg.to_vec();
+}
+
+#[given("a message with 10 OBX segments")]
+fn given_many_obx(world: &mut ParserWorld) {
+    let mut msg = String::from(
+        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ORU^R01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r"
+    );
+    for i in 1..=10 {
+        msg.push_str(&format!("OBX|{}|NM|1234-{}^Test^LN||{}\r", i, i, i * 10));
+    }
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given(regex = r#"^a message with HL7 version "([^"]+)"$"#)]
+fn given_hl7_version(world: &mut ParserWorld, version: String) {
+    let msg = format!(
+        "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|{}\rPID|1||123456^^^HOSP^MR||Doe^John\r",
+        version
+    );
+    world.raw_bytes = msg.into_bytes();
+}
+
+#[given("a batch message with BHS, 2 MSH messages, and BTS")]
+fn given_batch(world: &mut ParserWorld) {
+    world.raw_bytes = b"BHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120000|||BATCH001|Test batch\r\
+MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120001||ADT^A01|MSG001|P|2.5.1\r\
+PID|1||111111^^^HOSP^MR||Doe^John\r\
+MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120002||ADT^A01|MSG002|P|2.5.1\r\
+PID|1||222222^^^HOSP^MR||Smith^Jane\r\
+BTS|2\r".to_vec();
+}
+
+#[given("a file batch with FHS, BHS, 1 MSH message, BTS, and FTS")]
+fn given_file_batch(world: &mut ParserWorld) {
+    world.raw_bytes = b"FHS|^~\\&|FileSender|FileFacility|FileReceiver|FileFacility|20250128120000|||FILE001|Test file batch\r\
+BHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120001|||BATCH001|Test batch\r\
+MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120002||ADT^A01|MSG001|P|2.5.1\r\
+PID|1||123456^^^HOSP^MR||Doe^John\r\
+BTS|1\r\
+FTS|1\r".to_vec();
+}
+
+// ============================================================================
+// When Steps
+// ============================================================================
+
+#[when("I parse the message")]
+fn when_parse(world: &mut ParserWorld) {
+    let result = parse(&world.raw_bytes);
+    match &result {
+        Ok(msg) => {
+            world.message = Some(msg.clone());
+            world.error = None;
+        }
+        Err(e) => {
+            world.error = Some(e.clone());
+            world.message = None;
+        }
+    }
+    world.parse_result = Some(result);
+}
+
+#[when("I attempt to parse the message")]
+fn when_attempt_parse(world: &mut ParserWorld) {
+    when_parse(world);
+}
+
+#[when("I parse the MLLP message")]
+fn when_parse_mllp(world: &mut ParserWorld) {
+    let result = parse_mllp(&world.raw_bytes);
+    match &result {
+        Ok(msg) => {
+            world.message = Some(msg.clone());
+            world.error = None;
+        }
+        Err(e) => {
+            world.error = Some(e.clone());
+            world.message = None;
+        }
+    }
+    world.parse_result = Some(result);
+}
+
+#[when("I parse the batch")]
+fn when_parse_batch(world: &mut ParserWorld) {
+    match parse_batch(&world.raw_bytes) {
+        Ok(batch) => {
+            world.batch = Some(batch);
+            world.error = None;
+        }
+        Err(e) => {
+            world.error = Some(e);
+            world.batch = None;
+        }
+    }
+}
+
+#[when("I parse the file batch")]
+fn when_parse_file_batch(world: &mut ParserWorld) {
+    match parse_file_batch(&world.raw_bytes) {
+        Ok(fb) => {
+            world.file_batch = Some(fb);
+            world.error = None;
+        }
+        Err(e) => {
+            world.error = Some(e);
+            world.file_batch = None;
+        }
+    }
+}
+
+// ============================================================================
+// Then Steps
+// ============================================================================
+
+#[then("parsing should succeed")]
+fn then_parse_success(world: &mut ParserWorld) {
+    assert!(
+        world.message.is_some(),
+        "Expected parsing to succeed, but got error: {:?}",
+        world.error
+    );
+}
+
+#[then("parsing should fail")]
+fn then_parse_fail(world: &mut ParserWorld) {
+    assert!(
+        world.error.is_some(),
+        "Expected parsing to fail, but it succeeded"
+    );
+}
+
+#[then(regex = r#"^the message should have (\d+) segments$"#)]
+fn then_segment_count(world: &mut ParserWorld, count: usize) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    assert_eq!(
+        msg.segments.len(),
+        count,
+        "Expected {} segments, got {}",
+        count,
+        msg.segments.len()
+    );
+}
+
+#[then(regex = r#"^segment (\d+) should be "([^"]+)"$"#)]
+fn then_segment_id(world: &mut ParserWorld, index: usize, expected_id: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let segment = &msg.segments[index - 1];
+    let actual_id = std::str::from_utf8(&segment.id).unwrap();
+    assert_eq!(
+        actual_id, expected_id,
+        "Segment {} should be '{}', got '{}'",
+        index, expected_id, actual_id
+    );
+}
+
+#[then(regex = r#"^MSH\.3 should be "([^"]+)"$"#)]
+fn then_msh3(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.3").expect("MSH.3 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.4 should be "([^"]+)"$"#)]
+fn then_msh4(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.4").expect("MSH.4 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.5 should be "([^"]+)"$"#)]
+fn then_msh5(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.5").expect("MSH.5 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.6 should be "([^"]+)"$"#)]
+fn then_msh6(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.6").expect("MSH.6 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.9\.1 should be "([^"]+)"$"#)]
+fn then_msh9_1(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.9.1").expect("MSH.9.1 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.9\.2 should be "([^"]+)"$"#)]
+fn then_msh9_2(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.9.2").expect("MSH.9.2 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.10 should be "([^"]+)"$"#)]
+fn then_msh10(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.10").expect("MSH.10 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.11 should be "([^"]+)"$"#)]
+fn then_msh11(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.11").expect("MSH.11 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^MSH\.12 should be "([^"]+)"$"#)]
+fn then_msh12(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "MSH.12").expect("MSH.12 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^the field delimiter should be "([^"]+)"$"#)]
+fn then_field_delim(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let expected_char = expected.chars().next().unwrap();
+    assert_eq!(msg.delims.field, expected_char);
+}
+
+#[then(regex = r#"^the component delimiter should be "([^"]+)"$"#)]
+fn then_comp_delim(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let expected_char = expected.chars().next().unwrap();
+    assert_eq!(msg.delims.comp, expected_char);
+}
+
+#[then(regex = r#"^the repetition delimiter should be "([^"]+)"$"#)]
+fn then_rep_delim(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let expected_char = expected.chars().next().unwrap();
+    assert_eq!(msg.delims.rep, expected_char);
+}
+
+#[then(regex = r#"^the escape delimiter should be "([^"]+)"$"#)]
+fn then_esc_delim(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let expected_char = expected.chars().next().unwrap();
+    assert_eq!(msg.delims.esc, expected_char);
+}
+
+#[then(regex = r#"^the subcomponent delimiter should be "([^"]+)"$"#)]
+fn then_sub_delim(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let expected_char = expected.chars().next().unwrap();
+    assert_eq!(msg.delims.sub, expected_char);
+}
+
+#[then(regex = r#"^PID\.5\[1\]\.1 should be "([^"]+)"$"#)]
+fn then_pid5_rep1_comp1(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.5[1].1").expect("PID.5[1].1 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.5\[1\]\.2 should be "([^"]+)"$"#)]
+fn then_pid5_rep1_comp2(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.5[1].2").expect("PID.5[1].2 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.5\[2\]\.1 should be "([^"]+)"$"#)]
+fn then_pid5_rep2_comp1(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.5[2].1").expect("PID.5[2].1 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.5\[2\]\.2 should be "([^"]+)"$"#)]
+fn then_pid5_rep2_comp2(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.5[2].2").expect("PID.5[2].2 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.3\.1 should be "([^"]+)"$"#)]
+fn then_pid3_comp1(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.3.1").expect("PID.3.1 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.3\.4 should be "([^"]+)"$"#)]
+fn then_pid3_comp4(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.3.4").expect("PID.3.4 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.3\.5 should be "([^"]+)"$"#)]
+fn then_pid3_comp5(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    let actual = get(msg, "PID.3.5").expect("PID.3.5 not found");
+    assert_eq!(actual, expected);
+}
+
+#[then(regex = r#"^PID\.3\.1 should contain subcomponents "([^"]+)" and "([^"]+)"$"#)]
+fn then_pid3_comp1_subcomponents(world: &mut ParserWorld, sub1: String, sub2: String) {
+    use hl7v2_model::Atom;
+    let msg = world.message.as_ref().expect("No parsed message");
+    let pid = msg.segments.iter().find(|s| &s.id == b"PID").expect("PID not found");
+    // PID-3 is field index 2 (0-based)
+    let comp = &pid.fields[2].reps[0].comps[0];
+    assert!(comp.subs.len() >= 2, "Expected at least 2 subcomponents, got {}", comp.subs.len());
+    assert_eq!(comp.subs[0], Atom::Text(sub1));
+    assert_eq!(comp.subs[1], Atom::Text(sub2));
+}
+
+#[then("the error should indicate an invalid segment")]
+fn then_error_invalid_segment(world: &mut ParserWorld) {
+    let err = world.error.as_ref().expect("Expected an error");
+    assert!(
+        matches!(err, Error::InvalidSegmentId),
+        "Expected InvalidSegmentId error, got: {:?}",
+        err
+    );
+}
+
+#[then("the error should indicate an invalid charset")]
+fn then_error_invalid_charset(world: &mut ParserWorld) {
+    let err = world.error.as_ref().expect("Expected an error");
+    assert!(
+        matches!(err, Error::InvalidCharset),
+        "Expected InvalidCharset error, got: {:?}",
+        err
+    );
+}
+
+#[then(regex = r#"^the unescaped field value should contain "([^"]+)"$"#)]
+fn then_unescaped_contains(world: &mut ParserWorld, expected: String) {
+    let msg = world.message.as_ref().expect("No parsed message");
+    // OBX-5 contains the escape-sequence value
+    let value = get(msg, "OBX.5").expect("OBX.5 not found");
+    assert!(
+        value.contains(&expected),
+        "Expected OBX.5 ('{}') to contain '{}'",
+        value,
+        expected
+    );
+}
+
+#[then("batch parsing should succeed")]
+fn then_batch_success(world: &mut ParserWorld) {
+    assert!(
+        world.batch.is_some(),
+        "Expected batch parsing to succeed, but got error: {:?}",
+        world.error
+    );
+}
+
+#[then(regex = r#"^the batch should contain (\d+) messages$"#)]
+fn then_batch_message_count(world: &mut ParserWorld, count: usize) {
+    let batch = world.batch.as_ref().expect("No parsed batch");
+    assert_eq!(
+        batch.messages.len(),
+        count,
+        "Expected {} messages in batch, got {}",
+        count,
+        batch.messages.len()
+    );
+}
+
+#[then("file batch parsing should succeed")]
+fn then_file_batch_success(world: &mut ParserWorld) {
+    assert!(
+        world.file_batch.is_some(),
+        "Expected file batch parsing to succeed, but got error: {:?}",
+        world.error
+    );
+}
+
+#[then(regex = r#"^the file batch should contain (\d+) batch$"#)]
+fn then_file_batch_count(world: &mut ParserWorld, count: usize) {
+    let fb = world.file_batch.as_ref().expect("No parsed file batch");
+    assert_eq!(
+        fb.batches.len(),
+        count,
+        "Expected {} batches in file batch, got {}",
+        count,
+        fb.batches.len()
+    );
+}
+
+// ============================================================================
+// Cucumber Main
+// ============================================================================
+
+#[tokio::main]
+async fn main() {
+    ParserWorld::run("features/parser.feature").await;
+}

--- a/crates/hl7v2-parser/tests/integration_tests.rs
+++ b/crates/hl7v2-parser/tests/integration_tests.rs
@@ -236,7 +236,11 @@ fn test_complex_message_with_all_segment_types() {
     let message = parse(hl7.as_bytes()).unwrap();
 
     // Verify all segment types are present
-    let segment_ids: Vec<&str> = message.segments.iter().map(hl7v2_model::Segment::id_str).collect();
+    let segment_ids: Vec<&str> = message
+        .segments
+        .iter()
+        .map(hl7v2_model::Segment::id_str)
+        .collect();
 
     assert!(segment_ids.contains(&"MSH"));
     assert!(segment_ids.contains(&"EVN"));

--- a/crates/hl7v2-parser/tests/integration_tests.rs
+++ b/crates/hl7v2-parser/tests/integration_tests.rs
@@ -236,7 +236,7 @@ fn test_complex_message_with_all_segment_types() {
     let message = parse(hl7.as_bytes()).unwrap();
 
     // Verify all segment types are present
-    let segment_ids: Vec<&str> = message.segments.iter().map(|s| s.id_str()).collect();
+    let segment_ids: Vec<&str> = message.segments.iter().map(hl7v2_model::Segment::id_str).collect();
 
     assert!(segment_ids.contains(&"MSH"));
     assert!(segment_ids.contains(&"EVN"));

--- a/crates/hl7v2-path/CLAUDE.md
+++ b/crates/hl7v2-path/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-path
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-path
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-path
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-path -- -D warnings
-`
+```

--- a/crates/hl7v2-path/tests/bdd_tests.rs
+++ b/crates/hl7v2-path/tests/bdd_tests.rs
@@ -91,13 +91,13 @@ fn then_segment(world: &mut PathWorld, segment: String) {
     assert_eq!(path.segment, segment);
 }
 
-#[then(regex = r#"^the field should be (\d+)$"#)]
+#[then(regex = r"^the field should be (\d+)$")]
 fn then_field(world: &mut PathWorld, field: usize) {
     let path = world.path.as_ref().expect("No path");
     assert_eq!(path.field, field);
 }
 
-#[then(regex = r#"^the repetition should be (\d+)$"#)]
+#[then(regex = r"^the repetition should be (\d+)$")]
 fn then_repetition(world: &mut PathWorld, rep: usize) {
     let path = world.path.as_ref().expect("No path");
     assert_eq!(path.repetition, Some(rep));
@@ -109,7 +109,7 @@ fn then_repetition_none(world: &mut PathWorld) {
     assert_eq!(path.repetition, None);
 }
 
-#[then(regex = r#"^the component should be (\d+)$"#)]
+#[then(regex = r"^the component should be (\d+)$")]
 fn then_component(world: &mut PathWorld, comp: usize) {
     let path = world.path.as_ref().expect("No path");
     assert_eq!(path.component, Some(comp));
@@ -121,7 +121,7 @@ fn then_component_none(world: &mut PathWorld) {
     assert_eq!(path.component, None);
 }
 
-#[then(regex = r#"^the subcomponent should be (\d+)$"#)]
+#[then(regex = r"^the subcomponent should be (\d+)$")]
 fn then_subcomponent(world: &mut PathWorld, sub: usize) {
     let path = world.path.as_ref().expect("No path");
     assert_eq!(path.subcomponent, Some(sub));

--- a/crates/hl7v2-prof/CLAUDE.md
+++ b/crates/hl7v2-prof/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-prof
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-prof
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-prof
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-prof -- -D warnings
-`
+```

--- a/crates/hl7v2-prof/src/lib.rs
+++ b/crates/hl7v2-prof/src/lib.rs
@@ -1131,7 +1131,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).length() > N"
     if script.contains(".length() > ") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.length\(\)\s*>\s*(\d+)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.length\(\)\s*>\s*(\d+)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
             let required_length: usize = captures[2].parse().map_err(|_| ())?;
@@ -1160,7 +1160,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH) in ['A', 'B', 'C']"
     if script.contains(" in [") {
-        let re = Regex::new(r#"field\(([^)]+)\)\s+in\s+\[([^\]]+)\]"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\s+in\s+\[([^\]]+)\]").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
             let values_str = &captures[2];
@@ -1169,7 +1169,7 @@ fn evaluate_custom_rule_script(
                 // Parse the allowed values
                 let allowed_values: Vec<&str> = values_str
                     .split(',')
-                    .map(|s| s.trim())
+                    .map(str::trim)
                     .map(|s| s.trim_matches('\''))
                     .collect();
 
@@ -1194,7 +1194,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).matches_regex('PATTERN')"
     if script.contains(".matches_regex(") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.matches_regex\('([^']+)'\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.matches_regex\('([^']+)'\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
             let pattern = &captures[2];
@@ -1222,7 +1222,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).starts_with('PREFIX')"
     if script.contains(".starts_with(") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.starts_with\('([^']+)'\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.starts_with\('([^']+)'\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
             let prefix = &captures[2];
@@ -1249,7 +1249,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).ends_with('SUFFIX')"
     if script.contains(".ends_with(") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.ends_with\('([^']+)'\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.ends_with\('([^']+)'\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
             let suffix = &captures[2];
@@ -1276,7 +1276,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).is_numeric()"
     if script.contains(".is_numeric()") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.is_numeric\(\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.is_numeric\(\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
 
@@ -1299,7 +1299,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH1) == field(PATH2)"
     if script.contains(" == field(") {
-        let re = Regex::new(r#"field\(([^)]+)\)\s*==\s*field\(([^)]+)\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\s*==\s*field\(([^)]+)\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path1 = &captures[1];
             let path2 = &captures[2];
@@ -1328,7 +1328,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).is_phone_number()"
     if script.contains(".is_phone_number()") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.is_phone_number\(\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.is_phone_number\(\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
 
@@ -1354,7 +1354,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).is_email()"
     if script.contains(".is_email()") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.is_email\(\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.is_email\(\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
 
@@ -1380,7 +1380,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).is_ssn()"
     if script.contains(".is_ssn()") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.is_ssn\(\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.is_ssn\(\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
 
@@ -1403,7 +1403,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH).is_valid_birth_date()"
     if script.contains(".is_valid_birth_date()") {
-        let re = Regex::new(r#"field\(([^)]+)\)\.is_valid_birth_date\(\)"#).map_err(|_| ())?;
+        let re = Regex::new(r"field\(([^)]+)\)\.is_valid_birth_date\(\)").map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
 
@@ -1426,7 +1426,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "is_valid_age_range(field(PATH1), field(PATH2))"
     if script.contains("is_valid_age_range(") {
-        let re = Regex::new(r#"is_valid_age_range\(field\(([^)]+)\),\s*field\(([^)]+)\)\)"#)
+        let re = Regex::new(r"is_valid_age_range\(field\(([^)]+)\),\s*field\(([^)]+)\)\)")
             .map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path1 = &captures[1];
@@ -1453,7 +1453,7 @@ fn evaluate_custom_rule_script(
 
     // Pattern: "field(PATH) between VALUE1 and VALUE2"
     if script.contains(" between ") && script.contains(" and ") {
-        let re = Regex::new(r#"field\(([^)]+)\)\s+between\s+([^\s]+)\s+and\s+([^\s]+)"#)
+        let re = Regex::new(r"field\(([^)]+)\)\s+between\s+([^\s]+)\s+and\s+([^\s]+)")
             .map_err(|_| ())?;
         if let Some(captures) = re.captures(script) {
             let path = &captures[1];
@@ -1533,7 +1533,7 @@ fn evaluate_custom_rule_simple(msg: &Message, rule: &CustomRule, issues: &mut Ve
                     // Split by comma and remove quotes
                     let allowed_values: Vec<&str> = values_str
                         .split(',')
-                        .map(|s| s.trim())
+                        .map(str::trim)
                         .map(|s| s.trim_matches('\''))
                         .collect();
 
@@ -1561,7 +1561,7 @@ fn evaluate_custom_rule_simple(msg: &Message, rule: &CustomRule, issues: &mut Ve
             if let Some(value) = hl7v2_core::get(msg, path) {
                 // Extract the regex pattern
                 let pattern_part = &rule.script[path_end + 15..];
-                if pattern_part.starts_with("'") && pattern_part.ends_with("')") {
+                if pattern_part.starts_with('\'') && pattern_part.ends_with("')") {
                     let pattern = &pattern_part[1..pattern_part.len() - 2];
                     // Simple regex matching (in a real implementation, we would use regex crate)
                     if !value.contains(pattern) && pattern != ".*" {

--- a/crates/hl7v2-prof/src/loader.rs
+++ b/crates/hl7v2-prof/src/loader.rs
@@ -256,7 +256,7 @@ impl ProfileLoader {
             .headers()
             .get(reqwest::header::ETAG)
             .and_then(|h| h.to_str().ok())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
 
         let content = response.text().await?;
 

--- a/crates/hl7v2-prof/tests/loader_tests.rs
+++ b/crates/hl7v2-prof/tests/loader_tests.rs
@@ -302,7 +302,7 @@ async fn test_prefetch_all() {
         .await;
 
     assert_eq!(results.len(), 3);
-    assert!(results.iter().all(|r| r.is_ok()));
+    assert!(results.iter().all(std::result::Result::is_ok));
 }
 
 #[tokio::test]

--- a/crates/hl7v2-query/CLAUDE.md
+++ b/crates/hl7v2-query/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-query
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-query
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-query
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-query -- -D warnings
-`
+```

--- a/crates/hl7v2-query/tests/bdd_tests.rs
+++ b/crates/hl7v2-query/tests/bdd_tests.rs
@@ -98,7 +98,7 @@ impl QueryWorld {
 
         // If path has 3+ parts (segment.field.component), use the standard get
         if parts.len() >= 3 {
-            return get(msg, path).map(|s| s.to_string());
+            return get(msg, path).map(std::string::ToString::to_string);
         }
 
         // Path has only segment.field — join all components with ^
@@ -121,7 +121,7 @@ impl QueryWorld {
         let field = if segment_id == "MSH" {
             if field_index <= 2 {
                 // MSH-1 (separator) and MSH-2 (encoding chars) — just use get()
-                return get(msg, path).map(|s| s.to_string());
+                return get(msg, path).map(std::string::ToString::to_string);
             }
             let adjusted = field_index - 2;
             segment.fields.get(adjusted)?
@@ -408,7 +408,7 @@ fn given_message_custom_delimiters(world: &mut QueryWorld) {
     world.message = Some(message);
 }
 
-#[given(regex = r#"a ([A-Z]{3}\^[A-Z0-9]{2,3}) message"#)]
+#[given(regex = r"a ([A-Z]{3}\^[A-Z0-9]{2,3}) message")]
 fn given_message_type(world: &mut QueryWorld, message_type: String) {
     let delims = Delims::default();
     let mut msh = QueryWorld::create_msh_segment(&delims);

--- a/crates/hl7v2-server/CLAUDE.md
+++ b/crates/hl7v2-server/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-server
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-server
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-server
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-server -- -D warnings
-`
+```

--- a/crates/hl7v2-stream/CLAUDE.md
+++ b/crates/hl7v2-stream/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-stream
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-stream
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-stream
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-stream -- -D warnings
-`
+```

--- a/crates/hl7v2-stream/benches/streaming.rs
+++ b/crates/hl7v2-stream/benches/streaming.rs
@@ -80,7 +80,7 @@ fn parse_and_collect(msg: &str) -> Vec<Event> {
 fn bench_throughput_small_messages(c: &mut Criterion) {
     let mut group = c.benchmark_group("throughput_small");
 
-    for size in [1, 5, 10, 50].iter() {
+    for size in &[1, 5, 10, 50] {
         let msg = generate_multiple_messages(*size);
         let bytes = msg.len();
 
@@ -96,7 +96,7 @@ fn bench_throughput_small_messages(c: &mut Criterion) {
 fn bench_throughput_large_messages(c: &mut Criterion) {
     let mut group = c.benchmark_group("throughput_large");
 
-    for segments in [100, 500, 1000, 5000].iter() {
+    for segments in &[100, 500, 1000, 5000] {
         let msg = generate_large_message(*segments);
         let bytes = msg.len();
 
@@ -116,7 +116,7 @@ fn bench_throughput_large_messages(c: &mut Criterion) {
 fn bench_field_sizes(c: &mut Criterion) {
     let mut group = c.benchmark_group("field_sizes");
 
-    for field_size in [100, 1_000, 10_000, 100_000].iter() {
+    for field_size in &[100, 1_000, 10_000, 100_000] {
         let msg = generate_message_with_long_field(*field_size);
         let bytes = msg.len();
 
@@ -206,7 +206,7 @@ fn bench_buffer_sizes(c: &mut Criterion) {
 
     let msg = generate_large_message(1000);
 
-    for buffer_size in [64, 256, 1024, 4096, 16384].iter() {
+    for buffer_size in &[64, 256, 1024, 4096, 16384] {
         group.bench_with_input(
             BenchmarkId::new("buffer", buffer_size),
             buffer_size,

--- a/crates/hl7v2-stream/src/lib.rs
+++ b/crates/hl7v2-stream/src/lib.rs
@@ -439,7 +439,7 @@ impl<D: BufRead> StreamParser<D> {
             // For any other segment
             if self.in_message
                 && segment_data.len() >= 3
-                && segment_data[0..3].iter().all(|c| c.is_ascii_alphanumeric())
+                && segment_data[0..3].iter().all(u8::is_ascii_alphanumeric)
             {
                 let segment_id = segment_data[0..3].to_vec();
 
@@ -450,7 +450,7 @@ impl<D: BufRead> StreamParser<D> {
             } else if !self.in_message
                 && self.pre_msh
                 && segment_data.len() >= 3
-                && segment_data[0..3].iter().all(|c| c.is_ascii_alphanumeric())
+                && segment_data[0..3].iter().all(u8::is_ascii_alphanumeric)
             {
                 // We're in pre-MSH mode but this isn't an MSH segment,
                 // so start a message with default delimiters

--- a/crates/hl7v2-template-values/CLAUDE.md
+++ b/crates/hl7v2-template-values/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-template-values
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-template-values
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-template-values
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-template-values -- -D warnings
-`
+```

--- a/crates/hl7v2-template/CLAUDE.md
+++ b/crates/hl7v2-template/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-template
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-template
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-template
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-template -- -D warnings
-`
+```

--- a/crates/hl7v2-template/src/lib.rs
+++ b/crates/hl7v2-template/src/lib.rs
@@ -444,7 +444,7 @@ pub fn generate_golden_hashes(
 
     // Calculate hash for each message
     let mut hashes = Vec::with_capacity(count);
-    for message in messages.iter() {
+    for message in &messages {
         // Convert message to string
         let message_string = hl7v2_core::write(message);
 

--- a/crates/hl7v2-template/src/tests.rs
+++ b/crates/hl7v2-template/src/tests.rs
@@ -12,9 +12,7 @@ fn test_template_creation() {
     let template = Template {
         name: "test".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -333,9 +331,7 @@ fn test_value_source_uuid_v4() {
     let template = Template {
         name: "test".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values,
     };
 
@@ -414,9 +410,7 @@ fn test_generate_corpus() {
     let template = Template {
         name: "test".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -429,18 +423,14 @@ fn test_generate_diverse_corpus() {
     let template1 = Template {
         name: "adt_a01".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
     let template2 = Template {
         name: "oru_r01".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -454,18 +444,14 @@ fn test_generate_distributed_corpus() {
     let template1 = Template {
         name: "adt".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
     let template2 = Template {
         name: "oru".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -484,9 +470,7 @@ fn test_generate_golden_hashes() {
     let template = Template {
         name: "test".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -504,9 +488,7 @@ fn test_verify_golden_hashes() {
     let template = Template {
         name: "test".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -522,9 +504,7 @@ fn test_verify_golden_hashes_mismatch() {
     let template = Template {
         name: "test".to_string(),
         delims: r"^~\&".to_string(),
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -560,9 +540,7 @@ fn test_generate_invalid_delims() {
     let template = Template {
         name: "test".to_string(),
         delims: "^^".to_string(), // Too short
-        segments: vec![
-            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
-        ],
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 

--- a/crates/hl7v2-template/src/tests.rs
+++ b/crates/hl7v2-template/src/tests.rs
@@ -11,9 +11,9 @@ use std::collections::HashMap;
 fn test_template_creation() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -27,7 +27,7 @@ fn test_template_creation() {
 fn test_template_clone() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec!["MSH|...".to_string()],
         values: HashMap::new(),
     };
@@ -41,7 +41,7 @@ fn test_template_clone() {
 fn test_template_debug() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec!["MSH|...".to_string()],
         values: HashMap::new(),
     };
@@ -59,10 +59,10 @@ fn test_template_debug() {
 fn test_generate_single_message() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -78,9 +78,9 @@ fn test_generate_single_message() {
 fn test_generate_multiple_messages() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -93,9 +93,9 @@ fn test_generate_multiple_messages() {
 fn test_generate_zero_messages() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -112,9 +112,9 @@ fn test_generate_zero_messages() {
 fn test_generate_deterministic() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -136,10 +136,10 @@ fn test_generate_different_seeds() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -204,7 +204,7 @@ fn test_generate_segment_msh() {
     let values = HashMap::new();
 
     let segment = generate_segment(
-        r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#,
+        r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1",
         &values,
         &delims,
         &mut rng
@@ -220,7 +220,7 @@ fn test_generate_segment_pid() {
     let values = HashMap::new();
 
     let segment = generate_segment(
-        r#"PID|1||123456^^^HOSP^MR||Doe^John"#,
+        r"PID|1||123456^^^HOSP^MR||Doe^John",
         &values,
         &delims,
         &mut rng,
@@ -266,10 +266,10 @@ fn test_value_source_fixed() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -288,10 +288,10 @@ fn test_value_source_numeric() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values,
     };
@@ -306,17 +306,17 @@ fn test_value_source_from() {
     values.insert(
         "PID.5".to_string(),
         vec![ValueSource::From(vec![
-            r#"Smith^John"#.to_string(),
-            r#"Doe^Jane"#.to_string(),
+            r"Smith^John".to_string(),
+            r"Doe^Jane".to_string(),
         ])],
     );
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456||Doe^John"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456||Doe^John".to_string(),
         ],
         values,
     };
@@ -332,9 +332,9 @@ fn test_value_source_uuid_v4() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values,
     };
@@ -367,10 +367,10 @@ fn test_value_source_date() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456||Doe^John||19800101"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456||Doe^John||19800101".to_string(),
         ],
         values,
     };
@@ -393,10 +393,10 @@ fn test_value_source_gaussian() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1"#.to_string(),
-            r#"OBX|1|NM|TEST||100.0|units"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string(),
+            r"OBX|1|NM|TEST||100.0|units".to_string(),
         ],
         values,
     };
@@ -413,9 +413,9 @@ fn test_value_source_gaussian() {
 fn test_generate_corpus() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -428,18 +428,18 @@ fn test_generate_corpus() {
 fn test_generate_diverse_corpus() {
     let template1 = Template {
         name: "adt_a01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
 
     let template2 = Template {
         name: "oru_r01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -453,18 +453,18 @@ fn test_generate_diverse_corpus() {
 fn test_generate_distributed_corpus() {
     let template1 = Template {
         name: "adt".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
 
     let template2 = Template {
         name: "oru".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ORU^R01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -483,9 +483,9 @@ fn test_generate_distributed_corpus() {
 fn test_generate_golden_hashes() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -503,9 +503,9 @@ fn test_generate_golden_hashes() {
 fn test_verify_golden_hashes() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -521,9 +521,9 @@ fn test_verify_golden_hashes() {
 fn test_verify_golden_hashes_mismatch() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -546,7 +546,7 @@ fn test_verify_golden_hashes_mismatch() {
 fn test_generate_invalid_segment_id() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec!["INVALID|1|2|3".to_string()],
         values: HashMap::new(),
     };
@@ -561,7 +561,7 @@ fn test_generate_invalid_delims() {
         name: "test".to_string(),
         delims: "^^".to_string(), // Too short
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -578,9 +578,9 @@ fn test_generate_invalid_delims() {
 fn test_msh_segment_field_handling() {
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -608,10 +608,10 @@ fn test_realistic_name() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456||Doe^John"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456||Doe^John".to_string(),
         ],
         values,
     };
@@ -627,10 +627,10 @@ fn test_realistic_address() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456||Doe^John|||M|||123 Main St"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456||Doe^John|||M|||123 Main St".to_string(),
         ],
         values,
     };
@@ -646,10 +646,10 @@ fn test_realistic_phone() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456||Doe^John||(555)123-4567"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|123|P|2.5.1".to_string(),
+            r"PID|1||123456||Doe^John||(555)123-4567".to_string(),
         ],
         values,
     };

--- a/crates/hl7v2-template/tests/integration_tests.rs
+++ b/crates/hl7v2-template/tests/integration_tests.rs
@@ -7,10 +7,10 @@ use std::collections::HashMap;
 fn create_basic_template() -> Template {
     Template {
         name: "ADT_A01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
         ],
         values: HashMap::new(),
     }
@@ -27,10 +27,10 @@ fn create_template_with_values() -> Template {
 
     Template {
         name: "ADT_A01_Dynamic".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||{{PID.3}}||{{PID.5.1}}"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||{{PID.3}}||{{PID.5.1}}".to_string(),
         ],
         values,
     }
@@ -69,10 +69,10 @@ fn integration_different_seeds_different_results() {
 
     let template = Template {
         name: "test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1"#.to_string(),
-            r#"PID|1||{{PID.3}}||Test"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1".to_string(),
+            r"PID|1||{{PID.3}}||Test".to_string(),
         ],
         values,
     };
@@ -101,18 +101,18 @@ fn integration_corpus_generation() {
 fn integration_diverse_corpus() {
     let template1 = Template {
         name: "ADT_A01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App1|Fac1|App2|Fac2|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App1|Fac1|App2|Fac2|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
 
     let template2 = Template {
         name: "ORU_R01".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App1|Fac1|App2|Fac2|20250128152312||ORU^R01|2|P|2.5.1"#.to_string(),
+            r"MSH|^~\&|App1|Fac1|App2|Fac2|20250128152312||ORU^R01|2|P|2.5.1".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -170,9 +170,9 @@ fn integration_manifest_creation() {
 fn integration_msh_segment_handling() {
     let template = Template {
         name: "MSH_Test".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|123|P|2.5.1|||AL|AL"#.to_string(),
+            r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|123|P|2.5.1|||AL|AL".to_string(),
         ],
         values: HashMap::new(),
     };
@@ -192,7 +192,7 @@ fn integration_custom_delimiters() {
     let template = Template {
         name: "CustomDelims".to_string(),
         delims: "@#$%".to_string(), // component@, repetition#, escape$, subcomponent%
-        segments: vec![r#"MSH|@#$%|App|Fac|App|Fac|20250128152312||ADT@A01|1|P|2.5.1"#.to_string()],
+        segments: vec![r"MSH|@#$%|App|Fac|App|Fac|20250128152312||ADT@A01|1|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 
@@ -211,12 +211,12 @@ fn integration_custom_delimiters() {
 fn integration_multiple_segments() {
     let template = Template {
         name: "MultiSegment".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
-            r#"EVN|A01|20250128152312"#.to_string(),
-            r#"PID|1||12345||Doe^John^A||19800101|M"#.to_string(),
-            r#"PV1|1|I|ICU^101^^HOSP|||||||ADM||||||||IN|||||||||||||||||||||||||20250128152312"#
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
+            r"EVN|A01|20250128152312".to_string(),
+            r"PID|1||12345||Doe^John^A||19800101|M".to_string(),
+            r"PV1|1|I|ICU^101^^HOSP|||||||ADM||||||||IN|||||||||||||||||||||||||20250128152312"
                 .to_string(),
         ],
         values: HashMap::new(),
@@ -242,10 +242,10 @@ fn integration_value_source_fixed() {
 
     let template = Template {
         name: "FixedValue".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
-            r#"PID|1||123||{{PID.5.1}}"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
+            r"PID|1||123||{{PID.5.1}}".to_string(),
         ],
         values,
     };
@@ -275,10 +275,10 @@ fn integration_value_source_from() {
 
     let template = Template {
         name: "FromValue".to_string(),
-        delims: r#"^~\&"#.to_string(),
+        delims: r"^~\&".to_string(),
         segments: vec![
-            r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
-            r#"PID|1||123||Test||19700101|{{PID.8}}"#.to_string(),
+            r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
+            r"PID|1||123||Test||19700101|{{PID.8}}".to_string(),
         ],
         values,
     };
@@ -293,8 +293,8 @@ fn integration_value_source_from() {
 fn integration_empty_template_values() {
     let template = Template {
         name: "EmptyValues".to_string(),
-        delims: r#"^~\&"#.to_string(),
-        segments: vec![r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string()],
+        delims: r"^~\&".to_string(),
+        segments: vec![r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string()],
         values: HashMap::new(),
     };
 

--- a/crates/hl7v2-template/tests/property_tests.rs
+++ b/crates/hl7v2-template/tests/property_tests.rs
@@ -16,10 +16,10 @@ prop_compose! {
     fn arb_basic_template()(name in arb_template_name()) -> Template {
         Template {
             name,
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1"#.to_string(),
-                r#"PID|1||123456^^^HOSP^MR||Doe^John"#.to_string(),
+                r"MSH|^~\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1".to_string(),
+                r"PID|1||123456^^^HOSP^MR||Doe^John".to_string(),
             ],
             values: HashMap::new(),
         }
@@ -54,9 +54,9 @@ proptest! {
     fn prop_golden_hashes_length(seed in 0u64..10000u64, count in 1usize..20) {
         let template = Template {
             name: "test".to_string(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
+                r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
             ],
             values: HashMap::new(),
         };
@@ -76,9 +76,9 @@ proptest! {
     fn prop_golden_hash_verification(seed in 0u64..10000u64, count in 1usize..10) {
         let template = Template {
             name: "test".to_string(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
+                r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
             ],
             values: HashMap::new(),
         };
@@ -102,10 +102,10 @@ proptest! {
 
         let template = Template {
             name: "test".to_string(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
-                r#"PID|1||{{PID.3}}||Test"#.to_string(),
+                r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
+                r"PID|1||{{PID.3}}||Test".to_string(),
             ],
             values,
         };
@@ -126,9 +126,9 @@ proptest! {
     fn prop_corpus_batch_generation(seed in 0u64..10000u64, total in 10usize..100, batch in 5usize..20) {
         let template = Template {
             name: "test".to_string(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
+                r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
             ],
             values: HashMap::new(),
         };
@@ -187,9 +187,9 @@ proptest! {
     fn prop_message_hash_consistency(seed in 0u64..10000u64) {
         let template = Template {
             name: "test".to_string(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
+                r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
             ],
             values: HashMap::new(),
         };
@@ -209,9 +209,9 @@ proptest! {
     fn prop_template_name_preserved(name in arb_template_name()) {
         let template = Template {
             name: name.clone(),
-            delims: r#"^~\&"#.to_string(),
+            delims: r"^~\&".to_string(),
             segments: vec![
-                r#"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1"#.to_string(),
+                r"MSH|^~\&|App|Fac|App|Fac|20250128152312||ADT^A01|1|P|2.5.1".to_string(),
             ],
             values: HashMap::new(),
         };

--- a/crates/hl7v2-test-utils/CLAUDE.md
+++ b/crates/hl7v2-test-utils/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-test-utils
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-test-utils
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-test-utils
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-test-utils -- -D warnings
-`
+```

--- a/crates/hl7v2-test-utils/src/assertions.rs
+++ b/crates/hl7v2-test-utils/src/assertions.rs
@@ -142,7 +142,7 @@ pub fn assert_segment_equals(message: &Message, segment_name: &str, expected: &s
                 message
                     .segments
                     .iter()
-                    .map(|s| s.id_str())
+                    .map(hl7v2_model::Segment::id_str)
                     .collect::<Vec<_>>()
                     .join(", ")
             )
@@ -260,7 +260,7 @@ pub fn assert_field_exists(message: &Message, path: &str) {
             message
                 .segments
                 .iter()
-                .map(|s| s.id_str())
+                .map(hl7v2_model::Segment::id_str)
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -323,7 +323,7 @@ pub fn assert_segment_exists(message: &Message, segment_name: &str) {
         message
             .segments
             .iter()
-            .map(|s| s.id_str())
+            .map(hl7v2_model::Segment::id_str)
             .collect::<Vec<_>>()
             .join(", ")
     );
@@ -466,7 +466,7 @@ pub fn assert_segment_count(message: &Message, expected_count: usize) {
         message
             .segments
             .iter()
-            .map(|s| s.id_str())
+            .map(hl7v2_model::Segment::id_str)
             .collect::<Vec<_>>()
             .join(", ")
     );

--- a/crates/hl7v2-test-utils/src/fixtures.rs
+++ b/crates/hl7v2-test-utils/src/fixtures.rs
@@ -363,7 +363,7 @@ mod tests {
     #[test]
     fn test_invalid_truncated() {
         let msg = SampleMessages::invalid("truncated").unwrap();
-        assert!(!msg.ends_with("\r"));
+        assert!(!msg.ends_with('\r'));
     }
 
     #[test]

--- a/crates/hl7v2-validation/CLAUDE.md
+++ b/crates/hl7v2-validation/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-validation
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-validation
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-validation
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-validation -- -D warnings
-`
+```

--- a/crates/hl7v2-validation/src/lib.rs
+++ b/crates/hl7v2-validation/src/lib.rs
@@ -801,10 +801,9 @@ pub fn check_rule_condition(msg: &Message, condition: &RuleCondition) -> bool {
 
     // Right-hand value(s):
     let rhs_first = condition.value.as_deref();
-    let rhs_list: Vec<&str> = condition
-        .values
-        .as_ref()
-        .map_or(Vec::new(), |v| v.iter().map(std::string::String::as_str).collect());
+    let rhs_list: Vec<&str> = condition.values.as_ref().map_or(Vec::new(), |v| {
+        v.iter().map(std::string::String::as_str).collect()
+    });
 
     match condition.operator.as_str() {
         // value/string ops

--- a/crates/hl7v2-validation/src/lib.rs
+++ b/crates/hl7v2-validation/src/lib.rs
@@ -268,7 +268,7 @@ pub fn is_hierarchic_designator(value: &str) -> bool {
 /// Check if value is a valid phone number (basic validation)
 pub fn is_phone_number(value: &str) -> bool {
     // Remove common phone number formatting characters
-    let cleaned: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    let cleaned: String = value.chars().filter(char::is_ascii_digit).collect();
 
     // Basic phone number validation (7-15 digits)
     cleaned.len() >= 7 && cleaned.len() <= 15 && cleaned.chars().all(|c| c.is_ascii_digit())
@@ -305,7 +305,7 @@ pub fn is_email(value: &str) -> bool {
 /// Check if value is a valid SSN (Social Security Number) format
 pub fn is_ssn(value: &str) -> bool {
     // Remove dashes and spaces
-    let cleaned: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    let cleaned: String = value.chars().filter(char::is_ascii_digit).collect();
 
     // SSN should be exactly 9 digits
     if cleaned.len() != 9 {
@@ -427,7 +427,7 @@ pub fn validate_checksum(value: &str, algorithm: &str) -> bool {
 /// Validate Luhn checksum (used for credit cards, etc.)
 pub fn validate_luhn_checksum(value: &str) -> bool {
     // Remove any non-digit characters
-    let digits: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    let digits: String = value.chars().filter(char::is_ascii_digit).collect();
 
     if digits.len() < 2 {
         return false;
@@ -804,7 +804,7 @@ pub fn check_rule_condition(msg: &Message, condition: &RuleCondition) -> bool {
     let rhs_list: Vec<&str> = condition
         .values
         .as_ref()
-        .map_or(Vec::new(), |v| v.iter().map(|s| s.as_str()).collect());
+        .map_or(Vec::new(), |v| v.iter().map(std::string::String::as_str).collect());
 
     match condition.operator.as_str() {
         // value/string ops

--- a/crates/hl7v2-validation/tests/bdd_tests.rs
+++ b/crates/hl7v2-validation/tests/bdd_tests.rs
@@ -1398,7 +1398,11 @@ fn when_validate_segment_order(world: &mut ValidationWorld) {
     world.validation_passed = true;
 
     if let Some(msg) = &world.parsed_message {
-        let segment_names: Vec<&str> = msg.segments.iter().map(hl7v2_core::Segment::id_str).collect();
+        let segment_names: Vec<&str> = msg
+            .segments
+            .iter()
+            .map(hl7v2_core::Segment::id_str)
+            .collect();
 
         let evn_idx = segment_names.iter().position(|&s| s == "EVN");
         let pid_idx = segment_names.iter().position(|&s| s == "PID");

--- a/crates/hl7v2-validation/tests/bdd_tests.rs
+++ b/crates/hl7v2-validation/tests/bdd_tests.rs
@@ -80,7 +80,7 @@ impl ValidationWorld {
     fn get_last_field_value(&self) -> Option<String> {
         let msg = self.parsed_message.as_ref()?;
         let path = self.last_validated_field.as_ref()?;
-        hl7v2_query::get(msg, path).map(|s| s.to_string())
+        hl7v2_query::get(msg, path).map(std::string::ToString::to_string)
     }
 
     fn add_error(&mut self, code: &str, path: &str, detail: &str) {
@@ -1398,7 +1398,7 @@ fn when_validate_segment_order(world: &mut ValidationWorld) {
     world.validation_passed = true;
 
     if let Some(msg) = &world.parsed_message {
-        let segment_names: Vec<&str> = msg.segments.iter().map(|s| s.id_str()).collect();
+        let segment_names: Vec<&str> = msg.segments.iter().map(hl7v2_core::Segment::id_str).collect();
 
         let evn_idx = segment_names.iter().position(|&s| s == "EVN");
         let pid_idx = segment_names.iter().position(|&s| s == "PID");
@@ -1603,7 +1603,7 @@ fn then_error_lists_values(world: &mut ValidationWorld) {
     let has_values = world
         .issues
         .iter()
-        .any(|i| i.detail.contains("M") || i.code == "INVALID_CODE_VALUE");
+        .any(|i| i.detail.contains('M') || i.code == "INVALID_CODE_VALUE");
     assert!(has_values, "Expected error listing valid values not found");
 }
 

--- a/crates/hl7v2-validation/tests/integration_tests.rs
+++ b/crates/hl7v2-validation/tests/integration_tests.rs
@@ -507,7 +507,7 @@ fn test_segment_order_adt_a01() {
     let msg = parse_message(msg_content);
 
     // Expected order for ADT^A01: MSH, EVN, PID, PV1
-    let segment_names: Vec<&str> = msg.segments.iter().map(|s| s.id_str()).collect();
+    let segment_names: Vec<&str> = msg.segments.iter().map(hl7v2_core::Segment::id_str).collect();
 
     assert!(segment_names.contains(&"MSH"), "Should have MSH");
     assert!(segment_names.contains(&"PID"), "Should have PID");

--- a/crates/hl7v2-validation/tests/integration_tests.rs
+++ b/crates/hl7v2-validation/tests/integration_tests.rs
@@ -507,7 +507,11 @@ fn test_segment_order_adt_a01() {
     let msg = parse_message(msg_content);
 
     // Expected order for ADT^A01: MSH, EVN, PID, PV1
-    let segment_names: Vec<&str> = msg.segments.iter().map(hl7v2_core::Segment::id_str).collect();
+    let segment_names: Vec<&str> = msg
+        .segments
+        .iter()
+        .map(hl7v2_core::Segment::id_str)
+        .collect();
 
     assert!(segment_names.contains(&"MSH"), "Should have MSH");
     assert!(segment_names.contains(&"PID"), "Should have PID");

--- a/crates/hl7v2-validation/tests/snapshot_tests.rs
+++ b/crates/hl7v2-validation/tests/snapshot_tests.rs
@@ -570,7 +570,7 @@ fn snapshot_adt_a01_validation_report() {
         let condition = RuleCondition {
             field: field.to_string(),
             operator: op.to_string(),
-            value: value.map(|s| s.to_string()),
+            value: value.map(std::string::ToString::to_string),
             values,
         };
 
@@ -608,7 +608,7 @@ fn snapshot_oru_r01_validation_report() {
         let condition = RuleCondition {
             field: field.to_string(),
             operator: op.to_string(),
-            value: value.map(|s| s.to_string()),
+            value: value.map(std::string::ToString::to_string),
             values,
         };
 

--- a/crates/hl7v2-writer/CLAUDE.md
+++ b/crates/hl7v2-writer/CLAUDE.md
@@ -1,16 +1,16 @@
 # hl7v2-writer
 
 ## Build
-`ash
+```bash
 cargo build -p hl7v2-writer
-`
+```
 
 ## Test
-`ash
+```bash
 cargo test -p hl7v2-writer
-`
+```
 
 ## Lint
-`ash
+```bash
 cargo clippy -p hl7v2-writer -- -D warnings
-`
+```

--- a/crates/hl7v2-writer/src/lib.rs
+++ b/crates/hl7v2-writer/src/lib.rs
@@ -306,7 +306,7 @@ mod integration_tests {
         let result = String::from_utf8(bytes).unwrap();
 
         assert!(result.starts_with("MSH|"));
-        assert!(result.ends_with("\r"));
+        assert!(result.ends_with('\r'));
     }
 
     #[test]

--- a/crates/hl7v2-writer/src/tests.rs
+++ b/crates/hl7v2-writer/src/tests.rs
@@ -38,7 +38,7 @@ fn test_write_minimal_msh() {
 
     assert!(result.starts_with("MSH|"));
     assert!(result.contains("^~\\&"));
-    assert!(result.ends_with("\r"));
+    assert!(result.ends_with('\r'));
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn test_write_msh_with_fields() {
     // ^ is component separator, gets escaped as \S\
     assert!(result.contains("ADT\\S\\A01"));
     assert!(result.contains("MSG00001"));
-    assert!(result.ends_with("\r"));
+    assert!(result.ends_with('\r'));
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn test_write_single_segment() {
     assert!(result.contains("12345"));
     // ^ is component separator, gets escaped as \S\
     assert!(result.contains("DOE\\S\\JOHN\\S\\A"));
-    assert!(result.ends_with("\r"));
+    assert!(result.ends_with('\r'));
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn test_write_single_repetition() {
     let result = String::from_utf8(bytes).unwrap();
 
     assert!(result.contains("VALUE"));
-    assert!(!result.contains("~")); // No repetition separator
+    assert!(!result.contains('~')); // No repetition separator
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn test_write_single_component() {
     let result = String::from_utf8(bytes).unwrap();
 
     assert!(result.contains("SINGLE"));
-    assert!(!result.contains("^")); // No component separator in single component
+    assert!(!result.contains('^')); // No component separator in single component
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn test_write_single_subcomponent() {
     let result = String::from_utf8(bytes).unwrap();
 
     assert!(result.contains("SINGLE"));
-    assert!(!result.contains("&")); // No subcomponent separator
+    assert!(!result.contains('&')); // No subcomponent separator
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn test_write_no_escape_needed() {
 
     // No escaping needed
     assert!(result.contains("normal text 123"));
-    assert!(!result.contains("\\"));
+    assert!(!result.contains('\\'));
 }
 
 // ============================================================================
@@ -811,7 +811,7 @@ fn test_to_json_string_basic() {
     let json_str = to_json_string(&message);
 
     assert!(json_str.contains("segments"));
-    assert!(!json_str.contains("\n")); // Compact format
+    assert!(!json_str.contains('\n')); // Compact format
 }
 
 #[test]
@@ -828,7 +828,7 @@ fn test_to_json_string_pretty() {
     let json_str = to_json_string_pretty(&message);
 
     assert!(json_str.contains("segments"));
-    assert!(json_str.contains("\n")); // Pretty format has newlines
+    assert!(json_str.contains('\n')); // Pretty format has newlines
 }
 
 // ============================================================================

--- a/crates/hl7v2-writer/tests/bdd_tests.rs
+++ b/crates/hl7v2-writer/tests/bdd_tests.rs
@@ -273,7 +273,7 @@ fn given_message_charset(world: &mut WriterWorld) {
     world.message = Some(message);
 }
 
-#[given(regex = r#"a message of type ([A-Z]{3}\^[A-Z0-9]{2,3})"#)]
+#[given(regex = r"a message of type ([A-Z]{3}\^[A-Z0-9]{2,3})")]
 fn given_message_type(world: &mut WriterWorld, message_type: String) {
     let delims = Delims::default();
     let mut msh = WriterWorld::create_msh_segment(&delims);
@@ -390,17 +390,17 @@ fn then_output_custom_delimiters(world: &mut WriterWorld) {
 
 #[then("the repetitions should be separated by tilde \"~\"")]
 fn then_repetitions_tilde(world: &mut WriterWorld) {
-    assert!(world.output_str.contains("~"));
+    assert!(world.output_str.contains('~'));
 }
 
 #[then("the components should be separated by caret \"^\"")]
 fn then_components_caret(world: &mut WriterWorld) {
-    assert!(world.output_str.contains("^"));
+    assert!(world.output_str.contains('^'));
 }
 
 #[then("the subcomponents should be separated by ampersand \"&\"")]
 fn then_subcomponents_ampersand(world: &mut WriterWorld) {
-    assert!(world.output_str.contains("&"));
+    assert!(world.output_str.contains('&'));
 }
 
 #[then("the special characters should be properly escaped")]
@@ -457,7 +457,7 @@ fn then_long_values_preserved(world: &mut WriterWorld) {
 
 #[then("the special characters should be preserved or properly escaped")]
 fn then_special_chars_preserved(world: &mut WriterWorld) {
-    assert!(world.output_str.contains(",") || world.output_str.contains("\\E\\"));
+    assert!(world.output_str.contains(',') || world.output_str.contains("\\E\\"));
 }
 
 #[then("the output should start with MLLP start block")]

--- a/crates/hl7v2-writer/tests/integration_tests.rs
+++ b/crates/hl7v2-writer/tests/integration_tests.rs
@@ -72,7 +72,7 @@ fn test_adt_a01_message() {
     assert!(result.contains("PV1|"));
 
     // Verify segment count
-    assert_eq!(result.matches("\r").count(), 4);
+    assert_eq!(result.matches('\r').count(), 4);
 }
 
 #[test]

--- a/crates/hl7v2/Cargo.toml
+++ b/crates/hl7v2/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hl7v2"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+homepage = "https://github.com/EffortlessMetrics/hl7v2-rs"
+documentation = "https://docs.rs/hl7v2"
+description = "HL7 v2 message parser and processor for Rust"
+readme = "README.md"
+
+[features]
+default = []
+network = ["hl7v2-core/network"]
+stream = ["hl7v2-core/stream"]
+
+[dependencies]
+hl7v2-core = { version = "1.2.0", path = "../hl7v2-core" }

--- a/crates/hl7v2/README.md
+++ b/crates/hl7v2/README.md
@@ -1,0 +1,39 @@
+# hl7v2
+
+HL7 v2 message parser and processor for Rust.
+
+This is the canonical entry point for the
+[`hl7v2-rs`](https://github.com/EffortlessMetrics/hl7v2-rs) workspace.
+
+## Quick start
+
+```rust
+use hl7v2::{parse, get};
+
+let msg = parse(b"MSH|^~\\&|App||Fac||20250128||ADT^A01|123|P|2.5.1\rPID|1||PAT123||Doe^John\r").unwrap();
+assert_eq!(get(&msg, "PID.5.1"), Some("Doe"));
+```
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| `stream` | Streaming/event-based parser |
+| `network` | Async MLLP client/server (TCP/TLS) |
+
+## Microcrates
+
+For finer-grained dependencies, use the individual crates directly:
+
+| Crate | Purpose |
+|-------|---------|
+| `hl7v2-model` | Core data types |
+| `hl7v2-parser` | Message parsing |
+| `hl7v2-writer` | Message serialization |
+| `hl7v2-escape` | Escape sequence handling |
+| `hl7v2-mllp` | MLLP framing |
+| `hl7v2-normalize` | Message normalization |
+
+## License
+
+AGPL-3.0-or-later

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -1,0 +1,23 @@
+//! # hl7v2
+//!
+//! HL7 v2 message parser and processor for Rust.
+//!
+//! This crate is the canonical entry point for the
+//! [`hl7v2-rs`](https://github.com/EffortlessMetrics/hl7v2-rs) workspace.
+//! It re-exports everything from [`hl7v2-core`](https://crates.io/crates/hl7v2-core).
+//!
+//! ## Quick start
+//!
+//! ```rust
+//! use hl7v2::{parse, get};
+//!
+//! let msg = parse(b"MSH|^~\\&|App||Fac||20250128||ADT^A01|123|P|2.5.1\rPID|1||PAT123||Doe^John\r").unwrap();
+//! assert_eq!(get(&msg, "PID.5.1"), Some("Doe"));
+//! ```
+//!
+//! ## Features
+//!
+//! - `stream` — streaming/event-based parser
+//! - `network` — async MLLP client/server
+
+pub use hl7v2_core::*;

--- a/examples/ack_generation.rs
+++ b/examples/ack_generation.rs
@@ -47,7 +47,7 @@ fn acceptance_ack_example() {
     let original = parse(VALID_ADT_MESSAGE).expect("Message should parse");
     println!(
         "{}",
-        String::from_utf8_lossy(VALID_ADT_MESSAGE).replace("\r", "\r\n")
+        String::from_utf8_lossy(VALID_ADT_MESSAGE).replace('\r', "\r\n")
     );
     println!();
 
@@ -80,7 +80,7 @@ fn rejection_ack_example() {
     let original = parse(INCOMPLETE_MESSAGE).expect("Message should parse");
     println!(
         "{}",
-        String::from_utf8_lossy(INCOMPLETE_MESSAGE).replace("\r", "\r\n")
+        String::from_utf8_lossy(INCOMPLETE_MESSAGE).replace('\r', "\r\n")
     );
     println!();
 
@@ -111,7 +111,7 @@ fn error_ack_example() {
     let original = parse(INVALID_DATA_MESSAGE).expect("Message should parse");
     println!(
         "{}",
-        String::from_utf8_lossy(INVALID_DATA_MESSAGE).replace("\r", "\r\n")
+        String::from_utf8_lossy(INVALID_DATA_MESSAGE).replace('\r', "\r\n")
     );
     println!();
 
@@ -277,7 +277,7 @@ fn ack_workflow_example() {
 fn display_ack(ack_msg: &Message) {
     println!("ACK Message:");
     let bytes = write(ack_msg);
-    println!("{}", String::from_utf8_lossy(&bytes).replace("\r", "\r\n"));
+    println!("{}", String::from_utf8_lossy(&bytes).replace('\r', "\r\n"));
 }
 
 /// Simulated message processing with ACK generation

--- a/examples/batch_processing.rs
+++ b/examples/batch_processing.rs
@@ -164,8 +164,8 @@ struct ProcessResult {
 /// Process a single message
 fn process_message(message: &Message, num: usize) -> ProcessResult {
     // Extract patient information
-    let patient_id = get(message, "PID.3.1").map(|s| s.to_string());
-    let patient_name = get(message, "PID.5").map(|s| s.to_string());
+    let patient_id = get(message, "PID.3.1").map(std::string::ToString::to_string);
+    let patient_name = get(message, "PID.5").map(std::string::ToString::to_string);
 
     println!("Message {}:", num);
     if let Some(ref id) = patient_id {
@@ -210,7 +210,7 @@ fn create_batch_example() {
     let output = write_batch_manually(&batch);
 
     println!("\nBatch output:");
-    println!("{}", String::from_utf8_lossy(&output).replace("\r", "\r\n"));
+    println!("{}", String::from_utf8_lossy(&output).replace('\r', "\r\n"));
     println!();
 }
 
@@ -303,8 +303,8 @@ fn batch_error_handling_example() {
 #[allow(dead_code)]
 fn process_message_safe(message: &Message, index: usize) -> ProcessResult {
     // Use pattern matching for safe extraction
-    let patient_id = get(message, "PID.3.1").map(|s| s.to_string());
-    let patient_name = get(message, "PID.5").map(|s| s.to_string());
+    let patient_id = get(message, "PID.3.1").map(std::string::ToString::to_string);
+    let patient_name = get(message, "PID.5").map(std::string::ToString::to_string);
 
     // Validate required fields
     if patient_id.is_none() {

--- a/examples/mllp_client.rs
+++ b/examples/mllp_client.rs
@@ -53,7 +53,7 @@ async fn main() {
 
     // Example 2: Client with custom configuration
     println!("--- Example 2: Custom Configuration ---\n");
-    let config_info = r#"
+    let config_info = r"
 Client configuration:
     MllpClientBuilder::new()
         .connect_timeout(Duration::from_secs(5))
@@ -61,7 +61,7 @@ Client configuration:
         .write_timeout(Duration::from_secs(10))
         .max_frame_size(10 * 1024 * 1024)  // 10MB
         .build()
-"#;
+";
     println!("{}", config_info);
     println!();
 
@@ -139,7 +139,7 @@ fn display_ack_details(ack: &Message) {
     println!("Full ACK message:");
     println!(
         "{}",
-        String::from_utf8_lossy(&ack_bytes).replace("\r", "\r\n")
+        String::from_utf8_lossy(&ack_bytes).replace('\r', "\r\n")
     );
 }
 

--- a/examples/streaming_parser.rs
+++ b/examples/streaming_parser.rs
@@ -137,7 +137,7 @@ fn event_processing_example() {
                         ("MSH", 12) => msg.version = Some(value.to_string()),
                         ("PID", 3) if value.contains("^^^") => {
                             // Extract patient ID (first component)
-                            msg.patient_id = value.split('^').next().map(|s| s.to_string());
+                            msg.patient_id = value.split('^').next().map(std::string::ToString::to_string);
                         }
                         ("PID", 5) => msg.patient_name = Some(value.to_string()),
                         _ => {}

--- a/examples/streaming_parser.rs
+++ b/examples/streaming_parser.rs
@@ -137,7 +137,10 @@ fn event_processing_example() {
                         ("MSH", 12) => msg.version = Some(value.to_string()),
                         ("PID", 3) if value.contains("^^^") => {
                             // Extract patient ID (first component)
-                            msg.patient_id = value.split('^').next().map(std::string::ToString::to_string);
+                            msg.patient_id = value
+                                .split('^')
+                                .next()
+                                .map(std::string::ToString::to_string);
                         }
                         ("PID", 5) => msg.patient_name = Some(value.to_string()),
                         _ => {}

--- a/examples/template_generation.rs
+++ b/examples/template_generation.rs
@@ -118,7 +118,7 @@ fn programmatic_template_example() {
             if let Some(msg) = messages.first() {
                 println!("Generated Message:");
                 let bytes = write(msg);
-                println!("{}", String::from_utf8_lossy(&bytes).replace("\r", "\r\n"));
+                println!("{}", String::from_utf8_lossy(&bytes).replace('\r', "\r\n"));
 
                 // Show extracted values
                 println!("\nExtracted values:");

--- a/examples/validation_basics.rs
+++ b/examples/validation_basics.rs
@@ -277,7 +277,7 @@ fn invalid_message_example() {
     println!("Invalid message (missing fields, invalid values):");
     println!(
         "{}",
-        String::from_utf8_lossy(invalid_message).replace("\r", "\r\n")
+        String::from_utf8_lossy(invalid_message).replace('\r', "\r\n")
     );
     println!();
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -462,7 +462,7 @@ hl7v2-test-utils = {{ path = "../hl7v2-test-utils" }}
 
     // README.md
     let readme = format!(
-        r#"# {crate_name}
+        r"# {crate_name}
 
 {description}
 
@@ -471,13 +471,13 @@ hl7v2-test-utils = {{ path = "../hl7v2-test-utils" }}
 ```rust
 use {crate_name}::*;
 ```
-"#
+"
     );
     fs::write(crate_path.join("README.md"), readme)?;
 
     // CLAUDE.md
     let claude = format!(
-        r#"# {crate_name} Development
+        r"# {crate_name} Development
 
 ## Build & Test
 
@@ -486,7 +486,7 @@ cargo build -p {crate_name}
 cargo test -p {crate_name}
 cargo clippy -p {crate_name} -- -D warnings
 ```
-"#
+"
     );
     fs::write(crate_path.join("CLAUDE.md"), claude)?;
 
@@ -521,7 +521,7 @@ fn hook_pre_commit() -> Result<()> {
     let staged = git_output(&["diff", "--cached", "--name-only", "--diff-filter=ACMR"])?;
     let staged_files: Vec<&str> = staged
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .filter(|l| !l.is_empty())
         .collect();
 
@@ -742,7 +742,7 @@ fn command_exists(cmd: &str) -> bool {
 }
 
 enum ChangedScope {
-    /// Only crates/<name>/ files changed — scoped gate possible
+    /// Only `crates/<name>/` files changed — scoped gate possible
     Crates(Vec<String>),
     /// Non-crate files changed — full workspace gate required
     Workspace,


### PR DESCRIPTION
## Summary

Follow-up to #142. Expands BDD test coverage from 7 crates to 13, fixes documentation, and applies clippy fixes.

1. **Fix corrupted CLAUDE.md fences** — all 28 crate CLAUDE.md files had a backspace character in opening code fences. Fixed.

2. **Add BDD cucumber tests for 6 more crates** (110 + 176 = 286 new scenarios):
   - `escape`: 35 scenarios
   - `mllp`: 11 scenarios
   - `datetime`: 44 scenarios
   - `parser`: 20 scenarios
   - `datatype`: 137 scenarios
   - `faker`: 39 scenarios

3. **Apply clippy pedantic fixes** — redundant closures, inline format args, single-char patterns, raw string hashes, etc.

## BDD Test Status

**435 total scenarios across 13 crates, all passing.**

| Crate | Scenarios | Status |
|-------|-----------|--------|
| ack | 15 | pass |
| batch | 20 | pass |
| json | 22 | pass |
| normalize | 22 | pass |
| path | 26 | pass |
| query | 24 | pass |
| writer | 20 | pass |
| **escape** | **35** | **pass** |
| **mllp** | **11** | **pass** |
| **datetime** | **44** | **pass** |
| **parser** | **20** | **pass** |
| **datatype** | **137** | **pass** |
| **faker** | **39** | **pass** |

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --lib --workspace --all-features` — all unit tests green
- [x] All 13 BDD suites: 435 scenarios, 435 passed, 0 failures