### PR TITLE
refactor: make normalize crate a compatibility shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,9 +1823,7 @@ name = "hl7v2-normalize"
 version = "1.2.0"
 dependencies = [
  "cucumber",
- "hl7v2-model",
- "hl7v2-parser",
- "hl7v2-writer",
+ "hl7v2",
  "proptest",
  "tokio",
 ]

--- a/crates/hl7v2-normalize/Cargo.toml
+++ b/crates/hl7v2-normalize/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["hl7", "healthcare", "normalize", "canonical"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
-hl7v2-writer = { version = "1.2.0", path = "../hl7v2-writer" }
+hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+    "normalize",
+] }
 
 [dev-dependencies]
 proptest = "1.6"
@@ -25,4 +25,3 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 [[test]]
 name = "bdd_tests"
 harness = false
-

--- a/crates/hl7v2-normalize/src/lib.rs
+++ b/crates/hl7v2-normalize/src/lib.rs
@@ -1,37 +1,8 @@
-//! HL7 v2 message normalization.
+//! Deprecated compatibility crate.
 //!
-//! This crate provides normalization for raw HL7 v2 bytes by parsing and
-//! writing messages in a consistent format. Optionally, delimiters can be
-//! rewritten to canonical HL7 delimiters (`|^~\&`).
-//!
-//! # Example
-//!
-//! ```
-//! use hl7v2_normalize::normalize;
-//!
-//! let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\r";
-//! let normalized = normalize(hl7, true).unwrap();
-//! assert!(normalized.starts_with(b"MSH|^~\\&|"));
-//! ```
+//! Use `hl7v2::normalize` instead.
 
-use hl7v2_model::{Delims, Error};
-use hl7v2_parser::parse;
-use hl7v2_writer::write;
-
-/// Normalize HL7 v2 bytes.
-///
-/// The message is parsed and rewritten using `hl7v2_writer`. When
-/// `canonical_delims` is `true`, the output message delimiters are rewritten
-/// to canonical HL7 delimiters (`|^~\&`).
-pub fn normalize(bytes: &[u8], canonical_delims: bool) -> Result<Vec<u8>, Error> {
-    let mut message = parse(bytes)?;
-
-    if canonical_delims {
-        message.delims = Delims::default();
-    }
-
-    Ok(write(&message))
-}
+pub use hl7v2::normalize::normalize;
 
 #[cfg(test)]
 mod tests;

--- a/crates/hl7v2-normalize/src/tests.rs
+++ b/crates/hl7v2-normalize/src/tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests for hl7v2-normalize
 
 use super::*;
+use hl7v2::Error;
 
 // =============================================================================
 // Basic Normalization Tests
@@ -100,7 +101,7 @@ fn normalize_roundtrips_valid_message() {
     let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r";
 
     let normalized = normalize(hl7, false).unwrap();
-    let reparsed = hl7v2_parser::parse(&normalized).unwrap();
+    let reparsed = hl7v2::parse(&normalized).unwrap();
 
     assert_eq!(reparsed.segments.len(), 2);
     assert_eq!(&reparsed.segments[0].id, b"MSH");
@@ -112,7 +113,7 @@ fn normalize_roundtrips_with_canonical() {
     let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r";
 
     let normalized = normalize(hl7, true).unwrap();
-    let reparsed = hl7v2_parser::parse(&normalized).unwrap();
+    let reparsed = hl7v2::parse(&normalized).unwrap();
 
     // Should still be valid
     assert_eq!(reparsed.segments.len(), 2);

--- a/crates/hl7v2-normalize/tests/bdd_tests.rs
+++ b/crates/hl7v2-normalize/tests/bdd_tests.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo test --test bdd_tests
 
 use cucumber::{World, given, then, when};
-use hl7v2_model::Error;
+use hl7v2::Error;
 use hl7v2_normalize::normalize;
 
 /// Test world for Normalize BDD tests

--- a/crates/hl7v2-normalize/tests/integration_tests.rs
+++ b/crates/hl7v2-normalize/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 //! Integration tests for hl7v2-normalize
 
+use hl7v2::{parse, write};
 use hl7v2_normalize::normalize;
 
 // =============================================================================
@@ -51,7 +52,7 @@ fn normalize_and_reparse() {
     let normalized = normalize(hl7, false).unwrap();
 
     // Parse the normalized message
-    let parsed = hl7v2_parser::parse(&normalized).unwrap();
+    let parsed = parse(&normalized).unwrap();
 
     assert_eq!(parsed.segments.len(), 2);
     assert_eq!(&parsed.segments[0].id, b"MSH");
@@ -65,8 +66,8 @@ fn normalize_and_write() {
     let normalized = normalize(hl7, false).unwrap();
 
     // Parse and write again
-    let parsed = hl7v2_parser::parse(&normalized).unwrap();
-    let rewritten = hl7v2_writer::write(&parsed);
+    let parsed = parse(&normalized).unwrap();
+    let rewritten = write(&parsed);
 
     // Should be equivalent
     assert_eq!(normalized, rewritten);

--- a/crates/hl7v2-normalize/tests/property_tests.rs
+++ b/crates/hl7v2-normalize/tests/property_tests.rs
@@ -1,5 +1,6 @@
 //! Property-based tests for hl7v2-normalize using proptest
 
+use hl7v2::parse;
 use hl7v2_normalize::normalize;
 use proptest::prelude::*;
 
@@ -229,7 +230,7 @@ proptest! {
         let normalized = normalize(hl7.as_bytes(), false).unwrap();
 
         // Should be parseable
-        let parsed = hl7v2_parser::parse(&normalized);
+        let parsed = parse(&normalized);
         prop_assert!(parsed.is_ok());
 
         let message = parsed.unwrap();
@@ -281,7 +282,7 @@ proptest! {
         let normalized = normalize(hl7.as_bytes(), false).unwrap();
 
         // Parse to verify field separator
-        let message = hl7v2_parser::parse(&normalized).unwrap();
+        let message = parse(&normalized).unwrap();
         prop_assert_eq!(message.delims.field, '|');
     }
 }


### PR DESCRIPTION
## Summary
- turn `hl7v2-normalize` into a deprecated compatibility crate that re-exports `hl7v2::normalize::normalize`
- replace its direct model/parser/writer dependencies with the canonical `hl7v2` facade using only the `normalize` feature
- update normalize crate tests to use `hl7v2` for parse/write/error helpers instead of depending on old microcrates

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 test -p hl7v2-normalize`
- `cargo +1.93.0 test -p hl7v2 --features normalize`
- `cargo +1.93.0 test -p hl7v2-core --all-features`
- `cargo +1.93.0 test -p hl7v2-gen --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `git diff --check HEAD`