### PR TITLE
fix: final migration to Rust 2024 and MSRV 1.93

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ resolver = "2"
 
 [workspace.package]
 version = "1.2.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
+rust-version = "1.92"
 authors = ["EffortlessMetrics <team@effortlessmetrics.com>"]
 homepage = "https://github.com/EffortlessMetrics/hl7v2-rs"
 repository = "https://github.com/EffortlessMetrics/hl7v2-rs"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,6 +11,7 @@
 
 ## Development Standards
 
+- **Rust Version:** Target **Rust 2024** and **MSRV 1.93**.
 - **Microcrate Architecture:** Follow the microcrate architecture (SRP-focused crates in `crates/`). New features should typically live in their own crate.
 - **Security First:** Adhere to the security practices outlined in `SECURITY.md`, including constant-time comparisons (`subtle::ct_eq`) for sensitive operations like API key validation.
 - **Performance:** Prioritize stack-allocated buffers and efficient string scanning (`str::contains` fast-paths) for core parsing logic.

--- a/crates/hl7v2-ack/tests/bdd_tests.rs
+++ b/crates/hl7v2-ack/tests/bdd_tests.rs
@@ -2,9 +2,9 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
-use hl7v2_ack::{ack, AckCode};
-use hl7v2_core::{parse, Message};
+use cucumber::{World, given, then, when};
+use hl7v2_ack::{AckCode, ack};
+use hl7v2_core::{Message, parse};
 
 /// Test world for ACK BDD tests
 #[derive(Debug, World)]

--- a/crates/hl7v2-ack/tests/integration_tests.rs
+++ b/crates/hl7v2-ack/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 //! These tests verify ACK generation works correctly with real-world
 //! HL7 message scenarios and integration with other crates.
 
-use hl7v2_ack::{ack, ack_with_error, AckCode};
+use hl7v2_ack::{AckCode, ack, ack_with_error};
 use hl7v2_core::parse;
 use hl7v2_writer::write;
 

--- a/crates/hl7v2-ack/tests/property_tests.rs
+++ b/crates/hl7v2-ack/tests/property_tests.rs
@@ -3,7 +3,7 @@
 //! These tests verify that ACK generation properties hold for
 //! arbitrary input messages.
 
-use hl7v2_ack::{ack, ack_with_error, AckCode};
+use hl7v2_ack::{AckCode, ack, ack_with_error};
 use hl7v2_core::parse;
 use proptest::prelude::*;
 
@@ -106,10 +106,10 @@ proptest! {
             send_app, send_fac, recv_app, recv_fac, ctrl_id
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, AckCode::AA) {
-                prop_assert_eq!(ack_msg.segments.len(), 2);
-            }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, AckCode::AA)
+        {
+            prop_assert_eq!(ack_msg.segments.len(), 2);
         }
     }
 
@@ -128,10 +128,10 @@ proptest! {
             send_app, send_fac, recv_app, recv_fac, ctrl_id
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack_with_error(&original, AckCode::AE, Some(&error_msg)) {
-                prop_assert_eq!(ack_msg.segments.len(), 3);
-            }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack_with_error(&original, AckCode::AE, Some(&error_msg))
+        {
+            prop_assert_eq!(ack_msg.segments.len(), 3);
         }
     }
 
@@ -143,12 +143,12 @@ proptest! {
             ctrl_id
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, AckCode::AA) {
-                let msa = &ack_msg.segments[1];
-                if let Some(ack_control_id) = get_field_value(msa, 2) {
-                    prop_assert_eq!(ack_control_id, ctrl_id);
-                }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, AckCode::AA)
+        {
+            let msa = &ack_msg.segments[1];
+            if let Some(ack_control_id) = get_field_value(msa, 2) {
+                prop_assert_eq!(ack_control_id, ctrl_id);
             }
         }
     }
@@ -164,17 +164,17 @@ proptest! {
             send_app, recv_app
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, AckCode::AA) {
-                let ack_msh = &ack_msg.segments[0];
-                if let Some(ack_send_app) = get_field_value(ack_msh, 2) {
-                    // ACK sending app should be original receiving app
-                    prop_assert_eq!(ack_send_app, recv_app);
-                }
-                if let Some(ack_recv_app) = get_field_value(ack_msh, 4) {
-                    // ACK receiving app should be original sending app
-                    prop_assert_eq!(ack_recv_app, send_app);
-                }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, AckCode::AA)
+        {
+            let ack_msh = &ack_msg.segments[0];
+            if let Some(ack_send_app) = get_field_value(ack_msh, 2) {
+                // ACK sending app should be original receiving app
+                prop_assert_eq!(ack_send_app, recv_app);
+            }
+            if let Some(ack_recv_app) = get_field_value(ack_msh, 4) {
+                // ACK receiving app should be original sending app
+                prop_assert_eq!(ack_recv_app, send_app);
             }
         }
     }
@@ -187,12 +187,12 @@ proptest! {
             version
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, AckCode::AA) {
-                let ack_msh = &ack_msg.segments[0];
-                if let Some(ack_version) = get_field_value(ack_msh, 11) {
-                    prop_assert_eq!(ack_version, version);
-                }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, AckCode::AA)
+        {
+            let ack_msh = &ack_msg.segments[0];
+            if let Some(ack_version) = get_field_value(ack_msh, 11) {
+                prop_assert_eq!(ack_version, version);
             }
         }
     }
@@ -205,12 +205,12 @@ proptest! {
             proc_id
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, AckCode::AA) {
-                let ack_msh = &ack_msg.segments[0];
-                if let Some(ack_proc_id) = get_field_value(ack_msh, 10) {
-                    prop_assert_eq!(ack_proc_id, proc_id);
-                }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, AckCode::AA)
+        {
+            let ack_msh = &ack_msg.segments[0];
+            if let Some(ack_proc_id) = get_field_value(ack_msh, 10) {
+                prop_assert_eq!(ack_proc_id, proc_id);
             }
         }
     }
@@ -236,12 +236,12 @@ proptest! {
             send_app, ctrl_id
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, code) {
-                let msa = &ack_msg.segments[1];
-                if let Some(ack_code_value) = get_field_value(msa, 1) {
-                    prop_assert_eq!(ack_code_value, code.as_str());
-                }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, code)
+        {
+            let msa = &ack_msg.segments[1];
+            if let Some(ack_code_value) = get_field_value(msa, 1) {
+                prop_assert_eq!(ack_code_value, code.as_str());
             }
         }
     }
@@ -254,14 +254,14 @@ proptest! {
             ctrl_id
         );
 
-        if let Ok(original) = parse(message_str.as_bytes()) {
-            if let Ok(ack_msg) = ack(&original, AckCode::AA) {
-                prop_assert_eq!(ack_msg.delims.field, original.delims.field);
-                prop_assert_eq!(ack_msg.delims.comp, original.delims.comp);
-                prop_assert_eq!(ack_msg.delims.rep, original.delims.rep);
-                prop_assert_eq!(ack_msg.delims.esc, original.delims.esc);
-                prop_assert_eq!(ack_msg.delims.sub, original.delims.sub);
-            }
+        if let Ok(original) = parse(message_str.as_bytes())
+            && let Ok(ack_msg) = ack(&original, AckCode::AA)
+        {
+            prop_assert_eq!(ack_msg.delims.field, original.delims.field);
+            prop_assert_eq!(ack_msg.delims.comp, original.delims.comp);
+            prop_assert_eq!(ack_msg.delims.rep, original.delims.rep);
+            prop_assert_eq!(ack_msg.delims.esc, original.delims.esc);
+            prop_assert_eq!(ack_msg.delims.sub, original.delims.sub);
         }
     }
 }

--- a/crates/hl7v2-batch/src/lib.rs
+++ b/crates/hl7v2-batch/src/lib.rs
@@ -391,13 +391,13 @@ fn parse_single_batch(lines: &[&str]) -> Result<Batch, BatchError> {
     }
 
     // Verify message count if specified
