### PR TITLE
docs: sync release readiness after crate collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Documentation
+
+- Clarified the post-collapse public package surface: `hl7v2`, `hl7v2-python`,
+  `hl7v2-server`, and `hl7v2-cli`.
+- Marked old implementation crate READMEs as private deprecated compatibility
+  shims and pointed new Rust users to `hl7v2` module paths.
+- Added the 2026-05-07 workspace-patched publish dry-run receipt for the final
+  four-crate package graph.
+
+---
+
 ## [1.3.0] - 2026-05-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
-    # Top-level name-claim crate
+    # Public library crate
     "crates/hl7v2",
-    # Microcrates (SRP-focused)
+    # Private deprecated compatibility shims for collapsed implementation modules
     "crates/hl7v2-model",
     "crates/hl7v2-escape",
     "crates/hl7v2-mllp",
@@ -20,20 +20,22 @@ members = [
     "crates/hl7v2-path",
     "crates/hl7v2-faker",
     "crates/hl7v2-corpus",
-    # Higher-level crates
+    # Private compatibility shims and feature-module test harnesses
     "crates/hl7v2-core",
     "crates/hl7v2-bench",
     "crates/hl7v2-prof",
     "crates/hl7v2-redact",
     "crates/hl7v2-lifecycle",
     "crates/hl7v2-guard",
-    "crates/hl7v2-python",
     "crates/hl7v2-template",
     "crates/hl7v2-template-values",
     "crates/hl7v2-gen",
     "crates/hl7v2-ack",
+    # Public wrapper and binding crates
+    "crates/hl7v2-python",
     "crates/hl7v2-cli",
     "crates/hl7v2-server",
+    # Internal test crates
     "crates/hl7v2-e2e-tests",
     # Testing utilities
     "crates/hl7v2-test-utils",
@@ -209,9 +211,6 @@ tonic = "0.12.3"
 prost = "0.13.5"
 tonic-build = "0.12.3"
 protoc-bin-vendored = "3"
-hl7v2-core = { version = "1.2.0", path = "crates/hl7v2-core" }
-hl7v2-model = { version = "1.2.0", path = "crates/hl7v2-model" }
-hl7v2-test-utils = { version = "1.2.0", path = "crates/hl7v2-test-utils" }
 
 # Example dependencies (workspace examples)
 [package]

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.0 (Stable / Rust 2024). For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.0 (Rust 2024). Current `main` is tested and package-verified, but the crates.io publish sequence has not been executed. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
 | Layer | Status | Evidence |
 | --- | --- | --- |
-| **Parser / Core** | Stable | Main CI, workspace tests, and contract checks green on `6de37e0` |
+| **Parser / Core** | Stable | Main CI, workspace tests, and contract checks green after the `hl7v2` facade and foundation-module collapse |
 | **Writer / Normalize** | Stable | Writer tests plus HTTP/gRPC normalization contract coverage |
 | **MLLP / Network** | Stable | MLLP parse/framing tests and CI matrix coverage |
 | **REST Server** | Stable | Runtime and OpenAPI agree for parse, validate, ACK, and normalize routes |
@@ -24,7 +24,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Not included in the local Python 3.14/PyO3 validation proof |
-| **Publish Readiness** | Package-verified | Direct registry-state dry-run is proven through `hl7v2-core`; workspace-patched dry-run verifies crates 17-30 |
+| **Publish Readiness** | Package-verified | Workspace-patched dry-run verifies the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli` |
 
 ## Features
 
@@ -37,40 +37,23 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 
 ## Crates
 
-The project is organized into focused microcrates following the Single Responsibility Principle:
+The public Rust package surface is intentionally small:
 
-### Foundation Layer
-- `hl7v2-model`: Core data types and message structure
-- `hl7v2-escape`: HL7 escape sequence handling
-- `hl7v2-mllp`: MLLP frame parsing and generation
-- `hl7v2-path`: Field path parsing and access
-- `hl7v2-datetime`: Date/time handling for HL7
+| Crate | Role |
+| --- | --- |
+| `hl7v2` | Canonical Rust library crate. Normal Rust users should depend on this crate. |
+| `hl7v2-server` | HTTP/gRPC runtime service with Axum, Tonic, metrics, auth, and deployment behavior. |
+| `hl7v2-cli` | Command-line binary distribution. |
+| `hl7v2-python` | PyO3/Python binding package. |
 
-### Parsing Layer
-- `hl7v2-parser`: Message parsing
-- `hl7v2-writer`: Message serialization
-- `hl7v2-stream`: Event-based streaming parser
-- `hl7v2-batch`: Batch file handling (BHS/BTS)
-- `hl7v2-datatype`: Data type validation
+Implementation boundaries live as modules under `hl7v2`, including
+`hl7v2::model`, `hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`,
+`hl7v2::transport`, `hl7v2::conformance`, `hl7v2::synthetic`,
+`hl7v2::lifecycle`, and `hl7v2::experimental`.
 
-### Network Layer
-- `hl7v2-network`: MLLP client/server/codec for TCP connections
-
-### Validation Layer
-- `hl7v2-prof`: Profile loading and management
-- `hl7v2-validation`: Validation logic and types
-
-### Generation Layer
-- `hl7v2-gen`: Template-based message generation
-- `hl7v2-ack`: ACK message generation
-- `hl7v2-faker`: Realistic test data generation
-
-### Application Layer
-- `hl7v2-cli`: Command-line interface
-- `hl7v2-server`: HTTP/REST API server
-
-### Facade
-- `hl7v2-core`: Convenience crate that re-exports common functionality
+Old implementation microcrate names are retained only as private deprecated
+compatibility shims unless a future compatibility release deliberately changes
+that policy. They are not the product surface for new code.
 
 ## Installation
 
@@ -184,7 +167,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 
 ## Key Features
 
-### Core Parsing (hl7v2-core)
+### Core Parsing (`hl7v2`)
 
 - **Fast, safe parsing**: Written in Rust with zero unsafe code in public APIs
 - **Event-based streaming parser**: Process HL7 messages as a sequence of events
@@ -194,7 +177,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 - **JSON serialization**: Convert messages to canonical JSON format
 - **Field path access**: Query message fields with path notation (e.g., "PID.5[1].1")
 
-### Profile Validation (hl7v2-prof)
+### Profile Validation (`hl7v2::conformance`)
 
 - **Profile inheritance**: Load and compose profiles with parent resolution and merging
 - **Comprehensive validation rules**:
@@ -208,7 +191,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 - **Local profile loading**: Load YAML-based profiles from files
 - **Flexible rule composition**: Merge profiles with child precedence
 
-### Synthetic Message Generation (hl7v2-gen)
+### Synthetic Message Generation (`hl7v2::synthetic`)
 
 - **Template-based generation**: Define message templates with variable value sources
 - **Realistic data generators**: Names (gender-aware), addresses, phone numbers, SSNs, MRNs, ICD-10, LOINC codes
@@ -217,14 +200,14 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 - **Error injection**: Generate invalid messages with segmentation/format errors for testing
 - **Corpus tools**: Generate collections with golden hash verification for test data reproducibility
 
-### CLI Interface (hl7v2-cli)
+### CLI Interface (`hl7v2-cli`)
 
 - **Unified command interface**: parse, normalize, validate, acknowledge, generate
 - **Input/output formats**: Raw HL7, JSON, MLLP framing
 - **Interactive mode**: Command-line REPL for exploratory use
 - **File I/O**: Read from files or stdin, write to files or stdout
 
-### HTTP/REST API Server (hl7v2-server)
+### HTTP/REST API Server (`hl7v2-server`)
 
 - **RESTful API**: Parse, validate, acknowledge, and normalize HL7 messages over HTTP
 - **Health & Readiness**: Production-ready health checks
@@ -240,55 +223,27 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for production deployment guide.
 
 ## Architecture
 
-The project uses a modular crate-based architecture organized into layers:
+The project uses one canonical Rust library crate with SRP modules inside it,
+plus separate runtime and binding wrappers:
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│                    Application Layer                          │
-│  ┌─────────────────┐  ┌─────────────────┐                   │
-│  │   hl7v2-cli     │  │  hl7v2-server   │                   │
-│  └─────────────────┘  └─────────────────┘                   │
-├──────────────────────────────────────────────────────────────┤
-│                    Generation Layer                           │
-│  ┌───────────┐ ┌────────────┐ ┌──────────────┐              │
-│  │ hl7v2-gen │ │ hl7v2-ack  │ │ hl7v2-faker  │              │
-│  └───────────┘ └────────────┘ └──────────────┘              │
-├──────────────────────────────────────────────────────────────┤
-│                   Validation Layer                            │
-│  ┌────────────┐ ┌─────────────────┐                         │
-│  │ hl7v2-prof │ │ hl7v2-validation│                         │
-│  └────────────┘ └─────────────────┘                         │
-├──────────────────────────────────────────────────────────────┤
-│                    Network Layer                              │
-│  ┌────────────────┐                                          │
-│  │ hl7v2-network  │  MLLP client/server/codec                │
-│  └────────────────┘                                          │
-├──────────────────────────────────────────────────────────────┤
-│                    Parsing Layer                              │
-│  ┌──────────────┐ ┌──────────────┐ ┌─────────────┐          │
-│  │ hl7v2-parser │ │ hl7v2-writer │ │ hl7v2-stream│          │
-│  └──────────────┘ └──────────────┘ └─────────────┘          │
-│  ┌──────────────┐ ┌───────────────┐                         │
-│  │ hl7v2-batch  │ │ hl7v2-datatype│                         │
-│  └──────────────┘ └───────────────┘                         │
-├──────────────────────────────────────────────────────────────┤
-│                   Foundation Layer                            │
-│  ┌────────────┐ ┌──────────────┐ ┌───────────┐ ┌──────────┐ │
-│  │hl7v2-model │ │ hl7v2-escape │ │hl7v2-mllp │ │hl7v2-path│ │
-│  └────────────┘ └──────────────┘ └───────────┘ └──────────┘ │
-│  ┌──────────────┐                                            │
-│  │ hl7v2-datetime│                                            │
-│  └──────────────┘                                            │
-├──────────────────────────────────────────────────────────────┤
-│                       Facade                                  │
-│  ┌────────────────────────────────────────────────────────┐  │
-│  │                    hl7v2-core                          │  │
-│  │        Re-exports common functionality for convenience │  │
-│  └────────────────────────────────────────────────────────┘  │
-└──────────────────────────────────────────────────────────────┘
+```text
+hl7v2
+  model, parser, writer, query, transport, conformance, synthetic,
+  batch, stream, ack, normalize, redact, lifecycle, experimental
+
+hl7v2-server
+  HTTP/gRPC service, metrics, auth, CORS, deployment/runtime config
+
+hl7v2-cli
+  command-line binary
+
+hl7v2-python
+  PyO3 binding package
 ```
 
-Each crate is independently usable as a library, enabling integration into other Rust projects. Use specific microcrates for minimal dependency footprints, or use `hl7v2-core` as a convenience facade.
+The deprecated compatibility crates re-export `hl7v2` modules and should not
+gain new behavior. See [ADR-015](docs/adr/0015-collapse-public-crate-surface.md)
+and [the module map](docs/architecture/module-map.md) for the migration policy.
 
 ## Performance Characteristics
 
@@ -305,12 +260,12 @@ For exact benchmark numbers and hardware, see [docs/STATUS.md](docs/STATUS.md).
 The parser uses a "zero-allocation where possible" approach rather than true zero-copy:
 
 - **Small messages**: Parsed in-place with minimal allocations
-- **Large messages**: Use the streaming parser ([`hl7v2-stream`](crates/hl7v2-stream)) for bounded memory usage
+- **Large messages**: Use `hl7v2::stream` for bounded memory usage
 - **Trade-off**: Safety and ergonomics are prioritized over raw performance
 
 ### Why not true zero-copy?
 
-The standard parser (`hl7v2-parser`) uses `Vec<u8>` internally for owned data, which provides:
+The standard parser (`hl7v2::parser`) uses `Vec<u8>` internally for owned data, which provides:
 - Safe lifetime management without complex borrow checker patterns
 - Ergonomic API that doesn't require managing input lifetimes
 - Ability to modify and re-serialize messages
@@ -318,13 +273,14 @@ The standard parser (`hl7v2-parser`) uses `Vec<u8>` internally for owned data, w
 For production use with large HL7 messages or memory-constrained environments, use the streaming parser with configured memory bounds:
 
 ```rust
-use hl7v2_stream::{StreamParser, ParserConfig};
+use std::io::{BufReader, Cursor};
+use hl7v2::stream::StreamParserBuilder;
 
-let config = ParserConfig {
-    max_message_size: 1024 * 1024,  // 1 MB limit
-    ..Default::default()
-};
-let parser = StreamParser::with_config(config);
+let hl7_bytes = b"MSH|^~\\&|App||Fac||20250128||ADT^A01|123|P|2.5.1\r";
+let reader = BufReader::new(Cursor::new(hl7_bytes));
+let parser = StreamParserBuilder::new()
+    .max_message_size(1024 * 1024)
+    .build(reader);
 ```
 
 ## HL7 Standards Compliance

--- a/crates/hl7v2-ack/README.md
+++ b/crates/hl7v2-ack/README.md
@@ -1,6 +1,10 @@
 # hl7v2-ack
 
-HL7 v2 ACK (Acknowledgment) message generation and processing.
+Deprecated compatibility crate for HL7 v2 ACK generation.
+Use `hl7v2::ack` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-batch/README.md
+++ b/crates/hl7v2-batch/README.md
@@ -1,6 +1,10 @@
 # hl7v2-batch
 
-HL7 v2 Batch (FHS/BHS) file processing and iteration.
+Deprecated compatibility crate for HL7 v2 batch file processing.
+Use `hl7v2::batch` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-corpus/README.md
+++ b/crates/hl7v2-corpus/README.md
@@ -1,6 +1,10 @@
 # hl7v2-corpus
 
-Management and storage of HL7 v2 message collections.
+Deprecated compatibility crate for synthetic HL7 v2 corpus helpers.
+Use `hl7v2::synthetic::corpus` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-datatype/README.md
+++ b/crates/hl7v2-datatype/README.md
@@ -1,6 +1,10 @@
 # hl7v2-datatype
 
-HL7 v2 primitive and composite data type definitions.
+Deprecated compatibility crate for HL7 v2 datatype validation.
+Use `hl7v2::conformance::datatype` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-datetime/README.md
+++ b/crates/hl7v2-datetime/README.md
@@ -1,6 +1,10 @@
 # hl7v2-datetime
 
-Specialized HL7 v2 date, time, and timestamp parsing.
+Deprecated compatibility crate for HL7 v2 date, time, and timestamp parsing.
+Use `hl7v2::conformance::datatype::datetime` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-escape/README.md
+++ b/crates/hl7v2-escape/README.md
@@ -1,6 +1,10 @@
 # hl7v2-escape
 
-HL7 v2 escape sequence encoding and decoding.
+Deprecated compatibility crate for HL7 v2 escape sequence handling.
+Use `hl7v2::escape` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-faker/README.md
+++ b/crates/hl7v2-faker/README.md
@@ -1,6 +1,10 @@
 # hl7v2-faker
 
-Generator for realistic, anonymized HL7 v2 test data.
+Deprecated compatibility crate for synthetic HL7 v2 faker helpers.
+Use `hl7v2::synthetic::faker` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-gen/README.md
+++ b/crates/hl7v2-gen/README.md
@@ -1,6 +1,10 @@
 # hl7v2-gen
 
-Code generation utilities for creating Rust models from HL7 v2 profiles.
+Deprecated compatibility crate for HL7 v2 synthetic generation helpers.
+Use `hl7v2::synthetic::generate` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-lifecycle/README.md
+++ b/crates/hl7v2-lifecycle/README.md
@@ -1,6 +1,9 @@
 # hl7v2-lifecycle
 
-Message archival, retention, and compliance management for HL7 v2 messages.
+Deprecated compatibility crate for HL7 v2 lifecycle helpers.
+Use `hl7v2::lifecycle` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 See [EFF-839](/EFF/issues/EFF-839) for full specification.
-

--- a/crates/hl7v2-mllp/README.md
+++ b/crates/hl7v2-mllp/README.md
@@ -1,6 +1,10 @@
 # hl7v2-mllp
 
-Implementation of the Minimal Lower Layer Protocol (MLLP) framing.
+Deprecated compatibility crate for HL7 v2 MLLP framing.
+Use `hl7v2::transport::mllp` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-model/README.md
+++ b/crates/hl7v2-model/README.md
@@ -1,6 +1,10 @@
 # hl7v2-model
 
-Core data structures representing HL7 v2 messages, segments, and fields.
+Deprecated compatibility crate for HL7 v2 model types.
+Use `hl7v2::model` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-normalize/README.md
+++ b/crates/hl7v2-normalize/README.md
@@ -1,6 +1,10 @@
 # hl7v2-normalize
 
-Utilities for normalizing HL7 v2 messages to a canonical form.
+Deprecated compatibility crate for HL7 v2 normalization helpers.
+Use `hl7v2::normalize` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-parser/README.md
+++ b/crates/hl7v2-parser/README.md
@@ -1,6 +1,10 @@
 # hl7v2-parser
 
-Fast and robust HL7 v2 message parser.
+Deprecated compatibility crate for HL7 v2 message parsing.
+Use `hl7v2::parser` or the top-level `hl7v2::parse` helpers for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-prof/README.md
+++ b/crates/hl7v2-prof/README.md
@@ -1,6 +1,10 @@
 # hl7v2-prof
 
-HL7 v2 message profile and conformance processing.
+Deprecated compatibility crate for HL7 v2 profile loading and validation.
+Use `hl7v2::conformance::profile` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-query/README.md
+++ b/crates/hl7v2-query/README.md
@@ -1,6 +1,10 @@
 # hl7v2-query
 
-HL7 v2 message querying and data extraction API.
+Deprecated compatibility crate for HL7 v2 message querying.
+Use `hl7v2::query` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-template-values/README.md
+++ b/crates/hl7v2-template-values/README.md
@@ -1,6 +1,10 @@
 # hl7v2-template-values
 
-Value generators and providers for HL7 v2 templates.
+Deprecated compatibility crate for HL7 v2 synthetic template values.
+Use `hl7v2::synthetic::values` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-template/README.md
+++ b/crates/hl7v2-template/README.md
@@ -1,6 +1,10 @@
 # hl7v2-template
 
-Template-based HL7 v2 message generation.
+Deprecated compatibility crate for HL7 v2 synthetic templates.
+Use `hl7v2::synthetic::template` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-validation/README.md
+++ b/crates/hl7v2-validation/README.md
@@ -1,6 +1,10 @@
 # hl7v2-validation
 
-Comprehensive HL7 v2 message, segment, and field validation.
+Deprecated compatibility crate for HL7 v2 validation primitives.
+Use `hl7v2::conformance::validation` for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/crates/hl7v2-writer/README.md
+++ b/crates/hl7v2-writer/README.md
@@ -1,6 +1,10 @@
 # hl7v2-writer
 
-HL7 v2 message serializer and writer.
+Deprecated compatibility crate for HL7 v2 message writing.
+Use `hl7v2::writer` or the top-level `hl7v2::write` helpers for new Rust code.
+
+This crate is private (`publish = false`) and re-exports the canonical
+`hl7v2` API. It should not gain new behavior.
 
 ## Usage
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -36,9 +36,9 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green on current `main`; API Contracts are unchanged unless contract files are touched.
+- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green on current `main` at `3482fd4`; API Contracts are unchanged unless contract files are touched.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. See `docs/audits/publish-dry-run-2026-05-06.md` for the older pre-freeze proof.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. See `docs/audits/publish-dry-run-2026-05-07.md`.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -2,6 +2,21 @@
 
 This document is the working map for collapsing implementation microcrates into modules under the canonical `hl7v2` Rust library crate. It implements the policy from [ADR-015](../adr/0015-collapse-public-crate-surface.md).
 
+## Current State
+
+As of 2026-05-07, the implementation modules have been collapsed into
+`hl7v2`, and `cargo run -p xtask -- publish-plan` resolves the final public
+package graph:
+
+- `hl7v2`
+- `hl7v2-python`
+- `hl7v2-server`
+- `hl7v2-cli`
+
+The old implementation package names remain in the workspace as private
+deprecated compatibility shims and test harnesses. They are retained only to
+prove old import paths while the compatibility policy is still active.
+
 ## Boundary Rule
 
 Crates are product and distribution surfaces. SRP implementation units are modules unless they require a separate release, package, binary, runtime service, or foreign-language binding boundary.

--- a/docs/audits/publish-dry-run-2026-05-07.md
+++ b/docs/audits/publish-dry-run-2026-05-07.md
@@ -1,0 +1,73 @@
+# Publish Dry-Run Receipt - 2026-05-07
+
+## Context
+
+This receipt records package verification after the foundation implementation
+carriers were collapsed into `hl7v2` at merge commit `3482fd4`.
+
+The old foundation package names are now private deprecated compatibility shims:
+
+- `hl7v2-model`
+- `hl7v2-escape`
+- `hl7v2-mllp`
+
+They are not part of the crates.io publish plan.
+
+## Commands
+
+Run locally on Windows:
+
+```powershell
+cargo +1.93.0 run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches --allow-dirty
+```
+
+`PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` is required on this machine because the
+local Python toolchain is newer than the PyO3 version in this workspace expects
+by default.
+
+## Publish Order
+
+`cargo +1.93.0 run -p xtask -- publish-plan` returned the final public package
+graph:
+
+| Order | Crate |
+| --- | --- |
+| 1 | `hl7v2` |
+| 2 | `hl7v2-python` |
+| 3 | `hl7v2-server` |
+| 4 | `hl7v2-cli` |
+
+## Dry-Run Result
+
+The workspace-patched dry run passed for all four packages:
+
+```text
+Dry-running hl7v2...
+Dry-running hl7v2-python...
+Dry-running hl7v2-server...
+Dry-running hl7v2-cli...
+Publish dry-run checks passed!
+```
+
+Package verification completed for:
+
+| Crate | Package size | Result |
+| --- | ---: | --- |
+| `hl7v2` | 732.2 KiB | Pass |
+| `hl7v2-python` | 69.1 KiB | Pass |
+| `hl7v2-server` | 287.4 KiB | Pass |
+| `hl7v2-cli` | 276.3 KiB | Pass |
+
+## Interpretation
+
+Current status is **package-verified**, not published.
+
+The workspace-patched dry run proves the package contents and verification build
+against the current unpublished workspace dependency chain. It is not a claim
+that crates are available in the public crates.io index, and it does not replace
+the final dependency-ordered `cargo publish --dry-run` immediately before a real
+publish.
+
+The real publish sequence has not been executed.


### PR DESCRIPTION
## Summary
- replace the root README's old microcrate product story with the final four-package surface
- mark stale compatibility crate READMEs as private deprecated shims that re-export `hl7v2` modules
- add the 2026-05-07 four-crate workspace-patched publish dry-run receipt and point status docs at it
- clean stale workspace dependency aliases that were no longer referenced

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 check --examples`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches --allow-dirty`

## Notes
- No runtime, OpenAPI, proto, schema, or compatibility-shim behavior changes.
- #380 remains parked.