### PR TITLE
refactor: route examples through hl7v2 facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,13 +1746,7 @@ name = "hl7v2-examples"
 version = "1.2.0"
 dependencies = [
  "chrono",
- "hl7v2-ack",
- "hl7v2-batch",
- "hl7v2-core",
- "hl7v2-network",
- "hl7v2-prof",
- "hl7v2-stream",
- "hl7v2-template",
+ "hl7v2",
  "serde_json",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,13 +221,15 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-hl7v2-core = { workspace = true }
-hl7v2-ack = { version = "1.2.0", path = "crates/hl7v2-ack" }
-hl7v2-batch = { version = "1.2.0", path = "crates/hl7v2-batch" }
-hl7v2-prof = { version = "1.2.0", path = "crates/hl7v2-prof" }
-hl7v2-template = { version = "1.2.0", path = "crates/hl7v2-template" }
-hl7v2-stream = { version = "1.2.0", path = "crates/hl7v2-stream" }
-hl7v2-network = { version = "1.2.0", path = "crates/hl7v2-network" }
+hl7v2 = { version = "1.2.0", path = "crates/hl7v2", features = [
+    "profile",
+    "ack",
+    "normalize",
+    "batch",
+    "stream",
+    "network",
+    "synthetic",
+] }
 tokio = { workspace = true }
 chrono = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/ack_generation.rs
+++ b/examples/ack_generation.rs
@@ -7,8 +7,7 @@
 //!
 //! Run with: cargo run --example ack_generation
 
-use hl7v2_ack::{AckCode, ack, ack_with_error};
-use hl7v2_core::{Message, get, parse, write};
+use hl7v2::{AckCode, Error, Message, ack, ack_with_error, get, parse, write};
 
 /// A valid ADT^A01 message
 const VALID_ADT_MESSAGE: &[u8] = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|MSG12345|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
@@ -330,7 +329,7 @@ fn process_message_with_ack(hl7_bytes: &[u8]) -> Result<Vec<u8>, String> {
 #[derive(Debug)]
 #[allow(dead_code)]
 enum ProcessError {
-    Parse(hl7v2_core::Error),
+    Parse(Error),
     Validation(Vec<String>),
     Processing(String),
 }

--- a/examples/batch_processing.rs
+++ b/examples/batch_processing.rs
@@ -7,8 +7,8 @@
 //!
 //! Run with: cargo run --example batch_processing
 
-use hl7v2_batch::{Batch, FileBatch, parse_batch};
-use hl7v2_core::{Message, get, parse, write};
+use hl7v2::batch::{Batch, FileBatch, parse_batch};
+use hl7v2::{Message, Segment, get, parse, write};
 
 /// Sample batch file with FHS/BHS headers and multiple messages
 const SAMPLE_BATCH: &[u8] = b"FHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120000||BATCH001\rBHS|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120000||BATCH001\rMSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120001||ADT^A01^ADT_A01|MSG001|P|2.5.1\rPID|1||PAT001^^^HOSP^MR||Smith^John||19800101|M\rMSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120002||ADT^A01^ADT_A01|MSG002|P|2.5.1\rPID|1||PAT002^^^HOSP^MR||Jones^Jane||19850215|F\rMSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128120003||ADT^A01^ADT_A01|MSG003|P|2.5.1\rPID|1||PAT003^^^HOSP^MR||Brown^Bob||19900320|M\rBTS|3\rFTS|3\r";
@@ -74,7 +74,7 @@ fn display_file_batch_info(file_batch: &FileBatch) {
     println!("File Batch Information:");
 
     if let Some(header) = file_batch.header.as_ref() {
-        let header: &hl7v2_core::Segment = header;
+        let header: &Segment = header;
         println!("  Has FHS header: {}", header.id_str());
     }
 
@@ -97,7 +97,7 @@ fn display_file_batch_info(file_batch: &FileBatch) {
     }
 
     if let Some(trailer) = file_batch.trailer.as_ref() {
-        let trailer: &hl7v2_core::Segment = trailer;
+        let trailer: &Segment = trailer;
         println!("\n  Has FTS trailer: {}", trailer.id_str());
     }
 }

--- a/examples/message_building.rs
+++ b/examples/message_building.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with: cargo run --example message_building
 
-use hl7v2_core::{
+use hl7v2::{
     Atom,
     Comp,
     Delims,

--- a/examples/mllp_client.rs
+++ b/examples/mllp_client.rs
@@ -10,8 +10,8 @@
 //!
 //! Run with: cargo run --example mllp_client
 
-use hl7v2_core::{Message, get, parse, write};
-use hl7v2_network::MllpClientBuilder;
+use hl7v2::transport::network::MllpClientBuilder;
+use hl7v2::{Message, get, parse, write};
 use std::time::Duration;
 
 /// Default MLLP server address

--- a/examples/parsing_basics.rs
+++ b/examples/parsing_basics.rs
@@ -7,7 +7,7 @@
 //!
 //! Run with: cargo run --example parsing_basics
 
-use hl7v2_core::{Error, Message, get, parse};
+use hl7v2::{Error, Message, get, parse};
 
 /// A simple HL7 v2 ADT^A01 (Admit) message
 const SAMPLE_MESSAGE: &[u8] = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John^Middle||19700101|M|||123 Main St^^Anytown^CA^12345||5551234567\r";

--- a/examples/streaming_parser.rs
+++ b/examples/streaming_parser.rs
@@ -7,7 +7,7 @@
 //!
 //! Run with: cargo run --example streaming_parser
 
-use hl7v2_stream::{Event, StreamParser};
+use hl7v2::{Event, StreamParser};
 use std::io::{BufReader, Cursor};
 
 /// A moderately sized HL7 message for demonstration
@@ -258,7 +258,7 @@ fn demonstrate_async_pattern() {
 
     println!("Async streaming with backpressure:");
     println!("```rust");
-    println!("use hl7v2_stream::{{StreamParserBuilder, AsyncStreamParser, Event}};");
+    println!("use hl7v2::{{AsyncStreamParser, Event, StreamParserBuilder}};");
     println!("use tokio::sync::mpsc;");
     println!();
     println!("#[tokio::main]");

--- a/examples/template_generation.rs
+++ b/examples/template_generation.rs
@@ -7,8 +7,8 @@
 //!
 //! Run with: cargo run --example template_generation
 
-use hl7v2_core::{get, write};
-use hl7v2_template::{Template, ValueSource, generate};
+use hl7v2::synthetic::template::{Template, ValueSource, generate};
+use hl7v2::{get, write};
 use std::collections::HashMap;
 
 fn main() {

--- a/examples/validation_basics.rs
+++ b/examples/validation_basics.rs
@@ -7,8 +7,7 @@
 //!
 //! Run with: cargo run --example validation_basics
 
-use hl7v2_core::parse;
-use hl7v2_prof::{Issue, Profile, Severity, load_profile, validate};
+use hl7v2::{Issue, Profile, Severity, load_profile, parse, validate};
 
 /// Sample ADT^A01 message for validation
 const SAMPLE_MESSAGE: &[u8] = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
@@ -159,10 +158,7 @@ fn minimal_validation_example() {
             println!("  Version: {}", p.version);
             println!(
                 "  Segments: {:?}",
-                p.segments
-                    .iter()
-                    .map(|s: &hl7v2_prof::SegmentSpec| &s.id)
-                    .collect::<Vec<_>>()
+                p.segments.iter().map(|s| &s.id).collect::<Vec<_>>()
             );
             println!("  Constraints: {}", p.constraints.len());
             p


### PR DESCRIPTION
### Motivation
- Continue the demicrocrating sequence after governed lint policy landed.
- Stop workspace examples from proving first-party microcrate APIs directly.
- Force example consumers through the canonical `hl7v2` facade before implementation files move.

### Description
- Replaces the root example package's direct dependencies on `hl7v2-core`, `hl7v2-ack`, `hl7v2-batch`, `hl7v2-prof`, `hl7v2-template`, `hl7v2-stream`, and `hl7v2-network` with one `hl7v2` dependency and the required features.
- Updates `examples/*.rs` imports to use `hl7v2` top-level exports or namespaced facade modules such as `hl7v2::batch`, `hl7v2::transport::network`, and `hl7v2::synthetic::template`.
- Updates `Cargo.lock` so the example package depends on `hl7v2` instead of the microcrates.

### Validation
- `cargo +1.93.0 check --examples` passed.
- `cargo +1.93.0 run --example parsing_basics` passed.
- `cargo +1.93.0 run --example ack_generation` passed.
- `cargo +1.93.0 run --example validation_basics` passed.
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed` passed.

### Notes
- No implementation files moved.
- No server, CLI, Python, OpenAPI, schema, or runtime behavior changes.
- #380 remains parked.