### PR TITLE
fix: prove publish dry-run packaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,7 +1794,6 @@ dependencies = [
  "chrono",
  "hl7v2-core",
  "hl7v2-model",
- "hl7v2-test-utils",
  "serde",
  "serde_json",
  "sha2",
@@ -1909,7 +1908,6 @@ name = "hl7v2-python"
 version = "1.2.0"
 dependencies = [
  "hl7v2-core",
- "hl7v2-test-utils",
  "pyo3",
 ]
 
@@ -1930,7 +1928,6 @@ version = "1.2.0"
 dependencies = [
  "hl7v2-core",
  "hl7v2-model",
- "hl7v2-test-utils",
  "serde",
 ]
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Not included in the local Python 3.14/PyO3 validation proof |
-| **Publish Readiness** | Partial | Publish order is known; dry-run is proven through `hl7v2-core` and stops at `hl7v2` until `hl7v2-core` is on crates.io |
+| **Publish Readiness** | Package-verified | Direct registry-state dry-run is proven through `hl7v2-core`; workspace-patched dry-run verifies crates 17-30 |
 
 ## Features
 

--- a/crates/hl7v2-lifecycle/Cargo.toml
+++ b/crates/hl7v2-lifecycle/Cargo.toml
@@ -19,5 +19,4 @@ chrono = { workspace = true, features = ["serde"] }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-hl7v2-test-utils = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -18,6 +18,3 @@ crate-type = ["cdylib"]
 [dependencies]
 hl7v2-core = { workspace = true }
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
-
-[dev-dependencies]
-hl7v2-test-utils = { workspace = true }

--- a/crates/hl7v2-redact/Cargo.toml
+++ b/crates/hl7v2-redact/Cargo.toml
@@ -15,6 +15,3 @@ categories.workspace = true
 hl7v2-core = { workspace = true }
 hl7v2-model = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-
-[dev-dependencies]
-hl7v2-test-utils = { workspace = true }

--- a/crates/hl7v2-server/build.rs
+++ b/crates/hl7v2-server/build.rs
@@ -2,6 +2,8 @@
 
 extern crate tonic_build;
 
+use std::path::PathBuf;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let protoc = protoc_bin_vendored::protoc_bin_path()?;
 
@@ -11,16 +13,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::set_var("PROTOC", protoc);
     }
 
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+    let workspace_proto_dir = manifest_dir.join("../../api/proto");
+    let workspace_proto = workspace_proto_dir.join("hl7v2/v1/hl7v2.proto");
+    let packaged_proto_dir = manifest_dir.join("proto");
+    let packaged_proto = packaged_proto_dir.join("hl7v2/v1/hl7v2.proto");
+    let (proto_dir, proto_file) = if workspace_proto.exists() {
+        (workspace_proto_dir, workspace_proto)
+    } else {
+        (packaged_proto_dir, packaged_proto)
+    };
+
+    let workspace_openapi = manifest_dir.join("../../api/openapi/hl7v2-api-v1.yaml");
+    let packaged_openapi = manifest_dir.join("openapi/hl7v2-api-v1.yaml");
+    let openapi_yaml = if workspace_openapi.exists() {
+        workspace_openapi
+    } else {
+        packaged_openapi
+    };
+
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_protos(
-            &["../../api/proto/hl7v2/v1/hl7v2.proto"],
-            &["../../api/proto"],
-        )?;
+        .compile_protos(&[proto_file.as_path()], &[proto_dir.as_path()])?;
 
