### PR TITLE
docs: record partial publish readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 
 | Layer | Status | Evidence |
 | --- | --- | --- |
-| **Parser / Core** | Stable | Verified in PR #364 (Audit) + 120+ tests |
-| **Writer / Normalize** | Stable | Verified contract tests land |
-| **MLLP / Network** | Stable | E2E tests (OS-assigned ports) land |
-| **REST Server** | Stable | Integration tests land |
-| **gRPC Service** | Beta | Contract tests landing in PR #365 |
-| **Lifecycle** | Beta | Domain tests landing in PR #366 |
-| **Guard / Anomaly** | Experimental | Statistical baseline proven in PR #367 |
+| **Parser / Core** | Stable | Main CI, workspace tests, and contract checks green on `6de37e0` |
+| **Writer / Normalize** | Stable | Writer tests plus HTTP/gRPC normalization contract coverage |
+| **MLLP / Network** | Stable | MLLP parse/framing tests and CI matrix coverage |
+| **REST Server** | Stable | Runtime and OpenAPI agree for parse, validate, ACK, and normalize routes |
+| **gRPC Service** | Beta | Contract tests cover Parse, Validate, GenerateAck, Normalize, and HealthCheck; ParseStream is explicitly unsupported |
+| **Lifecycle** | Beta | Domain tests exist, but lifecycle is not part of the current HTTP/gRPC contract gate |
+| **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
-| **Python Bindings** | Beta | Smoke tests landing land |
+| **Python Bindings** | Experimental | Not included in the local Python 3.14/PyO3 validation proof |
+| **Publish Readiness** | Partial | Publish order is known; dry-run is proven through `hl7v2-core` and stops at `hl7v2` until `hl7v2-core` is on crates.io |
 
 ## Features
 
@@ -113,7 +114,7 @@ curl -X POST http://localhost:8080/hl7/validate \
   -H "Content-Type: application/json" \
   -d '{
     "message": "MSH|^~\\&|...",
-    "profile_yaml": "..."  # YAML profile content
+    "profile": "..."
   }'
 ```
 
@@ -124,7 +125,7 @@ curl http://localhost:8080/ready
 curl http://localhost:8080/metrics  # Prometheus metrics
 ```
 
-See the [OpenAPI specification](schemas/openapi/hl7v2-api.yaml) for complete API documentation.
+See the [OpenAPI specification](api/openapi/hl7v2-api-v1.yaml) for complete API documentation.
 
 ### CLI Tools
 
@@ -220,13 +221,13 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 
 ### HTTP/REST API Server (hl7v2-server)
 
-- **RESTful API**: Parse and validate HL7 messages over HTTP
+- **RESTful API**: Parse, validate, acknowledge, and normalize HL7 messages over HTTP
 - **Health & Readiness**: Production-ready health checks
 - **Prometheus metrics**: Request counts, latencies, error rates
 - **Concurrency limiting**: Built-in backpressure (100 concurrent requests default)
-- **CORS support**: Cross-origin requests enabled
+- **CORS support**: Configurable allowed origins, with permissive local default
 - **Compression**: Gzip compression for responses
