### PR TITLE
fix(server): align HTTP runtime API contract

### DIFF
--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -8,13 +8,20 @@ info:
     This API provides endpoints for:
     - Parsing HL7 v2 messages
     - Validating messages against conformance profiles
+    - Generating ACK messages
+    - Normalizing HL7 v2 messages
 
     ## Authentication
 
-    All endpoints require API Key authentication via the `X-API-Key` header:
+    HL7 processing endpoints under `/hl7/*` require API Key authentication via
+    the `X-API-Key` header when the server is configured with an API key:
     ```
     X-API-Key: <your-api-key>
     ```
+
+    Health, readiness, metrics, and API documentation endpoints are public by
+    design so load balancers, scrapers, and local operators can inspect service
+    state without application credentials.
 
     ## Rate Limiting
 
@@ -151,6 +158,72 @@ paths:
         '401':
           description: Unauthorized
 
+  /hl7/ack:
+    post:
+      summary: Generate HL7 ACK
+      description: |
+        Generate an HL7 v2 ACK message for a parsed inbound message.
+      tags: [hl7]
+      operationId: generateAck
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AckRequest'
+      responses:
+        '200':
+          description: ACK generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AckResponse'
+        '400':
+          description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
+  /hl7/normalize:
+    post:
+      summary: Normalize HL7 message
+      description: |
+        Parse and rewrite an HL7 v2 message with stable delimiters and optional MLLP output framing.
+      tags: [hl7]
+      operationId: normalizeMessage
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NormalizeRequest'
+      responses:
+        '200':
+          description: Message normalized successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NormalizeResponse'
+        '400':
+          description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -257,6 +330,79 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ValidationWarning'
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    AckRequest:
+      type: object
+      required: [message, code]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        code:
+          type: string
+          enum: [AA, AE, AR, CA, CE, CR]
+          description: ACK code to generate
+        error_message:
+          type: string
+          nullable: true
+          description: Optional error text for ERR segment generation
+        mllp_framed:
+          type: boolean
+          default: false
+          description: Whether the input message is MLLP framed
+        mllp_frame:
+          type: boolean
+          default: false
+          description: Whether to MLLP frame the ACK response
+
+    AckResponse:
+      type: object
+      required: [ack_message, ack_code, metadata]
+      properties:
+        ack_message:
+          type: string
+          description: Generated ACK message
+        ack_code:
+          type: string
+          enum: [AA, AE, AR, CA, CE, CR]
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    NormalizeRequest:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        mllp_framed:
+          type: boolean
+          default: false
+          description: Whether the input message is MLLP framed
+        options:
+          $ref: '#/components/schemas/NormalizeOptions'
+
+    NormalizeOptions:
+      type: object
+      properties:
+        canonical_delimiters:
+          type: boolean
+          default: true
+          description: Rewrite delimiters to canonical HL7 delimiters
+        mllp_frame:
+          type: boolean
+          default: false
+          description: Whether to MLLP frame the normalized response
+
+    NormalizeResponse:
+      type: object
+      required: [normalized_message, metadata]
+      properties:
+        normalized_message:
+          type: string
+          description: Normalized HL7 message
         metadata:
           $ref: '#/components/schemas/MessageMetadata'
 

--- a/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
@@ -18,6 +18,7 @@ async fn test_auth_missing_api_key_fails() {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
+        cors_allowed_origins: Default::default(),
     });
     let app = build_router(state);
 
@@ -47,6 +48,7 @@ async fn test_auth_valid_api_key_succeeds() {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
+        cors_allowed_origins: Default::default(),
     });
     let app = build_router(state);
 
@@ -82,6 +84,7 @@ async fn test_auth_invalid_api_key_fails() {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
+        cors_allowed_origins: Default::default(),
     });
     let app = build_router(state);
 
@@ -112,6 +115,7 @@ async fn test_health_metrics_public() {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
+        cors_allowed_origins: Default::default(),
     });
     let app = build_router(state);
 

--- a/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
@@ -34,6 +34,7 @@ fn create_test_router() -> axum::Router {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: None,
+        cors_allowed_origins: Default::default(),
     });
     build_router(state)
 }