-    println!("cargo:rerun-if-changed=../../api/proto/hl7v2/v1/hl7v2.proto");
-    println!("cargo:rerun-if-changed=../../api/proto");
+    println!(
+        "cargo:rustc-env=HL7V2_OPENAPI_YAML={}",
+        openapi_yaml.display()
+    );
+    println!("cargo:rerun-if-changed={}", proto_file.display());
+    println!("cargo:rerun-if-changed={}", proto_dir.display());
+    println!("cargo:rerun-if-changed={}", openapi_yaml.display());
 
     Ok(())
 }

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1,0 +1,446 @@
+openapi: 3.1.0
+info:
+  title: HL7v2-rs HTTP API
+  version: 1.2.0
+  description: |
+    RESTful API for HL7 v2 message parsing, validation, and processing.
+
+    This API provides endpoints for:
+    - Parsing HL7 v2 messages
+    - Validating messages against conformance profiles
+    - Generating ACK messages
+    - Normalizing HL7 v2 messages
+
+    ## Authentication
+
+    HL7 processing endpoints under `/hl7/*` require API Key authentication via
+    the `X-API-Key` header when the server is configured with an API key:
+    ```
+    X-API-Key: <your-api-key>
+    ```
+
+    Health, readiness, metrics, and API documentation endpoints are public by
+    design so load balancers, scrapers, and local operators can inspect service
+    state without application credentials.
+
+    ## Rate Limiting
+
+    - 120 requests per minute per IP
+    - Exceeded limits return 429 Too Many Requests
+
+    ## Tracing
+
+    The system uses internal tracing spans. Correlation IDs may be added in future versions.
+  contact:
+    name: HL7v2-rs Team
+    url: https://github.com/EffortlessMetrics/hl7v2-rs
+  license:
+    name: AGPL-3.0-or-later
+    url: https://github.com/EffortlessMetrics/hl7v2-rs/blob/main/LICENSE
+
+servers:
+  - url: http://localhost:8080
+    description: Local development
+
+tags:
+  - name: health
+    description: Health and readiness checks
+  - name: hl7
+    description: HL7 v2 message operations
+
+paths:
+  /health:
+    get:
+      summary: Health check
+      description: Returns service status and uptime
+      tags: [health]
+      operationId: healthCheck
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /ready:
+    get:
+      summary: Readiness check
+      description: Returns JSON ready status
+      tags: [health]
+      operationId: readinessCheck
+      responses:
+        '200':
+          description: Service is ready
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ready:
+                    type: boolean
+
+  /metrics:
+    get:
+      summary: Prometheus metrics
+      description: Returns metrics in Prometheus text format
+      tags: [health]
+      operationId: getMetrics
+      responses:
+        '200':
+          description: Metrics data
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /hl7/parse:
+    post:
+      summary: Parse HL7 message
+      description: |
+        Parse an HL7 v2 message and return metadata and optional JSON.
+      tags: [hl7]
+      operationId: parseMessage
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParseRequest'
+      responses:
+        '200':
+          description: Message parsed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ParseResponse'
+        '400':
+          description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
+  /hl7/validate:
+    post:
+      summary: Validate HL7 message
+      description: |
+        Validate an HL7 message against a conformance profile.
+      tags: [hl7]
+      operationId: validateMessage
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidateRequest'
+      responses:
+        '200':
+          description: Validation complete
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateResponse'
+        '400':
+          description: Invalid request or profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
+  /hl7/ack:
+    post:
+      summary: Generate HL7 ACK
+      description: |
+        Generate an HL7 v2 ACK message for a parsed inbound message.
+      tags: [hl7]
+      operationId: generateAck
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AckRequest'
+      responses:
+        '200':
+          description: ACK generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AckResponse'
+        '400':
+          description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
+  /hl7/normalize:
+    post:
+      summary: Normalize HL7 message
+      description: |
+        Parse and rewrite an HL7 v2 message with stable delimiters and optional MLLP output framing.
+      tags: [hl7]
+      operationId: normalizeMessage
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NormalizeRequest'
+      responses:
+        '200':
+          description: Message normalized successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NormalizeResponse'
+        '400':
+          description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: API Key authentication via header
+
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, version, uptime_seconds]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+        version:
+          type: string
+        uptime_seconds:
+          type: integer
+
+    ParseRequest:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        mllp_framed:
+          type: boolean
+          default: false
+        options:
+          $ref: '#/components/schemas/ParseOptions'
+
+    ParseOptions:
+      type: object
+      properties:
+        include_json:
+          type: boolean
+          default: true
+        validate_structure:
+          type: boolean
+          default: true
+
+    ParseResponse:
+      type: object
+      required: [metadata]
+      properties:
+        message:
+          type: object
+          description: Parsed message in JSON format
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+        warnings:
+          type: array
+          items:
+            type: string
+
+    MessageMetadata:
+      type: object
+      required: [message_type, version, sending_application, sending_facility, message_control_id, segment_count, charsets]
+      properties:
+        message_type:
+          type: string
+        version:
+          type: string
+        sending_application:
+          type: string
+        sending_facility:
+          type: string
+        message_control_id:
+          type: string
+        segment_count:
+          type: integer
+        charsets:
+          type: array
+          items:
+            type: string
+
+    ValidateRequest:
+      type: object
+      required: [message, profile]
+      properties:
+        message:
+          type: string
+        profile:
+          type: string
+          description: Profile content (YAML)
+        mllp_framed:
+          type: boolean
+          default: false
+
+    ValidateResponse:
+      type: object
+      required: [valid, metadata]
+      properties:
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationWarning'
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    AckRequest:
+      type: object
+      required: [message, code]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        code:
+          type: string
+          enum: [AA, AE, AR, CA, CE, CR]
+          description: ACK code to generate
+        error_message:
+          type: string
+          nullable: true
+          description: Optional error text for ERR segment generation
+        mllp_framed:
+          type: boolean
+          default: false
+          description: Whether the input message is MLLP framed
+        mllp_frame:
+          type: boolean
+          default: false
+          description: Whether to MLLP frame the ACK response
+
+    AckResponse:
+      type: object
+      required: [ack_message, ack_code, metadata]
+      properties:
+        ack_message:
+          type: string
+          description: Generated ACK message
+        ack_code:
+          type: string
+          enum: [AA, AE, AR, CA, CE, CR]
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    NormalizeRequest:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        mllp_framed:
+          type: boolean
+          default: false
+          description: Whether the input message is MLLP framed
+        options:
+          $ref: '#/components/schemas/NormalizeOptions'
+
+    NormalizeOptions:
+      type: object
+      properties:
+        canonical_delimiters:
+          type: boolean
+          default: true
+          description: Rewrite delimiters to canonical HL7 delimiters
+        mllp_frame:
+          type: boolean
+          default: false
+          description: Whether to MLLP frame the normalized response
+
+    NormalizeResponse:
+      type: object
+      required: [normalized_message, metadata]
+      properties:
+        normalized_message:
+          type: string
+          description: Normalized HL7 message
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    ValidationError:
+      type: object
+      required: [code, message, severity]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        location:
+          type: string
+          nullable: true
+        severity:
+          type: string
+          enum: [error, warning, info]
+
+    ValidationWarning:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        location:
+          type: string
+          nullable: true
+
+    ErrorResponse:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        details:
+          type: object
+          nullable: true

