### PR TITLE
fix(contracts): validate config fixtures

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -4,10 +4,23 @@ on:
   push:
     paths:
       - 'api/**'
+      - 'schemas/**'
+      - 'profiles/**'
+      - 'config.example.toml'
+      - 'config/**'
+      - '.spectral.yml'
+      - 'buf.gen.yaml'
       - '.github/workflows/contracts.yml'
   pull_request:
     paths:
       - 'api/**'
+      - 'schemas/**'
+      - 'profiles/**'
+      - 'config.example.toml'
+      - 'config/**'
+      - '.spectral.yml'
+      - 'buf.gen.yaml'
+      - '.github/workflows/contracts.yml'
 
 jobs:
   validate-openapi:
@@ -95,16 +108,48 @@ jobs:
             -d 'profiles/*.yaml' \
             --spec=draft7
 
+      - name: Convert Config TOML Fixtures
+        run: |
+          python3 - <<'PY'
+          import json
+          import tomllib
+          from pathlib import Path
+
+          inputs = [Path("config.example.toml")]
+          config_dir = Path("config")
+          if config_dir.exists():
+              inputs.extend(sorted(config_dir.glob("*.toml")))
+
+          out_dir = Path("target/contracts/config")
+          out_dir.mkdir(parents=True, exist_ok=True)
+
+          for path in inputs:
+              data = tomllib.loads(path.read_text(encoding="utf-8"))
+              output = out_dir / f"{path.stem}.json"
+              output.write_text(
+                  json.dumps(data, indent=2, sort_keys=True),
+                  encoding="utf-8",
+              )
+              print(f"{path} -> {output}")
+          PY
+
       - name: Validate Config Schema
         run: |
           ajv validate -c ajv-formats \
             -s schemas/config/hl7v2-config-v1.schema.json \
-            -d 'config/*.toml' \
+            -d 'target/contracts/config/*.json' \
             --spec=draft7
 
       - name: Validate Test Data
         run: |
-          for schema in schemas/**/*.schema.json; do
+          find schemas -name '*.schema.json' -print0 | while IFS= read -r -d '' schema; do
             echo "Validating $schema"
-            ajv compile -c ajv-formats -s "$schema"
+            if [ "$schema" = "schemas/segment_field.schema.json" ]; then
+              ajv compile -c ajv-formats -s "$schema" --spec=draft7
+            else
+              ajv compile -c ajv-formats \
+                -s "$schema" \
+                -r schemas/segment_field.schema.json \
+                --spec=draft7
+            fi
           done

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+ignore:
+  - "**/*.md"
+  - ".github/**"
+  - ".spectral.yml"
+  - "api/**"
+  - "buf.gen.yaml"
+  - "codecov.yml"
+  - "config.example.toml"
+  - "docs/**"
+  - "profiles/**"
+  - "schemas/**"

--- a/crates/hl7v2-cli/src/config.rs
+++ b/crates/hl7v2-cli/src/config.rs
@@ -119,3 +119,53 @@ pub fn apply_env_overrides(config: &mut Config) {
         config.logging.level = log_level;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, load_config};
+    use std::fs;
+
+    #[test]
+    fn config_example_matches_loader_shape() {
+        let config: Config = toml::from_str(include_str!("../../../config.example.toml"))
+            .expect("config.example.toml should match Config");
+
+        assert_example_config(config);
+    }
+
+    #[test]
+    fn load_config_reads_toml_file() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("hl7v2.toml");
+        fs::write(&path, include_str!("../../../config.example.toml"))
+            .expect("config fixture should be written");
+
+        let config = load_config(&path).expect("TOML config should load");
+
+        assert_example_config(config);
+    }
+
+    #[test]
+    fn load_config_reads_yaml_file() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("hl7v2.yaml");
+        fs::write(
+            &path,
+            "server:\n  host: 0.0.0.0\n  port: 8080\ncli:\n  default_version: 2.5.1\n  output_format: text\nlogging:\n  level: info\n  log_to_file: false\n",
+        )
+        .expect("config fixture should be written");
+
+        let config = load_config(&path).expect("YAML config should load");
+
+        assert_example_config(config);
+    }
+
+    fn assert_example_config(config: Config) {
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 8080);
+        assert_eq!(config.cli.default_version, "2.5.1");
+        assert_eq!(config.cli.output_format, "text");
+        assert_eq!(config.logging.level, "info");
+        assert!(!config.logging.log_to_file);
+    }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -41,10 +41,9 @@ Corpus generation reproducibility tracking:
 
 ### Config (`config/hl7v2-config-v1.schema.json`)
 CLI and server configuration (hl7v2.toml):
-- Server modes (HTTP, gRPC, MLLP)
-- Profile loading and caching
-- Validation settings
-- Logging and telemetry
+- Server host, port, and optional API key
+- CLI defaults
+- Logging defaults
 
 ## Usage
 