@@ -888,6 +889,7 @@ mod server_integration {
             bind_address: addr.to_string(),
             max_body_size: 10 * 1024 * 1024,
             api_key: None,
+            cors_allowed_origins: Default::default(),
         };
 
         // Build server

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -28,16 +28,7 @@ pub async fn parse_handler(
     State(_state): State<Arc<AppState>>,
     Json(request): Json<ParseRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Parse the message
-    let message_bytes = request.message.as_bytes();
-
-    let message = if request.mllp_framed {
-        hl7v2_core::parse_mllp(message_bytes)
-            .map_err(|e| AppError::Parse(format!("MLLP parse error: {}", e)))?
-    } else {
-        hl7v2_core::parse(message_bytes)
-            .map_err(|e| AppError::Parse(format!("Parse error: {}", e)))?
-    };
+    let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
 
     // Extract metadata
     let metadata = extract_metadata(&message)?;
@@ -63,16 +54,7 @@ pub async fn validate_handler(
     State(_state): State<Arc<AppState>>,
     Json(request): Json<ValidateRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Parse the message
-    let message_bytes = request.message.as_bytes();
-
-    let message = if request.mllp_framed {
-        hl7v2_core::parse_mllp(message_bytes)
-            .map_err(|e| AppError::Parse(format!("MLLP parse error: {}", e)))?
-    } else {
-        hl7v2_core::parse(message_bytes)
-            .map_err(|e| AppError::Parse(format!("Parse error: {}", e)))?
-    };
+    let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
 
     // Extract metadata
     let metadata = extract_metadata(&message)?;
@@ -126,6 +108,96 @@ pub async fn validate_handler(
     Ok((StatusCode::OK, Json(response)))
 }
 
+/// Handler for POST /hl7/ack
+pub async fn ack_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(request): Json<AckRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
+    let ack_code = map_ack_code(request.code);
+
+    let ack_message = if let Some(error_message) = request.error_message.as_deref() {
+        hl7v2_gen::ack_with_error(&message, ack_code, Some(error_message))
+    } else {
+        hl7v2_gen::ack(&message, ack_code)
+    }
+    .map_err(|e| AppError::Internal(format!("Failed to generate ACK: {}", e)))?;
+
+    let metadata = extract_metadata(&ack_message)?;
+    let ack_bytes = hl7v2_writer::write(&ack_message);
+    let ack_bytes = if request.mllp_frame {
+        hl7v2_mllp::wrap_mllp(&ack_bytes)
+    } else {
+        ack_bytes
+    };
+
+    let response = AckResponse {
+        ack_message: String::from_utf8(ack_bytes)
+            .map_err(|e| AppError::Internal(format!("ACK was not UTF-8: {}", e)))?,
+        ack_code: request.code.as_str().to_string(),
+        metadata,
+    };
+
+    Ok((StatusCode::OK, Json(response)))
+}
+
+/// Handler for POST /hl7/normalize
+pub async fn normalize_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(request): Json<NormalizeRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let message_bytes = request.message.as_bytes();
+    let input = if request.mllp_framed {
+        hl7v2_mllp::unwrap_mllp(message_bytes)
+            .map_err(|e| AppError::Parse(format!("MLLP parse error: {}", e)))?
+    } else {
+        message_bytes
+    };
+
+    let normalized_bytes = hl7v2_normalize::normalize(input, request.options.canonical_delimiters)
+        .map_err(|e| AppError::Parse(format!("Normalize error: {}", e)))?;
+    let normalized_message = hl7v2_core::parse(&normalized_bytes)
+        .map_err(|e| AppError::Parse(format!("Normalized message parse error: {}", e)))?;
+    let metadata = extract_metadata(&normalized_message)?;
+
+    let response_bytes = if request.options.mllp_frame {
+        hl7v2_mllp::wrap_mllp(&normalized_bytes)
+    } else {
+        normalized_bytes
+    };
+
+    let response = NormalizeResponse {
+        normalized_message: String::from_utf8(response_bytes)
+            .map_err(|e| AppError::Internal(format!("Normalized message was not UTF-8: {}", e)))?,
+        metadata,
+    };
+
+    Ok((StatusCode::OK, Json(response)))
+}
+
+fn parse_request_message(
+    message_bytes: &[u8],
+    mllp_framed: bool,
+) -> Result<hl7v2_core::Message, AppError> {
+    if mllp_framed {
+        hl7v2_core::parse_mllp(message_bytes)
+            .map_err(|e| AppError::Parse(format!("MLLP parse error: {}", e)))
+    } else {
+        hl7v2_core::parse(message_bytes).map_err(|e| AppError::Parse(format!("Parse error: {}", e)))
+    }
+}
+
+fn map_ack_code(code: AckRequestCode) -> hl7v2_gen::AckCode {
+    match code {
+        AckRequestCode::Aa => hl7v2_gen::AckCode::AA,
+        AckRequestCode::Ae => hl7v2_gen::AckCode::AE,
+        AckRequestCode::Ar => hl7v2_gen::AckCode::AR,
+        AckRequestCode::Ca => hl7v2_gen::AckCode::CA,
+        AckRequestCode::Ce => hl7v2_gen::AckCode::CE,
+        AckRequestCode::Cr => hl7v2_gen::AckCode::CR,
+    }
+}
+
 /// Extract message metadata from parsed message
 fn extract_metadata(message: &hl7v2_core::Message) -> Result<MessageMetadata, AppError> {
     // Find MSH segment
@@ -139,9 +211,7 @@ fn extract_metadata(message: &hl7v2_core::Message) -> Result<MessageMetadata, Ap
     }
 
     // Extract MSH fields
