### PR TITLE
refactor: freeze collapsed compatibility shims

### DIFF
--- a/crates/hl7v2-ack/Cargo.toml
+++ b/crates/hl7v2-ack/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-ack"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-batch/Cargo.toml
+++ b/crates/hl7v2-batch/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-batch"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-core/Cargo.toml
+++ b/crates/hl7v2-core/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-core"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-corpus/Cargo.toml
+++ b/crates/hl7v2-corpus/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-corpus"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-datatype/Cargo.toml
+++ b/crates/hl7v2-datatype/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-datatype"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-datetime/Cargo.toml
+++ b/crates/hl7v2-datetime/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-datetime"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-faker/Cargo.toml
+++ b/crates/hl7v2-faker/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-faker"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-gen/Cargo.toml
+++ b/crates/hl7v2-gen/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-gen"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-guard/Cargo.toml
+++ b/crates/hl7v2-guard/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hl7v2-guard"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-lifecycle/Cargo.toml
+++ b/crates/hl7v2-lifecycle/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hl7v2-lifecycle"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-network/Cargo.toml
+++ b/crates/hl7v2-network/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-network"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-normalize/Cargo.toml
+++ b/crates/hl7v2-normalize/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-normalize"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-parser/Cargo.toml
+++ b/crates/hl7v2-parser/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-parser"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-path/Cargo.toml
+++ b/crates/hl7v2-path/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-path"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-prof/Cargo.toml
+++ b/crates/hl7v2-prof/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-prof"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-query/Cargo.toml
+++ b/crates/hl7v2-query/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-query"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-redact/Cargo.toml
+++ b/crates/hl7v2-redact/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hl7v2-redact"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-stream/Cargo.toml
+++ b/crates/hl7v2-stream/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-stream"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-template-values/Cargo.toml
+++ b/crates/hl7v2-template-values/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-template-values"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-template/Cargo.toml
+++ b/crates/hl7v2-template/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-template"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-validation/Cargo.toml
+++ b/crates/hl7v2-validation/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-validation"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/hl7v2-writer/Cargo.toml
+++ b/crates/hl7v2-writer/Cargo.toml
@@ -2,6 +2,7 @@
 readme = "README.md"
 name = "hl7v2-writer"
 version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,24 +2,20 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-06
+> **Last Updated**: 2026-05-07
 > **Project Status**: v1.2.0 current release; current `main` is tested and package-verified, but the real crates.io publish sequence has not been executed.
 
 ## Core Components
 
 | Crate | Status | Coverage | Notes |
 |-------|--------|----------|-------|