@@ -59,6 +58,18 @@ ajv validate -s schemas/profile/profile-v1.schema.json -d profiles/adt_a01.yaml
 
 # Validate all profiles
 ajv validate -s schemas/profile/profile-v1.schema.json -d 'profiles/*.yaml'
+
+# Validate the checked-in TOML config fixture
+python3 - <<'PY'
+import json
+import tomllib
+from pathlib import Path
+
+data = tomllib.loads(Path("config.example.toml").read_text(encoding="utf-8"))
+Path("target/contracts/config").mkdir(parents=True, exist_ok=True)
+Path("target/contracts/config/config.example.json").write_text(json.dumps(data), encoding="utf-8")
+PY
+ajv validate -s schemas/config/hl7v2-config-v1.schema.json -d target/contracts/config/config.example.json
 ```
 
 ### In Rust Code
@@ -86,15 +97,25 @@ fn main() {
 
 ### CI Integration
 
-The CI pipeline validates all YAML files against their schemas:
+The API Contracts workflow validates profiles, converted config fixtures, and
+schema syntax:
 
 ```yaml
-# .github/workflows/ci.yml
+# .github/workflows/contracts.yml
 - name: Validate Schemas
   run: |
     npm install -g ajv-cli
     ajv validate -s schemas/profile/profile-v1.schema.json -d 'profiles/*.yaml'
