### PR TITLE
[EFF-639] Add container image vulnerability scanning to CI/CD pipeline

### DIFF
--- a/.paperclip/EFF-639-scaffold.md
+++ b/.paperclip/EFF-639-scaffold.md
@@ -1,0 +1,31 @@
+# EFF-639: Container Image Vulnerability Scanning
+
+## Overview
+Add container image vulnerability scanning to the CI/CD pipeline using Trivy.
+
+## Implementation Plan
+
+### 1. Add container-scan job to `.github/workflows/security.yml`
+- Build Docker image: `docker build -t hl7v2-rs:scan -f infrastructure/docker/Dockerfile .`
+- Run Trivy scan with SARIF output
+- Upload results to GitHub Security tab
+- Block on CRITICAL/HIGH severity vulnerabilities
+
+### 2. Add to nightly workflow
+- Continuous monitoring of base image CVEs
+- Drift detection for new vulnerabilities
+
+### 3. Optional: SBOM generation
+- Generate Software Bill of Materials for compliance
+
+## References
+- Issue: EFF-639
+- Parent: EFF-1006 (Security: Kyverno Policy Compliance)
+- Tool: [Trivy](https://github.com/aquasecurity/trivy-action)
+
+## Test Plan
+See `tests/container_vulnerability_scan_tests.rs` (to be added by Red Test Builder)
+
+## Blockers
+- OAuth scope limitation prevents direct workflow file modification via API
+- Requires workflow scope to push `.github/workflows/security.yml` changes


### PR DESCRIPTION
## Summary

This PR adds container image vulnerability scanning to the CI/CD pipeline to address the security gap where Docker images are built but never scanned for CVEs before deployment.

## Problem

- Docker images may contain vulnerable base OS packages (Alpine)
- No visibility into image security posture before production
- Compliance frameworks (SOC2, ISO 27001) require artifact scanning
- Supply chain risk from `rust:1.89-alpine` and `alpine:latest` base images

## Proposed Solution

Add Trivy container scanning to `.github/workflows/security.yml`:
- Build image before scanning: `docker build -t hl7v2-rs:scan -f infrastructure/docker/Dockerfile .`
- Scan with Trivy using SARIF output format
- Upload results to GitHub Security tab
- Block on CRITICAL/HIGH severity vulnerabilities
- Add to nightly workflow for drift detection

## Implementation Status

- [x] Scaffold PR structure
- [ ] Add container-scan job to security.yml (requires OAuth workflow scope)
- [ ] Add to nightly.yml for continuous monitoring
- [ ] Consider SBOM generation for compliance
- [ ] Determine severity threshold for blocking CI

## Related

- Issue: EFF-639
- Parent: EFF-1006 (Security: Kyverno Policy Compliance and Enforcement)
- Related: EFF-312 (Docker Compose latest tags), EFF-335 (Container scanning)

## Notes

Workflow file modifications (`.github/workflows/security.yml`) require OAuth `workflow` scope which is not available via the current API token. These changes will need to be made through the PR review process or by an agent with elevated permissions.

---
**Next Owner**: Red Test Builder