### PR TITLE
docs: deprecate hl7v2-core facade

### DIFF
--- a/crates/hl7v2-core/Cargo.toml
+++ b/crates/hl7v2-core/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
-description = "High-level API and core functionality for hl7v2-rs."
+description = "Deprecated compatibility facade for hl7v2-rs. Use the hl7v2 crate."
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -45,4 +45,3 @@ proptest = "1.6"
 [[test]]
 name = "bdd_tests"
 harness = false
-

--- a/crates/hl7v2-core/README.md
+++ b/crates/hl7v2-core/README.md
@@ -1,7 +1,21 @@
 # hl7v2-core
 
-High-level API and core functionality for hl7v2-rs.
+Deprecated compatibility facade for hl7v2-rs.
+
+Use the `hl7v2` crate for new Rust code:
+
+```toml
+[dependencies]
+hl7v2 = "1.2.0"
+```
+
+`hl7v2-core` is retained temporarily while the old implementation microcrates
+are collapsed into modules under `hl7v2`. It should not be treated as a second
+public facade or a stable product surface.
 
 ## Usage
 
-For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.
+For usage examples, see the
+[examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples)
+directory in the root of the repository. Those examples import through
+`hl7v2`.

--- a/crates/hl7v2-core/src/lib.rs
+++ b/crates/hl7v2-core/src/lib.rs
@@ -1,6 +1,11 @@
-//! Core parsing and data model for HL7 v2 messages.
+//! Deprecated compatibility facade for HL7 v2 parsing and data model APIs.
 //!
-//! This crate provides a unified facade for the HL7 v2 microcrates:
+//! Use the `hl7v2` crate for new Rust code. `hl7v2-core` is retained
+//! temporarily while the old implementation microcrates are collapsed into
+//! modules under `hl7v2`.
+//!
+//! This crate currently re-exports selected HL7 v2 microcrates for
+//! compatibility:
 //! - `hl7v2-model`: Core data types (Message, Segment, Field, etc.)
 //! - `hl7v2-escape`: Escape sequence handling
 //! - `hl7v2-mllp`: MLLP framing protocol
@@ -10,8 +15,8 @@
 //! - `hl7v2-stream`: Streaming/event-based parsing (optional, enable with `stream` feature)
 //! - `hl7v2-network`: Network client/server (optional, enable with `network` feature)
 //!
-//! For backward compatibility, all types and functions are re-exported here.
-//! For new code, consider using the microcrates directly for finer-grained dependencies.
+//! For backward compatibility, the existing types and functions are
+//! re-exported here. Do not add new public API to this crate.
 //!
 //! # Memory Efficiency
 //!


### PR DESCRIPTION
## Summary
- mark `hl7v2-core` as a deprecated compatibility facade in package metadata, README, and rustdoc
- direct new Rust users to the canonical `hl7v2` crate
- preserve the current `hl7v2-core` implementation and dependency graph to avoid cycles before the floor-up module collapse

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 check -p hl7v2-core --all-features --all-targets`
- `cargo +1.93.0 test -p hl7v2-core --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`