-    ajv validate -s schemas/config/hl7v2-config-v1.schema.json -d 'config/*.toml'
+    python3 - <<'PY'
+    import json
+    import tomllib
+    from pathlib import Path
+
+    data = tomllib.loads(Path("config.example.toml").read_text(encoding="utf-8"))
+    Path("target/contracts/config").mkdir(parents=True, exist_ok=True)
+    Path("target/contracts/config/config.example.json").write_text(json.dumps(data), encoding="utf-8")
+    PY
+    ajv validate -s schemas/config/hl7v2-config-v1.schema.json -d 'target/contracts/config/*.json'
 ```
 
 ## Schema Versioning

--- a/schemas/config/hl7v2-config-v1.schema.json
+++ b/schemas/config/hl7v2-config-v1.schema.json
@@ -2,153 +2,91 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://schemas.hl7v2-rs.org/config/v1",
   "title": "HL7v2-rs Configuration Schema",
-  "description": "Configuration file for CLI and server modes",
+  "description": "Configuration file for the currently implemented CLI configuration loader",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "server": {
       "type": "object",
-      "description": "Server mode configuration",
+      "description": "HTTP server defaults used by CLI configuration helpers",
+      "additionalProperties": false,
       "properties": {
-        "http": {
-          "type": "object",
-          "properties": {
-            "enabled": {"type": "boolean", "default": true},
-            "host": {"type": "string", "default": "0.0.0.0"},
-            "port": {"type": "integer", "minimum": 1, "maximum": 65535, "default": 8080},
-            "tls": {
-              "type": "object",
-              "properties": {
-                "enabled": {"type": "boolean", "default": false},
-                "cert_path": {"type": "string"},
-                "key_path": {"type": "string"},
-                "require_client_cert": {"type": "boolean", "default": false}
-              }
-            }
-          }
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "default": "127.0.0.1",
+          "description": "Host or IP address for the server to bind"
         },
-        "grpc": {
-          "type": "object",
-          "properties": {
-            "enabled": {"type": "boolean", "default": false},
-            "host": {"type": "string", "default": "0.0.0.0"},
-            "port": {"type": "integer", "minimum": 1, "maximum": 65535, "default": 9090}
-          }
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 8080,
+          "description": "TCP port for the server to bind"
         },
-        "mllp": {
-          "type": "object",
-          "properties": {
-            "enabled": {"type": "boolean", "default": false},
-            "host": {"type": "string", "default": "0.0.0.0"},
-            "port": {"type": "integer", "minimum": 1, "maximum": 65535, "default": 2575},
-            "read_timeout_ms": {"type": "integer", "default": 30000},
-            "write_timeout_ms": {"type": "integer", "default": 30000}
-          }
-        },
-        "concurrency": {
-          "type": "object",
-          "properties": {
-            "max_connections": {"type": "integer", "default": 1000},
-            "queue_capacity": {"type": "integer", "default": 1024},
-            "worker_threads": {"type": "integer", "minimum": 1}
-          }
+        "api_key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional API key for protected HL7 HTTP routes"
         }
       }
     },
-    "profiles": {
+    "cli": {
       "type": "object",
-      "description": "Profile loading configuration",
+      "description": "Command-line defaults",
+      "additionalProperties": false,
       "properties": {
-        "directory": {"type": "string", "default": "./profiles"},
-        "cache": {
-          "type": "object",
-          "properties": {
-            "enabled": {"type": "boolean", "default": true},
-            "max_size_mb": {"type": "integer", "default": 100},
-            "ttl_seconds": {"type": "integer", "default": 3600}
-          }
+        "default_version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
+          "default": "2.5.1",
+          "description": "Default HL7 version used by CLI commands"
         },
-        "remote": {
-          "type": "object",
-          "properties": {
-            "enabled": {"type": "boolean", "default": false},
-            "sources": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "url": {"type": "string"},
-                  "type": {"type": "string", "enum": ["http", "s3", "gcs"]},
-                  "auth": {
-                    "type": "object",
-                    "properties": {
-                      "type": {"type": "string", "enum": ["none", "basic", "bearer", "aws", "gcp"]},
-                      "credentials": {"type": "object"}
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "output_format": {
+          "type": "string",
+          "enum": ["text", "json"],
+          "default": "text",
+          "description": "Default CLI output format"
         }
-      }
-    },
-    "validation": {
-      "type": "object",
-      "properties": {
-        "default_profile": {"type": "string"},
-        "strict_mode": {"type": "boolean", "default": false},
-        "fail_on_warning": {"type": "boolean", "default": false}
       }
     },
     "logging": {
       "type": "object",
+      "description": "Logging defaults",
+      "additionalProperties": false,
       "properties": {
         "level": {
           "type": "string",
           "enum": ["trace", "debug", "info", "warn", "error"],
-          "default": "info"
+          "default": "info",
+          "description": "Minimum log level"
         },
-        "format": {
+        "log_to_file": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether logs should also be written to a file"
+        },
+        "log_path": {
           "type": "string",
-          "enum": ["json", "text"],
-          "default": "json"
-        },
-        "redact_phi": {"type": "boolean", "default": true}
-      }
-    },
-    "telemetry": {
-      "type": "object",
-      "properties": {
-        "enabled": {"type": "boolean", "default": false},
-        "endpoint": {"type": "string"},
-        "metrics": {"type": "boolean", "default": true},
-        "traces": {"type": "boolean", "default": true}
+          "minLength": 1,
+          "description": "Optional path for file logging"
+        }
       }
     }
   },
   "examples": [
     {
       "server": {
-        "http": {
-          "enabled": true,
-          "port": 8080
-        },
-        "mllp": {
-          "enabled": true,
-          "port": 2575
-        }
+        "host": "0.0.0.0",
+        "port": 8080
       },
-      "profiles": {
-        "directory": "./profiles",
-        "cache": {
-          "enabled": true,
-          "max_size_mb": 100
-        }
+      "cli": {
+        "default_version": "2.5.1",
+        "output_format": "text"
       },
       "logging": {
         "level": "info",
-        "format": "json",
-        "redact_phi": true
+        "log_to_file": false
       }
     }
   ]

--- a/schemas/message.schema.json
+++ b/schemas/message.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.org/schemas/hl7v2/message.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["meta", "segments"],
   "properties": {

--- a/schemas/segment_field.schema.json
+++ b/schemas/segment_field.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://example.org/schemas/hl7v2/segment_field.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
   "items": {
     "type": "array",


### PR DESCRIPTION
## Summary
- expand API Contracts path filters so workflow, schema, profile, config, Spectral, and Buf template changes trigger the contract workflow on PRs and pushes
- convert checked-in TOML config fixtures to JSON before AJV validation, so config schema validation covers a real `config.example.toml` instance instead of an unmatched TOML glob
- tighten the config schema to the currently implemented CLI config loader shape and add Rust loader tests for TOML/YAML config examples
- make schema compilation cover every `*.schema.json`, including the root schemas and their shared `segment_field` reference
- add Codecov ignore rules for docs/schema/workflow/API metadata so patch coverage measures executable code changes

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy -p hl7v2-cli --all-features --all-targets -- -D warnings`
- `cargo test -p hl7v2-cli --bin hl7v2-cli config`
- `cargo test -p hl7v2-cli --all-features`
- `npx -y yaml-lint codecov.yml .github/workflows/contracts.yml`
- `curl.exe -sS -X POST --data-binary "@codecov.yml" https://codecov.io/validate`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml` (0 errors; existing contact-email warning remains)
- `npx @redocly/cli build-docs api/openapi/hl7v2-api-v1.yaml -o target/api-reference-test.html`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/profile/profile-v1.schema.json -d 'profiles/*.yaml' --spec=draft7`
- converted `config.example.toml` with Python `tomllib`, then `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d 'target/contracts/config/*.json' --spec=draft7`
- compiled all seven `schemas/**/*.schema.json` / root schema files with AJV draft-07 plus the shared `segment_field` reference
- checked that an extra config property is rejected by the tightened config schema

## Local caveat
- `buf` is not installed in this Windows environment, so proto lint is left to the API Contracts CI job. This PR does not change proto files.