### PR TITLE
refactor: freeze hl7v2-json compatibility shim

### DIFF
--- a/crates/hl7v2-json/Cargo.toml
+++ b/crates/hl7v2-json/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-json"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
- mark `hl7v2-json` as `publish = false`
- keep the existing compatibility shim source and README unchanged
- freeze this old JSON microcrate as private now that JSON implementation lives under `hl7v2::writer::json`

## Validation
- `cargo +1.93.0 check -p hl7v2-json --all-targets`
- `cargo +1.93.0 test -p hl7v2-json`
- `cargo +1.93.0 check -p hl7v2 --no-default-features`
- `cargo +1.93.0 check -p hl7v2 --features json`
- `cargo +1.93.0 check -p hl7v2-json -p hl7v2-writer -p hl7v2-normalize -p hl7v2-datatype -p hl7v2-datetime --all-targets`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches --allow-dirty`