-    let message_type = hl7v2_core::get(message, "MSH.9")
-        .unwrap_or("UNKNOWN")
-        .to_string();
+    let message_type = joined_components(message, "MSH.9").unwrap_or_else(|| "UNKNOWN".to_string());
 
     let version = hl7v2_core::get(message, "MSH.12")
         .unwrap_or("2.5")
@@ -162,6 +232,25 @@ fn extract_metadata(message: &hl7v2_core::Message) -> Result<MessageMetadata, Ap
         segment_count: message.segments.len(),
         charsets: message.charsets.clone(),
     })
+}
+
+fn joined_components(message: &hl7v2_core::Message, path: &str) -> Option<String> {
+    let mut components = Vec::new();
+
+    for index in 1.. {
+        let component_path = format!("{}.{}", path, index);
+        match hl7v2_core::get(message, &component_path) {
+            Some(value) if !value.is_empty() => components.push(value.to_string()),
+            Some(_) => {}
+            None => break,
+        }
+    }
+
+    if components.is_empty() {
+        hl7v2_core::get(message, path).map(str::to_string)
+    } else {
+        Some(components.join("^"))
+    }
 }
 
 /// Application error type with specific error variants.

--- a/crates/hl7v2-server/src/lib.rs
+++ b/crates/hl7v2-server/src/lib.rs
@@ -5,6 +5,7 @@
 //! - Parsing HL7 messages
 //! - Validating messages against profiles
 //! - Generating ACK messages
+//! - Normalizing HL7 messages
 //! - Health checks
 //!
 //! # Features
@@ -39,7 +40,7 @@ pub mod routes;
 pub mod server;
 
 pub use routes::build_router;
-pub use server::{AppState, Server, ServerBuilder, ServerConfig};
+pub use server::{AppState, CorsAllowedOrigins, Server, ServerBuilder, ServerConfig};
 
 /// Server error types
 #[derive(Debug, thiserror::Error)]

--- a/crates/hl7v2-server/src/main.rs
+++ b/crates/hl7v2-server/src/main.rs
@@ -1,6 +1,6 @@
 //! HL7v2 HTTP/REST API server binary.
 
-use hl7v2_server::Server;
+use hl7v2_server::{CorsAllowedOrigins, Server};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -28,10 +28,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::warn!("API key authentication disabled (public access enabled)");
     }
 