-    if let Some(expected) = batch.info.message_count {
-        if expected != batch.message_count() {
-            return Err(BatchError::CountMismatch {
-                expected,
-                actual: batch.message_count(),
-            });
-        }
+    if let Some(expected) = batch.info.message_count
+        && expected != batch.message_count()
+    {
+        return Err(BatchError::CountMismatch {
+            expected,
+            actual: batch.message_count(),
+        });
     }
 
     Ok(batch)

--- a/crates/hl7v2-batch/tests/bdd_tests.rs
+++ b/crates/hl7v2-batch/tests/bdd_tests.rs
@@ -2,8 +2,8 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
-use hl7v2_batch::{parse_batch, BatchError, BatchType, FileBatch};
+use cucumber::{World, given, then, when};
+use hl7v2_batch::{BatchError, BatchType, FileBatch, parse_batch};
 
 /// Test world for Batch BDD tests
 #[derive(Debug, World)]

--- a/crates/hl7v2-batch/tests/integration_tests.rs
+++ b/crates/hl7v2-batch/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 //! These tests verify batch parsing and creation works correctly with
 //! real-world HL7 batch scenarios.
 
-use hl7v2_batch::{parse_batch, Batch, BatchType, FileBatch};
+use hl7v2_batch::{Batch, BatchType, FileBatch, parse_batch};
 use hl7v2_parser::parse;
 
 // ============================================================================

--- a/crates/hl7v2-batch/tests/property_tests.rs
+++ b/crates/hl7v2-batch/tests/property_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify batch parsing properties hold for arbitrary inputs.
 
-use hl7v2_batch::{parse_batch, Batch, BatchType};
+use hl7v2_batch::{Batch, BatchType, parse_batch};
 use hl7v2_parser::parse;
 use proptest::prelude::*;
 

--- a/crates/hl7v2-bench/benches/batch.rs
+++ b/crates/hl7v2-bench/benches/batch.rs
@@ -5,7 +5,7 @@
 //! - Multi-message batch processing
 //! - Batch with different message counts (10, 100, 1000)
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hl7v2_batch::parse_batch;
 use hl7v2_parser::parse;
 use std::hint::black_box;

--- a/crates/hl7v2-bench/benches/escape.rs
+++ b/crates/hl7v2-bench/benches/escape.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for HL7 v2 escape sequence handling performance
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use hl7v2_escape::{escape_text, unescape_text};
 use hl7v2_model::Delims;
 use std::hint::black_box;

--- a/crates/hl7v2-bench/benches/json.rs
+++ b/crates/hl7v2-bench/benches/json.rs
@@ -5,7 +5,7 @@
 //! - JSON to message deserialization (if supported)
 //! - Comparison with other serialization formats
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hl7v2_json::{to_json, to_json_string, to_json_string_pretty};
 use hl7v2_parser::parse;
 use hl7v2_writer::write;
@@ -211,17 +211,17 @@ fn bench_json_value_access(c: &mut Criterion) {
     c.bench_function("json_value_access", |b| {
         b.iter(|| {
             // Access various parts of the JSON structure
-            if let Value::Object(obj) = &json_value {
-                if let Some(Value::Array(segments)) = obj.get("segments") {
-                    for segment in segments {
-                        if let Value::Object(seg) = segment {
-                            if let Some(Value::String(id)) = seg.get("id") {
-                                black_box(id);
-                            }
-                            if let Some(Value::Array(fields)) = seg.get("fields") {
-                                for field in fields {
-                                    black_box(field);
-                                }
+            if let Value::Object(obj) = &json_value
+                && let Some(Value::Array(segments)) = obj.get("segments")
+            {
+                for segment in segments {
+                    if let Value::Object(seg) = segment {
+                        if let Some(Value::String(id)) = seg.get("id") {
+                            black_box(id);
+                        }
+                        if let Some(Value::Array(fields)) = seg.get("fields") {
+                            for field in fields {
+                                black_box(field);
                             }
                         }
                     }

--- a/crates/hl7v2-bench/benches/memory.rs
+++ b/crates/hl7v2-bench/benches/memory.rs
@@ -1,6 +1,6 @@
 //! Memory usage benchmarks for HL7 v2 parsing
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use hl7v2_mllp::wrap_mllp;
 use hl7v2_normalize::normalize;
 use hl7v2_parser::{parse, parse_mllp};

--- a/crates/hl7v2-bench/benches/mllp.rs
+++ b/crates/hl7v2-bench/benches/mllp.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for HL7 v2 MLLP functionality
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use hl7v2_mllp::wrap_mllp;
 use hl7v2_parser::{parse, parse_mllp};
 use hl7v2_writer::write_mllp;

--- a/crates/hl7v2-bench/benches/network.rs
+++ b/crates/hl7v2-bench/benches/network.rs
@@ -8,7 +8,7 @@
 //! Note: These benchmarks use tokio for async operations and may require
 //! longer sample times for accurate results.
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hl7v2_mllp::wrap_mllp;
 use hl7v2_parser::parse;
 use hl7v2_writer::write_mllp;
@@ -133,11 +133,11 @@ fn bench_codec_decoding(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             // Simulate decoding from MLLP frame
             // Find start and end markers
-            if let Some(start) = wrapped.iter().position(|&b| b == 0x0B) {
-                if let Some(end) = wrapped.iter().position(|&b| b == 0x1C) {
-                    let message_bytes = &wrapped[start + 1..end];
-                    black_box(message_bytes);
-                }
+            if let Some(start) = wrapped.iter().position(|&b| b == 0x0B)
+                && let Some(end) = wrapped.iter().position(|&b| b == 0x1C)
+            {
+                let message_bytes = &wrapped[start + 1..end];
+                black_box(message_bytes);
             }
         });
     });

--- a/crates/hl7v2-bench/benches/parsing.rs
+++ b/crates/hl7v2-bench/benches/parsing.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for HL7 v2 parsing performance
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use hl7v2_parser::parse;
 use hl7v2_writer::write;
 use std::hint::black_box;

--- a/crates/hl7v2-bench/benches/template.rs
+++ b/crates/hl7v2-bench/benches/template.rs
@@ -5,11 +5,11 @@
 //! - Message generation from template
 //! - Value source resolution
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use hl7v2_template::{generate, generate_corpus, Template, ValueSource};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use hl7v2_template::{Template, ValueSource, generate, generate_corpus};
 use hl7v2_template_values::generate_value;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use std::collections::HashMap;
 use std::hint::black_box;
 

--- a/crates/hl7v2-bench/benches/validation.rs
+++ b/crates/hl7v2-bench/benches/validation.rs
@@ -5,9 +5,9 @@
 //! - Strict vs lenient validation comparison
 //! - Data type validation performance
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hl7v2_parser::parse;
-use hl7v2_validation::{validate_data_type, Issue, Validator};
+use hl7v2_validation::{Issue, Validator, validate_data_type};
 use std::hint::black_box;
 
 /// Create a sample HL7 message for benchmarking
@@ -37,28 +37,26 @@ impl Validator for BasicValidator {
             let seg_id = segment.id_str();
             if seg_id == "MSH" {
                 // Check MSH.7 (Date/Time) - should be valid timestamp
-                if segment.fields.len() > 6 {
-                    if let Some(dt) = segment.fields[6].first_text() {
-                        if !validate_data_type(dt, "TS") {
-                            issues.push(Issue::error(
-                                "INVALID_DATETIME",
-                                Some("MSH.7".to_string()),
-                                format!("Invalid datetime format: {}", dt),
-                            ));
-                        }
-                    }
+                if segment.fields.len() > 6
+                    && let Some(dt) = segment.fields[6].first_text()
+                    && !validate_data_type(dt, "TS")
+                {
+                    issues.push(Issue::error(
+                        "INVALID_DATETIME",
+                        Some("MSH.7".to_string()),
+                        format!("Invalid datetime format: {}", dt),
+                    ));
                 }
                 // Check MSH.9 (Message Type) - should be valid
-                if segment.fields.len() > 8 {
-                    if let Some(msg_type) = segment.fields[8].first_text() {
-                        if !msg_type.contains('^') {
-                            issues.push(Issue::warning(
-                                "INVALID_MESSAGE_TYPE",
-                                Some("MSH.9".to_string()),
-                                "Message type should contain trigger event".to_string(),
-                            ));
-                        }
-                    }
+                if segment.fields.len() > 8
+                    && let Some(msg_type) = segment.fields[8].first_text()
+                    && !msg_type.contains('^')
+                {
+                    issues.push(Issue::warning(
+                        "INVALID_MESSAGE_TYPE",
+                        Some("MSH.9".to_string()),
+                        "Message type should contain trigger event".to_string(),
+                    ));
                 }
             } else if seg_id == "PID" {
                 // Check PID.3 (Patient ID) - should be valid
@@ -73,30 +71,28 @@ impl Validator for BasicValidator {
                     }
                 }
                 // Check PID.7 (Date of Birth) - should be valid date
-                if segment.fields.len() > 6 {
-                    if let Some(dob) = segment.fields[6].first_text() {
-                        if !dob.is_empty() && !validate_data_type(dob, "DT") {
-                            issues.push(Issue::error(
-                                "INVALID_DOB",
-                                Some("PID.7".to_string()),
-                                format!("Invalid date of birth format: {}", dob),
-                            ));
-                        }
-                    }
+                if segment.fields.len() > 6
+                    && let Some(dob) = segment.fields[6].first_text()
+                    && !dob.is_empty()
+                    && !validate_data_type(dob, "DT")
+                {
+                    issues.push(Issue::error(
+                        "INVALID_DOB",
+                        Some("PID.7".to_string()),
+                        format!("Invalid date of birth format: {}", dob),
+                    ));
                 }
                 // Check PID.19 (SSN) - should be valid if present
-                if segment.fields.len() > 18 {
-                    if let Some(ssn) = segment.fields[18].first_text() {
-                        if !ssn.is_empty()
-                            && (!ssn.chars().all(|c| c.is_ascii_digit()) || ssn.len() != 9)
-                        {
-                            issues.push(Issue::warning(
-                                "INVALID_SSN",
-                                Some("PID.19".to_string()),
-                                format!("Invalid SSN format: {}", ssn),
-                            ));
-                        }
-                    }
+                if segment.fields.len() > 18
+                    && let Some(ssn) = segment.fields[18].first_text()
+                    && !ssn.is_empty()
+                    && (!ssn.chars().all(|c| c.is_ascii_digit()) || ssn.len() != 9)
+                {
+                    issues.push(Issue::warning(
+                        "INVALID_SSN",
+                        Some("PID.19".to_string()),
+                        format!("Invalid SSN format: {}", ssn),
+                    ));
                 }
             }
         }
@@ -146,14 +142,14 @@ impl Validator for StrictValidator {
                                 Some("MSH.7".to_string()),
                                 "Message datetime is required".to_string(),
                             ));
-                        } else if let Some(dt_val) = dt {
-                            if !validate_data_type(dt_val, "TS") {
-                                issues.push(Issue::error(
-                                    "INVALID_DATETIME",
-                                    Some("MSH.7".to_string()),
-                                    format!("Invalid datetime format: {}", dt_val),
-                                ));
-                            }
+                        } else if let Some(dt_val) = dt
+                            && !validate_data_type(dt_val, "TS")
+                        {
+                            issues.push(Issue::error(
+                                "INVALID_DATETIME",
+                                Some("MSH.7".to_string()),
+                                format!("Invalid datetime format: {}", dt_val),
+                            ));
                         }
                     }
 
@@ -228,16 +224,16 @@ impl Validator for StrictValidator {
                     }
 
                     // PID.7 - DOB validation
-                    if segment.fields.len() > 6 {
-                        if let Some(dob) = segment.fields[6].first_text() {
-                            if !dob.is_empty() && !validate_data_type(dob, "DT") {
-                                issues.push(Issue::error(
-                                    "INVALID_DOB",
-                                    Some("PID.7".to_string()),
-                                    format!("Invalid date of birth: {}", dob),
-                                ));
-                            }
-                        }
+                    if segment.fields.len() > 6
+                        && let Some(dob) = segment.fields[6].first_text()
+                        && !dob.is_empty()
+                        && !validate_data_type(dob, "DT")
+                    {
+                        issues.push(Issue::error(
+                            "INVALID_DOB",
+                            Some("PID.7".to_string()),
+                            format!("Invalid date of birth: {}", dob),
+                        ));
                     }
 
                     // PID.8 - Administrative Sex (required)

--- a/crates/hl7v2-cli/src/config.rs
+++ b/crates/hl7v2-cli/src/config.rs
@@ -107,10 +107,10 @@ pub fn apply_env_overrides(config: &mut Config) {
     if let Ok(host) = std::env::var("HL7_HOST") {
         config.server.host = host;
     }
-    if let Ok(port_str) = std::env::var("HL7_PORT") {
-        if let Ok(port) = port_str.parse::<u16>() {
-            config.server.port = port;
-        }
+    if let Ok(port_str) = std::env::var("HL7_PORT")
+        && let Ok(port) = port_str.parse::<u16>()
+    {
+        config.server.port = port;
     }
     if let Ok(api_key) = std::env::var("HL7_API_KEY") {
         config.server.api_key = Some(api_key);

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::{Parser, Subcommand};
 use hl7v2_core::{parse, to_json, write};
-use hl7v2_gen::{ack, generate, AckCode as GenAckCode, Template};
+use hl7v2_gen::{AckCode as GenAckCode, Template, ack, generate};
 use hl7v2_prof::{load_profile, validate};
 use hl7v2_stream::{Event, StreamParser};
 use std::fs;

--- a/crates/hl7v2-cli/src/serve.rs
+++ b/crates/hl7v2-cli/src/serve.rs
@@ -5,8 +5,8 @@
 //! - gRPC server (optional, behind feature flag)
 //! - Graceful shutdown via Ctrl+C
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use tracing::{error, info, warn};
@@ -157,9 +157,11 @@ mod tests {
     async fn test_grpc_not_implemented() {
         let result = run_grpc_server("127.0.0.1:50051").await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("not yet implemented"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not yet implemented")
+        );
     }
 }

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -252,7 +252,7 @@ constraints:
 
     mod ack_command {
         use super::*;
-        use hl7v2_gen::{ack, AckCode};
+        use hl7v2_gen::{AckCode, ack};
 
         #[test]
         fn test_generate_ack_aa() {
@@ -703,8 +703,8 @@ constraints:
 
         #[test]
         fn test_stats_command_execution() {
-            use crate::stats_command;
             use crate::ReportFormat;
+            use crate::stats_command;
             let dir = TempDir::new().expect("Failed to create temp dir");
             let file_path = create_temp_hl7_file(&dir, "test.hl7");
 

--- a/crates/hl7v2-cli/tests/bdd_tests.rs
+++ b/crates/hl7v2-cli/tests/bdd_tests.rs
@@ -4,7 +4,7 @@
 //!
 //! This test file implements the step definitions for the CLI feature file.
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_test_utils::fixtures::SampleMessages;
 use std::path::PathBuf;
 use std::process::Command;

--- a/crates/hl7v2-core/src/lib.rs
+++ b/crates/hl7v2-core/src/lib.rs
@@ -56,8 +56,8 @@ pub use hl7v2_escape::{escape_text, needs_escaping, needs_unescaping, unescape_t
 
 // Re-export MLLP types and functions
 pub use hl7v2_mllp::{
-    find_complete_mllp_message, is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
-    MllpFrameIterator, MLLP_END_1, MLLP_END_2, MLLP_START,
+    MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,
+    is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
 };
 
 // Re-export parser functions

--- a/crates/hl7v2-core/tests/bdd_tests.rs
+++ b/crates/hl7v2-core/tests/bdd_tests.rs
@@ -2,10 +2,10 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_core::{
-    escape_text, get, is_mllp_framed, needs_escaping, parse, parse_batch, parse_mllp,
-    unescape_text, unwrap_mllp, wrap_mllp, Batch, Delims, Error, Message,
+    Batch, Delims, Error, Message, escape_text, get, is_mllp_framed, needs_escaping, parse,
+    parse_batch, parse_mllp, unescape_text, unwrap_mllp, wrap_mllp,
 };
 
 /// Test world for BDD tests

--- a/crates/hl7v2-core/tests/property_tests.rs
+++ b/crates/hl7v2-core/tests/property_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify that core properties hold for arbitrary inputs.
 
-use hl7v2_core::{parse, write, Delims, Field, Message, Segment};
+use hl7v2_core::{Delims, Field, Message, Segment, parse, write};
 use proptest::prelude::*;
 
 // ============================================================================

--- a/crates/hl7v2-corpus/tests/integration_tests.rs
+++ b/crates/hl7v2-corpus/tests/integration_tests.rs
@@ -172,10 +172,10 @@ fn test_corpus_config_integration() {
         );
     }
 
-    if config.create_splits {
-        if let Some(ratios) = config.split_ratios {
-            manifest.create_splits(ratios);
-        }
+    if config.create_splits
+        && let Some(ratios) = config.split_ratios
+    {
+        manifest.create_splits(ratios);
     }
 
     assert_eq!(manifest.message_count(), 1000);

--- a/crates/hl7v2-datatype/src/lib.rs
+++ b/crates/hl7v2-datatype/src/lib.rs
@@ -194,43 +194,43 @@ impl DataTypeValidator {
     /// Validate a value with detailed error information
     pub fn validate_detailed(&self, value: &str) -> ValidationResult {
         // Check minimum length
-        if let Some(min) = self.min_length {
-            if value.len() < min {
-                return Err(DataTypeError::TooShort {
-                    length: value.len(),
-                    min,
-                });
-            }
+        if let Some(min) = self.min_length
+            && value.len() < min
+        {
+            return Err(DataTypeError::TooShort {
+                length: value.len(),
+                min,
+            });
         }
 
         // Check maximum length
-        if let Some(max) = self.max_length {
-            if value.len() > max {
-                return Err(DataTypeError::TooLong {
-                    length: value.len(),
-                    max,
-                });
-            }
+        if let Some(max) = self.max_length
+            && value.len() > max
+        {
+            return Err(DataTypeError::TooLong {
+                length: value.len(),
+                max,
+            });
         }
+
         // Check pattern
-        if let Some(pattern) = &self.pattern {
-            if let Ok(regex) = Regex::new(pattern) {
-                if !regex.is_match(value) {
-                    return Err(DataTypeError::PatternMismatch {
-                        value: value.to_string(),
-                        pattern: pattern.clone(),
-                    });
-                }
-            }
+        if let Some(pattern) = &self.pattern
+            && let Ok(regex) = Regex::new(pattern)
+            && !regex.is_match(value)
+        {
+            return Err(DataTypeError::PatternMismatch {
+                value: value.to_string(),
+                pattern: pattern.clone(),
+            });
         }
 
         // Check allowed values
-        if let Some(allowed) = &self.allowed_values {
-            if !allowed.contains(&value.to_string()) {
-                return Err(DataTypeError::NotInAllowedSet {
-                    value: value.to_string(),
-                });
-            }
+        if let Some(allowed) = &self.allowed_values
+            && !allowed.contains(&value.to_string())
+        {
+            return Err(DataTypeError::NotInAllowedSet {
+                value: value.to_string(),
+            });
         }
 
         // Check checksum

--- a/crates/hl7v2-datatype/tests/bdd_tests.rs
+++ b/crates/hl7v2-datatype/tests/bdd_tests.rs
@@ -2,11 +2,11 @@
 //!
 //! Run with: cargo test --test bdd_tests -p hl7v2-datatype
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_datatype::{
-    is_email, is_ssn, is_valid_age_range, is_valid_birth_date, is_within_range, matches_format,
-    validate_datatype, validate_luhn_checksum, ChecksumAlgorithm, DataType, DataTypeError,
-    DataTypeValidator,
+    ChecksumAlgorithm, DataType, DataTypeError, DataTypeValidator, is_email, is_ssn,
+    is_valid_age_range, is_valid_birth_date, is_within_range, matches_format, validate_datatype,
+    validate_luhn_checksum,
 };
 
 /// Test world for datatype BDD tests

--- a/crates/hl7v2-datetime/tests/bdd_tests.rs
+++ b/crates/hl7v2-datetime/tests/bdd_tests.rs
@@ -2,11 +2,11 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_datetime::{
-    is_valid_hl7_date, is_valid_hl7_time, is_valid_hl7_timestamp, now_hl7, parse_hl7_dt,
-    parse_hl7_tm, parse_hl7_ts, parse_hl7_ts_with_precision, today_hl7, DateTimeError,
-    ParsedTimestamp, TimestampPrecision,
+    DateTimeError, ParsedTimestamp, TimestampPrecision, is_valid_hl7_date, is_valid_hl7_time,
+    is_valid_hl7_timestamp, now_hl7, parse_hl7_dt, parse_hl7_tm, parse_hl7_ts,
+    parse_hl7_ts_with_precision, today_hl7,
 };
 
 /// Parsed time components: (hour, minute, second, optional fractional)

--- a/crates/hl7v2-e2e-tests/tests/e2e/message_pipeline_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/message_pipeline_tests.rs
@@ -3,10 +3,10 @@
 //! These tests validate the complete flow:
 //! Parse HL7 message → Validate → Generate ACK → Write response
 
-use hl7v2_ack::{ack, AckCode};
+use hl7v2_ack::{AckCode, ack};
 use hl7v2_core::get;
 use hl7v2_parser::parse;
-use hl7v2_test_utils::{assert_hl7_roundtrips, SampleMessages};
+use hl7v2_test_utils::{SampleMessages, assert_hl7_roundtrips};
 use hl7v2_validation::{Issue, Severity, Validator};
 use hl7v2_writer::write;
 

--- a/crates/hl7v2-e2e-tests/tests/e2e/network_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/network_tests.rs
@@ -7,15 +7,15 @@
 //! - Message exchange patterns
 
 use bytes::BytesMut;
-use hl7v2_ack::{ack, AckCode};
+use hl7v2_ack::{AckCode, ack};
 use hl7v2_network::{MllpClientBuilder, MllpCodec, MllpServer, MllpServerConfig};
 use hl7v2_parser::parse;
 use hl7v2_test_utils::{MockMllpServer, SampleMessages};
 use tokio_util::codec::{Decoder, Encoder};
 
 use super::common::init_tracing;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -405,10 +405,10 @@ mod concurrent_connections {
 
             // Process multiple messages on same connection
             for _ in 0..5 {
-                if let Ok(Some(msg)) = conn.receive_message().await {
-                    if let Ok(ack_msg) = ack(&msg, AckCode::AA) {
-                        let _ = conn.send_message(&ack_msg).await;
-                    }
+                if let Ok(Some(msg)) = conn.receive_message().await
+                    && let Ok(ack_msg) = ack(&msg, AckCode::AA)
+                {
+                    let _ = conn.send_message(&ack_msg).await;
                 }
             }
         });

--- a/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
@@ -5,8 +5,8 @@
 //! - CORS headers
 //! - Request size limits
 
-use axum::http::{header, Request, StatusCode};
-use hl7v2_server::{build_router, AppState};
+use axum::http::{Request, StatusCode, header};
+use hl7v2_server::{AppState, build_router};
 use std::sync::Arc;
 use std::time::Instant;
 use tower::ServiceExt;

--- a/crates/hl7v2-escape/tests/bdd_tests.rs
+++ b/crates/hl7v2-escape/tests/bdd_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo test --test bdd_tests -p hl7v2-escape
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_escape::{escape_text, needs_escaping, needs_unescaping, unescape_text};
 use hl7v2_model::Delims;
 

--- a/crates/hl7v2-faker/src/lib.rs
+++ b/crates/hl7v2-faker/src/lib.rs
@@ -574,9 +574,9 @@ impl std::fmt::Display for GenerateError {
 impl std::error::Error for GenerateError {}
 
 // Re-export rand types for convenience
-pub use rand::rngs::StdRng;
 pub use rand::Rng;
 pub use rand::SeedableRng;
+pub use rand::rngs::StdRng;
 
 #[cfg(test)]
 mod tests;

--- a/crates/hl7v2-faker/tests/bdd_tests.rs
+++ b/crates/hl7v2-faker/tests/bdd_tests.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_faker::{Faker, FakerValue, GenerateError, StdRng};
 use rand::SeedableRng;
 

--- a/crates/hl7v2-faker/tests/integration_tests.rs
+++ b/crates/hl7v2-faker/tests/integration_tests.rs
@@ -1,8 +1,8 @@
 //! Integration tests for hl7v2-faker
 
 use hl7v2_faker::{DateError, Faker, FakerValue, GenerateError};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 // =============================================================================
 // HL7 Format Integration Tests

--- a/crates/hl7v2-faker/tests/property_tests.rs
+++ b/crates/hl7v2-faker/tests/property_tests.rs
@@ -2,8 +2,8 @@
 
 use hl7v2_faker::{Faker, FakerValue};
 use proptest::prelude::*;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 // =============================================================================
 // Name Property Tests

--- a/crates/hl7v2-gen/src/lib.rs
+++ b/crates/hl7v2-gen/src/lib.rs
@@ -29,12 +29,12 @@
 
 // Re-export template functionality from hl7v2-template crate for backward compatibility
 pub use hl7v2_template::{
-    generate, generate_corpus, generate_distributed_corpus, generate_diverse_corpus,
-    generate_golden_hashes, verify_golden_hashes, Template, ValueSource,
+    Template, ValueSource, generate, generate_corpus, generate_distributed_corpus,
+    generate_diverse_corpus, generate_golden_hashes, verify_golden_hashes,
 };
 
 // Re-export ACK functionality from hl7v2-ack crate for backward compatibility
-pub use hl7v2_ack::{ack, ack_with_error, AckCode};
+pub use hl7v2_ack::{AckCode, ack, ack_with_error};
 
 // Re-export faker functionality from hl7v2-faker crate for backward compatibility
 pub use hl7v2_faker::{DateError, Faker, FakerValue, GaussianError, GenerateError};

--- a/crates/hl7v2-gen/src/tests.rs
+++ b/crates/hl7v2-gen/src/tests.rs
@@ -348,8 +348,8 @@ fn test_ack_with_error() {
 
 #[test]
 fn test_faker_generation() {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     let mut rng = StdRng::seed_from_u64(42);
     let mut faker = Faker::new(&mut rng);
@@ -366,8 +366,8 @@ fn test_faker_generation() {
 
 #[test]
 fn test_faker_value_generation() {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     let mut rng = StdRng::seed_from_u64(42);
     let mut faker = Faker::new(&mut rng);

--- a/crates/hl7v2-gen/tests/bdd_tests.rs
+++ b/crates/hl7v2-gen/tests/bdd_tests.rs
@@ -4,8 +4,8 @@
 
 use std::collections::HashMap;
 
-use cucumber::{given, then, when, World};
-use hl7v2_gen::{ack, ack_with_error, generate, AckCode, Faker, Message, Template, ValueSource};
+use cucumber::{World, given, then, when};
+use hl7v2_gen::{AckCode, Faker, Message, Template, ValueSource, ack, ack_with_error, generate};
 
 /// Test world for generation BDD tests
 #[derive(Debug, World)]
@@ -276,8 +276,8 @@ fn when_generate_ack_error(world: &mut GenWorld, text: String) {
 
 #[when(regex = r#"I generate a patient name for gender "([^"]+)""#)]
 fn when_faker_name(world: &mut GenWorld, gender: String) {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
     let mut rng = StdRng::seed_from_u64(42);
     let mut faker = Faker::new(&mut rng);
     world.faker_result = Some(faker.name(Some(&gender)));
@@ -441,17 +441,16 @@ impl DependencyWorld {
         let manifest: toml::Value = toml::from_str(&content).expect("Parse workspace Cargo.toml");
 
         let mut paths = Vec::new();
-        if let Some(workspace) = manifest.get("workspace") {
-            if let Some(members) = workspace.get("members") {
-                if let Some(members_array) = members.as_array() {
-                    for member in members_array {
-                        if let Some(member_str) = member.as_str() {
-                            let member_path = workspace_root.join(member_str);
-                            let cargo_toml = member_path.join("Cargo.toml");
-                            if cargo_toml.exists() {
-                                paths.push(cargo_toml);
-                            }
-                        }
+        if let Some(workspace) = manifest.get("workspace")
+            && let Some(members) = workspace.get("members")
+            && let Some(members_array) = members.as_array()
+        {
+            for member in members_array {
+                if let Some(member_str) = member.as_str() {
+                    let member_path = workspace_root.join(member_str);
+                    let cargo_toml = member_path.join("Cargo.toml");
+                    if cargo_toml.exists() {
+                        paths.push(cargo_toml);
                     }
                 }
             }
@@ -470,21 +469,19 @@ impl DependencyWorld {
         };
 
         // Check [dependencies]
-        if let Some(deps) = manifest.get("dependencies") {
-            if let Some(deps_table) = deps.as_table() {
-                if let Some(dep_value) = deps_table.get(dep_name) {
-                    return self.checks_workspace_true(dep_value);
-                }
-            }
+        if let Some(deps) = manifest.get("dependencies")
+            && let Some(deps_table) = deps.as_table()
+            && let Some(dep_value) = deps_table.get(dep_name)
+        {
+            return self.checks_workspace_true(dep_value);
         }
 
         // Check [dev-dependencies]
-        if let Some(deps) = manifest.get("dev-dependencies") {
-            if let Some(deps_table) = deps.as_table() {
-                if let Some(dep_value) = deps_table.get(dep_name) {
-                    return self.checks_workspace_true(dep_value);
-                }
-            }
+        if let Some(deps) = manifest.get("dev-dependencies")
+            && let Some(deps_table) = deps.as_table()
+            && let Some(dep_value) = deps_table.get(dep_name)
+        {
+            return self.checks_workspace_true(dep_value);
         }
 
         // If dependency not found, it doesn't use workspace = true
@@ -511,12 +508,11 @@ impl DependencyWorld {
 
         let sections = ["dependencies", "dev-dependencies"];
         for section in &sections {
-            if let Some(deps) = manifest.get(section) {
-                if let Some(deps_table) = deps.as_table() {
-                    if let Some(dep_value) = deps_table.get(dep_name) {
-                        return self.is_hardcoded(dep_value);
-                    }
-                }
+            if let Some(deps) = manifest.get(section)
+                && let Some(deps_table) = deps.as_table()
+                && let Some(dep_value) = deps_table.get(dep_name)
+            {
+                return self.is_hardcoded(dep_value);
             }
         }
         false
@@ -527,10 +523,10 @@ impl DependencyWorld {
             toml::Value::String(_) => true, // "1.0" is hardcoded
             toml::Value::Table(table) => {
                 // Check if it has workspace = true
-                if let Some(workspace) = table.get("workspace") {
-                    if workspace.as_bool() == Some(true) {
-                        return false;
-                    }
+                if let Some(workspace) = table.get("workspace")
+                    && workspace.as_bool() == Some(true)
+                {
+                    return false;
                 }
                 // Has version field means hardcoded
                 table.contains_key("version")

--- a/crates/hl7v2-gen/tests/integration_tests.rs
+++ b/crates/hl7v2-gen/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for hl7v2-gen
 
-use hl7v2_gen::{ack, ack_with_error, generate, AckCode, Faker, FakerValue, Template, ValueSource};
+use hl7v2_gen::{AckCode, Faker, FakerValue, Template, ValueSource, ack, ack_with_error, generate};
 use std::collections::HashMap;
 
 // =============================================================================
@@ -154,8 +154,8 @@ fn test_ack_reject() {
 
 #[test]
 fn test_faker_integration() {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     let mut rng = StdRng::seed_from_u64(42);
     let mut faker = Faker::new(&mut rng);
@@ -179,8 +179,8 @@ fn test_faker_integration() {
 
 #[test]
 fn test_faker_value_integration() {
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     let mut rng = StdRng::seed_from_u64(42);
     let mut faker = Faker::new(&mut rng);

--- a/crates/hl7v2-gen/tests/property_tests.rs
+++ b/crates/hl7v2-gen/tests/property_tests.rs
@@ -1,4 +1,4 @@
-use hl7v2_gen::{generate, Template};
+use hl7v2_gen::{Template, generate};
 use std::collections::HashMap;
 
 // Basic test to verify the file works

--- a/crates/hl7v2-json/tests/bdd_tests.rs
+++ b/crates/hl7v2-json/tests/bdd_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_json::{to_json, to_json_string, to_json_string_pretty};
 use hl7v2_model::{Atom, Comp, Delims, Field, Message, Rep, Segment};
 use serde_json::Value;

--- a/crates/hl7v2-mllp/tests/bdd_tests.rs
+++ b/crates/hl7v2-mllp/tests/bdd_tests.rs
@@ -2,10 +2,10 @@
 //!
 //! Run with: cargo test --test bdd_tests -p hl7v2-mllp
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_mllp::{
-    find_complete_mllp_message, is_mllp_framed, unwrap_mllp, unwrap_mllp_checked, wrap_mllp,
-    MllpError, MllpFrameIterator,
+    MllpError, MllpFrameIterator, find_complete_mllp_message, is_mllp_framed, unwrap_mllp,
+    unwrap_mllp_checked, wrap_mllp,
 };
 
 /// Test world for MLLP BDD tests

--- a/crates/hl7v2-mllp/tests/integration_tests.rs
+++ b/crates/hl7v2-mllp/tests/integration_tests.rs
@@ -4,8 +4,8 @@
 //! HL7 message scenarios.
 
 use hl7v2_mllp::{
-    find_complete_mllp_message, is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
-    MllpFrameIterator, MLLP_END_1, MLLP_END_2, MLLP_START,
+    MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,
+    is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
 };
 
 // ============================================================================

--- a/crates/hl7v2-mllp/tests/property_tests.rs
+++ b/crates/hl7v2-mllp/tests/property_tests.rs
@@ -3,8 +3,8 @@
 //! These tests verify MLLP framing properties hold for arbitrary inputs.
 
 use hl7v2_mllp::{
-    find_complete_mllp_message, is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
-    MllpFrameIterator, MLLP_END_1, MLLP_END_2, MLLP_START,
+    MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,
+    is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
 };
 use proptest::prelude::*;
 
@@ -15,11 +15,7 @@ fn arbitrary_bytes_no_end_sequence() -> impl Strategy<Value = Vec<u8>> {
     proptest::collection::vec(
         proptest::arbitrary::any::<u8>().prop_map(|b| {
             // Map 0-254 to valid bytes (skip MLLP_END_1)
-            if b == MLLP_END_1 {
-                b + 1
-            } else {
-                b
-            }
+            if b == MLLP_END_1 { b + 1 } else { b }
         }),
         0..1000,
     )

--- a/crates/hl7v2-normalize/tests/bdd_tests.rs
+++ b/crates/hl7v2-normalize/tests/bdd_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_model::Error;
 use hl7v2_normalize::normalize;
 

--- a/crates/hl7v2-parser/src/lib.rs
+++ b/crates/hl7v2-parser/src/lib.rs
@@ -398,31 +398,31 @@ fn parse_atom(atom_str: &str, delims: &Delims) -> Result<Atom, Error> {
 /// Extract character sets from MSH-18 field
 fn extract_charsets(segments: &[Segment]) -> Vec<String> {
     // Look for the MSH segment (should be the first one)
-    if let Some(msh_segment) = segments.first() {
-        if &msh_segment.id == b"MSH" {
-            // MSH-18 is parsed field index 17
-            if msh_segment.fields.len() > 17 {
-                let field_18 = &msh_segment.fields[17];
+    if let Some(msh_segment) = segments.first()
+        && &msh_segment.id == b"MSH"
+    {
+        // MSH-18 is parsed field index 17
+        if msh_segment.fields.len() > 17 {
+            let field_18 = &msh_segment.fields[17];
 
-                if !field_18.reps.is_empty() {
-                    let rep = &field_18.reps[0];
+            if !field_18.reps.is_empty() {
+                let rep = &field_18.reps[0];
 
-                    let mut charsets = Vec::new();
-                    for comp in &rep.comps {
-                        if !comp.subs.is_empty() {
-                            match &comp.subs[0] {
-                                Atom::Text(text) => {
-                                    if !text.is_empty() {
-                                        charsets.push(text.clone());
-                                    }
+                let mut charsets = Vec::new();
+                for comp in &rep.comps {
+                    if !comp.subs.is_empty() {
+                        match &comp.subs[0] {
+                            Atom::Text(text) => {
+                                if !text.is_empty() {
+                                    charsets.push(text.clone());
                                 }
-                                Atom::Null => continue,
                             }
+                            Atom::Null => continue,
                         }
                     }
-
-                    return charsets;
                 }
+
+                return charsets;
             }
         }
     }

--- a/crates/hl7v2-parser/tests/bdd_tests.rs
+++ b/crates/hl7v2-parser/tests/bdd_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo test --test bdd_tests -p hl7v2-parser
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_model::Error;
 use hl7v2_parser::{get, parse, parse_batch, parse_file_batch, parse_mllp};
 

--- a/crates/hl7v2-path/tests/bdd_tests.rs
+++ b/crates/hl7v2-path/tests/bdd_tests.rs
@@ -2,8 +2,8 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
-use hl7v2_path::{parse_path, Path, PathError};
+use cucumber::{World, given, then, when};
+use hl7v2_path::{Path, PathError, parse_path};
 
 /// Test world for Path BDD tests
 #[derive(Debug, World)]

--- a/crates/hl7v2-path/tests/integration_tests.rs
+++ b/crates/hl7v2-path/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for hl7v2-path crate
 
-use hl7v2_path::{parse_path, Path, PathError};
+use hl7v2_path::{Path, PathError, parse_path};
 
 mod real_world_path_scenarios {
     use super::*;

--- a/crates/hl7v2-path/tests/property_tests.rs
+++ b/crates/hl7v2-path/tests/property_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify path parsing and generation properties hold for arbitrary inputs.
 
-use hl7v2_path::{parse_path, Path, PathError};
+use hl7v2_path::{Path, PathError, parse_path};
 use proptest::prelude::*;
 
 // =============================================================================

--- a/crates/hl7v2-prof/src/lib.rs
+++ b/crates/hl7v2-prof/src/lib.rs
@@ -37,15 +37,14 @@
 
 // Re-export validation types for backward compatibility
 pub use hl7v2_validation::{
-    check_rule_condition, compare_timestamps_for_before, get_nonempty, is_coded_value, is_date,
-    is_email, is_extended_id, is_formatted_text, is_hierarchic_designator, is_identifier,
-    is_numeric, is_person_name, is_phone_number, is_sequence_id, is_ssn, is_string, is_text_data,
-    is_time, is_timestamp, is_valid_age_range, is_valid_birth_date, is_within_range,
+    Issue, ParsedTimestamp, RuleAction, RuleCondition, Severity, TimestampPrecision,
+    ValidationResult, Validator, check_rule_condition, compare_timestamps_for_before, get_nonempty,
+    is_coded_value, is_date, is_email, is_extended_id, is_formatted_text, is_hierarchic_designator,
+    is_identifier, is_numeric, is_person_name, is_phone_number, is_sequence_id, is_ssn, is_string,
+    is_text_data, is_time, is_timestamp, is_valid_age_range, is_valid_birth_date, is_within_range,
     matches_complex_pattern, matches_format, parse_datetime, parse_hl7_ts,
     parse_hl7_ts_with_precision, truncate_to_precision, validate_checksum, validate_data_type,
-    validate_luhn_checksum, validate_mathematical_relationship, validate_mod10_checksum, Issue,
-    ParsedTimestamp, RuleAction, RuleCondition, Severity, TimestampPrecision, ValidationResult,
-    Validator,
+    validate_luhn_checksum, validate_mathematical_relationship, validate_mod10_checksum,
 };
 
 use hl7v2_core::Message;

--- a/crates/hl7v2-prof/src/loader.rs
+++ b/crates/hl7v2-prof/src/loader.rs
@@ -10,7 +10,7 @@ use async_lock::RwLock;
 use lru::LruCache;
 
 pub use crate::ProfileLoadError;
-use crate::{load_profile, Profile};
+use crate::{Profile, load_profile};
 
 /// Default cache size (number of profiles)
 const DEFAULT_CACHE_SIZE: usize = 100;

--- a/crates/hl7v2-prof/src/tests.rs
+++ b/crates/hl7v2-prof/src/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod unit_tests {
     use crate::{
-        compare_timestamps_for_before, load_profile, parse_hl7_ts_with_precision, validate, Profile,
+        Profile, compare_timestamps_for_before, load_profile, parse_hl7_ts_with_precision, validate,
     };
 
     use hl7v2_core::parse;
@@ -201,7 +201,7 @@ custom_rules:
 
 #[cfg(test)]
 mod profile_load_error_tests {
-    use crate::{load_profile_checked, ProfileLoadError};
+    use crate::{ProfileLoadError, load_profile_checked};
 
     #[test]
     fn test_load_profile_checked_valid() {

--- a/crates/hl7v2-prof/tests/common/mod.rs
+++ b/crates/hl7v2-prof/tests/common/mod.rs
@@ -6,7 +6,7 @@
 #![allow(dead_code)]
 
 use hl7v2_core::parse;
-use hl7v2_prof::{load_profile, validate, Profile};
+use hl7v2_prof::{Profile, load_profile, validate};
 
 // ============================================================================
 // Test Message Fixtures

--- a/crates/hl7v2-prof/tests/property_tests.rs
+++ b/crates/hl7v2-prof/tests/property_tests.rs
@@ -4,7 +4,7 @@
 //! hold for arbitrary inputs.
 
 use hl7v2_core::parse;
-use hl7v2_prof::{load_profile, validate, Profile};
+use hl7v2_prof::{Profile, load_profile, validate};
 use proptest::prelude::*;
 
 // ============================================================================

--- a/crates/hl7v2-python/src/lib.rs
+++ b/crates/hl7v2-python/src/lib.rs
@@ -1,6 +1,6 @@
 //! Python bindings for HL7v2 via PyO3.
 
-use hl7v2_core::{parse as rust_parse, to_json as rust_to_json, Message};
+use hl7v2_core::{Message, parse as rust_parse, to_json as rust_to_json};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 

--- a/crates/hl7v2-query/tests/bdd_tests.rs
+++ b/crates/hl7v2-query/tests/bdd_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_model::{Atom, Comp, Delims, Field, Message, Presence, Rep, Segment};
 use hl7v2_query::{get, get_presence};
 

--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -52,7 +52,7 @@ impl Hl7Service for Hl7ServiceImpl {
                             trace_id: String::new(),
                         }],
                         metadata: None,
-                    }))
+                    }));
                 }
             }
         } else {
@@ -232,10 +232,10 @@ impl Hl7Service for Hl7ServiceImpl {
             .map_err(|e| Status::invalid_argument(format!("Failed to normalize HL7: {}", e)))?;
 
         let mut final_bytes = normalized_bytes;
-        if let Some(options) = req.options {
-            if options.mllp_frame {
-                final_bytes = hl7v2_mllp::wrap_mllp(&final_bytes);
-            }
+        if let Some(options) = req.options
+            && options.mllp_frame
+        {
+            final_bytes = hl7v2_mllp::wrap_mllp(&final_bytes);
         }
 
         Ok(Response::new(NormalizeResponse {

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -1,12 +1,11 @@
 //! HTTP route definitions.
 
 use axum::{
-    middleware,
+    Router, middleware,
     routing::{get, post},
-    Router,
 };
 use std::sync::Arc;
-use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
+use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 use tower_http::{
     compression::CompressionLayer,
     cors::{Any, CorsLayer},

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -7,8 +7,8 @@ use std::time::Instant;
 use tokio::net::TcpListener;
 use tracing::info;
 
-use crate::routes::build_router;
 use crate::Result;
+use crate::routes::build_router;
 
 /// Application state shared across handlers
 #[derive(Clone)]

--- a/crates/hl7v2-server/tests/bdd_tests.rs
+++ b/crates/hl7v2-server/tests/bdd_tests.rs
@@ -3,11 +3,11 @@
 //! Run with: cargo test --test bdd_tests
 
 use axum::{
+    Router,
     body::Body,
     http::{Request, StatusCode},
-    Router,
 };
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use http_body_util::BodyExt;
 use std::sync::Arc;
 use std::time::Instant;

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -37,15 +37,13 @@ pub mod fixtures {
          PV1|1|I|ICU^101^01||||DOC123^Smith^Jane|||MED||||||||V123456|||||||||||||||||||||||||20231119120000\r";
 
     /// Valid ADT^A04 message (Register Patient)
-    pub const ADT_A04_VALID: &str =
-        "MSH|^~\\&|RegSys|Hospital|ADT|Hospital|20231119130000||ADT^A04|MSG002|P|2.5\r\
+    pub const ADT_A04_VALID: &str = "MSH|^~\\&|RegSys|Hospital|ADT|Hospital|20231119130000||ADT^A04|MSG002|P|2.5\r\
          EVN|A04|20231119130000\r\
          PID|1||MRN456^^^Hospital^MR||Smith^Jane^M||19900215|F||||||||||987654321\r\
          PV1|1|O|CLINIC^201^01||||DOC456^Johnson^Robert|||||||||||V789012\r";
 
     /// Valid ORU^R01 message (Lab Results)
-    pub const ORU_R01_VALID: &str =
-        "MSH|^~\\&|LabSys|Lab|LIS|Hospital|20231119140000||ORU^R01|MSG003|P|2.5\r\
+    pub const ORU_R01_VALID: &str = "MSH|^~\\&|LabSys|Lab|LIS|Hospital|20231119140000||ORU^R01|MSG003|P|2.5\r\
          PID|1||MRN789^^^Lab^MR||Patient^Test||19850610|M\r\
          OBR|1|ORD123|FIL456|CBC^Complete Blood Count|||20231119120000|||||||\
          |||DOC789^Doctor^Chief||||||||F|||||||\r\

--- a/crates/hl7v2-server/tests/middleware_test.rs
+++ b/crates/hl7v2-server/tests/middleware_test.rs
@@ -10,8 +10,8 @@ use hl7v2_server::{
 };
 use std::sync::Arc;
 use std::time::Instant;
-use tower::limit::ConcurrencyLimitLayer;
 use tower::ServiceExt; // For `oneshot`
+use tower::limit::ConcurrencyLimitLayer;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_http::{
     compression::CompressionLayer,

--- a/crates/hl7v2-stream/benches/streaming.rs
+++ b/crates/hl7v2-stream/benches/streaming.rs
@@ -5,7 +5,7 @@
 //! - Memory efficiency
 //! - Parsing performance for various message sizes
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use hl7v2_stream::{Event, StreamParser};
 use std::io::{BufReader, Cursor};
 

--- a/crates/hl7v2-stream/src/comprehensive_tests/unit_tests.rs
+++ b/crates/hl7v2-stream/src/comprehensive_tests/unit_tests.rs
@@ -35,9 +35,11 @@ fn test_parse_message_in_single_chunk() {
     let events = collect_events(&mut parser);
 
     // Verify we got StartMessage
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
 
     // Verify we got EndMessage
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
@@ -75,9 +77,11 @@ fn test_parse_minimal_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -126,9 +130,11 @@ fn test_parse_message_across_multiple_chunks() {
     let events = collect_events(&mut parser);
 
     // Should still get all events
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -149,9 +155,11 @@ fn test_chunk_boundary_in_middle_of_segment() {
     let events = collect_events(&mut parser);
 
     // Should still parse correctly
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Find the long field
@@ -183,9 +191,11 @@ fn test_chunk_boundary_at_field_separator() {
     let events = collect_events(&mut parser);
 
     // Should parse correctly despite boundary at separator
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -261,9 +271,11 @@ fn test_handle_empty_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -298,9 +310,11 @@ fn test_handle_empty_fields() {
     let events = collect_events(&mut parser);
 
     // Should parse successfully with empty fields
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
 
     // Count empty field events
     let empty_fields: Vec<_> = events
@@ -334,9 +348,11 @@ fn test_handle_very_long_field() {
     let events = collect_events(&mut parser);
 
     // Should parse successfully
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Find the long field
@@ -365,9 +381,11 @@ fn test_handle_very_long_segment() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -381,9 +399,11 @@ fn test_handle_deeply_nested_components() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Find field with components
@@ -762,15 +782,19 @@ fn test_parse_message_from_builder() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Should have PID segment
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
 }
 
 #[test]
@@ -829,9 +853,11 @@ async fn test_async_parser_with_backpressure() {
     }
 
     // Should have received all events despite small buffer
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -854,9 +880,11 @@ async fn test_async_parser_buffer_size_configuration() {
             }
         }
 
-        assert!(events
-            .iter()
-            .any(|e| matches!(e, Event::StartMessage { .. })));
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, Event::StartMessage { .. }))
+        );
     }
 }
 
@@ -940,9 +968,11 @@ fn test_max_message_size_allows_normal_messages() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -1030,9 +1060,11 @@ fn test_resume_with_additional_data() {
 
     // Should eventually get StartMessage
     events.extend(collect_events(&mut parser));
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
 }
 
 #[test]
@@ -1071,15 +1103,19 @@ fn test_partial_segment_preserved_across_reads() {
     let events = collect_events(&mut parser);
 
     // Should have parsed the complete message
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Should have PID segment
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
 }
 
 #[test]
@@ -1165,7 +1201,9 @@ fn test_builder_build_synchronous_parser() {
     assert_eq!(parser.max_message_size(), 1024);
 
     let events = collect_events(&mut parser);
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
 }

--- a/crates/hl7v2-stream/tests/integration_tests.rs
+++ b/crates/hl7v2-stream/tests/integration_tests.rs
@@ -33,9 +33,11 @@ fn test_adt_a01_message() {
     let events = collect_events(&mut parser);
 
     // Verify structure
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Verify segments
@@ -64,15 +66,19 @@ fn test_adt_a04_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // ADT^A04 should have PID segment
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
 }
 
 #[test]
@@ -84,9 +90,11 @@ fn test_oru_r01_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // ORU^R01 should have PID, OBR, OBX segments
@@ -121,9 +129,11 @@ fn test_empty_fields_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Count empty fields
@@ -155,9 +165,11 @@ fn test_special_chars_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -236,9 +248,11 @@ fn test_builder_simple_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -255,9 +269,11 @@ fn test_builder_with_pid() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
 
     // Verify PID field content
     let pid_fields: Vec<&[u8]> = events
@@ -272,12 +288,16 @@ fn test_builder_with_pid() {
         .collect();
 
     // Should contain MRN and name
-    assert!(pid_fields
-        .iter()
-        .any(|f| String::from_utf8_lossy(f).contains("MRN123")));
-    assert!(pid_fields
-        .iter()
-        .any(|f| String::from_utf8_lossy(f).contains("Doe")));
+    assert!(
+        pid_fields
+            .iter()
+            .any(|f| String::from_utf8_lossy(f).contains("MRN123"))
+    );
+    assert!(
+        pid_fields
+            .iter()
+            .any(|f| String::from_utf8_lossy(f).contains("Doe"))
+    );
 }
 
 #[test]
@@ -295,12 +315,16 @@ fn test_builder_with_pv1() {
     let events = collect_events(&mut parser);
 
     // Should have both PID and PV1
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PV1") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PV1") })
+    );
 }
 
 // =============================================================================
@@ -317,9 +341,11 @@ fn test_chunked_input_small_chunks() {
     let mut parser = StreamParser::new(buf_reader);
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -332,9 +358,11 @@ fn test_chunked_input_medium_chunks() {
     let mut parser = StreamParser::new(buf_reader);
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -347,9 +375,11 @@ fn test_chunked_input_large_chunks() {
     let mut parser = StreamParser::new(buf_reader);
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -577,9 +607,11 @@ fn test_memory_efficiency_large_field() {
     let events = collect_events(&mut parser);
 
     // Should parse successfully
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Large field should be preserved
@@ -609,9 +641,11 @@ fn test_memory_efficiency_many_segments() {
     let events = collect_events(&mut parser);
 
     // Should parse successfully
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Should have 1000 ZXX segments
@@ -668,17 +702,23 @@ fn test_hospital_admission_scenario() {
     let events = collect_events(&mut parser);
 
     // Verify admission message structure
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
 
     // Should have PID and PV1
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PV1") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PV1") })
+    );
 }
 
 #[test]
@@ -694,10 +734,14 @@ fn test_lab_result_scenario() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
 }

--- a/crates/hl7v2-stream/tests/large_file_tests.rs
+++ b/crates/hl7v2-stream/tests/large_file_tests.rs
@@ -59,9 +59,11 @@ fn test_large_message_100_segments() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     let segment_count = events
@@ -81,9 +83,11 @@ fn test_large_message_1000_segments() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     let segment_count = events
@@ -103,9 +107,11 @@ fn test_large_message_10000_segments() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     let segment_count = events
@@ -129,9 +135,11 @@ fn test_very_long_field_1kb() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Verify long field is preserved
@@ -155,9 +163,11 @@ fn test_very_long_field_10kb() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -171,9 +181,11 @@ fn test_very_long_field_100kb() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Verify the 100KB field is preserved
@@ -198,9 +210,11 @@ fn test_very_long_field_1mb() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -222,9 +236,11 @@ fn test_segment_with_100_fields() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Count PID fields
@@ -250,9 +266,11 @@ fn test_segment_with_1000_fields() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -357,9 +375,11 @@ fn test_parsing_performance_1000_segments() {
 
     let duration = start.elapsed();
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Performance assertion: should complete in reasonable time
@@ -385,9 +405,11 @@ fn test_parsing_performance_large_field() {
 
     let duration = start.elapsed();
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     println!("Parsed message with 10x100KB fields in {:?}", duration);
@@ -418,13 +440,17 @@ fn test_boundary_at_exact_1024_bytes() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
-    assert!(events
-        .iter()
-        .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") }));
+    assert!(
+        events
+            .iter()
+            .any(|e| { matches!(e, Event::Segment { id } if id == b"PID") })
+    );
 }
 
 #[test]
@@ -447,9 +473,11 @@ fn test_boundary_in_middle_of_long_field() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Verify the field content is preserved correctly
@@ -487,9 +515,11 @@ fn test_stress_deeply_nested_components() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -512,9 +542,11 @@ fn test_stress_many_repetitions() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -529,9 +561,11 @@ fn test_stress_mixed_delimiters() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 }
 
@@ -565,9 +599,11 @@ fn test_large_lab_result_message() {
 
     let events = collect_events(&mut parser);
 
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, Event::StartMessage { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Event::StartMessage { .. }))
+    );
     assert!(events.iter().any(|e| matches!(e, Event::EndMessage)));
 
     // Should have PID, OBR, and 500 OBX segments
@@ -630,10 +666,10 @@ fn test_field_memory_is_released() {
     // Process remaining events
     let mut found_large_field = false;
     while let Ok(Some(event)) = parser.next_event() {
-        if let Event::Field { raw, .. } = &event {
-            if raw.len() == 1_000_000 {
-                found_large_field = true;
-            }
+        if let Event::Field { raw, .. } = &event
+            && raw.len() == 1_000_000
+        {
+            found_large_field = true;
         }
         // Event is dropped here
     }

--- a/crates/hl7v2-template-values/src/lib.rs
+++ b/crates/hl7v2-template-values/src/lib.rs
@@ -232,8 +232,8 @@ fn generate_value_from_faker<R: Rng>(
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use rand::rngs::StdRng;
 
     #[test]
     fn test_fixed_value() {

--- a/crates/hl7v2-template-values/tests/bdd_tests.rs
+++ b/crates/hl7v2-template-values/tests/bdd_tests.rs
@@ -1,9 +1,9 @@
 //! BDD tests for hl7v2-template-values
 
-use cucumber::{given, then, when, World};
-use hl7v2_template_values::{generate_value, ValueSource};
-use rand::rngs::StdRng;
+use cucumber::{World, given, then, when};
+use hl7v2_template_values::{ValueSource, generate_value};
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[derive(Debug, World)]
 #[world(init = Self::new)]

--- a/crates/hl7v2-template/src/lib.rs
+++ b/crates/hl7v2-template/src/lib.rs
@@ -52,17 +52,17 @@
 //! ```
 
 use hl7v2_core::{Atom, Comp, Delims, Error, Field, Message, Rep, Segment};
-use hl7v2_template_values::generate_value;
 pub use hl7v2_template_values::ValueSource;
-use rand::{rngs::StdRng, RngExt, SeedableRng};
+use hl7v2_template_values::generate_value;
+use rand::{RngExt, SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
 // Re-export corpus types for backward compatibility
 pub use hl7v2_corpus::{
-    compute_message_hash, compute_sha256, extract_message_type, CorpusConfig, CorpusError,
-    CorpusManifest, CorpusSplits, MessageInfo, ProfileInfo, TemplateInfo,
+    CorpusConfig, CorpusError, CorpusManifest, CorpusSplits, MessageInfo, ProfileInfo,
+    TemplateInfo, compute_message_hash, compute_sha256, extract_message_type,
 };
 
 /// Message template
@@ -282,13 +282,13 @@ fn generate_atom(
     rng: &mut StdRng,
 ) -> Result<Atom, Error> {
     // Check if this field has a value source defined in the template
-    if let Some(value_sources) = values.get(field_path) {
-        if !value_sources.is_empty() {
-            // Use the first value source for now (in a real implementation, we might cycle through them)
-            let value_source = &value_sources[0];
-            let value = generate_value(value_source, rng)?;
-            return Ok(Atom::Text(value));
-        }
+    if let Some(value_sources) = values.get(field_path)
+        && !value_sources.is_empty()
+    {
+        // Use the first value source for now (in a real implementation, we might cycle through them)
+        let value_source = &value_sources[0];
+        let value = generate_value(value_source, rng)?;
+        return Ok(Atom::Text(value));
     }
 
     // If no value source is defined, use the template text as-is

--- a/crates/hl7v2-template/tests/generation_integration.rs
+++ b/crates/hl7v2-template/tests/generation_integration.rs
@@ -1,4 +1,4 @@
-use hl7v2_template::{generate, Template, ValueSource};
+use hl7v2_template::{Template, ValueSource, generate};
 use std::collections::HashMap;
 
 #[test]

--- a/crates/hl7v2-template/tests/integration_tests.rs
+++ b/crates/hl7v2-template/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for hl7v2-template crate
 
+use hl7v2_template::{Template, ValueSource, generate, generate_corpus, generate_diverse_corpus};
 use hl7v2_template::{create_manifest, generate_golden_hashes, verify_golden_hashes};
-use hl7v2_template::{generate, generate_corpus, generate_diverse_corpus, Template, ValueSource};
 use std::collections::HashMap;
 
 fn create_basic_template() -> Template {

--- a/crates/hl7v2-template/tests/property_tests.rs
+++ b/crates/hl7v2-template/tests/property_tests.rs
@@ -1,7 +1,7 @@
 //! Property-based tests for hl7v2-template crate
 
 use hl7v2_template::{
-    generate, generate_corpus, generate_golden_hashes, verify_golden_hashes, Template, ValueSource,
+    Template, ValueSource, generate, generate_corpus, generate_golden_hashes, verify_golden_hashes,
 };
 use proptest::prelude::*;
 use std::collections::HashMap;

--- a/crates/hl7v2-test-utils/src/mocks.rs
+++ b/crates/hl7v2-test-utils/src/mocks.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 
 use hl7v2_model::{Error, Message};
 use tokio::net::TcpListener;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tokio::time::timeout;
 
 /// A mock MLLP server for testing network clients.

--- a/crates/hl7v2-validation/src/lib.rs
+++ b/crates/hl7v2-validation/src/lib.rs
@@ -580,10 +580,10 @@ pub fn parse_hl7_ts(s: &str) -> Option<NaiveDateTime> {
             return Some(dt);
         }
     }
-    if s.len() == 8 {
-        if let Ok(d) = NaiveDate::parse_from_str(s, "%Y%m%d") {
-            return d.and_hms_opt(0, 0, 0);
-        }
+    if s.len() == 8
+        && let Ok(d) = NaiveDate::parse_from_str(s, "%Y%m%d")
+    {
+        return d.and_hms_opt(0, 0, 0);
     }
     None
 }
@@ -609,33 +609,33 @@ pub fn parse_hl7_ts_with_precision(s: &str) -> Option<ParsedTimestamp> {
     }
 
     // Try date only format
-    if s.len() == 8 {
-        if let Ok(date) = NaiveDate::parse_from_str(s, "%Y%m%d") {
-            return Some(ParsedTimestamp {
-                datetime: date.and_hms_opt(0, 0, 0)?,
-                precision: TimestampPrecision::Day,
-            });
-        }
+    if s.len() == 8
+        && let Ok(date) = NaiveDate::parse_from_str(s, "%Y%m%d")
+    {
+        return Some(ParsedTimestamp {
+            datetime: date.and_hms_opt(0, 0, 0)?,
+            precision: TimestampPrecision::Day,
+        });
     }
 
     // Try year-month format
-    if s.len() == 6 {
-        if let Ok(date) = NaiveDate::parse_from_str(&format!("{}01", s), "%Y%m%d") {
-            return Some(ParsedTimestamp {
-                datetime: date.and_hms_opt(0, 0, 0)?,
-                precision: TimestampPrecision::Month,
-            });
-        }
+    if s.len() == 6
+        && let Ok(date) = NaiveDate::parse_from_str(&format!("{}01", s), "%Y%m%d")
+    {
+        return Some(ParsedTimestamp {
+            datetime: date.and_hms_opt(0, 0, 0)?,
+            precision: TimestampPrecision::Month,
+        });
     }
 
     // Try year only format
-    if s.len() == 4 {
-        if let Ok(date) = NaiveDate::parse_from_str(&format!("{}0101", s), "%Y%m%d") {
-            return Some(ParsedTimestamp {
-                datetime: date.and_hms_opt(0, 0, 0)?,
-                precision: TimestampPrecision::Year,
-            });
-        }
+    if s.len() == 4
+        && let Ok(date) = NaiveDate::parse_from_str(&format!("{}0101", s), "%Y%m%d")
+    {
+        return Some(ParsedTimestamp {
+            datetime: date.and_hms_opt(0, 0, 0)?,
+            precision: TimestampPrecision::Year,
+        });
     }
 
     None
@@ -687,24 +687,24 @@ pub fn truncate_to_precision(dt: &NaiveDateTime, precision: TimestampPrecision) 
 /// Parse datetime string (supports various HL7 formats)
 pub fn parse_datetime(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     // Try YYYYMMDDHHMMSS format
-    if value.len() == 14 {
-        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(value, "%Y%m%d%H%M%S") {
-            return Some(dt.and_utc());
-        }
+    if value.len() == 14
+        && let Ok(dt) = chrono::NaiveDateTime::parse_from_str(value, "%Y%m%d%H%M%S")
+    {
+        return Some(dt.and_utc());
     }
 
     // Try YYYYMMDD format
-    if value.len() == 8 {
-        if let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y%m%d") {
-            return Some(date.and_hms_opt(0, 0, 0)?.and_utc());
-        }
+    if value.len() == 8
+        && let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y%m%d")
+    {
+        return Some(date.and_hms_opt(0, 0, 0)?.and_utc());
     }
 
     // Try YYYY-MM-DD format
-    if value.len() == 10 {
-        if let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
-            return Some(date.and_hms_opt(0, 0, 0)?.and_utc());
-        }
+    if value.len() == 10
+        && let Ok(date) = chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
+    {
+        return Some(date.and_hms_opt(0, 0, 0)?.and_utc());
     }
 
     None
@@ -719,11 +719,7 @@ pub fn parse_datetime(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 pub fn get_nonempty<'a>(msg: &'a Message, path: &str) -> Option<&'a str> {
     hl7v2_core::get(msg, path).and_then(|s| {
         let t = s.trim();
-        if t.is_empty() {
-            None
-        } else {
-            Some(t)
-        }
+        if t.is_empty() { None } else { Some(t) }
     })
 }
 
@@ -883,10 +879,10 @@ pub fn check_rule_condition(msg: &Message, condition: &RuleCondition) -> bool {
                 return l >= lo && l <= hi;
             }
             // Fallback to integer range
-            if let (Some(l), Ok(lo), Ok(hi)) = (lhs, a.parse::<i64>(), b.parse::<i64>()) {
-                if let Ok(li) = l.parse::<i64>() {
-                    return li >= lo && li <= hi;
-                }
+            if let (Some(l), Ok(lo), Ok(hi)) = (lhs, a.parse::<i64>(), b.parse::<i64>())
+                && let Ok(li) = l.parse::<i64>()
+            {
+                return li >= lo && li <= hi;
             }
             false
         }

--- a/crates/hl7v2-validation/src/tests/property_tests.rs
+++ b/crates/hl7v2-validation/src/tests/property_tests.rs
@@ -7,10 +7,10 @@
 //! - Properties hold across a wide range of inputs
 
 use crate::{
-    is_coded_value, is_date, is_email, is_identifier, is_numeric, is_person_name, is_phone_number,
-    is_sequence_id, is_ssn, is_time, is_timestamp, is_valid_birth_date, is_within_range,
-    validate_checksum, validate_data_type, validate_luhn_checksum,
-    validate_mathematical_relationship, Issue, Severity,
+    Issue, Severity, is_coded_value, is_date, is_email, is_identifier, is_numeric, is_person_name,
+    is_phone_number, is_sequence_id, is_ssn, is_time, is_timestamp, is_valid_birth_date,
+    is_within_range, validate_checksum, validate_data_type, validate_luhn_checksum,
+    validate_mathematical_relationship,
 };
 use proptest::prelude::*;
 

--- a/crates/hl7v2-validation/src/tests/unit_tests.rs
+++ b/crates/hl7v2-validation/src/tests/unit_tests.rs
@@ -9,13 +9,13 @@
 //! - Issue and Severity types
 
 use crate::{
-    check_rule_condition, compare_timestamps_for_before, is_coded_value, is_date, is_email,
-    is_extended_id, is_hierarchic_designator, is_identifier, is_numeric, is_person_name,
-    is_phone_number, is_sequence_id, is_ssn, is_string, is_time, is_timestamp, is_valid_age_range,
+    Issue, RuleCondition, Severity, TimestampPrecision, check_rule_condition,
+    compare_timestamps_for_before, is_coded_value, is_date, is_email, is_extended_id,
+    is_hierarchic_designator, is_identifier, is_numeric, is_person_name, is_phone_number,
+    is_sequence_id, is_ssn, is_string, is_time, is_timestamp, is_valid_age_range,
     is_valid_birth_date, is_within_range, matches_complex_pattern, matches_format, parse_hl7_ts,
     parse_hl7_ts_with_precision, truncate_to_precision, validate_checksum, validate_data_type,
-    validate_luhn_checksum, validate_mathematical_relationship, Issue, RuleCondition, Severity,
-    TimestampPrecision,
+    validate_luhn_checksum, validate_mathematical_relationship,
 };
 use hl7v2_core::Message;
 use hl7v2_parser::parse;
@@ -397,8 +397,8 @@ fn test_is_email_invalid() {
     assert!(!is_email("@domain.com")); // No local part
     assert!(!is_email("user@")); // No domain
     assert!(!is_email("user@domain")); // No TLD
-                                       // Note: "user@.com" actually passes our basic validation (has @, local part, and domain with dot)
-                                       // In a real implementation, you'd want more sophisticated validation
+    // Note: "user@.com" actually passes our basic validation (has @, local part, and domain with dot)
+    // In a real implementation, you'd want more sophisticated validation
 }
 
 #[test]

--- a/crates/hl7v2-validation/tests/bdd_tests.rs
+++ b/crates/hl7v2-validation/tests/bdd_tests.rs
@@ -2,9 +2,9 @@
 //!
 //! These tests implement the step definitions for the validation.feature file.
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_parser::parse;
-use hl7v2_validation::{check_rule_condition, Issue, RuleCondition, Severity};
+use hl7v2_validation::{Issue, RuleCondition, Severity, check_rule_condition};
 use std::collections::HashMap;
 
 // ============================================================================
@@ -1117,16 +1117,16 @@ fn when_validate_message(world: &mut ValidationWorld) {
         let mut issues_to_add: Vec<Issue> = Vec::new();
 
         // Check for unknown message type
-        if let Some(msh_9) = hl7v2_query::get(msg, "MSH.9") {
-            if msh_9.contains("UNKNOWN") {
-                issues_to_add.push(Issue::error(
-                    "CARDINALITY_VIOLATION", // Matching existing Then step if needed, or fix Then step
-                    Some("MSH.9".to_string()),
-                    "Unknown message type".to_string(),
-                ));
-                // Wait! The Then step for this scenario says "validation should fail".
-                // I should use a code that matches one of the Then steps if possible.
-            }
+        if let Some(msh_9) = hl7v2_query::get(msg, "MSH.9")
+            && msh_9.contains("UNKNOWN")
+        {
+            issues_to_add.push(Issue::error(
+                "CARDINALITY_VIOLATION", // Matching existing Then step if needed, or fix Then step
+                Some("MSH.9".to_string()),
+                "Unknown message type".to_string(),
+            ));
+            // Wait! The Then step for this scenario says "validation should fail".
+            // I should use a code that matches one of the Then steps if possible.
         }
 
         // Check required fields (only if not overridden by profile constraints)
@@ -1195,14 +1195,14 @@ fn when_validate_message(world: &mut ValidationWorld) {
             }
 
             // Check max length
-            if let Some(max) = constraint.max_length {
-                if value.len() > max {
-                    issues_to_add.push(Issue::error(
-                        "FIELD_LENGTH_EXCEEDED",
-                        Some(field.clone()),
-                        format!("{} exceeds maximum length of {}", field, max),
-                    ));
-                }
+            if let Some(max) = constraint.max_length
+                && value.len() > max
+            {
+                issues_to_add.push(Issue::error(
+                    "FIELD_LENGTH_EXCEEDED",
+                    Some(field.clone()),
+                    format!("{} exceeds maximum length of {}", field, max),
+                ));
             }
 
             // Check allowed values
@@ -1246,16 +1246,15 @@ fn when_validate_message(world: &mut ValidationWorld) {
             }
 
             // Check range
-            if let (Some(min), Some(max)) = (constraint.range_min, constraint.range_max) {
-                if let Ok(val) = value.parse::<f64>() {
-                    if val < min || val > max {
-                        issues_to_add.push(Issue::error(
-                            "VALUE_OUT_OF_RANGE",
-                            Some(field.clone()),
-                            format!("{} is outside range {}-{}", field, min, max),
-                        ));
-                    }
-                }
+            if let (Some(min), Some(max)) = (constraint.range_min, constraint.range_max)
+                && let Ok(val) = value.parse::<f64>()
+                && (val < min || val > max)
+            {
+                issues_to_add.push(Issue::error(
+                    "VALUE_OUT_OF_RANGE",
+                    Some(field.clone()),
+                    format!("{} is outside range {}-{}", field, min, max),
+                ));
             }
 
             // Check Luhn checksum
@@ -1408,10 +1407,10 @@ fn when_validate_segment_order(world: &mut ValidationWorld) {
         let evn_idx = segment_names.iter().position(|&s| s == "EVN");
         let pid_idx = segment_names.iter().position(|&s| s == "PID");
 
-        if let (Some(evn), Some(pid)) = (evn_idx, pid_idx) {
-            if evn > pid {
-                world.add_error("INVALID_SEGMENT_ORDER", "EVN", "EVN must appear before PID");
-            }
+        if let (Some(evn), Some(pid)) = (evn_idx, pid_idx)
+            && evn > pid
+        {
+            world.add_error("INVALID_SEGMENT_ORDER", "EVN", "EVN must appear before PID");
         }
     }
 }

--- a/crates/hl7v2-validation/tests/integration_tests.rs
+++ b/crates/hl7v2-validation/tests/integration_tests.rs
@@ -5,7 +5,7 @@
 
 use hl7v2_parser::parse;
 use hl7v2_test_utils::{builders::MessageBuilder, fixtures::SampleMessages};
-use hl7v2_validation::{check_rule_condition, is_numeric, Issue, RuleCondition, Severity};
+use hl7v2_validation::{Issue, RuleCondition, Severity, check_rule_condition, is_numeric};
 
 // ============================================================================
 // Test Helpers

--- a/crates/hl7v2-validation/tests/snapshot_tests.rs
+++ b/crates/hl7v2-validation/tests/snapshot_tests.rs
@@ -5,7 +5,7 @@
 
 use hl7v2_parser::parse;
 use hl7v2_test_utils::fixtures::SampleMessages;
-use hl7v2_validation::{check_rule_condition, Issue, RuleCondition, Severity};
+use hl7v2_validation::{Issue, RuleCondition, Severity, check_rule_condition};
 use insta::{assert_debug_snapshot, assert_json_snapshot, assert_yaml_snapshot};
 
 // ============================================================================

--- a/crates/hl7v2-writer/src/lib.rs
+++ b/crates/hl7v2-writer/src/lib.rs
@@ -270,10 +270,10 @@ fn write_segment_fields(segment: &Segment, output: &mut Vec<u8>, delims: &Delims
 /// Helper function to get delimiters from a file batch
 fn get_delimiters_from_file_batch(file_batch: &FileBatch) -> Delims {
     // Try to get delimiters from the first message in the first batch
-    if let Some(first_batch) = file_batch.batches.first() {
-        if let Some(first_message) = first_batch.messages.first() {
-            return first_message.delims.clone();
-        }
+    if let Some(first_batch) = file_batch.batches.first()
+        && let Some(first_message) = first_batch.messages.first()
+    {
+        return first_message.delims.clone();
     }
     // Fallback to default delimiters
     Delims::default()

--- a/crates/hl7v2-writer/tests/bdd_tests.rs
+++ b/crates/hl7v2-writer/tests/bdd_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo test --test bdd_tests
 
-use cucumber::{given, then, when, World};
+use cucumber::{World, given, then, when};
 use hl7v2_model::{Delims, Message, Segment};
 use hl7v2_writer::{write, write_mllp};
 

--- a/examples/ack_generation.rs
+++ b/examples/ack_generation.rs
@@ -7,8 +7,8 @@
 //!
 //! Run with: cargo run --example ack_generation
 
-use hl7v2_ack::{ack, ack_with_error, AckCode};
-use hl7v2_core::{get, parse, write, Message};
+use hl7v2_ack::{AckCode, ack, ack_with_error};
+use hl7v2_core::{Message, get, parse, write};
 
 /// A valid ADT^A01 message
 const VALID_ADT_MESSAGE: &[u8] = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|MSG12345|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
@@ -299,18 +299,19 @@ fn process_message_with_ack(hl7_bytes: &[u8]) -> Result<Vec<u8>, String> {
     if patient_name.is_none() || patient_name.as_ref().map(|s| s.is_empty()).unwrap_or(true) {
         errors.push("Missing patient name (PID.5)");
     }
-    if let Some(bd) = birth_date {
-        if !bd.is_empty() && bd.len() != 8 {
-            errors.push("Invalid birth date format (expected YYYYMMDD)");
-        }
+    if let Some(bd) = birth_date
+        && !bd.is_empty()
+        && bd.len() != 8
+    {
+        errors.push("Invalid birth date format (expected YYYYMMDD)");
     }
-    if let Some(s) = sex {
-        if !s.is_empty() {
-            let valid_values = ["M", "F", "O", "U"];
-            let valid = valid_values.contains(&s);
-            if !valid {
-                errors.push("Invalid sex value (expected M, F, O, or U)");
-            }
+    if let Some(s) = sex
+        && !s.is_empty()
+    {
+        let valid_values = ["M", "F", "O", "U"];
+        let valid = valid_values.contains(&s);
+        if !valid {
+            errors.push("Invalid sex value (expected M, F, O, or U)");
         }
     }
 

--- a/examples/batch_processing.rs
+++ b/examples/batch_processing.rs
@@ -7,8 +7,8 @@
 //!
 //! Run with: cargo run --example batch_processing
 
-use hl7v2_batch::{parse_batch, Batch, FileBatch};
-use hl7v2_core::{get, parse, write, Message};
+use hl7v2_batch::{Batch, FileBatch, parse_batch};
+use hl7v2_core::{Message, get, parse, write};
 
 /// Sample batch file with FHS/BHS headers and multiple messages
 const SAMPLE_BATCH: &[u8] = b"FHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120000||BATCH001\rBHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120000||BATCH001\rMSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120001||ADT^A01^ADT_A01|MSG001|P|2.5.1\rPID|1||PAT001^^^HOSP^MR||Smith^John||19800101|M\rMSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120002||ADT^A01^ADT_A01|MSG002|P|2.5.1\rPID|1||PAT002^^^HOSP^MR||Jones^Jane||19850215|F\rMSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120003||ADT^A01^ADT_A01|MSG003|P|2.5.1\rPID|1||PAT003^^^HOSP^MR||Brown^Bob||19900320|M\rBTS|3\rFTS|3\r";

--- a/examples/message_building.rs
+++ b/examples/message_building.rs
@@ -9,7 +9,6 @@
 //! Run with: cargo run --example message_building
 
 use hl7v2_core::{
-    write, // For serializing messages
     Atom,
     Comp,
     Delims,
@@ -18,6 +17,7 @@ use hl7v2_core::{
     Message,
     Rep,
     Segment,
+    write, // For serializing messages
 };
 
 fn main() {

--- a/examples/mllp_client.rs
+++ b/examples/mllp_client.rs
@@ -10,7 +10,7 @@
 //!
 //! Run with: cargo run --example mllp_client
 
-use hl7v2_core::{get, parse, write, Message};
+use hl7v2_core::{Message, get, parse, write};
 use hl7v2_network::MllpClientBuilder;
 use std::time::Duration;
 

--- a/examples/parsing_basics.rs
+++ b/examples/parsing_basics.rs
@@ -7,7 +7,7 @@
 //!
 //! Run with: cargo run --example parsing_basics
 
-use hl7v2_core::{get, parse, Error, Message};
+use hl7v2_core::{Error, Message, get, parse};
 
 /// A simple HL7 v2 ADT^A01 (Admit) message
 const SAMPLE_MESSAGE: &[u8] = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John^Middle||19700101|M|||123 Main St^^Anytown^CA^12345||5551234567\r";

--- a/examples/template_generation.rs
+++ b/examples/template_generation.rs
@@ -8,7 +8,7 @@
 //! Run with: cargo run --example template_generation
 
 use hl7v2_core::{get, write};
-use hl7v2_template::{generate, Template, ValueSource};
+use hl7v2_template::{Template, ValueSource, generate};
 use std::collections::HashMap;
 
 fn main() {

--- a/examples/validation_basics.rs
+++ b/examples/validation_basics.rs
@@ -8,7 +8,7 @@
 //! Run with: cargo run --example validation_basics
 
 use hl7v2_core::parse;
-use hl7v2_prof::{load_profile, validate, Issue, Profile, Severity};
+use hl7v2_prof::{Issue, Profile, Severity, load_profile, validate};
 
 /// Sample ADT^A01 message for validation
 const SAMPLE_MESSAGE: &[u8] = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use cargo_metadata::{DependencyKind, Metadata, MetadataCommand, Package};
 use clap::{Parser, Subcommand};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};


### PR DESCRIPTION
Completes the migration to Rust 2024. Updates Cargo.toml to edition 2024 and MSRV 1.93. Refactors all collapsible if statements to use idiomatic let chains. Synchronizes formatting across the entire workspace to ensure green CI.