### PR TITLE
fix(ci): make AJV contract validation strict

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -50,14 +50,25 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Install protoc-gen-doc
+        run: go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
       - name: Lint Protos
         run: buf lint api/proto
 
       - name: Check Breaking Changes
         if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           buf breaking api/proto \
-            --against "https://github.com/${{ github.repository }}.git#branch=${{ github.base_ref }},subdir=api/proto"
+            --against "https://github.com/${REPOSITORY}.git#branch=${BASE_REF},subdir=api/proto"
 
       - name: Generate Proto Docs
         run: |
@@ -79,15 +90,17 @@ jobs:
 
       - name: Validate Profile Schemas
         run: |
-          ajv validate -c ajv-formats -s
- schemas/profile/profile-v1.schema.json \
-            -d 'profiles/*.yaml' --spec=draft7
+          ajv validate -c ajv-formats \
+            -s schemas/profile/profile-v1.schema.json \
+            -d 'profiles/*.yaml' \
+            --spec=draft7
 
       - name: Validate Config Schema
         run: |
-          ajv validate -c ajv-formats -s
- schemas/config/hl7v2-config-v1.schema.json \
-            -d 'config/*.toml' --spec=draft7 || true
+          ajv validate -c ajv-formats \
+            -s schemas/config/hl7v2-config-v1.schema.json \
+            -d 'config/*.toml' \
+            --spec=draft7
 
       - name: Validate Test Data
         run: |


### PR DESCRIPTION
## Summary
- fix malformed AJV schema invocations by keeping each `-s` flag paired with its schema path
- keep `ajv-formats` loaded for profile and config validation
- remove `|| true` from config schema validation so failures are gating
- install pinned `protoc-gen-doc` before the existing `buf generate` proto-doc step, so API Contracts no longer depends on a missing runner binary
- move PR branch/repository values into env vars before the `buf breaking` shell command to satisfy workflow injection checks
- normalize `.github/workflows/contracts.yml` to LF while touching it, so the added shell continuations are not mixed-EOL lines

## Validation
- `npx --yes @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `npx --yes @bufbuild/buf lint api/proto`
- `npx --yes -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/profile/profile-v1.schema.json -d 'profiles/*.yaml' --spec=draft7`
- `npx --yes -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d 'config/*.toml' --spec=draft7`
- `git diff --check`

Notes:
- Spectral exits cleanly but still reports the existing `info.contact` warning.
- `config/*.toml` currently has no local matches; this PR only makes the configured check strict instead of advisory.
- Local Windows does not have Go installed, so the `protoc-gen-doc` install/generate path is proven by GitHub Actions.