-- **OpenAPI 3.0 spec**: Complete API documentation at `schemas/openapi/hl7v2-api.yaml`
+- **OpenAPI 3.1 spec**: Complete API documentation at `api/openapi/hl7v2-api-v1.yaml`
 - **Docker ready**: Containerized deployment with Nix-built images
 - **Kubernetes ready**: Helm charts and manifests in `infrastructure/k8s/`
 

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -93,7 +93,7 @@ pub struct MessageMetadata {
 pub struct ValidateRequest {
     /// Raw HL7 message content
     pub message: String,
-    /// Profile to validate against (path or name)
+    /// Inline profile YAML content to validate against
     pub profile: String,
     /// Whether the message is MLLP framed
     #[serde(default)]

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -55,7 +55,7 @@ Validates an HL7 v2 message against a provided conformance profile.
 ```json
 {
   "message": "MSH|^~\\&|...",
-  "profile_yaml": "...",
+  "profile": "...",
   "mllp_framed": false
 }
 ```
@@ -71,14 +71,50 @@ curl -X POST http://localhost:8080/hl7/validate \
   --data-binary @- <<EOF
 {
   "message": "$MESSAGE",
-  "profile_yaml": "$(echo "$PROFILE_CONTENT" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}' ORS='')"
+  "profile": "$(echo "$PROFILE_CONTENT" | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}' ORS='')"
 }
 EOF
 ```
 
 ---
 
-### 3. Health & Metrics
+### 3. Generate ACK
+**POST** `/hl7/ack`
+
+Generates an HL7 ACK response from an inbound message.
+
+**Request Body:**
+```json
+{
+  "message": "MSH|^~\\&|...",
+  "code": "AA",
+  "mllp_framed": false,
+  "mllp_frame": false
+}
+```
+
+---
+
+### 4. Normalize HL7 Message
+**POST** `/hl7/normalize`
+
+Rewrites an HL7 message with stable delimiters and optional MLLP output framing.
+
+**Request Body:**
+```json
+{
+  "message": "MSH|^~\\&|...",
+  "mllp_framed": false,
+  "options": {
+    "canonical_delimiters": true,
+    "mllp_frame": false
+  }
+}
+```
+
+---
+
+### 5. Health & Metrics
 
 **Health Check:**
 ```bash
@@ -100,19 +136,16 @@ The API uses standard HTTP status codes and returns a JSON error body:
 
 ```json
 {
-  "error": "Validation failed",
-  "details": [
-    "PID.5.1 (Family Name) is required but missing",
-    "MSH.9.2 (Trigger Event) must be 'A01' for this profile"
-  ]
+  "code": "PROFILE_LOAD_ERROR",
+  "message": "Failed to load profile: missing required field `version`",
+  "details": null
 }
 ```
 
 ### Common Status Codes:
 - `200 OK`: Success.
-- `400 Bad Request`: Invalid JSON or missing required fields.
+- `400 Bad Request`: Invalid JSON, malformed HL7, or profile load error.
 - `401 Unauthorized`: Missing or invalid `X-API-Key`.
-- `422 Unprocessable Entity`: HL7 parsing or validation failed.
 - `429 Too Many Requests`: Rate limit exceeded.
 - `500 Internal Server Error`: Server configuration error.
 
@@ -123,4 +156,4 @@ The API uses standard HTTP status codes and returns a JSON error body:
 1. **Use MLLP Framing**: If you are sending messages from a system that already supports MLLP, set `"mllp_framed": true` to have the server handle the `\x0b` and `\x1c\x0d` bytes automatically.
 2. **Batching**: For high-volume processing, consider using a persistent connection or sending multiple messages in a single batch if supported by your workflow.
 3. **API Key Rotation**: Periodically rotate your `HL7V2_API_KEY` environment variable.
-4. **Client-side Validation**: Use the OpenAPI spec (`/api/docs`) to generate type-safe clients in your preferred language.
+4. **Client-side Validation**: Use `api/openapi/hl7v2-api-v1.yaml` or the server's documentation endpoint to generate type-safe clients in your preferred language.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,8 +2,8 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-03-05
-> **Project Status**: v1.2.0 (Stable Release)
+> **Last Updated**: 2026-05-06
+> **Project Status**: v1.2.0 current release; current `main` is tested, but full publish readiness is not yet proven.
 
 ## Core Components
 
@@ -18,7 +18,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2-prof` | ✅ 100% | 85% | Conformance profile engine (Modularized). |
 | `hl7v2-validation` | ✅ 100% | 82% | Rule-based message validation. |
 | `hl7v2-gen` | ✅ 100% | 80% | Synthetic data and ACK generation. |
-| `hl7v2-server` | ✅ 100% | 80% | Production HTTP/REST API with Metrics & Auth. |
+| `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
 
 ## Feature Set (v1.2.0)
@@ -26,7 +26,8 @@ This document provides a transparent view of which features are fully implemente
 ### 🚀 Connectivity
 - ✅ **MLLP Over TCP**: Fully implemented async client and server.
 - ✅ **TLS Support**: Secure framing using `rustls`.
-- ✅ **HTTP REST API**: Axum-based server with JSON endpoints.
+- ✅ **HTTP REST API**: Axum-based JSON endpoints for parse, validate, ACK, and normalize.
+- 🟡 **gRPC Service**: Unary RPCs have contract tests; `ParseStream` is explicitly unsupported.
 
 ### 🛡️ Security & Observability
 - ✅ **API Authentication**: Constant-time API Key validation.
@@ -38,11 +39,17 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **BDD Tests**: Real validation scenarios verified with Cucumber.
 - ✅ **E2E Tests**: Subprocess CLI and network integration tests.
 - ✅ **Property Testing**: Robust parsing and escaping edge-case coverage.
-- ✅ **Vulnerability Clean**: `cargo audit` returns 0 findings.
+- ✅ **Security Workflow**: Dependency audit, cargo-deny, Semgrep, Trivy, and secret scanning are green on current `main`.
+
+## Release and Publish Readiness
+
+- ✅ **Main workflows**: CI, Coverage, Security, and API Contracts were green on merge commit `6de37e0`.
+- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves 30 publishable crates.
+- 🟡 **Dry-run publish**: Direct `cargo publish --dry-run --locked` is proven through `hl7v2-core`; it stops at `hl7v2` because `hl7v2-core` is not yet present on crates.io. See `docs/audits/publish-dry-run-2026-05-06.md`.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Release v1.2.0 is tagged and verified.**
+**Release v1.2.0 is tagged. Current main is tested; full crates.io publish readiness still needs the publish sequence or a local-registry simulation for higher-level crates.**

--- a/docs/audits/final-release-integrity.md
+++ b/docs/audits/final-release-integrity.md
@@ -1,29 +1,32 @@
-# Final Release Integrity Audit
+# Release Integrity Status
 
 ## Scope
-Final verification of the `hl7v2-rs` workspace following the completion of v1.3.0 enterprise features, Rust 2024 migration, and CI/dependency rationalization.
+Current verification status for the `hl7v2-rs` workspace after the contract, HTTP runtime, gRPC proof, and schema workflow repairs through merge commit `6de37e0`.
+
+This document is not a v1.3.0 release approval. It separates green CI, behavior-tested surfaces, and crates.io publish readiness.
 
 ## Verified Success Baseline
-- **CI / Coverage / Security**: All main branch workflows are PASSED and green.
-- **Rust 2024 / MSRV 1.93**: Verified alignment across all 30+ crates.
-- **gRPC Contract Tests**: 100% pass rate for core service RPCs.
-- **Lifecycle Domain Tests**: Verified archival state machine and legal hold logic.
-- **Guard Performance**: Statistical baseline anomaly detection proven with learning fixtures.
-- **Example Compilation**: All 8+ advertised examples compile successfully as API consumers.
+- **CI / Coverage / Security / API Contracts**: All main branch workflows passed on `6de37e0`.
+- **Rust 2024 / MSRV 1.93**: Enforced by the workspace and CI matrix.
+- **HTTP Runtime Contracts**: OpenAPI and runtime agree for `/hl7/parse`, `/hl7/validate`, `/hl7/ack`, and `/hl7/normalize`.
+- **gRPC Contract Tests**: Unary Parse, Validate, GenerateAck, Normalize, and HealthCheck behavior is covered; ParseStream is explicitly unsupported.
+- **Schema Contracts**: Profile schemas, converted config fixtures, and schema compilation run strictly with `ajv-formats` and draft7.
 
 ## Dependency Health
 - **Rationalized**: Upgraded `thiserror` to 2.0 and `tokio` to 1.50.
 - **Consolidated**: Duplicate versions of `tonic`, `prost`, and `base64` have been resolved.
-- **Vulnerability Free**: `cargo audit` reports zero known security issues.
+- **Security Workflow**: Current main Security workflow is green.
 
 ## Publish Readiness
-- **Model / Escape / MLLP / Query / Parser / Writer / Normalize / Core**: `cargo publish --dry-run` PASSED.
-- **Higher-level Crates**: Ready for publication once base crates are released to crates.io.
+- **Publish Order**: `cargo run -p xtask -- publish-plan` resolves 30 publishable crates.
+- **Dry-run Proof**: Direct `cargo publish --dry-run --locked` passed for crates 1-16 in publish order, ending with `hl7v2-core`.
+- **Current Stop Condition**: Direct dry-run stopped at crate 17, `hl7v2`, because `hl7v2-core` is not yet present in the crates.io index. This is a registry-state boundary, not a source compilation failure.
+- **Higher-level Crates**: Not yet direct-dry-run proven from the current registry state. They need either the real dependency publish sequence or a local-registry simulation before the repo can claim full crates.io publish readiness.
 
 ## Documentation Accuracy
-- **README**: Feature status table accurately reflects Stable/Beta/Experimental tiers.
-- **CHANGELOG**: v1.3.0 entry comprehensively covers recent repairs and modernizations.
-- **ROADMAP**: Updated to project realistic targets for v1.4.0 (WASM/Java).
+- **README / STATUS / API Guide**: Distinguish tested runtime surfaces from partial publish readiness.
+- **OpenAPI**: Current HTTP contract lives at `api/openapi/hl7v2-api-v1.yaml`.
+- **Release Claims**: "Green" means current workflows passed. "Tested" means contract/runtime tests exist for the named surface. "Publish-ready" remains partial until higher-level crate dry-runs are proven.
 
 ## Conclusion
-The repository is in its most stable and technologically advanced state. All "emergency repairs" have been audited, proven with contract tests, and documented. The project is ready for the v1.3.0 release.
+The repository has a green and behavior-tested main branch, but full crates.io publish readiness is not yet proven. The next release-readiness step is to continue from the publish dry-run stop condition documented in `docs/audits/publish-dry-run-2026-05-06.md`.

--- a/docs/audits/publish-dry-run-2026-05-06.md
+++ b/docs/audits/publish-dry-run-2026-05-06.md
@@ -1,0 +1,85 @@
+# Publish Dry-Run Receipt - 2026-05-06
+
+## Context
+
+This receipt records the current crates.io publish-readiness boundary for `hl7v2-rs` after merge commit `6de37e0`.
+
+Commands run locally on Windows:
+
+```powershell
+cargo run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+cargo publish --dry-run -p <crate> --locked
+```
+
+`PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` was set before the dry-run loop because the local machine uses a newer Python toolchain than the PyO3 version in this workspace expects by default.
+
+## Publish Order
+
+`cargo run -p xtask -- publish-plan` returned 30 publishable crates:
+
+| Order | Crate | Direct dry-run result |
+| --- | --- | --- |
+| 1 | `hl7v2-datetime` | Pass |
+| 2 | `hl7v2-datatype` | Pass |
+| 3 | `hl7v2-faker` | Pass |
+| 4 | `hl7v2-model` | Pass |
+| 5 | `hl7v2-escape` | Pass |
+| 6 | `hl7v2-json` | Pass |
+| 7 | `hl7v2-mllp` | Pass |
+| 8 | `hl7v2-path` | Pass |
+| 9 | `hl7v2-query` | Pass |
+| 10 | `hl7v2-parser` | Pass |
+| 11 | `hl7v2-batch` | Pass |
+| 12 | `hl7v2-stream` | Pass |
+| 13 | `hl7v2-writer` | Pass |
+| 14 | `hl7v2-network` | Pass |
+| 15 | `hl7v2-normalize` | Pass |
+| 16 | `hl7v2-core` | Pass |
+| 17 | `hl7v2` | Blocked by registry dependency state |
+| 18 | `hl7v2-ack` | Not run after stop |
+| 19 | `hl7v2-corpus` | Not run after stop |
+| 20 | `hl7v2-guard` | Not run after stop |
+| 21 | `hl7v2-lifecycle` | Not run after stop |
+| 22 | `hl7v2-python` | Not run after stop |
+| 23 | `hl7v2-redact` | Not run after stop |
+| 24 | `hl7v2-template-values` | Not run after stop |
+| 25 | `hl7v2-template` | Not run after stop |
+| 26 | `hl7v2-gen` | Not run after stop |
+| 27 | `hl7v2-validation` | Not run after stop |
+| 28 | `hl7v2-prof` | Not run after stop |
+| 29 | `hl7v2-server` | Not run after stop |
+| 30 | `hl7v2-cli` | Not run after stop |
+
+## Stop Condition
+
+The direct dry-run stopped at `hl7v2`:
+
+```text
+error: failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `hl7v2-core` found
+  location searched: crates.io index
+  required by package `hl7v2 v1.2.0`
+```
+
+## Interpretation
+
+Crates 1-16 package and verify with `cargo publish --dry-run --locked`.
+
+The stop at `hl7v2` is expected for a direct dry-run before publishing the dependency chain: during packaging, Cargo resolves registry dependencies from crates.io, and `hl7v2-core` is not available there yet. This means higher-level crates are not proven publish-ready by direct dry-run from the current registry state.
+
+Do not claim full crates.io publish readiness until one of these is true:
+
+1. The real publish sequence has published dependencies through `hl7v2-core`, then direct dry-runs or publishes continue from `hl7v2`.
+2. A local-registry simulation proves the higher-level crates against packaged dependencies in publish order.
+
+## Current Label
+
+Current status is **partial publish readiness**:
+
+- green main workflows: proven
+- runtime and contract behavior: proven for the named HTTP/gRPC/schema surfaces
+- direct dry-run publish: proven through `hl7v2-core`
+- full workspace publish readiness: not yet proven


### PR DESCRIPTION
## Summary
- replace stale release-ready wording with separate green/tested/publish-readiness labels
- fix REST docs to use the actual `profile` request field and current OpenAPI path
- add a publish dry-run receipt showing crates 1-16 pass and the direct dry-run stop at `hl7v2` because `hl7v2-core` is not yet in the crates.io index

## Validation
- `git -c core.whitespace=cr-at-eol diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p hl7v2-server --all-features`
- `cargo run -p xtask -- publish-plan`
- local publish dry-run loop with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`: crates 1-16 passed; crate 17 `hl7v2` stopped with `no matching package named hl7v2-core found`