--- a/crates/hl7v2-server/proto/hl7v2/v1/hl7v2.proto
+++ b/crates/hl7v2-server/proto/hl7v2/v1/hl7v2.proto
@@ -1,0 +1,348 @@
+syntax = "proto3";
+
+package hl7v2.v1;
+
+option go_package = "github.com/EffortlessMetrics/hl7v2-rs/gen/go/hl7v2/v1;hl7v2v1";
+option java_package = "com.hl7v2rs.api.v1";
+option java_multiple_files = true;
+
+// HL7v2 Service provides gRPC endpoints for HL7 v2 message processing
+service HL7Service {
+  // Parse an HL7 v2 message
+  rpc Parse(ParseRequest) returns (ParseResponse);
+
+  // Parse multiple messages in a stream
+  rpc ParseStream(stream ParseStreamRequest) returns (stream ParseStreamResponse);
+
+  // Validate a message against a profile
+  rpc Validate(ValidateRequest) returns (ValidateResponse);
+
+  // Generate an acknowledgment (ACK) message
+  rpc GenerateAck(GenerateAckRequest) returns (GenerateAckResponse);
+
+  // Normalize a message
+  rpc Normalize(NormalizeRequest) returns (NormalizeResponse);
+
+  // Health check
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+}
+
+// Parse Request
+message ParseRequest {
+  // HL7 message bytes
+  bytes message = 1;
+
+  // Whether message is MLLP-framed
+  bool mllp_framed = 2;
+
+  // Parse options
+  ParseOptions options = 3;
+}
+
+message ParseStreamRequest {
+  // HL7 message bytes
+  bytes message = 1;
+
+  // Whether message is MLLP-framed
+  bool mllp_framed = 2;
+
+  // Parse options
+  ParseOptions options = 3;
+}
+
+message ParseOptions {
+  // Strict parsing mode
+  bool strict = 1;
+
+  // Expected HL7 version
+  string expected_version = 2;
+}
+
+// Parse Response
+message ParseResponse {
+  // Whether parsing succeeded
+  bool success = 1;
+
+  // Parsed message (if successful)
+  Message message = 2;
+
+  // Errors (if any)
+  repeated Error errors = 3;
+
+  // Metadata
+  MessageMetadata metadata = 4;
+}
+
+message ParseStreamResponse {
+  // Whether parsing succeeded
+  bool success = 1;
+
+  // Parsed message (if successful)
+  Message message = 2;
+
+  // Errors (if any)
+  repeated Error errors = 3;
+
+  // Metadata
+  MessageMetadata metadata = 4;
+}
+
+// Message representation
+message Message {
+  // Delimiters used
+  Delimiters delimiters = 1;
+
+  // Segments
+  repeated Segment segments = 2;
+}
+
+// Delimiters
+message Delimiters {
+  string field = 1;
+  string component = 2;
+  string repetition = 3;
+  string escape = 4;
+  string subcomponent = 5;
+}
+
+// Segment
+message Segment {
+  // Segment ID (e.g., "MSH", "PID")
+  string id = 1;
+
+  // Fields
+  repeated Field fields = 2;
+
+  // Sequence number (for repeated segments)
+  int32 sequence = 3;
+}
+
+// Field
+message Field {
+  // Field presence
+  enum Presence {
+    PRESENCE_UNSPECIFIED = 0;
+    PRESENCE_MISSING = 1;
+    PRESENCE_EMPTY = 2;
+    PRESENCE_NULL = 3;
+    PRESENCE_VALUE = 4;
+  }
+
+  Presence presence = 1;
+
+  // Simple value (for non-repeating, non-component fields)
+  optional string value = 2;
+
+  // Repetitions (for repeating fields)
+  repeated Repetition repetitions = 3;
+}
+
+// Repetition
+message Repetition {
+  // Simple value
+  optional string value = 1;
+
+  // Components
+  repeated Component components = 2;
+}
+
+// Component
+message Component {
+  // Component value
+  optional string value = 1;
+
+  // Subcomponents
+  repeated string subcomponents = 2;
+}
+
+// Message Metadata
+message MessageMetadata {
+  // Message type (e.g., "ADT^A01")
+  string message_type = 1;
+
+  // HL7 version (e.g., "2.5")
+  string version = 2;
+
+  // Message control ID
+  string control_id = 3;
+
+  // Sending facility
+  string sending_facility = 4;
+
+  // Receiving facility
+  string receiving_facility = 5;
+}
+
+// Validate Request
+message ValidateRequest {
+  // HL7 message bytes
+  bytes message = 1;
+
+  // Inline HL7v2 profile YAML content
+  string profile = 2;
+
+  // Whether message is MLLP-framed
+  bool mllp_framed = 3;
+
+  // Validation options
+  ValidationOptions options = 4;
+}
+
+message ValidationOptions {
+  // Fail on warnings
+  bool fail_on_warning = 1;
+
+  // Strict mode
+  bool strict = 2;
+}
+
+// Validate Response
+message ValidateResponse {
+  // Whether validation passed
+  bool valid = 1;
+
+  // Errors
+  repeated ValidationIssue errors = 2;
+
+  // Warnings
+  repeated ValidationIssue warnings = 3;
+
+  // Summary
+  ValidationSummary summary = 4;
+}
+
+// Validation Issue
+message ValidationIssue {
+  enum Severity {
+    SEVERITY_UNSPECIFIED = 0;
+    SEVERITY_ERROR = 1;
+    SEVERITY_WARNING = 2;
+    SEVERITY_INFO = 3;
+  }
+
+  // Error code
+  string code = 1;
+
+  // Human-readable message
+  string message = 2;
+
+  // Severity
+  Severity severity = 3;
+
+  // Location in message
+  Location location = 4;
+
+  // Remediation advice
+  string advice = 5;
+}
+
+// Location in message
+message Location {
+  // Segment ID
+  string segment = 1;
+
+  // Field number
+  int32 field = 2;
+
+  // Component number
+  int32 component = 3;
+
+  // Repetition number
+  int32 repetition = 4;
+
+  // Byte offset
+  int64 byte_offset = 5;
+}
+
+// Validation Summary
+message ValidationSummary {
+  int32 error_count = 1;
+  int32 warning_count = 2;
+  int32 info_count = 3;
+}
+
+// ACK Request
+message GenerateAckRequest {
+  // Original message
+  bytes message = 1;
+
+  // ACK code
+  enum AckCode {
+    ACK_CODE_UNSPECIFIED = 0;
+    ACK_CODE_AA = 1;  // Application Accept
+    ACK_CODE_AE = 2;  // Application Error
+    ACK_CODE_AR = 3;  // Application Reject
+  }
+
+  AckCode code = 2;
+
+  // Error message (for AE/AR)
+  optional string error_message = 3;
+}
+
+// ACK Response
+message GenerateAckResponse {
+  // Generated ACK message
+  bytes ack_message = 1;
+
+  // Parsed ACK (for verification)
+  Message parsed_ack = 2;
+}
+
+// Normalize Request
+message NormalizeRequest {
+  // Message to normalize
+  bytes message = 1;
+
+  // Normalization options
+  NormalizeOptions options = 2;
+}
+
+message NormalizeOptions {
+  // Use canonical delimiters
+  bool canonical_delimiters = 1;
+
+  // Add MLLP framing
+  bool mllp_frame = 2;
+
+  // Sort fields
+  bool sort_fields = 3;
+}
+
+// Normalize Response
+message NormalizeResponse {
+  // Normalized message
+  bytes normalized = 1;
+}
+
+// Health Check Request
+message HealthCheckRequest {}
+
+// Health Check Response
+message HealthCheckResponse {
+  enum ServingStatus {
+    SERVING_STATUS_UNSPECIFIED = 0;
+    SERVING_STATUS_SERVING = 1;
+    SERVING_STATUS_NOT_SERVING = 2;
+    SERVING_STATUS_SERVICE_UNKNOWN = 3;
+  }
+
+  ServingStatus status = 1;
+  string version = 2;
+  int64 uptime_seconds = 3;
+}
+
+// Error
+message Error {
+  // Error code
+  string code = 1;
+
+  // Error message
+  string message = 2;
+
+  // Additional details
+  map<string, string> details = 3;
+
+  // Trace ID
+  string trace_id = 4;
+}

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -23,7 +23,7 @@ use crate::middleware::{auth_middleware, create_concurrency_limit_layer};
 use crate::server::{AppState, CorsAllowedOrigins};
 
 /// OpenAPI specification content
