### PR TITLE
refactor: collapse normalize into hl7v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,6 @@ dependencies = [
  "hl7v2-mllp",
  "hl7v2-model",
  "hl7v2-network",
- "hl7v2-normalize",
  "hl7v2-parser",
  "hl7v2-prof",
  "hl7v2-query",

--- a/crates/hl7v2/Cargo.toml
+++ b/crates/hl7v2/Cargo.toml
@@ -29,7 +29,7 @@ profile = [
     "dep:regex",
 ]
 ack = ["dep:chrono"]
-normalize = ["dep:hl7v2-normalize"]
+normalize = []
 batch = []
 stream = ["dep:hl7v2-stream"]
 network = ["dep:hl7v2-network"]
@@ -67,7 +67,6 @@ serde_yaml = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4"], optional = true }
 
 hl7v2-json = { version = "1.2.0", path = "../hl7v2-json", optional = true }
-hl7v2-normalize = { version = "1.2.0", path = "../hl7v2-normalize", optional = true }
 hl7v2-prof = { version = "1.2.0", path = "../hl7v2-prof", optional = true }
 hl7v2-validation = { version = "1.2.0", path = "../hl7v2-validation", optional = true }
 hl7v2-stream = { version = "1.2.0", path = "../hl7v2-stream", optional = true }

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -109,11 +109,7 @@ pub mod conformance {
 pub mod ack;
 
 #[cfg(feature = "normalize")]
-pub mod normalize {
-    //! Message normalization.
-
-    pub use hl7v2_normalize::*;
-}
+pub mod normalize;
 
 #[cfg(feature = "batch")]
 pub mod batch;
@@ -154,7 +150,7 @@ pub use hl7v2_writer::{
 pub use query::path::{Path, parse_path};
 
 #[cfg(feature = "normalize")]
-pub use hl7v2_normalize::normalize;
+pub use normalize::normalize;
 
 #[cfg(feature = "ack")]
 pub use ack::{AckCode, ack, ack_with_error};

--- a/crates/hl7v2/src/normalize.rs
+++ b/crates/hl7v2/src/normalize.rs
@@ -1,0 +1,41 @@
+//! HL7 v2 message normalization.
+//!
+//! This module provides normalization for raw HL7 v2 bytes by parsing and
+//! writing messages in a consistent format. Optionally, delimiters can be
+//! rewritten to canonical HL7 delimiters (`|^~\&`).
+//!
+//! # Example
+//!
+//! ```
+//! use hl7v2::normalize;
+//!
+//! let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\r";
+//! let normalized = normalize(hl7, true).unwrap();
+//! assert!(normalized.starts_with(b"MSH|^~\\&|"));
+//! ```
+
+use crate::model::{Delims, Error};
+use crate::parser::parse;
+use crate::writer::write;
+
+/// Normalize HL7 v2 bytes.
+///
+/// The message is parsed and rewritten using `hl7v2::writer`. When
+/// `canonical_delims` is `true`, the output message delimiters are rewritten
+/// to canonical HL7 delimiters (`|^~\&`).
+///
+/// # Errors
+///
+/// Returns an error when the input bytes cannot be parsed as an HL7 v2 message.
+pub fn normalize(bytes: &[u8], canonical_delims: bool) -> Result<Vec<u8>, Error> {
+    let mut message = parse(bytes)?;
+
+    if canonical_delims {
+        message.delims = Delims::default();
+    }
+
+    Ok(write(&message))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/hl7v2/src/normalize/tests.rs
+++ b/crates/hl7v2/src/normalize/tests.rs
@@ -1,0 +1,128 @@
+//! Unit tests for message normalization.
+
+use super::*;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn ensure(condition: bool, message: &'static str) -> TestResult {
+    if condition {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(message).into())
+    }
+}
+
+#[test]
+fn normalize_basic_message() -> TestResult {
+    let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\r";
+
+    let normalized = normalize(hl7, false)?;
+
+    ensure(normalized.starts_with(b"MSH|^~\\&|"), "MSH not normalized")
+}
+
+#[test]
+fn normalize_with_canonical_delimiters() -> TestResult {
+    let hl7 = b"MSH*%$!?*SendingApp*SendingFac*ReceivingApp*ReceivingFac*20250128152312**ADT%A01*ABC123*P*2.5.1\r";
+
+    let normalized = normalize(hl7, true)?;
+    let normalized_str = String::from_utf8(normalized)?;
+
+    ensure(
+        normalized_str.starts_with("MSH|^~\\&|"),
+        "canonical delimiters not used",
+    )
+}
+
+#[test]
+fn normalize_preserves_custom_delimiters_when_not_canonical() -> TestResult {
+    let hl7 = b"MSH*%$!?*SendingApp*SendingFac*ReceivingApp*ReceivingFac*20250128152312**ADT%A01*ABC123*P*2.5.1\r";
+
+    let normalized = normalize(hl7, false)?;
+
+    ensure(
+        normalized.starts_with(b"MSH*%$!?*"),
+        "custom delimiters not preserved",
+    )
+}
+
+#[test]
+fn normalize_multi_segment_with_canonical() -> TestResult {
+    let hl7 = b"MSH*%$!?*SendingApp*SendingFac*ReceivingApp*ReceivingFac*20250128152312**ADT%A01*ABC123*P*2.5.1\rPID*1**123456%%%HOSP%MR**Doe%John\r";
+
+    let normalized = normalize(hl7, true)?;
+    let normalized_str = String::from_utf8(normalized)?;
+
+    ensure(
+        normalized_str.starts_with("MSH|^~\\&|"),
+        "canonical delimiters not used",
+    )?;
+    ensure(
+        normalized_str.contains("PID|1||123456^^^HOSP^MR||Doe^John"),
+        "PID segment not normalized",
+    )
+}
+
+#[test]
+fn normalize_rejects_invalid_message() -> TestResult {
+    let invalid = b"PID|1||12345\r";
+
+    ensure(
+        matches!(normalize(invalid, true), Err(Error::InvalidSegmentId)),
+        "invalid message did not return InvalidSegmentId",
+    )
+}
+
+#[test]
+fn normalize_roundtrips_with_canonical_delimiters() -> TestResult {
+    let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r";
+
+    let normalized = normalize(hl7, true)?;
+    let reparsed = crate::parser::parse(&normalized)?;
+
+    ensure(reparsed.segments.len() == 2, "unexpected segment count")?;
+    ensure(
+        reparsed.delims.field == '|',
+        "field delimiter not canonical",
+    )?;
+    ensure(
+        reparsed.delims.comp == '^',
+        "component delimiter not canonical",
+    )?;
+    ensure(
+        reparsed.delims.rep == '~',
+        "repetition delimiter not canonical",
+    )?;
+    ensure(
+        reparsed.delims.esc == '\\',
+        "escape delimiter not canonical",
+    )?;
+    ensure(
+        reparsed.delims.sub == '&',
+        "subcomponent delimiter not canonical",
+    )
+}
+
+#[test]
+fn normalize_preserves_escape_sequences() -> TestResult {
+    let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||12345||O\\F\\Brien^John\r";
+
+    let normalized = normalize(hl7, false)?;
+    let normalized_str = String::from_utf8(normalized)?;
+
+    ensure(
+        normalized_str.contains("O\\F\\Brien"),
+        "escape sequence not preserved",
+    )
+}
+
+#[test]
+fn normalize_preserves_unicode_text() -> TestResult {
+    let hl7 = "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||12345||Müller^Jöhn\r".as_bytes();
+
+    let normalized = normalize(hl7, false)?;
+    let normalized_str = String::from_utf8(normalized)?;
+
+    ensure(normalized_str.contains("Müller"), "last name not preserved")?;
+    ensure(normalized_str.contains("Jöhn"), "first name not preserved")
+}


### PR DESCRIPTION
## Summary
- move the normalize implementation into `hl7v2::normalize`
- remove the direct `hl7v2 -> hl7v2-normalize` feature/dependency edge
- keep the legacy `hl7v2-normalize` crate unchanged for current compatibility consumers

## Notes
`hl7v2-normalize` is intentionally not converted to a shim in this PR. `hl7v2-prof` and `hl7v2-validation` still depend on `hl7v2-core`, and `hl7v2-core` still re-exports `hl7v2-normalize`; making the old crate depend back on `hl7v2` now would risk a cycle under all-features builds. The shim can happen after the core/conformance path is collapsed or rewired.

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 clippy -p hl7v2 --no-default-features --features normalize --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2 --no-default-features --features normalize normalize`
- `cargo +1.93.0 test -p hl7v2 --all-features normalize`
- `cargo +1.93.0 test -p hl7v2-normalize`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 check --workspace --exclude hl7v2-python --all-features --all-targets`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `git diff --check`