### PR TITLE
ci: skip bdd custom harnesses in coverage nextest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,10 +91,13 @@ jobs:
           set -euo pipefail
           cargo llvm-cov clean --workspace
 
+          # Cucumber BDD binaries use a custom harness and do not support
+          # nextest's libtest discovery protocol. Standard CI runs them.
           cargo llvm-cov nextest \
             --workspace \
             --locked \
             --all-features \
+            -E 'not binary(bdd_tests)' \
             --no-report
 
           cargo llvm-cov report --json --output-path coverage.json


### PR DESCRIPTION
## Summary
- filter `bdd_tests` custom-harness binaries out of the `cargo llvm-cov nextest` coverage pass
- document that those Cucumber BDD binaries remain covered by the standard CI lane
- keep the coverage command on workspace/all-features libtest-compatible coverage instead of broad test cleanup

## Why
Post-merge main after #421 failed Codecov Coverage because `cargo nextest` enumerates test binaries with `--list`, while the Cucumber `bdd_tests` binaries use `harness = false` and reject that libtest discovery argument.

## Validation
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 llvm-cov nextest --workspace --locked --all-features -E 'not binary(bdd_tests)' --no-report`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`