-| `hl7v2-core` | ✅ 100% | 92% | Canonical parser, writer, and MLLP framing. |
-| `hl7v2-model` | ✅ 100% | 100% | Core AST and domain models. |
-| `hl7v2-parser` | ✅ 100% | 95% | High-performance NOM-based parser. |
-| `hl7v2-writer` | ✅ 100% | 94% | Optimized HL7 serialization. |
-| `hl7v2-stream` | ✅ 100% | 88% | Event-based streaming parser for large messages. |
-| `hl7v2-query` | ✅ 100% | 90% | Path-based field extraction (MSH.3.1). |
-| `hl7v2-prof` | ✅ 100% | 85% | Conformance profile engine (Modularized). |
-| `hl7v2-validation` | ✅ 100% | 82% | Rule-based message validation. |
-| `hl7v2-gen` | ✅ 100% | 80% | Synthetic data and ACK generation. |
+| `hl7v2` | ✅ 100% | 92% | Canonical Rust library facade for parsing, writing, validation, transport, ACK, normalization, and generation. |
+| `hl7v2-model` | ✅ 100% | 100% | Temporary publishable implementation carrier for core AST and domain models until the foundation module collapse lands. |
+| `hl7v2-escape` | ✅ 100% | 90% | Temporary publishable implementation carrier for escape handling until the foundation module collapse lands. |
+| `hl7v2-mllp` | ✅ 100% | 90% | Temporary publishable implementation carrier for MLLP framing until the foundation module collapse lands. |
 | `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
+| compatibility shims | ✅ Package-frozen | N/A | Old microcrate package names are private deprecated shims unless explicitly retained for compatibility. |
 
 ## Feature Set (v1.2.0)
 
@@ -43,13 +39,13 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, and API Contracts were green on merge commit `6de37e0`.
-- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves 30 publishable crates.
-- ✅ **Dry-run publish**: Direct `cargo publish --dry-run --locked` is proven through `hl7v2-core`; workspace-patched dry-run verification proves crates 17-30 while the dependency chain is still unpublished. See `docs/audits/publish-dry-run-2026-05-06.md`.
+- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green on current `main`; API Contracts are unchanged unless contract files are touched.
+- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves 7 publishable crates: `hl7v2-model`, `hl7v2-escape`, `hl7v2-mllp`, `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current 7-crate publish graph while the dependency chain is still unpublished. See `docs/audits/publish-dry-run-2026-05-06.md` for the older pre-freeze proof.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Release v1.2.0 is tagged. Current main is tested and package-verified; the remaining release operation is the actual crates.io publish sequence.**
+**Release v1.2.0 is tagged. Current main is tested and package-verified; do not publish until the remaining foundation implementation carriers are collapsed or intentionally retained.**

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2780,17 +2780,35 @@ mod tests {
     fn publish_order_uses_workspace_dependency_order() -> Result<()> {
         let ordered = publish_order(None)?;
 
-        ensure_contains(&ordered, "hl7v2-core")?;
-        ensure_contains(&ordered, "hl7v2")?;
-        for synthetic_shim in [
+        for public_surface in ["hl7v2", "hl7v2-server", "hl7v2-cli", "hl7v2-python"] {
+            ensure_contains(&ordered, public_surface)?;
+        }
+        for frozen_shim in [
+            "hl7v2-ack",
+            "hl7v2-batch",
+            "hl7v2-core",
             "hl7v2-corpus",
+            "hl7v2-datatype",
+            "hl7v2-datetime",
             "hl7v2-faker",
             "hl7v2-gen",
+            "hl7v2-guard",
+            "hl7v2-json",
+            "hl7v2-lifecycle",
+            "hl7v2-network",
+            "hl7v2-normalize",
+            "hl7v2-parser",
+            "hl7v2-path",
+            "hl7v2-prof",
+            "hl7v2-query",
+            "hl7v2-redact",
+            "hl7v2-stream",
             "hl7v2-template",
             "hl7v2-template-values",
+            "hl7v2-validation",
+            "hl7v2-writer",
         ] {
-            ensure_contains(&ordered, synthetic_shim)?;
-            assert_dependency_precedes(&ordered, "hl7v2", synthetic_shim)?;
+            ensure_not_contains(&ordered, frozen_shim)?;
         }
         if ordered.iter().any(|crate_name| crate_name == "xtask") {
             return Err(anyhow!("xtask should not be publishable"));
@@ -2799,22 +2817,20 @@ mod tests {
         assert_dependency_precedes(&ordered, "hl7v2-model", "hl7v2")?;
         assert_dependency_precedes(&ordered, "hl7v2-escape", "hl7v2")?;
         assert_dependency_precedes(&ordered, "hl7v2-mllp", "hl7v2")?;
-        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-core")?;
-        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-prof")?;
-        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-validation")?;
-        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-ack")?;
-        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-datatype")?;
+        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-server")?;
+        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-cli")?;
+        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-python")?;
         Ok(())
     }
 
     #[test]
     fn publish_order_can_resume_from_a_named_crate() -> Result<()> {
         let ordered = publish_order(None)?;
-        let resumed = publish_order(Some("hl7v2-core"))?;
+        let resumed = publish_order(Some("hl7v2"))?;
         let start = ordered
             .iter()
-            .position(|crate_name| crate_name == "hl7v2-core")
-            .ok_or_else(|| anyhow!("hl7v2-core should be publishable"))?;
+            .position(|crate_name| crate_name == "hl7v2")
+            .ok_or_else(|| anyhow!("hl7v2 should be publishable"))?;
         let expected = ordered
             .get(start..)
             .ok_or_else(|| anyhow!("resume start is outside publish order"))?
@@ -2829,21 +2845,32 @@ mod tests {
     }
 
     #[test]
-    fn workspace_patch_dependencies_include_publishable_dev_dependencies() -> Result<()> {
+    fn workspace_patch_dependencies_exclude_private_shims() -> Result<()> {
         let metadata = MetadataCommand::new().exec()?;
         let packages = publishable_workspace_packages(&metadata);
-        let dependencies = internal_workspace_dependency_closure("hl7v2-parser", &packages)?;
+        let dependencies = internal_workspace_dependency_closure("hl7v2", &packages)?;
 
-        for dependency in ["hl7v2-query", "hl7v2-writer"] {
+        for dependency in ["hl7v2-model", "hl7v2-escape", "hl7v2-mllp"] {
             if !dependencies.contains(dependency) {
                 return Err(anyhow!(
                     "workspace patch dependency closure should include {dependency}"
                 ));
             }
         }
-        if dependencies.contains("hl7v2-test-utils") {
+        for excluded in ["hl7v2-parser", "hl7v2-query", "hl7v2-test-utils"] {
+            if dependencies.contains(excluded) {
+                return Err(anyhow!(
+                    "workspace patch dependency closure should exclude non-publishable crate {excluded}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_not_contains(ordered: &[String], crate_name: &str) -> Result<()> {
+        if ordered.iter().any(|name| name == crate_name) {
             return Err(anyhow!(
-                "workspace patch dependency closure should exclude non-publishable test utils"
+                "{crate_name} should not be present in publish order"
             ));
         }
         Ok(())


### PR DESCRIPTION
## Summary
- mark already-collapsed deprecated compatibility shims as `publish = false`
- update `xtask` publish-order tests for the reduced publishable surface
- refresh `docs/STATUS.md` so current status no longer claims a 30-crate publish surface

The remaining publishable workspace packages are now `hl7v2-model`, `hl7v2-escape`, `hl7v2-mllp`, `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`. The first three remain temporary implementation carriers until the foundation module collapse lands.

## Validation
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 test -p xtask`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 check --workspace --exclude hl7v2-python --all-features --all-targets`
- `cargo +1.93.0 package -p hl7v2-model --locked --allow-dirty`
- `cargo +1.93.0 package -p hl7v2-escape --locked --allow-dirty`
- `cargo +1.93.0 package -p hl7v2-mllp --locked --allow-dirty`
- `cargo +1.93.0 package -p hl7v2 --locked --allow-dirty`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2-model --workspace-patches --allow-dirty`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

Direct `cargo package` for `hl7v2-server` is still blocked until `hl7v2` is present in the crates.io index; the workspace-patched publish dry-run is the pre-publish proof for dependent crates.