### PR TITLE
test: fix stream message count property

### DIFF
--- a/crates/hl7v2-stream/src/comprehensive_tests/property_tests.rs
+++ b/crates/hl7v2-stream/src/comprehensive_tests/property_tests.rs
@@ -61,9 +61,9 @@ fn hl7_message() -> impl Strategy<Value = String> {
         })
 }
 
-/// Strategy for generating multiple messages
-fn multiple_messages() -> impl Strategy<Value = String> {
-    prop::collection::vec(hl7_message(), 1..5).prop_map(|msgs| msgs.join(""))
+/// Strategy for generating multiple messages with their source count.
+fn multiple_messages() -> impl Strategy<Value = (usize, String)> {
+    prop::collection::vec(hl7_message(), 1..5).prop_map(|msgs| (msgs.len(), msgs.join("")))
 }
 
 /// Helper to collect all events from a parser
@@ -124,16 +124,12 @@ proptest! {
 
 proptest! {
     #[test]
-    fn prop_multiple_messages_multiple_events(msgs in multiple_messages()) {
+    fn prop_multiple_messages_multiple_events((expected_count, msgs) in multiple_messages()) {
         let cursor = Cursor::new(msgs.as_bytes());
         let buf_reader = BufReader::new(cursor);
         let mut parser = StreamParser::new(buf_reader);
 
         let events = collect_events(&mut parser);
-
-        // Count messages by counting MSH-triggered StartMessage events
-        // Note: We need to count actual messages in input
-        let expected_count = msgs.matches("MSH|").count();
 
         let start_count = events.iter()
             .filter(|e| matches!(e, Event::StartMessage { .. }))


### PR DESCRIPTION
## Summary
- fix the stream multi-message property to use the generated source message count instead of counting `MSH|` substrings
- avoid false failures when a non-MSH segment field contains `MSH|`

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PROPTEST_CASES='10000'; cargo +1.93.0 test -p hl7v2-stream prop_multiple_messages_multiple_events --all-features -- --nocapture`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `git diff --check`

## Notes
This repairs the post-#411 main Coverage failure in `hl7v2-stream::comprehensive_tests::property_tests::prop_multiple_messages_multiple_events`.