### PR TITLE
fix(server): reject invalid validation profiles

### DIFF
--- a/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
@@ -72,6 +72,22 @@ fn sample_oru_r01() -> String {
     .to_string()
 }
 
+/// Minimal profile accepted by the validation endpoint.
+fn default_validation_profile() -> &'static str {
+    r#"
+message_structure: "GENERIC"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "PID"
+    required: true
+constraints:
+  - path: "PID.3"
+    required: true
+"#
+}
+
 // =========================================================================
 // Health Endpoint Tests
 // =========================================================================
@@ -570,7 +586,7 @@ mod validate_endpoint {
 
         let request_body = json!({
             "message": sample_adt_a01(),
-            "profile": "default",
+            "profile": default_validation_profile(),
             "mllp_framed": false
         });
 
@@ -607,7 +623,7 @@ mod validate_endpoint {
 
         let request_body = json!({
             "message": sample_oru_r01(),
-            "profile": "default",
+            "profile": default_validation_profile(),
             "mllp_framed": false
         });
 
@@ -638,7 +654,7 @@ mod validate_endpoint {
 
         let request_body = json!({
             "message": "Invalid HL7",
-            "profile": "default",
+            "profile": default_validation_profile(),
             "mllp_framed": false
         });
 

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -77,26 +77,10 @@ pub async fn validate_handler(
     // Extract metadata
     let metadata = extract_metadata(&message)?;
 
-    // Load the profile and validate
-    // Note: The profile format in the request must match the Profile struct format.
-    // Test profiles using legacy formats (msh_constraints, field_constraints, etc.)
-    // will fail to parse.
-    let profile = match hl7v2_prof::load_profile_checked(&request.profile) {
-        Ok(p) => p,
-        Err(e) => {
-            // For backward compatibility with tests using legacy profile formats,
-            // we log the error but return a placeholder response.
-            // In production, this should return an error.
-            tracing::warn!("Profile load error: {}", e);
-            let response = ValidateResponse {
-                valid: true,
-                errors: Vec::new(),
-                warnings: Vec::new(),
-                metadata,
-            };
-            return Ok((StatusCode::OK, Json(response)));
-        }
-    };
+    // Load the profile before validation. Profile load failures are client
+    // errors, not successful validation results.
+    let profile = hl7v2_prof::load_profile_checked(&request.profile)
+        .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
 
     // Perform validation using the profile
     let issues = hl7v2_prof::validate(&message, &profile);

--- a/crates/hl7v2-server/tests/bdd_tests.rs
+++ b/crates/hl7v2-server/tests/bdd_tests.rs
@@ -111,9 +111,21 @@ fn given_invalid_json(world: &mut ServerWorld) {
 #[given("a valid HL7 ADT^A01 message payload with profile")]
 fn given_payload_with_profile(world: &mut ServerWorld) {
     let msg = "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20231119120000||ADT^A01|MSG001|P|2.5\rPID|1||MRN123^^^Facility^MR||Doe^John^A||19800101|M\r";
+    let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "PID"
+    required: true
+constraints:
+  - path: "PID.3"
+    required: true
+"#;
     let body = serde_json::json!({
         "message": msg,
-        "profile": "profiles/adt_a01.yaml",
+        "profile": profile,
         "mllp_framed": false
     });
     world.request_body = Some(serde_json::to_string(&body).unwrap());

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -123,12 +123,12 @@ hl7_tables:
     name: "Administrative Sex"
     version: "2.5.1"
     codes:
-      - code: "F"
-        display: "Female"
-      - code: "M"
-        display: "Male"
-      - code: "U"
-        display: "Unknown"
+      - value: "F"
+        description: "Female"
+      - value: "M"
+        description: "Male"
+      - value: "U"
+        description: "Unknown"
 
 valuesets:
   - path: "PID.8"

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -5,10 +5,23 @@ use axum::{
     http::{Request, StatusCode},
 };
 use http_body_util::BodyExt;
-use serde_json::json;
+use serde_json::{Value, json};
 use tower::ServiceExt;
 
 mod common;
+
+fn validate_request(request_body: Value) -> Request<Body> {
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            8080,
+        ))))
+        .uri("/hl7/validate")
+        .method("POST")
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+        .unwrap()
+}
 
 #[tokio::test]
 async fn test_validate_with_minimal_profile() {
@@ -20,27 +33,17 @@ async fn test_validate_with_minimal_profile() {
         "mllp_framed": false
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
     assert_eq!(
         response.status(),
         StatusCode::OK,
         "Validation with minimal profile should succeed"
     );
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body_json["valid"], true);
 }
 
 #[tokio::test]
@@ -53,21 +56,7 @@ async fn test_validate_adt_a01_with_matching_profile() {
         "mllp_framed": false
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
     assert_eq!(
         response.status(),
@@ -95,27 +84,13 @@ async fn test_validate_malformed_message_returns_error() {
         "mllp_framed": false
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
-    // Should return error for malformed message
-    assert!(
-        response.status().is_client_error() || response.status().is_server_error(),
-        "Malformed message should return error status"
-    );
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body_json["code"], "PARSE_ERROR");
 }
 
 #[tokio::test]
@@ -128,31 +103,66 @@ async fn test_validate_invalid_profile_yaml_returns_error() {
         "mllp_framed": false
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
-    // Invalid YAML profile might still succeed if parsed as simple string
-    // or may return an error depending on validation strictness
-    assert!(
-        response.status() == StatusCode::OK
-            || response.status().is_client_error()
-            || response.status().is_server_error(),
-        "Invalid profile should be handled gracefully, got: {}",
-        response.status()
-    );
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body_json["code"], "PROFILE_LOAD_ERROR");
+}
+
+#[tokio::test]
+async fn test_validate_profile_missing_required_fields_returns_profile_load_error() {
+    let app = common::create_test_router();
+
+    let request_body = json!({
+        "message": common::fixtures::MINIMAL_VALID,
+        "profile": r#"
+message_structure: "ADT_A01"
+segments:
+  - id: "MSH"
+"#,
+        "mllp_framed": false
+    });
+
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body_json["code"], "PROFILE_LOAD_ERROR");
+}
+
+#[tokio::test]
+async fn test_validate_invalid_message_against_profile_returns_valid_false() {
+    let app = common::create_test_router();
+
+    let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+constraints:
+  - path: "PID.3"
+    required: true
+"#;
+
+    let request_body = json!({
+        "message": common::fixtures::MINIMAL_VALID,
+        "profile": profile,
+        "mllp_framed": false
+    });
+
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(body_json["valid"], false);
+    assert_eq!(body_json["errors"][0]["code"], "MISSING_REQUIRED_FIELD");
 }
 
 #[tokio::test]
@@ -163,21 +173,7 @@ async fn test_validate_missing_message_field_returns_400() {
         "profile": common::profiles::MINIMAL_PROFILE
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
     assert!(
         response.status() == StatusCode::BAD_REQUEST
@@ -195,21 +191,7 @@ async fn test_validate_missing_profile_field_returns_400() {
         "message": common::fixtures::MINIMAL_VALID
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
     assert!(
         response.status() == StatusCode::BAD_REQUEST
@@ -283,21 +265,7 @@ async fn test_validate_returns_json_response() {
         "mllp_framed": false
     });
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = app.oneshot(validate_request(request_body)).await.unwrap();
 
     if response.status() == StatusCode::OK {
         let content_type = response


### PR DESCRIPTION
## Summary
- Return `400 PROFILE_LOAD_ERROR` when validation profile loading fails instead of returning `200 valid: true`.
- Add `/hl7/validate` coverage for malformed HL7, malformed profiles, missing required profile fields, valid profiles, and invalid messages against valid profiles.
- Update server and E2E test fixtures so validation tests exercise strict inline profile loading.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p hl7v2-server --all-features`
- `cargo test -p hl7v2-e2e-tests --test e2e --all-features`
- `cargo run -p xtask -- gate --check --changed`
- `cargo run -p xtask -- gate --check` attempted locally; blocked during workspace warm-up by local Python 3.14 / PyO3 0.24.2 compatibility before reaching branch code.