### PR TITLE
refactor: drop synthetic core dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,6 @@ name = "hl7v2-corpus"
 version = "1.2.0"
 dependencies = [
  "hl7v2",
- "hl7v2-core",
  "proptest",
  "serde_json",
 ]
@@ -1732,7 +1731,6 @@ version = "1.2.0"
 dependencies = [
  "cucumber",
  "hl7v2",
- "hl7v2-core",
  "hl7v2-normalize",
  "hl7v2-parser",
  "hl7v2-query",
@@ -1949,7 +1947,6 @@ name = "hl7v2-template"
 version = "1.2.0"
 dependencies = [
  "hl7v2",
- "hl7v2-core",
  "proptest",
 ]
 

--- a/crates/hl7v2-corpus/Cargo.toml
+++ b/crates/hl7v2-corpus/Cargo.toml
@@ -18,6 +18,5 @@ hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, featur
 ] }
 
 [dev-dependencies]
-hl7v2-core = { version = "1.2.0", path = "../hl7v2-core" }
 proptest = "1.6"
 serde_json = { workspace = true }

--- a/crates/hl7v2-corpus/tests/integration_tests.rs
+++ b/crates/hl7v2-corpus/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 //! Integration tests for hl7v2-corpus
 
-use hl7v2_core::{Atom, Comp, Delims, Field, Message, Rep, Segment};
+use hl7v2::{Atom, Comp, Delims, Field, Message, Rep, Segment};
 use hl7v2_corpus::*;
 
 /// Helper to create a test message
