### PR TITLE
ci: write nonempty coverage summary artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -102,7 +102,7 @@ jobs:
 
           cargo llvm-cov report --json --output-path coverage.json
           cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov report --text | tee coverage.txt
+          cargo llvm-cov report --summary-only | tee coverage.txt
 
       - name: Validate coverage output
         run: |


### PR DESCRIPTION
## Summary
- write `coverage.txt` from `cargo llvm-cov report --summary-only`
- keep JSON and LCOV report generation unchanged

## Why
The post-merge coverage run after #422 passed the `nextest` coverage execution and generated `coverage.json` and `lcov.info`, but the `cargo llvm-cov report --text | tee coverage.txt` step left `coverage.txt` empty. The workflow validates `coverage.txt` as a receipt artifact, so it needs a report mode that reliably writes stdout.

## Validation
- `cargo +1.93.0 llvm-cov report --summary-only | Tee-Object -FilePath coverage.txt` produced a non-empty `coverage.txt`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`