+    let cors_allowed_origins = std::env::var("HL7V2_CORS_ALLOWED_ORIGINS")
+        .map(|value| CorsAllowedOrigins::from_csv(&value))
+        .unwrap_or_default();
+    tracing::info!("CORS allowed origins: {:?}", cors_allowed_origins);
+
     // Create and run server
     let server = Server::builder()
         .bind(bind_address)
         .api_key(api_key)
+        .cors_allowed_origins(cors_allowed_origins)
         .build();
 
     server.serve().await?;

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -1,7 +1,7 @@
 //! Request and response models for the HTTP API.
 //!
 //! These models follow JSON:API conventions where appropriate and align
-//! with the OpenAPI specification in `schemas/openapi/hl7v2-api.yaml`.
+//! with the OpenAPI specification in `api/openapi/hl7v2-api-v1.yaml`.
 
 use serde::{Deserialize, Serialize};
 
@@ -112,6 +112,114 @@ pub struct ValidateResponse {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub warnings: Vec<ValidationWarning>,
     /// Message metadata
+    pub metadata: MessageMetadata,
+}
+
+/// ACK generation request body
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AckRequest {
+    /// Raw HL7 message content
+    pub message: String,
+    /// ACK code to generate
+    pub code: AckRequestCode,
+    /// Optional error text for ERR segment generation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// Whether the input message is MLLP framed
+    #[serde(default)]
+    pub mllp_framed: bool,
+    /// Whether to MLLP frame the ACK response
+    #[serde(default)]
+    pub mllp_frame: bool,
+}
+
+/// HTTP ACK codes.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AckRequestCode {
+    /// Application accept
+    #[serde(rename = "AA")]
+    Aa,
+    /// Application error
+    #[serde(rename = "AE")]
+    Ae,
+    /// Application reject
+    #[serde(rename = "AR")]
+    Ar,
+    /// Commit accept
+    #[serde(rename = "CA")]
+    Ca,
+    /// Commit error
+    #[serde(rename = "CE")]
+    Ce,
+    /// Commit reject
+    #[serde(rename = "CR")]
+    Cr,
+}
+
+impl AckRequestCode {
+    /// Return the HL7 code string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Aa => "AA",
+            Self::Ae => "AE",
+            Self::Ar => "AR",
+            Self::Ca => "CA",
+            Self::Ce => "CE",
+            Self::Cr => "CR",
+        }
+    }
+}
+
+/// ACK generation response body
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AckResponse {
+    /// Generated ACK message, optionally MLLP framed
+    pub ack_message: String,
+    /// Generated ACK code
+    pub ack_code: String,
+    /// Metadata extracted from the generated ACK message
+    pub metadata: MessageMetadata,
+}
+
+/// Normalize request body
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizeRequest {
+    /// Raw HL7 message content
+    pub message: String,
+    /// Whether the input message is MLLP framed
+    #[serde(default)]
+    pub mllp_framed: bool,
+    /// Normalization options
+    #[serde(default)]
+    pub options: NormalizeOptions,
+}
+
+/// Normalize options
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizeOptions {
+    /// Rewrite delimiters to canonical `|^~\&`
+    #[serde(default = "default_true")]
+    pub canonical_delimiters: bool,
+    /// MLLP frame the normalized response
+    #[serde(default)]
+    pub mllp_frame: bool,
+}
+
+impl Default for NormalizeOptions {
+    fn default() -> Self {
+        Self {
+            canonical_delimiters: true,
+            mllp_frame: false,
+        }
+    }
+}
+
+/// Normalize response body
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizeResponse {
+    /// Normalized HL7 message, optionally MLLP framed
+    pub normalized_message: String,
+    /// Metadata extracted from the normalized message
     pub metadata: MessageMetadata,
 }
 

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -1,22 +1,26 @@
 //! HTTP route definitions.
 
 use axum::{
-    Router, middleware,
+    Router,
+    http::HeaderValue,
+    middleware,
     routing::{get, post},
 };
 use std::sync::Arc;
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 use tower_http::{
     compression::CompressionLayer,
-    cors::{Any, CorsLayer},
+    cors::{AllowOrigin, Any, CorsLayer},
     trace::TraceLayer,
 };
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::handlers::{health_handler, parse_handler, validate_handler};
+use crate::handlers::{
+    ack_handler, health_handler, normalize_handler, parse_handler, validate_handler,
+};
 use crate::metrics::{metrics_handler, middleware::metrics_middleware};
 use crate::middleware::{auth_middleware, create_concurrency_limit_layer};
