### PR TITLE
test(server): prove gRPC contract behavior

### DIFF
--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -63,34 +63,7 @@ impl Hl7Service for Hl7ServiceImpl {
 
         match parse_result {
             Ok(msg) => {
-                let metadata = MessageMetadata {
-                    message_type: msg
-                        .segments
-                        .iter()
-                        .find(|s| &s.id == b"MSH")
-                        .and_then(|s: &RustSegment| s.fields.get(7))
-                        .and_then(|f: &RustField| f.first_text())
-                        .unwrap_or("UNKNOWN")
-                        .to_string(),
-                    version: msg
-                        .segments
-                        .iter()
-                        .find(|s| &s.id == b"MSH")
-                        .and_then(|s: &RustSegment| s.fields.get(10))
-                        .and_then(|f: &RustField| f.first_text())
-                        .unwrap_or("UNKNOWN")
-                        .to_string(),
-                    control_id: msg
-                        .segments
-                        .iter()
-                        .find(|s| &s.id == b"MSH")
-                        .and_then(|s: &RustSegment| s.fields.get(8))
-                        .and_then(|f: &RustField| f.first_text())
-                        .unwrap_or("UNKNOWN")
-                        .to_string(),
-                    sending_facility: String::new(),
-                    receiving_facility: String::new(),
-                };
+                let metadata = extract_grpc_metadata(&msg);
 
                 let proto_msg = proto::Message::from(msg);
 
@@ -262,6 +235,35 @@ impl Hl7Service for Hl7ServiceImpl {
 // ============================================================================
 // Conversions
 // ============================================================================
+
+fn extract_grpc_metadata(msg: &RustMessage) -> MessageMetadata {
+    MessageMetadata {
+        message_type: joined_components(msg, "MSH.9").unwrap_or_else(|| "UNKNOWN".to_string()),
+        version: hl7v2_core::get(msg, "MSH.12")
+            .unwrap_or("UNKNOWN")
+            .to_string(),
+        control_id: hl7v2_core::get(msg, "MSH.10")
+            .unwrap_or("UNKNOWN")
+            .to_string(),
+        sending_facility: hl7v2_core::get(msg, "MSH.4").unwrap_or("").to_string(),
+        receiving_facility: hl7v2_core::get(msg, "MSH.6").unwrap_or("").to_string(),
+    }
+}
+
+fn joined_components(msg: &RustMessage, field_path: &str) -> Option<String> {
+    let mut components = Vec::new();
+
+    for component in 1.. {
+        let path = format!("{field_path}.{component}");
+        match hl7v2_core::get(msg, &path) {
+            Some(value) if !value.is_empty() => components.push(value.to_string()),
+            _ if component == 1 => return None,
+            _ => break,
+        }
+    }
+
+    Some(components.join("^"))
+}
 
 impl From<RustMessage> for proto::Message {
     fn from(msg: RustMessage) -> Self {

--- a/crates/hl7v2-server/tests/bdd_tests.rs
+++ b/crates/hl7v2-server/tests/bdd_tests.rs
@@ -269,5 +269,16 @@ fn then_content_type(_world: &mut ServerWorld, _expected: String) {
 // Run the tests
 #[tokio::main]
 async fn main() {
+    // Cargo passes test filters to every test binary. Cucumber owns its own CLI
+    // parser, so skip this custom harness when a focused Rust test filter does
+    // not target the BDD scenarios.
+    if let Some(filter) = std::env::args().skip(1).find(|arg| !arg.starts_with('-'))
+        && !["bdd", "cucumber", "http", "server"]
+            .iter()
+            .any(|allowed| filter.contains(allowed))
+    {
+        return;
+    }
+
     ServerWorld::cucumber().run_and_exit("./features").await;
 }

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -5,13 +5,18 @@ mod tests {
     use hl7v2_server::grpc::Hl7ServiceImpl;
     use hl7v2_server::grpc::proto::hl7_service_server::Hl7Service;
     use hl7v2_server::grpc::proto::{
-        GenerateAckRequest, NormalizeRequest, ParseRequest, ValidateRequest,
+        GenerateAckRequest, HealthCheckRequest, NormalizeOptions, NormalizeRequest, ParseRequest,
+        ParseStreamRequest, ParseStreamResponse, ValidateRequest, generate_ack_request,
+        health_check_response, validation_issue,
     };
     use hl7v2_server::server::AppState;
+    use http_body_util::Empty;
     use metrics_exporter_prometheus::PrometheusBuilder;
     use std::sync::Arc;
     use std::time::Instant;
-    use tonic::Request;
+    use tonic::codec::{Codec, ProstCodec, Streaming};
+    use tonic::codegen::Bytes;
+    use tonic::{Code, Request};
 
     /// Helper to create a mock AppState
     fn mock_state() -> Arc<AppState> {
@@ -25,10 +30,46 @@ mod tests {
     }
 
     const SAMPLE_MSG: &[u8] = b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
+    const CUSTOM_DELIMS_MSG: &[u8] = b"MSH*%$!?*SENDAPP*SENDFAC*RECVAPP*RECVFAC*202605030101**ADT%A01*CTRL123*P*2.5\rPID*1**123456%%%HOSP%MR**Doe%John**19700101*M\r";
+    const PROFILE: &str = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+constraints:
+  - path: "PID.3"
+    required: true
+"#;
+
+    fn service() -> Hl7ServiceImpl {
+        Hl7ServiceImpl::new(mock_state())
+    }
+
+    async fn normalize(
+        service: &Hl7ServiceImpl,
+        message: &[u8],
+        canonical_delimiters: bool,
+        mllp_frame: bool,
+    ) -> Vec<u8> {
+        service
+            .normalize(Request::new(NormalizeRequest {
+                message: message.to_vec(),
+                options: Some(NormalizeOptions {
+                    canonical_delimiters,
+                    mllp_frame,
+                    sort_fields: false,
+                }),
+            }))
+            .await
+            .expect("RPC should succeed")
+            .into_inner()
+            .normalized
+    }
 
     #[tokio::test]
-    async fn test_grpc_parse_metadata() {
-        let service = Hl7ServiceImpl::new(mock_state());
+    async fn test_grpc_parse_raw_hl7_success() {
+        let service = service();
         let request = Request::new(ParseRequest {
             message: SAMPLE_MSG.to_vec(),
             mllp_framed: false,
@@ -39,17 +80,21 @@ mod tests {
         let inner = response.into_inner();
 
         assert!(inner.success);
+        let message = inner.message.expect("Parsed message should exist");
+        assert_eq!(message.segments[0].id, "MSH");
+        assert_eq!(message.segments[1].id, "PID");
+
         let metadata = inner.metadata.expect("Metadata should exist");
-        // NOTE: Current extractor only gets first component (e.g., "ADT" from "ADT^A01")
-        // This should be improved in a future pass to join components.
-        assert_eq!(metadata.message_type, "ADT");
+        assert_eq!(metadata.message_type, "ADT^A01");
         assert_eq!(metadata.control_id, "CTRL123");
         assert_eq!(metadata.version, "2.5");
+        assert_eq!(metadata.sending_facility, "SENDFAC");
+        assert_eq!(metadata.receiving_facility, "RECVFAC");
     }
 
     #[tokio::test]
-    async fn test_grpc_parse_mllp() {
-        let service = Hl7ServiceImpl::new(mock_state());
+    async fn test_grpc_parse_mllp_success() {
+        let service = service();
         let mllp_msg = hl7v2_mllp::wrap_mllp(SAMPLE_MSG);
 
         let request = Request::new(ParseRequest {
@@ -63,64 +108,95 @@ mod tests {
 
         assert!(inner.success);
         assert!(inner.message.is_some());
+        assert_eq!(
+            inner.metadata.expect("Metadata should exist").control_id,
+            "CTRL123"
+        );
     }
 
     #[tokio::test]
-    async fn test_grpc_generate_ack() {
-        let service = Hl7ServiceImpl::new(mock_state());
-        let request = Request::new(GenerateAckRequest {
-            message: SAMPLE_MSG.to_vec(),
-            code: 1, // AA
-            error_message: None,
-        });
-
-        let response = service
-            .generate_ack(request)
-            .await
-            .expect("RPC should succeed");
-        let inner = response.into_inner();
-
-        let ack_bytes = inner.ack_message;
-        assert!(ack_bytes.starts_with(b"MSH"));
-        let ack_str = String::from_utf8_lossy(&ack_bytes);
-        assert!(ack_str.contains("MSA|AA|CTRL123"));
-    }
-
-    #[tokio::test]
-    async fn test_grpc_normalize() {
-        let service = Hl7ServiceImpl::new(mock_state());
-        let request = Request::new(NormalizeRequest {
-            message: SAMPLE_MSG.to_vec(),
+    async fn test_grpc_parse_invalid_hl7_returns_parse_error() {
+        let service = service();
+        let request = Request::new(ParseRequest {
+            message: b"not an HL7 message".to_vec(),
+            mllp_framed: false,
             options: None,
         });
 
-        let response = service
-            .normalize(request)
-            .await
-            .expect("RPC should succeed");
+        let response = service.parse(request).await.expect("RPC should succeed");
         let inner = response.into_inner();
 
-        assert!(!inner.normalized.is_empty());
-        assert!(inner.normalized.starts_with(b"MSH"));
+        assert!(!inner.success);
+        assert!(inner.message.is_none());
+        assert_eq!(inner.errors.len(), 1);
+        assert_eq!(inner.errors[0].code, "PARSE_ERROR");
     }
 
     #[tokio::test]
-    async fn test_grpc_validate_valid_message() {
-        let service = Hl7ServiceImpl::new(mock_state());
-        // Simple profile that requires PID-3
-        let profile_yaml = "
-message_structure: 'ADT_A01'
-version: '2.5'
-segments:
-  - id: 'MSH'
-  - id: 'PID'
-constraints:
-  - path: 'PID.3'
-    required: true
-";
+    async fn test_grpc_generate_ack_maps_codes_and_preserves_control_id() {
+        let service = service();
+
+        for (code, expected) in [
+            (generate_ack_request::AckCode::Aa, "AA"),
+            (generate_ack_request::AckCode::Ae, "AE"),
+            (generate_ack_request::AckCode::Ar, "AR"),
+        ] {
+            let response = service
+                .generate_ack(Request::new(GenerateAckRequest {
+                    message: SAMPLE_MSG.to_vec(),
+                    code: code as i32,
+                    error_message: None,
+                }))
+                .await
+                .expect("RPC should succeed");
+            let inner = response.into_inner();
+
+            let ack_str = String::from_utf8(inner.ack_message).expect("ACK should be UTF-8");
+            assert!(ack_str.starts_with("MSH"));
+            assert!(
+                ack_str.contains(&format!("MSA|{}|CTRL123", expected)),
+                "ACK did not preserve code/control id: {ack_str}"
+            );
+            assert!(inner.parsed_ack.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_grpc_normalize_canonical_output_and_idempotence() {
+        let service = service();
+
+        let normalized = normalize(&service, CUSTOM_DELIMS_MSG, true, false).await;
+        let normalized_str = String::from_utf8(normalized.clone()).expect("HL7 should be UTF-8");
+
+        assert!(normalized_str.starts_with("MSH|^~\\&|"));
+        assert!(normalized_str.contains("ADT^A01"));
+        assert!(normalized_str.contains("PID|1||123456^^^HOSP^MR||Doe^John||19700101|M"));
+
+        let renormalized = normalize(&service, &normalized, true, false).await;
+        assert_eq!(normalized, renormalized);
+    }
+
+    #[tokio::test]
+    async fn test_grpc_normalize_optional_mllp_framing() {
+        let service = service();
+
+        let unframed = normalize(&service, SAMPLE_MSG, true, false).await;
+        let framed = normalize(&service, SAMPLE_MSG, true, true).await;
+
+        assert!(framed.starts_with(&[0x0b]));
+        assert!(framed.ends_with(&[0x1c, 0x0d]));
+        assert_eq!(
+            hl7v2_mllp::unwrap_mllp(&framed).unwrap(),
+            unframed.as_slice()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grpc_validate_valid_profile() {
+        let service = service();
         let request = Request::new(ValidateRequest {
             message: SAMPLE_MSG.to_vec(),
-            profile: profile_yaml.to_string(),
+            profile: PROFILE.to_string(),
             mllp_framed: false,
             options: None,
         });
@@ -130,25 +206,98 @@ constraints:
 
         assert!(inner.valid);
         assert!(inner.errors.is_empty());
+        assert!(inner.warnings.is_empty());
+        let summary = inner.summary.expect("Summary should exist");
+        assert_eq!(summary.error_count, 0);
+        assert_eq!(summary.warning_count, 0);
     }
 
     #[tokio::test]
-    async fn test_grpc_validate_invalid_message() {
-        let service = Hl7ServiceImpl::new(mock_state());
-        // Message with missing required fields for ADT^A01 usually
-        let invalid_msg = b"MSH|^~\\&|SENDER||||20260503||ADT^A01|CTRL|P|2.5\r";
+    async fn test_grpc_validate_invalid_profile_returns_invalid_argument() {
+        let service = service();
 
         let request = Request::new(ValidateRequest {
-            message: invalid_msg.to_vec(),
-            profile: "adt_a01".to_string(), // Assumes this profile exists in test environment or is handled
+            message: SAMPLE_MSG.to_vec(),
+            profile: "invalid: yaml: structure:".to_string(),
             mllp_framed: false,
             options: None,
         });
 
-        // This might fail if the profile is not found, but let's see how the mock environment handles it
-        let response = service.validate(request).await;
-        // The current implementation loads profile from string/URL.
-        // If it's not a valid YAML/path, it returns an error.
-        assert!(response.is_err(), "Should fail for non-existent profile");
+        let err = service
+            .validate(request)
+            .await
+            .expect_err("Malformed profile should fail the RPC");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("Failed to load profile"));
+    }
+
+    #[tokio::test]
+    async fn test_grpc_validate_separates_errors_from_warnings() {
+        let service = service();
+        let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+constraints:
+  - path: "PID.99"
+    required: true
+"#;
+
+        let request = Request::new(ValidateRequest {
+            message: SAMPLE_MSG.to_vec(),
+            profile: profile.to_string(),
+            mllp_framed: false,
+            options: None,
+        });
+
+        let response = service.validate(request).await.expect("RPC should succeed");
+        let inner = response.into_inner();
+
+        assert!(!inner.valid);
+        assert_eq!(inner.errors.len(), 1);
+        assert_eq!(inner.errors[0].code, "MISSING_REQUIRED_FIELD");
+        assert_eq!(
+            inner.errors[0].severity,
+            validation_issue::Severity::Error as i32
+        );
+        assert!(inner.warnings.is_empty());
+
+        let summary = inner.summary.expect("Summary should exist");
+        assert_eq!(summary.error_count, 1);
+        assert_eq!(summary.warning_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_grpc_health_check_reports_serving_version() {
+        let service = service();
+
+        let response = service
+            .health_check(Request::new(HealthCheckRequest {}))
+            .await
+            .expect("RPC should succeed");
+        let inner = response.into_inner();
+
+        assert_eq!(
+            inner.status,
+            health_check_response::ServingStatus::Serving as i32
+        );
+        assert_eq!(inner.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn test_grpc_parse_stream_is_explicitly_unsupported() {
+        let service = service();
+        let mut codec = ProstCodec::<ParseStreamResponse, ParseStreamRequest>::default();
+        let stream = Streaming::new_request(codec.decoder(), Empty::<Bytes>::new(), None, None);
+
+        let err = service
+            .parse_stream(Request::new(stream))
+            .await
+            .expect_err("ParseStream should be explicitly unsupported");
+
+        assert_eq!(err.code(), Code::Unimplemented);
+        assert_eq!(err.message(), "Streaming parse not yet implemented");
     }
 }


### PR DESCRIPTION
## Summary
- Expand `hl7v2-server` gRPC contract tests across Parse, Validate, GenerateAck, Normalize, HealthCheck, and ParseStream.
- Fix gRPC parse metadata to report full `MSH.9` message type plus facility fields using the same path-based extraction shape as HTTP.
- Make the custom BDD harness ignore unrelated Cargo test filters so `cargo test -p hl7v2-server grpc --all-features` reaches the gRPC test binary.

## Coverage added
- Parse: raw HL7 success, MLLP success, invalid HL7 parse error.
- Validate: valid profile, malformed profile error, invalid message/profile errors separated from warnings.
- GenerateAck: AA/AE/AR mapping and control ID propagation.
- Normalize: canonical output, idempotence, optional MLLP framing.
- HealthCheck: serving status and package version.
- ParseStream: explicitly asserted as unsupported with `UNIMPLEMENTED`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p hl7v2-server grpc --all-features`
- `cargo test -p hl7v2-server --all-features`
- `cargo run -p xtask -- gate --check --changed`
- `cargo run -p xtask -- gate --check` attempted locally; still aborts during workspace Python/PyO3 build-config warm-up before branch code.