-const OPENAPI_YAML: &str = include_str!("../../../api/openapi/hl7v2-api-v1.yaml");
+const OPENAPI_YAML: &str = include_str!(env!("HL7V2_OPENAPI_YAML"));
 
 /// Build the application router
 pub fn build_router(state: Arc<AppState>) -> Router {

--- a/crates/hl7v2-server/tests/proto_packaging_test.rs
+++ b/crates/hl7v2-server/tests/proto_packaging_test.rs
@@ -1,0 +1,27 @@
+#[test]
+fn packaged_proto_matches_workspace_contract() {
+    let workspace_proto = include_str!("../../../api/proto/hl7v2/v1/hl7v2.proto");
+    let packaged_proto = include_str!("../proto/hl7v2/v1/hl7v2.proto");
+
+    assert_eq!(
+        normalize_line_endings(packaged_proto),
+        normalize_line_endings(workspace_proto),
+        "packaged server proto copy must match api/proto source"
+    );
+}
+
+#[test]
+fn packaged_openapi_matches_workspace_contract() {
+    let workspace_openapi = include_str!("../../../api/openapi/hl7v2-api-v1.yaml");
+    let packaged_openapi = include_str!("../openapi/hl7v2-api-v1.yaml");
+
+    assert_eq!(
+        normalize_line_endings(packaged_openapi),
+        normalize_line_endings(workspace_openapi),
+        "packaged server OpenAPI copy must match api/openapi source"
+    );
+}
+
+fn normalize_line_endings(value: &str) -> String {
+    value.replace("\r\n", "\n")
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-06
-> **Project Status**: v1.2.0 current release; current `main` is tested, but full publish readiness is not yet proven.
+> **Project Status**: v1.2.0 current release; current `main` is tested and package-verified, but the real crates.io publish sequence has not been executed.
 
 ## Core Components
 
@@ -45,11 +45,11 @@ This document provides a transparent view of which features are fully implemente
 
 - ✅ **Main workflows**: CI, Coverage, Security, and API Contracts were green on merge commit `6de37e0`.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves 30 publishable crates.
-- 🟡 **Dry-run publish**: Direct `cargo publish --dry-run --locked` is proven through `hl7v2-core`; it stops at `hl7v2` because `hl7v2-core` is not yet present on crates.io. See `docs/audits/publish-dry-run-2026-05-06.md`.
+- ✅ **Dry-run publish**: Direct `cargo publish --dry-run --locked` is proven through `hl7v2-core`; workspace-patched dry-run verification proves crates 17-30 while the dependency chain is still unpublished. See `docs/audits/publish-dry-run-2026-05-06.md`.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Release v1.2.0 is tagged. Current main is tested; full crates.io publish readiness still needs the publish sequence or a local-registry simulation for higher-level crates.**
+**Release v1.2.0 is tagged. Current main is tested and package-verified; the remaining release operation is the actual crates.io publish sequence.**

--- a/docs/audits/final-release-integrity.md
+++ b/docs/audits/final-release-integrity.md
@@ -19,14 +19,14 @@ This document is not a v1.3.0 release approval. It separates green CI, behavior-
 
 ## Publish Readiness
 - **Publish Order**: `cargo run -p xtask -- publish-plan` resolves 30 publishable crates.
-- **Dry-run Proof**: Direct `cargo publish --dry-run --locked` passed for crates 1-16 in publish order, ending with `hl7v2-core`.
+- **Dry-run Proof**: Direct `cargo publish --dry-run --locked` passed for crates 1-16 in publish order, ending with `hl7v2-core`; workspace-patched dry-run verification passed for crates 17-30.
 - **Current Stop Condition**: Direct dry-run stopped at crate 17, `hl7v2`, because `hl7v2-core` is not yet present in the crates.io index. This is a registry-state boundary, not a source compilation failure.
-- **Higher-level Crates**: Not yet direct-dry-run proven from the current registry state. They need either the real dependency publish sequence or a local-registry simulation before the repo can claim full crates.io publish readiness.
+- **Higher-level Crates**: Package verification is proven by `cargo run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`; direct public-registry dry-run still requires the real dependency publish sequence.
 
 ## Documentation Accuracy
 - **README / STATUS / API Guide**: Distinguish tested runtime surfaces from partial publish readiness.
 - **OpenAPI**: Current HTTP contract lives at `api/openapi/hl7v2-api-v1.yaml`.
-- **Release Claims**: "Green" means current workflows passed. "Tested" means contract/runtime tests exist for the named surface. "Publish-ready" remains partial until higher-level crate dry-runs are proven.
+- **Release Claims**: "Green" means current workflows passed. "Tested" means contract/runtime tests exist for the named surface. "Package-verified" means every publishable crate has a dry-run verification path. "Published" remains false until crates.io upload actually runs.
 
 ## Conclusion
-The repository has a green and behavior-tested main branch, but full crates.io publish readiness is not yet proven. The next release-readiness step is to continue from the publish dry-run stop condition documented in `docs/audits/publish-dry-run-2026-05-06.md`.
+The repository has a green, behavior-tested, and package-verified main branch. The next release-readiness step is the actual dependency-ordered crates.io publish sequence documented by `cargo run -p xtask -- publish-plan`.

--- a/docs/audits/publish-dry-run-2026-05-06.md
+++ b/docs/audits/publish-dry-run-2026-05-06.md
@@ -10,6 +10,7 @@ Commands run locally on Windows:
 cargo run -p xtask -- publish-plan
 $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
 cargo publish --dry-run -p <crate> --locked
+cargo run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches
 ```
 
 `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` was set before the dry-run loop because the local machine uses a newer Python toolchain than the PyO3 version in this workspace expects by default.
@@ -18,38 +19,38 @@ cargo publish --dry-run -p <crate> --locked
 
 `cargo run -p xtask -- publish-plan` returned 30 publishable crates:
 
-| Order | Crate | Direct dry-run result |
-| --- | --- | --- |
-| 1 | `hl7v2-datetime` | Pass |
-| 2 | `hl7v2-datatype` | Pass |
-| 3 | `hl7v2-faker` | Pass |
-| 4 | `hl7v2-model` | Pass |
-| 5 | `hl7v2-escape` | Pass |
-| 6 | `hl7v2-json` | Pass |
-| 7 | `hl7v2-mllp` | Pass |
-| 8 | `hl7v2-path` | Pass |
-| 9 | `hl7v2-query` | Pass |
-| 10 | `hl7v2-parser` | Pass |
-| 11 | `hl7v2-batch` | Pass |
-| 12 | `hl7v2-stream` | Pass |
-| 13 | `hl7v2-writer` | Pass |
-| 14 | `hl7v2-network` | Pass |
-| 15 | `hl7v2-normalize` | Pass |
-| 16 | `hl7v2-core` | Pass |
-| 17 | `hl7v2` | Blocked by registry dependency state |
-| 18 | `hl7v2-ack` | Not run after stop |
-| 19 | `hl7v2-corpus` | Not run after stop |
-| 20 | `hl7v2-guard` | Not run after stop |
-| 21 | `hl7v2-lifecycle` | Not run after stop |
-| 22 | `hl7v2-python` | Not run after stop |
-| 23 | `hl7v2-redact` | Not run after stop |
-| 24 | `hl7v2-template-values` | Not run after stop |
-| 25 | `hl7v2-template` | Not run after stop |
-| 26 | `hl7v2-gen` | Not run after stop |
-| 27 | `hl7v2-validation` | Not run after stop |
-| 28 | `hl7v2-prof` | Not run after stop |
-| 29 | `hl7v2-server` | Not run after stop |
-| 30 | `hl7v2-cli` | Not run after stop |
+| Order | Crate | Direct registry-state dry-run | Workspace-patched dry-run |
+| --- | --- | --- | --- |
+| 1 | `hl7v2-datetime` | Pass | Covered by direct dry-run |
+| 2 | `hl7v2-datatype` | Pass | Covered by direct dry-run |
+| 3 | `hl7v2-faker` | Pass | Covered by direct dry-run |
+| 4 | `hl7v2-model` | Pass | Covered by direct dry-run |
+| 5 | `hl7v2-escape` | Pass | Covered by direct dry-run |
+| 6 | `hl7v2-json` | Pass | Covered by direct dry-run |
+| 7 | `hl7v2-mllp` | Pass | Covered by direct dry-run |
+| 8 | `hl7v2-path` | Pass | Covered by direct dry-run |
+| 9 | `hl7v2-query` | Pass | Covered by direct dry-run |
+| 10 | `hl7v2-parser` | Pass | Covered by direct dry-run |
+| 11 | `hl7v2-batch` | Pass | Covered by direct dry-run |
+| 12 | `hl7v2-stream` | Pass | Covered by direct dry-run |
+| 13 | `hl7v2-writer` | Pass | Covered by direct dry-run |
+| 14 | `hl7v2-network` | Pass | Covered by direct dry-run |
+| 15 | `hl7v2-normalize` | Pass | Covered by direct dry-run |
+| 16 | `hl7v2-core` | Pass | Covered by direct dry-run |
+| 17 | `hl7v2` | Blocked by registry dependency state | Pass |
+| 18 | `hl7v2-ack` | Not run after direct stop | Pass |
+| 19 | `hl7v2-corpus` | Not run after direct stop | Pass |
+| 20 | `hl7v2-guard` | Not run after direct stop | Pass |
+| 21 | `hl7v2-lifecycle` | Not run after direct stop | Pass |
+| 22 | `hl7v2-python` | Not run after direct stop | Pass |
+| 23 | `hl7v2-redact` | Not run after direct stop | Pass |
+| 24 | `hl7v2-template-values` | Not run after direct stop | Pass |
+| 25 | `hl7v2-template` | Not run after direct stop | Pass |
+| 26 | `hl7v2-gen` | Not run after direct stop | Pass |
+| 27 | `hl7v2-validation` | Not run after direct stop | Pass |
+| 28 | `hl7v2-prof` | Not run after direct stop | Pass |
+| 29 | `hl7v2-server` | Not run after direct stop | Pass |
+| 30 | `hl7v2-cli` | Not run after direct stop | Pass |
 
 ## Stop Condition
 
@@ -68,18 +69,24 @@ Caused by:
 
 Crates 1-16 package and verify with `cargo publish --dry-run --locked`.
 
-The stop at `hl7v2` is expected for a direct dry-run before publishing the dependency chain: during packaging, Cargo resolves registry dependencies from crates.io, and `hl7v2-core` is not available there yet. This means higher-level crates are not proven publish-ready by direct dry-run from the current registry state.
+The stop at `hl7v2` is expected for a direct dry-run before publishing the dependency chain: during packaging, Cargo resolves registry dependencies from crates.io, and `hl7v2-core` is not available there yet. This means higher-level crates cannot be direct-dry-run proven from the current public registry state until the dependency chain is actually published.
 
-Do not claim full crates.io publish readiness until one of these is true:
+The workspace-patched dry-run is a simulation command, not a crates.io upload and not a claim that dependencies already exist in the public registry. It still runs `cargo publish --dry-run --locked`; it supplies unpublished internal crates through generated Cargo `[patch.crates-io]` entries so higher-level packages verify against the current workspace dependency chain.
 
-1. The real publish sequence has published dependencies through `hl7v2-core`, then direct dry-runs or publishes continue from `hl7v2`.
-2. A local-registry simulation proves the higher-level crates against packaged dependencies in publish order.
+The simulation found and fixed concrete package verification defects:
+
+- `hl7v2-lifecycle`, `hl7v2-python`, and `hl7v2-redact` had unused dev-dependencies on unpublished `hl7v2-test-utils`.
+- `hl7v2-server` generated gRPC bindings from `api/proto` outside the package tarball.
+- `hl7v2-server` embedded OpenAPI YAML from `api/openapi` outside the package tarball.
+
+After those fixes, `cargo run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches` verifies crates 17-30 in publish order.
 
 ## Current Label
 
-Current status is **partial publish readiness**:
+Current status is **package-verified publish readiness**:
 
 - green main workflows: proven
 - runtime and contract behavior: proven for the named HTTP/gRPC/schema surfaces
 - direct dry-run publish: proven through `hl7v2-core`
-- full workspace publish readiness: not yet proven
+- higher-level package verification: proven by workspace-patched `cargo publish --dry-run`
+- real crates.io publish sequence: not executed

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@ use clap::{Parser, Subcommand};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
@@ -61,6 +62,18 @@ enum Commands {
         #[arg(long, default_value_t = 30)]
         retry_delay_secs: u64,
     },
+    /// Dry-run publish workspace crates in dependency order
+    PublishDryRun {
+        /// Resume from this crate name
+        #[arg(long)]
+        from: Option<String>,
+        /// Patch internal workspace crates to local paths during verification
+        #[arg(long)]
+        workspace_patches: bool,
+        /// Include uncommitted working tree changes in the dry-run package
+        #[arg(long)]
+        allow_dirty: bool,
+    },
     /// Scaffold a new microcrate
     Scaffold {
         /// Name of the crate (without hl7v2- prefix)
@@ -101,6 +114,11 @@ fn main() -> Result<()> {
             retry_attempts,
             retry_delay_secs,
         } => publish(from, yes, retry_attempts, retry_delay_secs)?,
+        Commands::PublishDryRun {
+            from,
+            workspace_patches,
+            allow_dirty,
+        } => publish_dry_run(from, workspace_patches, allow_dirty)?,
         Commands::Scaffold { name, description } => scaffold(&name, description)?,
         Commands::Docs { no_open } => docs(no_open)?,
         Commands::HookPreCommit => hook_pre_commit()?,
@@ -356,6 +374,99 @@ fn publish(
     Ok(())
 }
 
+fn publish_dry_run(from: Option<String>, workspace_patches: bool, allow_dirty: bool) -> Result<()> {
+    let metadata = MetadataCommand::new().exec()?;
+    let packages = publishable_workspace_packages(&metadata);
+    let ordered = topological_publish_order(&packages)?;
+    let crates = resume_publish_order(&ordered, from.as_deref())?;
+
+    println!("🧪 Dry-running crates.io publish verification");
+    if workspace_patches {
+        println!("Using local workspace patches for unpublished internal crates.");
+    }
+
+    for crate_name in crates {
+        let config_path = if workspace_patches {
+            workspace_patch_config(&crate_name, &packages)?
+        } else {
+            None
+        };
+        publish_dry_run_crate(&crate_name, config_path.as_deref(), allow_dirty)?;
+    }
+
+    println!("✅ Publish dry-run checks passed!");
+    Ok(())
+}
+
+fn publish_dry_run_crate(
+    crate_name: &str,
+    config_path: Option<&Path>,
+    allow_dirty: bool,
+) -> Result<()> {
+    println!("Dry-running {}...", crate_name);
+
+    let mut command = Command::new("cargo");
+    command.args(["publish", "--dry-run", "-p", crate_name, "--locked"]);
+    if allow_dirty {
+        command.arg("--allow-dirty");
+    }
+    if let Some(config_path) = config_path {
+        command.arg("--config").arg(config_path);
+    }
+
+    let status = command
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        return Err(anyhow!(
+            "Dry-run publish failed for {} with exit code: {:?}",
+            crate_name,
+            status.code()
+        ));
+    }
+
+    Ok(())
+}
+
+fn workspace_patch_config(
+    crate_name: &str,
+    packages: &HashMap<String, Package>,
+) -> Result<Option<PathBuf>> {
+    let dependencies = internal_workspace_dependency_closure(crate_name, packages)?;
+    if dependencies.is_empty() {
+        return Ok(None);
+    }
+
+    let config_dir = env::current_dir()?
+        .join("target")
+        .join("hl7v2-publish-dry-run")
+        .join("workspace-patches");
+    fs::create_dir_all(&config_dir)?;
+
+    let config_path = config_dir.join(format!("{crate_name}.toml"));
+    let mut config = String::from("[patch.crates-io]\n");
+    for dependency in dependencies {
+        let package = packages
+            .get(&dependency)
+            .expect("dependency closure only includes known packages");
+        let manifest_dir = package
+            .manifest_path
+            .parent()
+            .ok_or_else(|| anyhow!("Package {} has no manifest parent", dependency))?;
+        let path = manifest_dir.as_str().replace('\\', "/");
+        config.push('"');
+        config.push_str(&escape_toml_basic_string(&dependency));
+        config.push_str("\" = { path = \"");
+        config.push_str(&escape_toml_basic_string(&path));
+        config.push_str("\" }\n");
+    }
+
+    fs::write(&config_path, config)?;
+    Ok(Some(config_path))
+}
+
 fn publish_crate(crate_name: &str, retry_attempts: u32, retry_delay_secs: u64) -> Result<()> {
     let max_attempts = retry_attempts.max(1);
     for attempt in 1..=max_attempts {
@@ -568,6 +679,10 @@ fn publish_order(from: Option<&str>) -> Result<Vec<String>> {
     let packages = publishable_workspace_packages(&metadata);
     let ordered = topological_publish_order(&packages)?;
 
+    resume_publish_order(&ordered, from)
+}
+
+fn resume_publish_order(ordered: &[String], from: Option<&str>) -> Result<Vec<String>> {
     match from {
         Some(start) => {
             let index = ordered
@@ -576,7 +691,7 @@ fn publish_order(from: Option<&str>) -> Result<Vec<String>> {
                 .ok_or_else(|| anyhow!("Unknown publishable crate '{}'", start))?;
             Ok(ordered[index..].to_vec())
         }
-        None => Ok(ordered),
+        None => Ok(ordered.to_vec()),
     }
 }
 
@@ -662,12 +777,60 @@ fn internal_publish_dependencies(
     package: &Package,
     packages: &HashMap<String, Package>,
 ) -> BTreeSet<String> {
+    internal_workspace_dependencies(package, packages, false)
+}
+
+fn internal_workspace_dependency_closure(
+    crate_name: &str,
+    packages: &HashMap<String, Package>,
+) -> Result<BTreeSet<String>> {
+    let package = packages
+        .get(crate_name)
+        .ok_or_else(|| anyhow!("Unknown publishable crate '{}'", crate_name))?;
+    let mut dependencies = BTreeSet::new();
+    let mut stack: Vec<_> = internal_workspace_dependencies(package, packages, true)
+        .into_iter()
+        .collect();
+
+    while let Some(dependency) = stack.pop() {
+        if dependency == crate_name || !dependencies.insert(dependency.clone()) {
+            continue;
+        }
+
+        if let Some(package) = packages.get(&dependency) {
+            stack.extend(internal_workspace_dependencies(package, packages, true));
+        }
+    }
+
+    Ok(dependencies)
+}
+
+fn internal_workspace_dependencies(
+    package: &Package,
+    packages: &HashMap<String, Package>,
+    include_dev: bool,
+) -> BTreeSet<String> {
     package
         .dependencies
         .iter()
-        .filter(|dep| dep.kind != DependencyKind::Development)
+        .filter(|dep| include_dev || dep.kind != DependencyKind::Development)
         .filter_map(|dep| packages.contains_key(&dep.name).then_some(dep.name.clone()))
         .collect()
+}
+
+fn escape_toml_basic_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 fn run_command(cmd: &str, args: &[&str]) -> Result<()> {
@@ -812,6 +975,20 @@ mod tests {
             .expect("hl7v2-core should be publishable");
 
         assert_eq!(resumed, ordered[start..].to_vec());
+    }
+
+    #[test]
+    fn workspace_patch_dependencies_include_publishable_dev_dependencies() {
+        let metadata = MetadataCommand::new()
+            .exec()
+            .expect("workspace metadata should resolve");
+        let packages = publishable_workspace_packages(&metadata);
+        let dependencies = internal_workspace_dependency_closure("hl7v2-ack", &packages)
+            .expect("dependency closure should resolve");
+
+        assert!(dependencies.contains("hl7v2-core"));
+        assert!(dependencies.contains("hl7v2-writer"));
+        assert!(!dependencies.contains("hl7v2-test-utils"));
     }
 
     fn assert_dependency_precedes(ordered: &[String], dependency: &str, dependent: &str) {


### PR DESCRIPTION
## Summary
- add `xtask publish-dry-run` with explicit workspace-patch support for unpublished internal crates
- remove unused unpublished `hl7v2-test-utils` dev-deps that blocked package verification
- package `hl7v2-server` proto/OpenAPI contract assets and add drift tests so tarball verification works
- update publish-readiness docs from partial to package-verified while keeping the direct crates.io registry boundary explicit

## Validation
- `git -c core.whitespace=cr-at-eol diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p xtask`
- `cargo test -p hl7v2-server packaged_`
- `cargo test -p hl7v2-server --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