-use crate::server::AppState;
+use crate::server::{AppState, CorsAllowedOrigins};
 
 /// OpenAPI specification content
 const OPENAPI_YAML: &str = include_str!("../../../api/openapi/hl7v2-api-v1.yaml");
@@ -35,7 +39,9 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // Create API routes
     let mut api_routes = Router::new()
         .route("/parse", post(parse_handler))
-        .route("/validate", post(validate_handler));
+        .route("/validate", post(validate_handler))
+        .route("/ack", post(ack_handler))
+        .route("/normalize", post(normalize_handler));
 
     // Apply authentication if API key is configured in state
     if state.api_key.is_some() {
@@ -44,6 +50,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             auth_middleware,
         ));
     }
+
+    let cors_layer = build_cors_layer(&state.cors_allowed_origins);
 
     // Main router
     Router::new()
@@ -68,7 +76,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // Middleware layers (bottom to top execution order)
         .layer(middleware::from_fn(metrics_middleware))
         .layer(CompressionLayer::new())
-        .layer(build_cors_layer())
+        .layer(cors_layer)
         .layer(TraceLayer::new_for_http())
         .layer(GovernorLayer::new(governor_conf))
         .layer(create_concurrency_limit_layer()) // Concurrency limiting applied first (last in stack)
@@ -82,11 +90,22 @@ async fn ready_handler() -> &'static str {
 }
 
 /// Build CORS layer
-fn build_cors_layer() -> CorsLayer {
-    CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
-        .allow_headers(Any)
+fn build_cors_layer(origins: &CorsAllowedOrigins) -> CorsLayer {
+    let layer = CorsLayer::new().allow_methods(Any).allow_headers(Any);
+
+    match origins {
+        CorsAllowedOrigins::Any => layer.allow_origin(Any),
+        CorsAllowedOrigins::List(origins) => {
+            let origins = origins
+                .iter()
+                .map(|origin| {
+                    HeaderValue::from_str(origin)
+                        .expect("CORS allowed origin must be a valid header value")
+                })
+                .collect::<Vec<_>>();
+            layer.allow_origin(AllowOrigin::list(origins))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -109,6 +128,7 @@ mod tests {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
             api_key: Some(api_key.clone()),
+            cors_allowed_origins: CorsAllowedOrigins::default(),
         });
         (build_router(state), api_key)
     }
@@ -157,6 +177,7 @@ mod tests {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
             api_key: None,
+            cors_allowed_origins: CorsAllowedOrigins::default(),
         });
 
         let app = build_router(state);
@@ -189,6 +210,7 @@ mod tests {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
             api_key: None,
+            cors_allowed_origins: CorsAllowedOrigins::default(),
         });
 
         let app = build_router(state);
