### PR TITLE
fix(security): correct TruffleHog scan ranges

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -146,12 +146,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: TruffleHog OSS
+
+      - name: TruffleHog OSS (pull request)
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@v3.93.8
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --debug --only-verified
+
+      - name: TruffleHog OSS (push)
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        uses: trufflesecurity/trufflehog@v3.93.8
+        with:
+          path: ./
+          base: ${{ github.event.before }}
+          head: ${{ github.sha }}
+          extra_args: --debug --only-verified
+
+      - name: TruffleHog OSS (initial push)
+        if: github.event_name == 'push' && github.event.before == '0000000000000000000000000000000000000000'
+        uses: trufflesecurity/trufflehog@v3.93.8
+        with:
+          path: ./
+          head: ${{ github.sha }}
           extra_args: --debug --only-verified
 
   trivy-scan:


### PR DESCRIPTION
Fixes the Security workflow failure on push events by using event-specific TruffleHog base/head ranges. Scope limited to .github/workflows/security.yml.