### PR TITLE
refactor: make hl7v2 canonical facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,31 @@ dependencies = [
 name = "hl7v2"
 version = "1.2.0"
 dependencies = [
- "hl7v2-core",
+ "hl7v2-ack",
+ "hl7v2-batch",
+ "hl7v2-corpus",
+ "hl7v2-datatype",
+ "hl7v2-datetime",
+ "hl7v2-escape",
+ "hl7v2-faker",
+ "hl7v2-gen",
+ "hl7v2-guard",
+ "hl7v2-json",
+ "hl7v2-lifecycle",
+ "hl7v2-mllp",
+ "hl7v2-model",
+ "hl7v2-network",
+ "hl7v2-normalize",
+ "hl7v2-parser",
+ "hl7v2-path",
+ "hl7v2-prof",
+ "hl7v2-query",
+ "hl7v2-redact",
+ "hl7v2-stream",
+ "hl7v2-template",
+ "hl7v2-template-values",
+ "hl7v2-validation",
+ "hl7v2-writer",
 ]
 
 [[package]]

--- a/crates/hl7v2/Cargo.toml
+++ b/crates/hl7v2/Cargo.toml
@@ -14,9 +14,60 @@ description = "HL7 v2 message parser and processor for Rust"
 readme = "README.md"
 
 [features]
-default = []
-network = ["hl7v2-core/network"]
-stream = ["hl7v2-core/stream"]
+default = [
+    "json",
+    "profile",
+    "ack",
+    "normalize",
+]
+
+json = ["dep:hl7v2-json"]
+profile = [
+    "dep:hl7v2-prof",
+    "dep:hl7v2-validation",
+    "dep:hl7v2-datatype",
+    "dep:hl7v2-datetime",
+]
+ack = ["dep:hl7v2-ack"]
+normalize = ["dep:hl7v2-normalize"]
+batch = ["dep:hl7v2-batch"]
+stream = ["dep:hl7v2-stream"]
+network = ["dep:hl7v2-network"]
+synthetic = [
+    "dep:hl7v2-template",
+    "dep:hl7v2-template-values",
+    "dep:hl7v2-faker",
+    "dep:hl7v2-corpus",
+    "dep:hl7v2-gen",
+]
+redact = ["dep:hl7v2-redact"]
+lifecycle = ["dep:hl7v2-lifecycle"]
+experimental-guard = ["dep:hl7v2-guard"]
 
 [dependencies]
-hl7v2-core = { version = "1.2.0", path = "../hl7v2-core" }
+hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
+hl7v2-escape = { version = "1.2.0", path = "../hl7v2-escape" }
+hl7v2-mllp = { version = "1.2.0", path = "../hl7v2-mllp" }
+hl7v2-path = { version = "1.2.0", path = "../hl7v2-path" }
+hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
+hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
+hl7v2-writer = { version = "1.2.0", path = "../hl7v2-writer" }
+
+hl7v2-json = { version = "1.2.0", path = "../hl7v2-json", optional = true }
+hl7v2-normalize = { version = "1.2.0", path = "../hl7v2-normalize", optional = true }
+hl7v2-ack = { version = "1.2.0", path = "../hl7v2-ack", optional = true }
+hl7v2-prof = { version = "1.2.0", path = "../hl7v2-prof", optional = true }
+hl7v2-validation = { version = "1.2.0", path = "../hl7v2-validation", optional = true }
+hl7v2-datatype = { version = "1.2.0", path = "../hl7v2-datatype", optional = true }
+hl7v2-datetime = { version = "1.2.0", path = "../hl7v2-datetime", optional = true }
+hl7v2-batch = { version = "1.2.0", path = "../hl7v2-batch", optional = true }
+hl7v2-stream = { version = "1.2.0", path = "../hl7v2-stream", optional = true }
+hl7v2-network = { version = "1.2.0", path = "../hl7v2-network", optional = true }
+hl7v2-template = { version = "1.2.0", path = "../hl7v2-template", optional = true }
+hl7v2-template-values = { version = "1.2.0", path = "../hl7v2-template-values", optional = true }
+hl7v2-faker = { version = "1.2.0", path = "../hl7v2-faker", optional = true }
+hl7v2-corpus = { version = "1.2.0", path = "../hl7v2-corpus", optional = true }
+hl7v2-gen = { version = "1.2.0", path = "../hl7v2-gen", optional = true }
+hl7v2-redact = { version = "1.2.0", path = "../hl7v2-redact", optional = true }
+hl7v2-lifecycle = { version = "1.2.0", path = "../hl7v2-lifecycle", optional = true }
+hl7v2-guard = { version = "1.2.0", path = "../hl7v2-guard", optional = true }

--- a/crates/hl7v2/README.md
+++ b/crates/hl7v2/README.md
@@ -4,6 +4,7 @@ HL7 v2 message parser and processor for Rust.
 
 This is the canonical entry point for the
 [`hl7v2-rs`](https://github.com/EffortlessMetrics/hl7v2-rs) workspace.
+Use this crate for normal Rust library integration.
 
 ## Quick start
 
@@ -18,21 +19,29 @@ assert_eq!(get(&msg, "PID.5.1"), Some("Doe"));
 
 | Feature | Description |
 |---------|-------------|
+| `json` | JSON serialization helpers |
+| `profile` | Profile loading and conformance validation |
+| `ack` | ACK message generation |
+| `normalize` | Message normalization |
+| `batch` | Batch parsing and writing helpers |
 | `stream` | Streaming/event-based parser |
 | `network` | Async MLLP client/server (TCP/TLS) |
+| `synthetic` | Template, faker, corpus, and generation APIs |
+| `redact` | Redaction helpers |
+| `lifecycle` | Lifecycle and archive metadata helpers |
+| `experimental-guard` | Experimental guard/anomaly detection APIs |
 
-## Microcrates
+## API layout
 
-For finer-grained dependencies, use the individual crates directly:
+Common operations are available at the crate root:
 
-| Crate | Purpose |
-|-------|---------|
-| `hl7v2-model` | Core data types |
-| `hl7v2-parser` | Message parsing |
-| `hl7v2-writer` | Message serialization |
-| `hl7v2-escape` | Escape sequence handling |
-| `hl7v2-mllp` | MLLP framing |
-| `hl7v2-normalize` | Message normalization |
+```rust
+use hl7v2::{ack, get, normalize, parse, validate, write};
+```
+
+Implementer APIs are grouped under modules such as `hl7v2::model`,
+`hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`, `hl7v2::transport`,
+`hl7v2::conformance`, and `hl7v2::synthetic`.
 
 ## License
 

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -1,15 +1,16 @@
 //! # hl7v2
 //!
-//! HL7 v2 message parser and processor for Rust.
+//! Canonical Rust API for HL7 v2 parsing, writing, validation, transport,
+//! acknowledgement, normalization, and generation.
 //!
-//! This crate is the canonical entry point for the
-//! [`hl7v2-rs`](https://github.com/EffortlessMetrics/hl7v2-rs) workspace.
-//! It re-exports everything from [`hl7v2-core`](https://crates.io/crates/hl7v2-core).
+//! The implementation still lives in focused workspace crates during the
+//! crate-surface migration, but public Rust consumers should depend on this
+//! crate and import through `hl7v2`.
 //!
 //! ## Quick start
 //!
 //! ```rust
-//! use hl7v2::{parse, get};
+//! use hl7v2::{get, parse};
 //!
 //! let msg = parse(b"MSH|^~\\&|App||Fac||20250128||ADT^A01|123|P|2.5.1\rPID|1||PAT123||Doe^John\r").unwrap();
 //! assert_eq!(get(&msg, "PID.5.1"), Some("Doe"));
@@ -17,7 +18,222 @@
 //!
 //! ## Features
 //!
-//! - `stream` — streaming/event-based parser
-//! - `network` — async MLLP client/server
+//! - `json` - JSON serialization helpers.
+//! - `profile` - profile loading and conformance validation.
+//! - `ack` - ACK message generation.
+//! - `normalize` - message normalization.
+//! - `batch` - batch parsing and writing helpers.
+//! - `stream` - streaming/event-based parser.
+//! - `network` - async MLLP client/server.
+//! - `synthetic` - template, faker, corpus, and generation APIs.
+//! - `redact` - redaction helpers.
+//! - `lifecycle` - lifecycle and archive metadata helpers.
+//! - `experimental-guard` - experimental guard/anomaly detection APIs.
 
-pub use hl7v2_core::*;
+pub mod model {
+    //! Core HL7 v2 data structures.
+
+    pub use hl7v2_model::*;
+}
+
+pub mod escape {
+    //! HL7 escape sequence handling.
+
+    pub use hl7v2_escape::*;
+}
+
+pub mod transport {
+    //! HL7 v2 transport helpers.
+
+    pub mod mllp {
+        //! Minimal Lower Layer Protocol framing helpers.
+
+        pub use hl7v2_mllp::*;
+    }
+
+    #[cfg(feature = "network")]
+    pub mod network {
+        //! Async MLLP network client/server APIs.
+
+        pub use hl7v2_network::*;
+    }
+}
+
+pub mod parser {
+    //! HL7 v2 parser APIs.
+
+    pub use hl7v2_parser::*;
+}
+
+pub mod writer {
+    //! HL7 v2 writer and serialization APIs.
+
+    pub use hl7v2_writer::*;
+
+    #[cfg(feature = "json")]
+    pub mod json {
+        //! JSON serialization helpers.
+
+        pub use hl7v2_json::*;
+    }
+}
+
+pub mod query {
+    //! Message query helpers.
+
+    pub mod path {
+        //! HL7 path parsing.
+
+        pub use hl7v2_path::*;
+    }
+
+    pub use hl7v2_query::*;
+}
+
+#[cfg(feature = "profile")]
+pub mod conformance {
+    //! Profile, datatype, and validation APIs.
+
+    pub mod profile {
+        //! Profile loading and conformance validation.
+
+        pub use hl7v2_prof::*;
+    }
+
+    pub mod validation {
+        //! Reusable validation issue and rule primitives.
+
+        pub use hl7v2_validation::*;
+    }
+
+    pub mod datatype {
+        //! HL7 datatype validation.
+
+        pub mod datetime {
+            //! HL7 datetime parsing and validation.
+
+            pub use hl7v2_datetime::*;
+        }
+
+        pub use hl7v2_datatype::*;
+    }
+}
+
+#[cfg(feature = "ack")]
+pub mod ack {
+    //! ACK message generation.
+
+    pub use hl7v2_ack::*;
+}
+
+#[cfg(feature = "normalize")]
+pub mod normalize {
+    //! Message normalization.
+
+    pub use hl7v2_normalize::*;
+}
+
+#[cfg(feature = "batch")]
+pub mod batch {
+    //! Batch processing APIs.
+
+    pub use hl7v2_batch::*;
+}
+
+#[cfg(feature = "stream")]
+pub mod stream {
+    //! Streaming/event-based parsing APIs.
+
+    pub use hl7v2_stream::*;
+}
+
+#[cfg(feature = "synthetic")]
+pub mod synthetic {
+    //! Synthetic message generation APIs.
+
+    pub mod template {
+        //! Template-based message generation.
+
+        pub use hl7v2_template::*;
+    }
+
+    pub mod values {
+        //! Template value sources.
+
+        pub use hl7v2_template_values::*;
+    }
+
+    pub mod faker {
+        //! Faker-backed synthetic value generation.
+
+        pub use hl7v2_faker::*;
+    }
+
+    pub mod corpus {
+        //! Corpus metadata and hashing helpers.
+
+        pub use hl7v2_corpus::*;
+    }
+
+    pub mod generate {
+        //! Generation convenience facade.
+
+        pub use hl7v2_gen::*;
+    }
+}
+
+#[cfg(feature = "redact")]
+pub mod redact {
+    //! PHI redaction helpers.
+
+    pub use hl7v2_redact::*;
+}
+
+#[cfg(feature = "lifecycle")]
+pub mod lifecycle {
+    //! Message lifecycle and archive metadata helpers.
+
+    pub use hl7v2_lifecycle::*;
+}
+
+#[cfg(feature = "experimental-guard")]
+pub mod experimental {
+    //! Experimental APIs.
+
+    pub mod guard {
+        //! Experimental anomaly guard APIs.
+
+        pub use hl7v2_guard::*;
+    }
+}
+
+// Top-level convenience surface.
+pub use hl7v2_escape::{escape_text, needs_escaping, needs_unescaping, unescape_text};
+pub use hl7v2_mllp::{
+    MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,
+    is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
+};
+pub use hl7v2_model::{
+    Atom, Batch, Comp, Delims, Error, Field, FileBatch, Message, Presence, Rep, Segment,
+};
+pub use hl7v2_parser::{get, get_presence, parse, parse_batch, parse_file_batch, parse_mllp};
+pub use hl7v2_path::{Path, parse_path};
+pub use hl7v2_writer::{
+    to_json, to_json_string, to_json_string_pretty, write, write_batch, write_file_batch,
+    write_mllp,
+};
+
+#[cfg(feature = "normalize")]
+pub use hl7v2_normalize::normalize;
+
+#[cfg(feature = "ack")]
+pub use hl7v2_ack::{AckCode, ack, ack_with_error};
+
+#[cfg(feature = "profile")]
+pub use hl7v2_prof::{Profile, load_profile, load_profile_checked, validate};
+
+#[cfg(feature = "profile")]
+pub use hl7v2_validation::{Issue, Severity};
+
+#[cfg(feature = "stream")]
+pub use hl7v2_stream::{AsyncStreamParser, Event, StreamParser, StreamParserBuilder};


### PR DESCRIPTION
## Summary
- Replace the thin `hl7v2-core` wrapper with direct facade dependencies on the current microcrates.
- Add feature-gated `hl7v2` modules for model, escape, transport, parser, writer, query, conformance, ACK, normalize, batch, stream, synthetic, redact, lifecycle, and experimental guard APIs.
- Keep implementation files in place and update the `hl7v2` README away from direct microcrate guidance.

## Scope
- No implementation files moved.
- No server/CLI/Python import changes yet.
- No `hl7v2-core` shim changes yet.
- No runtime behavior changes intended.
- #380 remains untouched.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p hl7v2 --all-features --all-targets`
- `cargo test -p hl7v2 --all-features`
- `cargo check --examples`
- `cargo check -p hl7v2 --no-default-features --all-targets`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`