@@ -466,10 +466,10 @@ fn test_large_corpus_performance() {
 
 #[test]
 fn test_corpus_with_parsed_message() {
-    // Parse a real HL7 message using hl7v2-core
+    // Parse a real HL7 message using hl7v2
     let hl7_bytes = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r";
 
-    let message = hl7v2_core::parse(hl7_bytes).unwrap();
+    let message = hl7v2::parse(hl7_bytes).unwrap();
 
     // Extract message type
     let msg_type = extract_message_type(&message);

--- a/crates/hl7v2-gen/Cargo.toml
+++ b/crates/hl7v2-gen/Cargo.toml
@@ -23,7 +23,6 @@ rand = "0.10.0"
 cucumber = "0.22.1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
-hl7v2-core = { version = "1.2.0", path = "../hl7v2-core" }
 hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
 hl7v2-normalize = { version = "1.2.0", path = "../hl7v2-normalize" }
 hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }

--- a/crates/hl7v2-gen/tests/bdd_tests.rs
+++ b/crates/hl7v2-gen/tests/bdd_tests.rs
@@ -184,7 +184,7 @@ fn given_template_gaussian(world: &mut GenWorld) {
 
 #[given("a valid HL7 message to acknowledge")]
 fn given_valid_message_for_ack(world: &mut GenWorld) {
-    let msg = hl7v2_core::parse(
+    let msg = hl7v2::parse(
         b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r",
     )
     .unwrap();
@@ -291,15 +291,15 @@ fn when_faker_name(world: &mut GenWorld, gender: String) {
 fn then_identical(world: &mut GenWorld) {
     assert!(!world.messages_a.is_empty());
     assert!(!world.messages_b.is_empty());
-    let a = hl7v2_core::write(&world.messages_a[0]);
-    let b = hl7v2_core::write(&world.messages_b[0]);
+    let a = hl7v2::write(&world.messages_a[0]);
+    let b = hl7v2::write(&world.messages_b[0]);
     assert_eq!(a, b, "Messages with same seed should be identical");
 }
 
 #[then("the messages should differ")]
 fn then_differ(world: &mut GenWorld) {
-    let a = hl7v2_core::write(&world.messages_a[0]);
-    let b = hl7v2_core::write(&world.messages_b[0]);
+    let a = hl7v2::write(&world.messages_a[0]);
+    let b = hl7v2::write(&world.messages_b[0]);
     assert_ne!(a, b, "Messages with different seeds should differ");
 }
 
@@ -311,8 +311,8 @@ fn then_receive_n(world: &mut GenWorld, count: usize) {
 #[then("all messages should be valid HL7")]
 fn then_all_valid(world: &mut GenWorld) {
     for msg in &world.messages_a {
-        let bytes = hl7v2_core::write(msg);
-        let parsed = hl7v2_core::parse(&bytes);
+        let bytes = hl7v2::write(msg);
+        let parsed = hl7v2::parse(&bytes);
         assert!(parsed.is_ok(), "Message should be valid HL7");
     }
 }
@@ -320,8 +320,8 @@ fn then_all_valid(world: &mut GenWorld) {
 #[then("the generated message should be valid HL7")]
 fn then_generated_valid(world: &mut GenWorld) {
     let msg = &world.messages_a[0];
-    let bytes = hl7v2_core::write(msg);
-    let parsed = hl7v2_core::parse(&bytes);
+    let bytes = hl7v2::write(msg);
+    let parsed = hl7v2::parse(&bytes);
     assert!(parsed.is_ok(), "Generated message should be valid HL7");
 }
 
@@ -329,7 +329,7 @@ fn then_generated_valid(world: &mut GenWorld) {
 fn then_values_from_list(world: &mut GenWorld, list: String) {
     let allowed: Vec<&str> = list.split(',').collect();
     for msg in &world.messages_a {
-        if let Some(val) = hl7v2_core::get(msg, "PID.8") {
+        if let Some(val) = hl7v2::get(msg, "PID.8") {
             assert!(
                 allowed.contains(&val),
                 "PID.8 value '{}' not in allowed list {:?}",
@@ -360,7 +360,7 @@ fn then_ack_msh_msa_err(world: &mut GenWorld) {
 #[then(regex = r#"MSA\.1 should be "([^"]+)""#)]
 fn then_msa1(world: &mut GenWorld, expected: String) {
     let ack = world.ack_message.as_ref().expect("No ACK generated");
-    let val = hl7v2_core::get(ack, "MSA.1").expect("MSA.1 not found");
+    let val = hl7v2::get(ack, "MSA.1").expect("MSA.1 not found");
     assert_eq!(val, expected);
 }
 
@@ -378,8 +378,8 @@ fn then_contains_segment(world: &mut GenWorld, segment_id: String) {
 fn then_corpora_identical(world: &mut GenWorld) {
     assert_eq!(world.messages_a.len(), world.messages_b.len());
     for (a, b) in world.messages_a.iter().zip(world.messages_b.iter()) {
-        let wa = hl7v2_core::write(a);
-        let wb = hl7v2_core::write(b);
+        let wa = hl7v2::write(a);
+        let wb = hl7v2::write(b);
         assert_eq!(wa, wb, "Corpus messages with same seed should be identical");
     }
 }

--- a/crates/hl7v2-gen/tests/integration_tests.rs
+++ b/crates/hl7v2-gen/tests/integration_tests.rs
@@ -91,7 +91,7 @@ fn test_generation_with_uuid() {
     let messages = generate(&template, 42, 10).unwrap();
 
     // Each message should have a unique control ID
-    let mut control_ids: Vec<Vec<u8>> = messages.iter().map(hl7v2_core::write).collect();
+    let mut control_ids: Vec<Vec<u8>> = messages.iter().map(hl7v2::write).collect();
 
     // Check uniqueness
     control_ids.sort();
@@ -105,7 +105,7 @@ fn test_generation_with_uuid() {
 
 #[test]
 fn test_ack_commit_accept() {
-    let original = hl7v2_core::parse(
+    let original = hl7v2::parse(
         b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r"
     ).unwrap();
 
@@ -114,14 +114,14 @@ fn test_ack_commit_accept() {
     assert_eq!(ack_msg.segments.len(), 2);
 
     // Verify MSA segment has AA
-    let ack_bytes = hl7v2_core::write(&ack_msg);
+    let ack_bytes = hl7v2::write(&ack_msg);
     let ack_str = String::from_utf8(ack_bytes).unwrap();
     assert!(ack_str.contains("MSA|AA"));
 }
 
 #[test]
 fn test_ack_error() {
-    let original = hl7v2_core::parse(
+    let original = hl7v2::parse(
         b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||Doe^John\r"
     ).unwrap();
 
@@ -129,7 +129,7 @@ fn test_ack_error() {
 
     assert_eq!(ack_msg.segments.len(), 3); // MSH + MSA + ERR
 
-    let ack_bytes = hl7v2_core::write(&ack_msg);
+    let ack_bytes = hl7v2::write(&ack_msg);
     let ack_str = String::from_utf8(ack_bytes).unwrap();
     assert!(ack_str.contains("MSA|AE"));
     assert!(ack_str.contains("ERR"));
@@ -137,13 +137,13 @@ fn test_ack_error() {
 
 #[test]
 fn test_ack_reject() {
-    let original = hl7v2_core::parse(
+    let original = hl7v2::parse(
         b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\r"
     ).unwrap();
 
     let ack_msg = ack(&original, AckCode::AR).unwrap();
 
-    let ack_bytes = hl7v2_core::write(&ack_msg);
+    let ack_bytes = hl7v2::write(&ack_msg);
     let ack_str = String::from_utf8(ack_bytes).unwrap();
     assert!(ack_str.contains("MSA|AR"));
 }
@@ -218,10 +218,10 @@ fn test_generate_parse_query() {
     let message = &messages[0];
 
     // Write to bytes
-    let bytes = hl7v2_core::write(message);
+    let bytes = hl7v2::write(message);
 
     // Parse again
-    let reparsed = hl7v2_core::parse(&bytes).unwrap();
+    let reparsed = hl7v2::parse(&bytes).unwrap();
     assert_eq!(reparsed.segments.len(), 2);
 
     // Query using hl7v2-query
@@ -245,7 +245,7 @@ fn test_generate_normalize() {
     let message = &messages[0];
 
     // Write to bytes
-    let bytes = hl7v2_core::write(message);
+    let bytes = hl7v2::write(message);
 
     // Normalize
     let normalized = hl7v2_normalize::normalize(&bytes, true).unwrap();
@@ -321,7 +321,7 @@ fn test_adt_a04_generation() {
     let messages = generate(&template, 42, 1).unwrap();
     assert_eq!(messages.len(), 1);
 
-    let bytes = hl7v2_core::write(&messages[0]);
+    let bytes = hl7v2::write(&messages[0]);
     let str = String::from_utf8(bytes).unwrap();
     assert!(str.contains("ADT^A04"));
 }
@@ -365,8 +365,8 @@ fn test_same_seed_same_output() {
     let messages2 = generate(&template, 12345, 10).unwrap();
 
     for i in 0..10 {
-        let bytes1 = hl7v2_core::write(&messages1[i]);
-        let bytes2 = hl7v2_core::write(&messages2[i]);
+        let bytes1 = hl7v2::write(&messages1[i]);
+        let bytes2 = hl7v2::write(&messages2[i]);
         assert_eq!(bytes1, bytes2);
     }
 }
@@ -392,8 +392,8 @@ fn test_different_seed_different_output() {
     let messages1 = generate(&template, 111, 1).unwrap();
     let messages2 = generate(&template, 222, 1).unwrap();
 
-    let bytes1 = hl7v2_core::write(&messages1[0]);
-    let bytes2 = hl7v2_core::write(&messages2[0]);
+    let bytes1 = hl7v2::write(&messages1[0]);
+    let bytes2 = hl7v2::write(&messages2[0]);
 
     // Different seeds should produce different output (with high probability)
     assert_ne!(bytes1, bytes2);

--- a/crates/hl7v2-template/Cargo.toml
+++ b/crates/hl7v2-template/Cargo.toml
@@ -18,5 +18,4 @@ hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, featur
 ] }
 
 [dev-dependencies]
-hl7v2-core = { version = "1.2.0", path = "../hl7v2-core" }
 proptest = "1.6"

--- a/crates/hl7v2-template/tests/integration_tests.rs
+++ b/crates/hl7v2-template/tests/integration_tests.rs
@@ -82,8 +82,8 @@ fn integration_different_seeds_different_results() {
 
     // With different seeds and UUID generation, results should differ
     // (Note: this could theoretically fail if UUIDs collide, but extremely unlikely)
-    let msg1_str = hl7v2_core::write(&messages1[0]);
-    let msg2_str = hl7v2_core::write(&messages2[0]);
+    let msg1_str = hl7v2::write(&messages1[0]);
+    let msg2_str = hl7v2::write(&messages2[0]);
 
     // The UUID fields should be different
     assert_ne!(msg1_str, msg2_str);
@@ -317,7 +317,7 @@ fn integration_message_serialization() {
     let messages = generate(&template, 42, 1).unwrap();
 
     // Serialize to bytes
-    let bytes = hl7v2_core::write(&messages[0]);
+    let bytes = hl7v2::write(&messages[0]);
 
     // Should be valid UTF-8
     let s = String::from_utf8(bytes).unwrap();

--- a/crates/hl7v2-template/tests/property_tests.rs
+++ b/crates/hl7v2-template/tests/property_tests.rs
@@ -113,8 +113,8 @@ proptest! {
         let messages1 = generate(&template, seed1, 1).unwrap();
         let messages2 = generate(&template, seed2, 1).unwrap();
 
-        let msg1 = hl7v2_core::write(&messages1[0]);
-        let msg2 = hl7v2_core::write(&messages2[0]);
+        let msg1 = hl7v2::write(&messages1[0]);
+        let msg2 = hl7v2::write(&messages2[0]);
 
         // With UUID generation, different seeds should produce different results
         prop_assert_ne!(msg1, msg2);
@@ -226,7 +226,7 @@ proptest! {
         let messages = generate(&template, seed, count).unwrap();
 
         for msg in &messages {
-            let bytes = hl7v2_core::write(msg);
+            let bytes = hl7v2::write(msg);
             prop_assert!(String::from_utf8(bytes).is_ok());
         }
     }


### PR DESCRIPTION
## Summary
- remove the remaining `hl7v2-core` dev-dependencies from synthetic compatibility crates
- switch corpus/template/gen tests to use the canonical `hl7v2` facade for parse/write/get/model types
- update `Cargo.lock` so these test-only edges no longer keep `hl7v2-core` in the synthetic test graph

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 test -p hl7v2-corpus --all-features`
- `cargo +1.93.0 test -p hl7v2-template --all-features`
- `cargo +1.93.0 test -p hl7v2-gen --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `git diff --check`