@@ -227,7 +249,7 @@ mod tests {
         let response_data: crate::models::ParseResponse =
             serde_json::from_slice(&body_bytes).unwrap();
 
-        assert_eq!(response_data.metadata.message_type, "ADT");
+        assert_eq!(response_data.metadata.message_type, "ADT^A01");
         assert_eq!(response_data.metadata.version, "2.5");
         assert_eq!(response_data.metadata.sending_application, "SendingApp");
         assert!(response_data.message.is_some());
@@ -252,7 +274,7 @@ mod tests {
         let response_data: crate::models::ParseResponse =
             serde_json::from_slice(&body_bytes).unwrap();
 
-        assert_eq!(response_data.metadata.message_type, "ADT");
+        assert_eq!(response_data.metadata.message_type, "ADT^A01");
         assert_eq!(response_data.metadata.version, "2.5");
         assert_eq!(response_data.metadata.sending_application, "SendingApp");
         assert!(response_data.message.is_some());

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -19,6 +19,50 @@ pub struct AppState {
     pub metrics_handle: Arc<PrometheusHandle>,
     /// Optional API key for authentication
     pub api_key: Option<String>,
+    /// CORS origin policy for browser clients
+    pub cors_allowed_origins: CorsAllowedOrigins,
+}
+
+/// CORS origin policy.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum CorsAllowedOrigins {
+    /// Allow any origin.
+    #[default]
+    Any,
+    /// Allow only the listed origins.
+    List(Vec<String>),
+}
+
+impl CorsAllowedOrigins {
+    /// Build an allow-any origin policy.
+    pub fn any() -> Self {
+        Self::Any
+    }
+
+    /// Build a list-based origin policy.
+    pub fn list<I, S>(origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let origins = origins
+            .into_iter()
+            .map(Into::into)
+            .map(|origin: String| origin.trim().to_string())
+            .filter(|origin| !origin.is_empty())
+            .collect::<Vec<_>>();
+
+        if origins.is_empty() || origins.iter().any(|origin| origin == "*") {
+            Self::Any
+        } else {
+            Self::List(origins)
+        }
+    }
+
+    /// Parse a comma-separated origin list. Empty values and `*` mean any origin.
+    pub fn from_csv(value: &str) -> Self {
+        Self::list(value.split(','))
+    }
 }
 
 /// HTTP server configuration
@@ -30,6 +74,8 @@ pub struct ServerConfig {
     pub max_body_size: usize,
     /// Optional API key for authentication
     pub api_key: Option<String>,
+    /// CORS origin policy
+    pub cors_allowed_origins: CorsAllowedOrigins,
 }
 
 impl Default for ServerConfig {
@@ -38,6 +84,7 @@ impl Default for ServerConfig {
             bind_address: "0.0.0.0:8080".to_string(),
             max_body_size: 10 * 1024 * 1024, // 10MB
             api_key: None,
+            cors_allowed_origins: CorsAllowedOrigins::default(),
         }
     }
 }
@@ -58,6 +105,7 @@ impl Server {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
             api_key: config.api_key.clone(),
+            cors_allowed_origins: config.cors_allowed_origins.clone(),
         });
 
         Self { config, state }
@@ -126,6 +174,12 @@ impl ServerBuilder {
         self
     }
 
+    /// Set the CORS allowed origins.
+    pub fn cors_allowed_origins(mut self, origins: CorsAllowedOrigins) -> Self {
+        self.config.cors_allowed_origins = origins;
+        self
+    }
+
     /// Build the server
     pub fn build(self) -> Server {
         Server::new(self.config)
@@ -158,5 +212,19 @@ mod tests {
         let config = ServerConfig::default();
         assert_eq!(config.bind_address, "0.0.0.0:8080");
         assert_eq!(config.max_body_size, 10 * 1024 * 1024);
+        assert_eq!(config.cors_allowed_origins, CorsAllowedOrigins::Any);
+    }
+
+    #[test]
+    fn test_cors_allowed_origins_from_csv() {
+        assert_eq!(CorsAllowedOrigins::from_csv("*"), CorsAllowedOrigins::Any);
+        assert_eq!(CorsAllowedOrigins::from_csv(""), CorsAllowedOrigins::Any);
+        assert_eq!(
+            CorsAllowedOrigins::from_csv("https://app.example, https://ops.example"),
+            CorsAllowedOrigins::List(vec![
+                "https://app.example".to_string(),
+                "https://ops.example".to_string()
+            ])
+        );
     }
 }

--- a/crates/hl7v2-server/tests/bdd_tests.rs
+++ b/crates/hl7v2-server/tests/bdd_tests.rs
@@ -53,6 +53,7 @@ impl ServerWorld {
             start_time: Instant::now(),
             metrics_handle: Arc::new(metrics_handle),
             api_key: self.api_key.clone(),
+            cors_allowed_origins: Default::default(),
         });
         hl7v2_server::routes::build_router(state)
     }
