### PR TITLE
[WIP] feat(grpc): Implement gRPC server for HL7v2 toolkit (EFF-157)

### DIFF
--- a/.swarm/EFF-1194/bdd-scenarios.md
+++ b/.swarm/EFF-1194/bdd-scenarios.md
@@ -1,0 +1,267 @@
+# EFF-1194: gRPC Server Implementation - BDD Scenarios
+
+## Feature: gRPC Parse RPC
+
+### Scenario: Parse a valid HL7 message
+```gherkin
+Given the gRPC server is running on port 9090
+And a valid HL7 ADT^A01 message
+When I send a ParseRequest with the message bytes
+Then I receive a ParseResponse with success=true
+And the response contains the parsed Message structure
+And the metadata includes message type "ADT^A01"
+```
+
+### Scenario: Parse an MLLP-framed message
+```gherkin
+Given the gRPC server is running
+And an HL7 message wrapped in MLLP framing (0x0B ... 0x1C 0x0D)
+When I send a ParseRequest with mllp_framed=true
+Then I receive a successful ParseResponse
+And the MLLP framing is correctly stripped
+```
+
+### Scenario: Parse with invalid message
+```gherkin
+Given the gRPC server is running
+And an invalid/corrupted HL7 message
+When I send a ParseRequest
+Then I receive a ParseResponse with success=false
+And the errors array contains at least one error with INVALID_MESSAGE code
+```
+
+### Scenario: Parse with strict mode
+```gherkin
+Given the gRPC server is running
+And an HL7 message with version 2.3
+When I send a ParseRequest with strict=true and expected_version="2.5"
+Then I receive a ParseResponse with success=false
+And the errors indicate version mismatch
+```
+
+---
+
+## Feature: gRPC Validate RPC
+
+### Scenario: Validate message against profile
+```gherkin
+Given the gRPC server is running
+And a valid ADT^A01 message
+And a registered "adt-a01-basic" profile
+When I send a ValidateRequest with profile="adt-a01-basic"
+Then I receive a ValidateResponse with valid=true
+And the errors array is empty
+```
+
+### Scenario: Validation fails with errors
+```gherkin
+Given the gRPC server is running
+And an ADT^A01 message missing required PID-3 (Patient ID)
+And a strict "adt-a01-full" profile
+When I send a ValidateRequest with profile="adt-a01-full"
+Then I receive a ValidateResponse with valid=false
+And the errors array contains a REQUIRED_FIELD_MISSING error for PID-3
+```
+
+### Scenario: Validation with warnings
+```gherkin
+Given the gRPC server is running
+And an ADT^A01 message with extra optional segments
+And a basic profile that doesn't use those segments
+When I send a ValidateRequest with fail_on_warning=false
+Then I receive a ValidateResponse with valid=true
+And the warnings array contains UNEXPECTED_SEGMENT entries
+```
+
+---
+
+## Feature: gRPC GenerateAck RPC
+
+### Scenario: Generate Application Accept (AA) ACK
+```gherkin
+Given the gRPC server is running
+And a received HL7 message with control ID "MSG001"
+When I send an AckRequest with code=AA
+Then I receive an AckResponse
+And the ack_message contains an ACK segment with MSA-1="AA"
+And the MSA-2 matches the original control ID "MSG001"
+```
+
+### Scenario: Generate Application Error (AE) ACK
+```gherkin
+Given the gRPC server is running
+And a received HL7 message that failed processing
+When I send an AckRequest with code=AE and error_message="Invalid patient ID"
+Then I receive an AckResponse
+And the ack_message contains MSA-1="AE"
+And the ERR segment contains the error details
+```
+
+### Scenario: Generate Application Reject (AR) ACK
+```gherkin
+Given the gRPC server is running
+And a completely unsupported message type
+When I send an AckRequest with code=AR
+Then I receive an AckResponse
+And the ack_message contains MSA-1="AR"
+```
+
+---
+
+## Feature: gRPC Normalize RPC
+
+### Scenario: Normalize message with canonical delimiters
+```gherkin
+Given the gRPC server is running
+And an HL7 message using non-standard delimiters
+When I send a NormalizeRequest with canonical_delimiters=true
+Then I receive a NormalizeResponse
+And the normalized message uses standard |^~\& delimiters
+```
+
+### Scenario: Normalize and add MLLP framing
+```gherkin
+Given the gRPC server is running
+And a raw HL7 message without framing
+When I send a NormalizeRequest with mllp_frame=true
+Then I receive a NormalizeResponse
+And the normalized message is wrapped in MLLP framing bytes
+```
+
+---
+
+## Feature: gRPC ParseStream RPC (Bidirectional Streaming)
+
+### Scenario: Stream multiple messages
+```gherkin
+Given the gRPC server is running
+And a stream of 100 ParseRequests
+When I open a bidirectional ParseStream
+And send all 100 requests
+Then I receive exactly 100 ParseResponses
+And each response corresponds to its request
+And all responses are received within 5 seconds
+```
+
+### Scenario: Streaming with backpressure
+```gherkin
+Given the gRPC server is running
+And a client that sends messages faster than they can be processed
+When I open a ParseStream and flood with 10000 requests
+Then the server applies HTTP/2 flow control backpressure
+And no server-side buffer overflow occurs
+And memory usage remains stable
+```
+
+### Scenario: Streaming error handling
+```gherkin
+Given the gRPC server is running
+And a stream containing valid and invalid messages
+When I send a ParseStream with mixed valid/invalid messages
+Then valid messages return success responses
+And invalid messages return error responses
+And the stream remains open for subsequent messages
+```
+
+---
+
+## Feature: gRPC HealthCheck RPC
+
+### Scenario: Server is healthy
+```gherkin
+Given the gRPC server is running and fully initialized
+When I send a HealthCheckRequest
+Then I receive a HealthCheckResponse with status=SERVING
+And the version field matches the crate version
+And the uptime_seconds is greater than 0
+```
+
+### Scenario: Server not yet ready
+```gherkin
+Given the gRPC server is starting up
+When I send a HealthCheckRequest during initialization
+Then I receive a HealthCheckResponse with status=NOT_SERVING
+```
+
+---
+
+## Feature: gRPC Server Integration
+
+### Scenario: Server starts on configured port
+```gherkin
+Given the gRPC feature is enabled
+When I run "hl7v2 serve --mode grpc --port 9090"
+Then the server starts successfully
+And binds to port 9090
+And logs "Starting gRPC server on 0.0.0.0:9090"
+```
+
+### Scenario: Server graceful shutdown
+```gherkin
+Given the gRPC server is running with active connections
+When a SIGINT (Ctrl+C) is received
+Then the server stops accepting new connections
+And waits up to 30 seconds for in-flight requests to complete
+Then shuts down gracefully
+```
+
+### Scenario: Tower middleware integration
+```gherkin
+Given the gRPC server is running with tracing enabled
+When I send any RPC request
+Then the request is logged with trace_id
+And metrics are recorded for the RPC
+And rate limiting is applied per configuration
+```
+
+---
+
+## Feature: gRPC Client Integration
+
+### Scenario: tonic client can connect
+```gherkin
+Given the gRPC server is running
+And a Rust tonic client is configured
+When the client connects to the server
+Then the connection succeeds
+And the client can call the Parse RPC
+```
+
+### Scenario: Cross-language Go client
+```gherkin
+Given the gRPC server is running
+And a Go client generated from hl7v2.proto
+When the Go client connects and calls HealthCheck
+Then the call succeeds
+And the response contains valid health status
+```
+
+---
+
+## Feature: Error Handling
+
+### Scenario: Invalid proto request
+```gherkin
+Given the gRPC server is running
+When I send a malformed ParseRequest (missing required fields)
+Then I receive a gRPC INVALID_ARGUMENT status
+And the error message indicates the missing field
+```
+
+### Scenario: Server-side error
+```gherkin
+Given the gRPC server is running
+When an internal error occurs during message processing
+Then I receive a gRPC INTERNAL status
+And the error message does not expose sensitive details
+And the trace_id is included for debugging
+```
+
+### Scenario: Deadline exceeded
+```gherkin
+Given the gRPC server is running
+And a request with a 100ms deadline
+When the processing takes longer than 100ms
+Then I receive a gRPC DEADLINE_EXCEEDED status
+And the server cancels the in-flight processing
+```

