### PR TITLE
ci: repair nightly docs and corpus property checks

### DIFF
--- a/crates/hl7v2-corpus/tests/property_tests.rs
+++ b/crates/hl7v2-corpus/tests/property_tests.rs
@@ -99,11 +99,12 @@ proptest! {
     fn test_splits_cover_all_messages(
         seed: u64,
         num_messages in 10usize..100,
-        train_ratio in 0.1f64..0.8,
-        val_ratio in 0.1f64..0.3
+        train_parts in 50u8..70,
+        val_parts in 10u8..30
     ) {
-        let test_ratio = 1.0 - train_ratio - val_ratio;
-        prop_assume!(test_ratio > 0.0 && test_ratio < 0.5);
+        let train_ratio = f64::from(train_parts) / 100.0;
+        let val_ratio = f64::from(val_parts) / 100.0;
+        let test_ratio = f64::from(100u8 - train_parts - val_parts) / 100.0;
 
         let mut manifest = CorpusManifest::new(seed);
 

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -14,6 +14,7 @@ categories.workspace = true
 [lib]
 name = "hl7v2"
 crate-type = ["cdylib"]
+doc = false
 
 [dependencies]
 hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [

--- a/crates/hl7v2-query/src/lib.rs
+++ b/crates/hl7v2-query/src/lib.rs
@@ -153,7 +153,7 @@ pub fn get_presence(msg: &Message, path: &str) -> Presence {
 // Internal helper functions
 // ============================================================================
 
-/// Parse field and repetition indices from a string like "5" or "5[1]"
+/// Parse field and repetition indices from a string like `5` or `5[1]`.
 fn parse_field_and_rep(field_str: &str) -> Option<(usize, usize)> {
     if let Some(bracket_pos) = field_str.find('[') {
         // Has repetition index

--- a/crates/hl7v2/src/synthetic/generate.rs
+++ b/crates/hl7v2/src/synthetic/generate.rs
@@ -13,7 +13,7 @@
 //! # ACK Generation
 //!
 //! ACK (acknowledgment) generation functionality is available through
-//! [`crate::ack`] and re-exported here for convenience.
+//! [`mod@crate::ack`] and re-exported here for convenience.
 //!
 //! # Faker Data Generation
 //!


### PR DESCRIPTION
## Summary
- exclude the PyO3 extension crate from workspace rustdoc output to avoid the `hl7v2` doc filename collision
- make the corpus split property generate only valid train/validation/test ratios under high nightly proptest case counts
- fix two rustdoc links that become errors under `RUSTFLAGS=-Dwarnings`

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PROPTEST_CASES='10000'; $env:PROPTEST_MAX_DEFAULT_SIZE='1000'; cargo +1.93.0 test -p hl7v2-corpus --all-features`
- `$env:RUSTFLAGS='-Dwarnings'; cargo +1.93.0 doc --workspace --all-features --no-deps --document-private-items`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check -p hl7v2-python --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `git diff --check`