### PR TITLE
ci: scope coverage reports to workspace packages

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -100,9 +100,18 @@ jobs:
             -E 'not binary(bdd_tests)' \
             --no-report
 
-          cargo llvm-cov report --json --output-path coverage.json
-          cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov report --summary-only | tee coverage.txt
+          mapfile -t coverage_packages < <(
+            cargo metadata --no-deps --format-version 1 |
+              python3 -c 'import json, sys; print("\n".join(package["name"] for package in json.load(sys.stdin)["packages"]))'
+          )
+          coverage_args=()
+          for package in "${coverage_packages[@]}"; do
+            coverage_args+=("-p" "$package")
+          done
+
+          cargo llvm-cov "${coverage_args[@]}" --all-features report --json --output-path coverage.json
+          cargo llvm-cov "${coverage_args[@]}" --all-features report --lcov --output-path lcov.info
+          cargo llvm-cov "${coverage_args[@]}" --all-features report --summary-only | tee coverage.txt
 
       - name: Validate coverage output
         run: |


### PR DESCRIPTION
## Summary
- derive coverage report package selectors from `cargo metadata`
- generate JSON, LCOV, and text summary reports for the workspace package set after the `llvm-cov nextest` run
- keep the existing `bdd_tests` custom-harness exclusion from the nextest discovery path

## Why
Post-merge Codecov after #423 proved that tests pass and `coverage.txt` is non-empty, but `lcov.info` still failed `test -s`. `cargo llvm-cov report` does not accept `--workspace`; without explicit `-p` package selectors, it reports only the root examples package and can produce empty LCOV. This makes the report phase follow the actual workspace coverage run.

## Validation
- package-selector report generation produced non-empty `coverage.json`, `lcov.info`, and `coverage.txt`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`