### PR TITLE
test: make nightly property strategies non-rejecting

### DIFF
--- a/crates/hl7v2-escape/tests/property_tests.rs
+++ b/crates/hl7v2-escape/tests/property_tests.rs
@@ -17,23 +17,38 @@ fn text_without_delimiters() -> impl Strategy<Value = String> {
     "[A-Za-z0-9 ]{0,100}"
 }
 
-/// Generate custom delimiters
-#[allow(dead_code)]
-fn custom_delims() -> impl Strategy<Value = Delims> {
-    (
-        any::<char>(),
-        any::<char>(),
-        any::<char>(),
-        any::<char>(),
-        any::<char>(),
-    )
-        .prop_map(|(field, comp, rep, esc, sub)| Delims {
-            field,
-            comp,
-            rep,
-            esc,
-            sub,
-        })
+/// Generate custom delimiters that cannot appear in `text_without_delimiters`.
+fn custom_delims_outside_text_alphabet() -> impl Strategy<Value = Delims> {
+    prop::sample::select(vec![
+        Delims {
+            field: '|',
+            comp: '^',
+            rep: '~',
+            esc: '\\',
+            sub: '&',
+        },
+        Delims {
+            field: '!',
+            comp: '#',
+            rep: '$',
+            esc: '%',
+            sub: '@',
+        },
+        Delims {
+            field: ';',
+            comp: ':',
+            rep: '?',
+            esc: '/',
+            sub: '*',
+        },
+        Delims {
+            field: '(',
+            comp: ')',
+            rep: '[',
+            esc: ']',
+            sub: '{',
+        },
+    ])
 }
 
 proptest! {
@@ -138,20 +153,8 @@ proptest! {
     #[test]
     fn prop_custom_delimiters_roundtrip(
         text in "[A-Za-z0-9 ]{0,50}",
-        field in any::<char>(),
-        comp in any::<char>(),
-        rep in any::<char>(),
-        esc in any::<char>(),
-        sub in any::<char>()
+        delims in custom_delims_outside_text_alphabet()
     ) {
-        // Skip if delimiters conflict with text characters
-        prop_assume!(!text.contains(field));
-        prop_assume!(!text.contains(comp));
-        prop_assume!(!text.contains(rep));
-        prop_assume!(!text.contains(esc));
-        prop_assume!(!text.contains(sub));
-
-        let delims = Delims { field, comp, rep, esc, sub };
         let escaped = escape_text(&text, &delims);
         let unescaped = unescape_text(&escaped, &delims).unwrap();
         prop_assert_eq!(unescaped, text);

--- a/crates/hl7v2-prof/tests/property_tests.rs
+++ b/crates/hl7v2-prof/tests/property_tests.rs
@@ -796,9 +796,9 @@ datatypes:
         path in field_path_strategy(),
         datatype in prop_oneof![Just("ST"), Just("ID")],
         min_length in 0usize..100,
-        max_length in 1usize..200
+        length_delta in 1usize..100
     ) {
-        prop_assume!(min_length < max_length);
+        let max_length = min_length + length_delta;
 
         let yaml = format!(
             r#"
@@ -1144,9 +1144,9 @@ proptest! {
     fn prop_profile_segment_cardinality(
         msg_struct in message_structure_strategy(),
         min_occurs in 0usize..5,
-        max_occurs in 1usize..10
+        occurs_delta in 0usize..5
     ) {
-        prop_assume!(min_occurs <= max_occurs);
+        let max_occurs = min_occurs + occurs_delta;
 
         let yaml = format!(
             r#"


### PR DESCRIPTION
## Summary
- make the custom escape delimiter property generate delimiter sets that cannot conflict with its text generator
- generate ordered profile length and cardinality values directly instead of filtering invalid pairs with `prop_assume!`

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PROPTEST_CASES='10000'; $env:PROPTEST_MAX_DEFAULT_SIZE='1000'; $env:RUSTFLAGS='-Dwarnings'; cargo +1.93.0 test -p hl7v2-escape --test property_tests -- --nocapture prop_custom_delimiters_roundtrip`
- `$env:PROPTEST_CASES='10000'; $env:PROPTEST_MAX_DEFAULT_SIZE='1000'; $env:RUSTFLAGS='-Dwarnings'; cargo +1.93.0 test -p hl7v2-prof --test property_tests -- --nocapture prop_profile_with_advanced_datatype_constraints prop_profile_segment_cardinality`
- `$env:PROPTEST_CASES='10000'; $env:PROPTEST_MAX_DEFAULT_SIZE='1000'; $env:RUSTFLAGS='-Dwarnings'; cargo +1.93.0 test --workspace --test property_tests -- --nocapture`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `git diff --check`

## Nightly context
A manual Nightly dispatch on `main` after #409 proved Documentation fixed, then exposed Extended Property Tests still failing from reject-heavy `hl7v2-escape` and `hl7v2-prof` strategies. This PR addresses those strategy defects without changing runtime behavior.