@@ -273,7 +274,7 @@ async fn main() {
     // parser, so skip this custom harness when a focused Rust test filter does
     // not target the BDD scenarios.
     if let Some(filter) = std::env::args().skip(1).find(|arg| !arg.starts_with('-'))
-        && !["bdd", "cucumber", "http", "server"]
+        && !["bdd", "cucumber"]
             .iter()
             .any(|allowed| filter.contains(allowed))
     {

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -13,6 +13,7 @@ pub fn create_test_server() -> Server {
         bind_address: "127.0.0.1:0".to_string(), // Use random port for tests
         max_body_size: 1024 * 1024,              // 1MB
         api_key: None,
+        cors_allowed_origins: Default::default(),
     };
     Server::new(config)
 }
@@ -24,6 +25,7 @@ pub fn create_test_router() -> Router {
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: None,
+        cors_allowed_origins: Default::default(),
     });
     hl7v2_server::routes::build_router(state)
 }

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -26,6 +26,7 @@ mod tests {
             start_time: Instant::now(),
             metrics_handle: Arc::new(handle),
             api_key: None,
+            cors_allowed_origins: Default::default(),
         })
     }
 

--- a/crates/hl7v2-server/tests/http_runtime_contract_test.rs
+++ b/crates/hl7v2-server/tests/http_runtime_contract_test.rs
@@ -1,0 +1,267 @@
+//! HTTP runtime/API contract tests.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use hl7v2_server::{AppState, CorsAllowedOrigins, build_router};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use std::{sync::Arc, time::Instant};
+use tower::ServiceExt;
+
+const SAMPLE_MSG: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
+const CUSTOM_DELIMS_MSG: &str = "MSH*%$!?*SENDAPP*SENDFAC*RECVAPP*RECVFAC*202605030101**ADT%A01*CTRL123*P*2.5\rPID*1**123456%%%HOSP%MR**Doe%John**19700101*M\r";
+
+fn test_router(api_key: Option<&str>, cors_allowed_origins: CorsAllowedOrigins) -> axum::Router {
+    let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
+    let state = Arc::new(AppState {
+        start_time: Instant::now(),
+        metrics_handle: Arc::new(metrics_handle),
+        api_key: api_key.map(str::to_string),
+        cors_allowed_origins,
+    });
+    build_router(state)
+}
+
+async fn post_json(app: axum::Router, uri: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri(uri)
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let value = serde_json::from_slice(&body).unwrap_or_else(|_| json!({}));
+    (status, value)
+}
+
+#[tokio::test]
+async fn test_http_ack_maps_codes_and_preserves_control_id() {
+    for code in ["AA", "AE", "AR"] {
+        let (status, body) = post_json(
+            test_router(None, CorsAllowedOrigins::default()),
+            "/hl7/ack",
+            json!({
+                "message": SAMPLE_MSG,
+                "code": code,
+                "mllp_framed": false
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["ack_code"], code);
+        let ack = body["ack_message"].as_str().unwrap();
+        assert!(ack.contains(&format!("MSA|{}|CTRL123", code)));
+        assert_eq!(body["metadata"]["message_type"], "ACK^ADT");
+    }
+}
+
+#[tokio::test]
+async fn test_http_ack_malformed_message_returns_parse_error() {
+    let (status, body) = post_json(
+        test_router(None, CorsAllowedOrigins::default()),
+        "/hl7/ack",
+        json!({
+            "message": "not hl7",
+            "code": "AA"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "PARSE_ERROR");
+}
+
+#[tokio::test]
+async fn test_http_normalize_canonical_output_and_idempotence() {
+    let app = test_router(None, CorsAllowedOrigins::default());
+    let (status, body) = post_json(
+        app.clone(),
+        "/hl7/normalize",
+        json!({
+            "message": CUSTOM_DELIMS_MSG,
+            "options": {
+                "canonical_delimiters": true
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let normalized = body["normalized_message"].as_str().unwrap();
+    assert!(normalized.starts_with("MSH|^~\\&|"));
+    assert!(normalized.contains("ADT^A01"));
+    assert_eq!(body["metadata"]["message_type"], "ADT^A01");
+
+    let (status, renormalized) = post_json(
+        app,
+        "/hl7/normalize",
+        json!({
+            "message": normalized,
+            "options": {
+                "canonical_delimiters": true
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(renormalized["normalized_message"], normalized);
+}
+
+#[tokio::test]
+async fn test_http_normalize_optional_mllp_framing() {
+    let (status, body) = post_json(
+        test_router(None, CorsAllowedOrigins::default()),
+        "/hl7/normalize",
+        json!({
+            "message": SAMPLE_MSG,
+            "options": {
+                "mllp_frame": true
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let framed = body["normalized_message"].as_str().unwrap().as_bytes();
+    assert_eq!(framed[0], hl7v2_mllp::MLLP_START);
+    assert_eq!(
+        hl7v2_mllp::unwrap_mllp(framed).unwrap(),
+        SAMPLE_MSG.as_bytes()
+    );
+}
+
+#[tokio::test]
+async fn test_new_hl7_routes_require_api_key_when_configured() {
+    let app = test_router(Some("secret-key"), CorsAllowedOrigins::default());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/hl7/ack")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&json!({
+                        "message": SAMPLE_MSG,
+                        "code": "AA"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/hl7/normalize")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .header("X-API-Key", "secret-key")
+                .body(Body::from(
+                    serde_json::to_string(&json!({ "message": SAMPLE_MSG })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_metrics_stays_public_when_api_key_is_configured() {
+    let app = test_router(Some("secret-key"), CorsAllowedOrigins::default());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_cors_uses_configured_origin_list() {
+    let app = test_router(
+        None,
+        CorsAllowedOrigins::list(["https://app.example", "https://ops.example"]),
+    );
+
+    let allowed = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/health")
+                .header("Origin", "https://app.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        allowed
+            .headers()
+            .get("access-control-allow-origin")
+            .unwrap(),
+        "https://app.example"
+    );
+
+    let rejected = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/health")
+                .header("Origin", "https://unknown.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        rejected
+            .headers()
+            .get("access-control-allow-origin")
+            .is_none()
+    );
+}

--- a/crates/hl7v2-server/tests/middleware_test.rs
+++ b/crates/hl7v2-server/tests/middleware_test.rs
@@ -33,6 +33,7 @@ fn build_test_router(
         start_time: Instant::now(),
         metrics_handle: Arc::new(metrics_handle),
         api_key: None,
+        cors_allowed_origins: Default::default(),
     });
 
     // Rate limit configuration


### PR DESCRIPTION
## Summary
- add HTTP `/hl7/ack` and `/hl7/normalize` runtime routes backed by existing ACK/normalize libraries
- align OpenAPI auth/public-route truth: `/hl7/*` uses `X-API-Key` when configured; health/ready/metrics/docs stay public by design
- replace unconditional CORS-any behavior with configurable allowed origins via `HL7V2_CORS_ALLOWED_ORIGINS`, defaulting to existing any-origin behavior
- add focused HTTP runtime contract tests for ACK codes/control IDs, normalize idempotence/MLLP framing, auth, metrics, and configured CORS

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy -p hl7v2-server -p hl7v2-e2e-tests --all-features --all-targets -- -D warnings`
- `cargo test -p hl7v2-server --all-features`
- `cargo test -p hl7v2-e2e-tests --test e2e --all-features server_api`
- `cargo test -p hl7v2-e2e-tests --test e2e --all-features security_tests`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml` (0 errors; existing contact-email warning remains)
- `npx @redocly/cli build-docs api/openapi/hl7v2-api-v1.yaml -o target/api-reference-test.html`
- `cargo run -p xtask -- gate --check --changed --only fmt`

## Local caveat
- `cargo run -p xtask -- gate --check --changed` and its full-workspace `--only clippy` phase timed out locally after 10 minutes because the OpenAPI change makes `--changed` fall back to the full workspace. Scoped server/e2e clippy and tests above passed.