--- a/.swarm/EFF-1194/execution-spec.md
+++ b/.swarm/EFF-1194/execution-spec.md
@@ -1,0 +1,233 @@
+# EFF-1194: gRPC Server Implementation - Execution Specification
+
+## Overview
+
+This specification documents the implementation requirements for gRPC server support in the hl7v2-rs toolkit, addressing the gap between the complete proto file design and the current stub implementation.
+
+**Issue**: [EFF-1194](/EFF/issues/EFF-1194)  
+**GitHub Issue**: [#303](https://github.com/EffortlessMetrics/hl7v2-rs/issues/303)  
+**Branch**: `feature/grpc-server-impl`  
+**PR**: [#311](https://github.com/EffortlessMetrics/hl7v2-rs/pull/311)  
+**Status**: In Progress  
+**Priority**: High  
+
+---
+
+## Current State
+
+### Verified Gap
+
+| Component | Status | Evidence |
+|-----------|--------|----------|
+| Proto file | ✅ Complete | `api/proto/hl7v2.proto` - 323 lines, 6 RPCs |
+| ADR-0008 | ✅ Accepted | Tonic selected as gRPC framework |
+| CLI stub | ⚠️ Implemented | `crates/hl7v2-cli/src/serve.rs:102-110` - returns hardcoded error |
+| Tonic deps | ❌ Missing | No tonic/tonic-build/prost in workspace |
+| Codegen | ❌ Missing | No build.rs or generated code |
+| Service impl | ❌ Missing | No HL7Service trait implementation |
+
+### ADR Reference
+
+- **ADR-0008**: Tonic for gRPC Server - Status: **Accepted**
+- Architecture: Tonic (Tokio-native, Tower middleware compatible)
+- Proto path: `api/proto/hl7v2.proto`
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+1. **Parse RPC** - Parse HL7 v2 messages via gRPC
+   - Input: Raw HL7 message bytes
+   - Output: Structured message with metadata
+   - Support MLLP-framed messages
+
+2. **ParseStream RPC** - Bidirectional streaming for batch processing
+   - Stream-in: Multiple parse requests
+   - Stream-out: Corresponding parse responses
+   - Handle backpressure via HTTP/2 flow control
+
+3. **Validate RPC** - Profile validation endpoint
+   - Input: Message bytes + profile identifier
+   - Output: Validation result with errors/warnings
+
+4. **GenerateAck RPC** - ACK message generation
+   - Input: Original message + ACK code (AA/AE/AR)
+   - Output: Generated ACK message
+
+5. **Normalize RPC** - Message normalization
+   - Input: Message bytes + normalization options
+   - Output: Normalized message
+
+6. **HealthCheck RPC** - Service health status
+   - Standard gRPC health check protocol
+   - Include version and uptime
+
+### Non-Functional Requirements
+
+1. **Performance**: gRPC throughput should match or exceed HTTP API
+2. **Compatibility**: Share Tower middleware with existing Axum HTTP server
+3. **Port Strategy**: Separate gRPC port (9090) from HTTP port (8080)
+4. **Build**: protoc must be available in Nix dev shell and CI
+5. **Feature Flag**: gRPC behind `--features grpc` for lean default builds
+
+---
+
+## Architecture
+
+### Workspace Structure
+
+```
+crates/
+├── hl7v2-server/          # Existing HTTP server (Axum)
+│   └── src/
+│       └── grpc/          # NEW: gRPC module (conditionally compiled)
+├── hl7v2-cli/
+│   └── src/serve.rs       # MODIFIED: Replace run_grpc_server() stub
+└── hl7v2-grpc/            # OPTIONAL: Separate crate for gRPC types
+```
+
+### Dependency Strategy
+
+```toml
+# Root Cargo.toml [workspace.dependencies]
+tonic = "0.12"
+tonix-build = "0.12"
+prost = "0.13"
+prost-types = "0.13"
+
+# crates/hl7v2-server/Cargo.toml
+[features]
+default = []
+grpc = ["dep:tonic", "dep:prost", "tonic-build"]
+```
+
+### Proto Codegen
+
+```rust
+// crates/hl7v2-server/build.rs
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "grpc")]
+    {
+        tonic_build::configure()
+            .build_server(true)
+            .build_client(true)
+            .out_dir("src/grpc/gen")
+            .compile_protos(
+                &["../../api/proto/hl7v2.proto"],
+                &["../../api/proto"],
+            )?;
+    }
+    Ok(())
+}
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Infrastructure (2-3 hours)
+
+- [ ] Add tonic/prost dependencies to workspace Cargo.toml
+- [ ] Add tonic-build to workspace dependencies
+- [ ] Update Nix flake.nix to include protoc
+- [ ] Create build.rs in hl7v2-server crate
+- [ ] Add `grpc` feature flag to hl7v2-server/Cargo.toml
+- [ ] Verify proto code generation builds successfully
+
+**Acceptance**: `cargo build --features grpc` compiles without errors
+
+### Phase 2: Core RPCs (4-6 hours)
+
+- [ ] Implement proto-to-model type conversions
+- [ ] Implement Hl7Service trait for Parse RPC
+- [ ] Implement Validate RPC
+- [ ] Implement GenerateAck RPC
+- [ ] Implement Normalize RPC
+- [ ] Implement HealthCheck RPC
+
+**Acceptance**: All unary RPCs return valid responses for valid inputs
+
+### Phase 3: Streaming (3-4 hours)
+
+- [ ] Implement ParseStream bidirectional streaming
+- [ ] Handle request-response correlation
+- [ ] Implement backpressure handling
+- [ ] Add streaming error handling
+
+**Acceptance**: Can stream 1000+ messages with backpressure
+
+### Phase 4: Integration (2-3 hours)
+
+- [ ] Replace run_grpc_server() stub in CLI
+- [ ] Add Tower middleware (tracing, metrics)
+- [ ] Configure gRPC port (default 9090)
+- [ ] Add graceful shutdown handling
+
+**Acceptance**: `hl7v2 serve --mode grpc` starts functional server
+
+### Phase 5: Testing & Polish (3-4 hours)
+
+- [ ] Unit tests for each RPC handler
+- [ ] Integration tests with tonic client
+- [ ] Proto compatibility verification
+- [ ] Documentation updates
+- [ ] Benchmark comparison with HTTP API
+
+**Acceptance**: Test coverage >80%, benchmarks complete
+
+---
+
+## Test Strategy
+
+### Unit Tests
+
+- Each RPC handler tested in isolation
+- Type conversion tests (proto ↔ model)
+- Error handling tests
+
+### Integration Tests
+
+- End-to-end gRPC client/server tests
+- Streaming load tests
+- Middleware integration tests
+
+### Compatibility Tests
+
+- Proto backward compatibility checks
+- Cross-language client verification (Go, Java)
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| protoc build dependency | High | Update Nix shell, document in DEVELOPMENT.md |
+| Compile time increase | Medium | Feature flag keeps default builds lean |
+| Proto drift from model | Medium | Conversion tests, CI checks |
+| HTTP/2 proxy issues | Low | Document limitations, provide HTTP fallback |
+
+---
+
+## Open Questions
+
+1. Should we create a separate `hl7v2-grpc` crate or keep in `hl7v2-server`?
+2. Should gRPC be enabled by default once stable?
+3. Do we need TLS termination for gRPC (separate from mTLS)?
+
+---
+
+## Deliverables
+
+1. **Code**: Complete gRPC implementation in branch
+2. **Tests**: Unit and integration test suite
+3. **Docs**: Updated API documentation
+4. **CI**: Updated workflows with protoc
+
+---
+
+## Next Owner
+
+**Spec Verifier** - Review and approve this execution specification before implementation proceeds.

--- a/.swarm/EFF-1194/implementation-notes.md
+++ b/.swarm/EFF-1194/implementation-notes.md
@@ -1,0 +1,381 @@
+# EFF-1194: gRPC Server Implementation - Implementation Notes
+
+## Design Decisions
+
+### Decision 1: Feature Flag Strategy
+
+**Decision**: gRPC support will be behind a `grpc` feature flag in the `hl7v2-server` crate.
+
+**Rationale**:
+- Keeps default builds lean for users who only need HTTP
+- protoc build dependency is optional
+- Compile time impact is isolated
+
+**Implementation**:
+```toml
+# crates/hl7v2-server/Cargo.toml
+[features]
+default = []
+grpc = ["dep:tonic", "dep:prost", "dep:tonic-build"]
+```
+
+---
+
+### Decision 2: Crate Organization
+
+**Decision**: Keep gRPC code in `hl7v2-server` crate rather than creating a new `hl7v2-grpc` crate.
+
+**Rationale**:
+- gRPC and HTTP servers share significant logic (middleware, state management)
+- Single server crate aligns with "server modes" concept in CLI
+- Reduces cross-crate dependency complexity
+
+**Structure**:
+```
+crates/hl7v2-server/src/
+├── lib.rs              # Main exports
+├── http/               # Existing Axum HTTP server
+│   └── ...
+└── grpc/               # NEW: gRPC module
+    ├── mod.rs          # Feature-gated module
+    ├── gen/            # Generated proto code
+    │   └── hl7v2.v1.rs
+    ├── service.rs      # Hl7Service trait impl
+    ├── convert.rs      # Proto↔Model conversions
+    └── server.rs       # gRPC server setup
+```
+
+---
+
+### Decision 3: Code Generation Strategy
+
+**Decision**: Use `tonic-build` in a `build.rs` script with conditional compilation.
+
+**Rationale**:
+- Standard tonic approach
+- Generates both server and client code
+- Allows customization of output directory
+
+**Implementation**:
+```rust
+// crates/hl7v2-server/build.rs
+#[cfg(feature = "grpc")]
+fn build_proto() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .out_dir("src/grpc/gen")
+        .compile_protos(
+            &["../../api/proto/hl7v2.proto"],
+            &["../../api/proto"],
+        )?;
+    Ok(())
+}
+```
+
+**Note**: Generated files should be:
+- Committed to git for reproducibility
+- Regenerated when proto changes
+- Ignored by rustfmt via `#[rustfmt::skip]`
+
+---
+
+### Decision 4: Port Strategy
+
+**Decision**: gRPC server runs on a separate port from HTTP (default 9090 vs 8080).
+
+**Rationale**:
+- Clear separation of concerns
+- Independent scaling/configuration
+- HTTP/2 on gRPC port, HTTP/1.1 on HTTP port
+- Avoids content-type routing complexity
+
+**Configuration**:
+```rust
+// Default ports
+const DEFAULT_HTTP_PORT: u16 = 8080;
+const DEFAULT_GRPC_PORT: u16 = 9090;
+```
+
+---
+
+### Decision 5: Middleware Sharing
+
+**Decision**: Use Tower middleware layers shared between Axum HTTP and Tonic gRPC.
+
+**Rationale**:
+- Consistent observability (tracing, metrics)
+- Consistent cross-cutting concerns (auth, rate limiting)
+- Tower is the standard middleware interface for both
+
+**Implementation**:
+```rust
+// Shared middleware stack
+let middleware = ServiceBuilder::new()
+    .layer(TraceLayer::new_for_grpc())
+    .layer(RateLimitLayer::new(100, Duration::from_secs(1)))
+    .into_inner();
+
+// Applied to both HTTP and gRPC
+```
+
+---
+
+## Technical Implementation Details
+
+### Proto-to-Model Conversions
+
+The proto types need bidirectional conversion with `hl7v2-model` types:
+
+| Proto | Model | Conversion |
+|-------|-------|------------|
+| `Message` | `hl7v2_model::Message` | Full structure mapping |
+| `Segment` | `hl7v2_model::Segment` | Fields as Vec |
+| `Field` | `hl7v2_model::Field` | Atom-based presence |
+| `Delimiters` | `hl7v2_model::Delims` | Simple field mapping |
+| `ValidationIssue` | `hl7v2_validation::Issue` | Severity mapping |
+
+**Conversion Pattern**:
+```rust
+// From model to proto
+impl From<hl7v2_model::Message> for proto::Message {
+    fn from(msg: hl7v2_model::Message) -> Self {
+        // ... conversion logic
+    }
+}
+
+// From proto to model (may fail)
+impl TryFrom<proto::Message> for hl7v2_model::Message {
+    type Error = ConversionError;
+    fn try_from(msg: proto::Message) -> Result<Self, Self::Error> {
+        // ... conversion logic
+    }
+}
+```
+
+---
+
+### Hl7Service Trait Implementation
+
+```rust
+use tonic::{Request, Response, Status};
+
+pub struct Hl7ServiceImpl {
+    parser: Arc<MessageParser>,
+    validator: Arc<MessageValidator>,
+    // Shared state
+}
+
+#[tonic::async_trait]
+impl hl7_service_server::Hl7Service for Hl7ServiceImpl {
+    async fn parse(
+        &self,
+        request: Request<ParseRequest>,
+    ) -> Result<Response<ParseResponse>, Status> {
+        let req = request.into_inner();
+        
+        // Parse message bytes
+        let message = self.parser.parse(&req.message)
+            .map_err(|e| Status::invalid_argument(format!("Parse failed: {}", e)))?;
+        
+        // Convert to proto and respond
+        let response = ParseResponse {
+            success: true,
+            message: Some(message.into()),
+            errors: vec![],
+            metadata: extract_metadata(&message),
+        };
+        
+        Ok(Response::new(response))
+    }
+    
+    type ParseStreamStream = ReceiverStream<Result<ParseResponse, Status>>;
+    
+    async fn parse_stream(
+        &self,
+        request: Request<Streaming<ParseRequest>>,
+    ) -> Result<Response<Self::ParseStreamStream>, Status> {
+        let mut stream = request.into_inner();
+        let (tx, rx) = mpsc::channel(128);
+        
+        tokio::spawn(async move {
+            while let Some(req) = stream.message().await? {
+                let response = self.process_parse(req).await;
+                tx.send(response).await?;
+            }
+            Ok::<_, Status>(())
+        });
+        
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+    
+    // ... other RPC implementations
+}
+```
+
+---
+
+### CLI Integration
+
+Replace the stub in `crates/hl7v2-cli/src/serve.rs`:
+
+```rust
+#[cfg(feature = "grpc")]
+async fn run_grpc_server(bind_address: &str) -> Result<(), Box<dyn std::error::Error>> {
+    use hl7v2_server::grpc::{Hl7ServiceImpl, hl7_service_server};
+    
+    let addr = bind_address.parse()?;
+    let service = Hl7ServiceImpl::new();
+    
+    info!("Starting gRPC server on {}", bind_address);
+    
+    tonic::transport::Server::builder()
+        .add_service(hl7_service_server::Hl7ServiceServer::new(service))
+        .serve(addr)
+        .await?;
+    
+    Ok(())
+}
+
+#[cfg(not(feature = "grpc"))]
+async fn run_grpc_server(_bind_address: &str) -> Result<(), Box<dyn std::error::Error>> {
+    Err("gRPC support not enabled. Build with --features grpc".into())
+}
+```
+
+---
+
+## Build Infrastructure
+
+### Nix flake.nix Update
+
+Add protoc to dev shell:
+
+```nix
+# flake.nix - devShell
+packages = with pkgs; [
+  # ... existing packages
+  protobuf    # protoc compiler
+];
+```
+
+### CI Update
+
+Add protoc to GitHub Actions:
+
+```yaml
+- name: Install protoc
+  uses: arduino/setup-protoc@v2
+  with:
+    version: "23.x"
+```
+
+---
+
+## Options Considered
+
+### Option A: Separate hl7v2-grpc Crate (Rejected)
+
+**Pros**:
+- Cleaner separation of concerns
+- Could publish separately
+
+**Cons**:
+- Duplicated server logic
+- More complex dependency graph
+- Slower builds
+
+**Why rejected**: Not worth the overhead for the shared functionality.
+
+---
+
+### Option B: Same Port with Content-Type Routing (Rejected)
+
+**Pros**:
+- Single port exposure
+- Unified server entry point
+
+**Cons**:
+- Complex routing logic
+- HTTP/2 vs HTTP/1.1 complications
+- Harder to debug
+
+**Why rejected**: Separation of ports is clearer operationally.
+
+---
+
+### Option C: Prost-only (no Tonic) (Rejected)
+
+**Pros**:
+- Smaller dependency tree
+- More control over transport
+
+**Cons**:
+- Reinventing gRPC protocol
+- No streaming support
+- No ecosystem tooling
+
+**Why rejected**: Tonic is the standard; don't reinvent.
+
+---
+
+## Risk Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| protoc not in build env | Fail build with clear error message; document requirement |
+| Proto file changes | CI check that generated code is up-to-date |
+| Performance regression | Benchmark suite comparing gRPC vs HTTP throughput |
+| Binary size increase | Feature flag keeps default builds lean |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+Located in `crates/hl7v2-server/src/grpc/`
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[tokio::test]
+    async fn test_parse_rpc() {
+        let service = Hl7ServiceImpl::new();
+        let request = Request::new(ParseRequest {
+            message: b"MSH|...".to_vec(),
+            mllp_framed: false,
+            options: None,
+        });
+        
+        let response = service.parse(request).await.unwrap();
+        assert!(response.into_inner().success);
+    }
+}
+```
+
+### Integration Tests
+
+Located in `crates/hl7v2-server/tests/`
+
+```rust
+#[tokio::test]
+async fn test_grpc_health_check() {
+    let addr = start_test_server().await;
+    let client = HealthClient::connect(format!("http://{}", addr)).await.unwrap();
+    
+    let response = client.check(HealthCheckRequest {}).await.unwrap();
+    assert_eq!(response.into_inner().status, ServingStatus::Serving as i32);
+}
+```
+
+---
+
+## References
+
+- **ADR-0008**: Tonic for gRPC Server (`docs/adr/0008-tonic-for-grpc.md`)
+- **Proto file**: `api/proto/hl7v2.proto`
+- **CLI stub**: `crates/hl7v2-cli/src/serve.rs` lines 102-110
+- **Tonic docs**: https://docs.rs/tonic/latest/tonic/

--- a/crates/hl7v2-server/GRPC_IMPLEMENTATION.md
+++ b/crates/hl7v2-server/GRPC_IMPLEMENTATION.md
@@ -1,0 +1,29 @@
+# gRPC Server Implementation
+
+This crate will implement the gRPC server for the HL7v2 toolkit.
+
+## Overview
+
+Issue #157 identified that a comprehensive protobuf schema exists at `api/proto/hl7v2.proto`
+but has no implementation. This branch will implement the gRPC service.
+
+## Implementation Plan
+
+1. Add tonic/prost dependencies
+2. Set up build.rs for protobuf code generation
+3. Implement HL7Service trait
+4. Integrate with existing HTTP server
+
+## Proto Schema
+
+The proto file defines 6 RPCs:
+- Parse
+- Validate
+- GenerateAck
+- Normalize
+- ParseStream (streaming)
+- HealthCheck
+
+## Status
+
+🚧 Work in progress - see PR for details.


### PR DESCRIPTION
## Summary

This PR implements the gRPC server support for the HL7v2 toolkit, addressing issue #157 where a comprehensive protobuf schema exists but has no implementation.

## Current State

- **Branch**: `feature/grpc-server-impl`
- **Base**: `main`
- **Issue**: #157 - gRPC API defined but not implemented
- **Spec Status**: Verified - Proto schema at `api/proto/hl7v2.proto` (323 lines, 6 RPCs)
- **Head SHA**: `449c41b0`

## What's Being Implemented

### Phase 1: Infrastructure Setup
- [ ] Add `tonic` and `prost` dependencies to `crates/hl7v2-server/Cargo.toml`
- [ ] Set up `build.rs` with `tonic_build` for code generation
- [ ] Configure protobuf compilation pipeline

### Phase 2: Service Implementation
- [ ] Implement `HL7Service` trait for the generated server
- [ ] `Parse` - Parse HL7 messages via gRPC
- [ ] `Validate` - Profile validation endpoint
- [ ] `GenerateAck` - ACK message generation
- [ ] `Normalize` - Message normalization
- [ ] `ParseStream` - Streaming batch processing
- [ ] `HealthCheck` - Health check endpoint

### Phase 3: Integration
- [ ] Start gRPC server alongside HTTP (Axum)
- [ ] Verify port 9090 is properly served
- [ ] Add integration tests
- [ ] Update documentation

## Blockers & Caveats

- This is an early-stage draft PR - implementation in progress
- Initial scaffold commit pushed to establish PR surface
- Proto schema completeness: 100% - fully designed with 6 RPCs
- Infrastructure drift exists: docker-compose exposes port 9090 but no service

## Next Owner

**Red Test Builder** - After initial implementation commits are pushed, this PR will need:
1. Unit tests for each gRPC endpoint
2. Integration tests with tonic client
3. Proto compatibility verification

## PR Creation Status

- ✅ Branch exists remotely: `origin/feature/grpc-server-impl`
- ✅ Branch is clean (no contamination from other issues)
- ✅ Issue #157 verified with comprehensive spec
- ✅ Draft PR created with scaffold commit

---
**This is a draft PR intended for early-stage coordination. Do not merge until marked ready for review.**