### PR TITLE
docs: record final publish dry-run boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shims and pointed new Rust users to `hl7v2` module paths.
 - Added the 2026-05-07 workspace-patched publish dry-run receipt for the final
   four-crate package graph.
+- Recorded the direct crates.io dry-run result: `hl7v2` passes before publish,
+  while dependent crates correctly wait on `hl7v2` being present in the
+  crates.io index.
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -36,13 +36,13 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green on current `main` at `3482fd4`; API Contracts are unchanged unless contract files are touched.
+- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green on current `main` at `aafa0b0`; API Contracts are unchanged unless contract files are touched.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. See `docs/audits/publish-dry-run-2026-05-07.md`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-07.md`.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Release v1.2.0 is tagged. Current code is tested and package-verified; do not publish until post-merge CI/Coverage/Security/API Contracts and final crate dry-runs are green.**
+**Release v1.2.0 is tagged. Current code is tested and package-verified; publish must still run dependency-ordered final dry-runs and wait for each published dependency to appear in the crates.io index before publishing dependents.**

--- a/docs/audits/publish-dry-run-2026-05-07.md
+++ b/docs/audits/publish-dry-run-2026-05-07.md
@@ -3,7 +3,8 @@
 ## Context
 
 This receipt records package verification after the foundation implementation
-carriers were collapsed into `hl7v2` at merge commit `3482fd4`.
+carriers were collapsed into `hl7v2` at merge commit `3482fd4`, then refreshed
+after the release-readiness docs sync at `aafa0b0`.
 
 The old foundation package names are now private deprecated compatibility shims:
 
@@ -21,6 +22,10 @@ Run locally on Windows:
 cargo +1.93.0 run -p xtask -- publish-plan
 $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
 cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches --allow-dirty
+cargo +1.93.0 publish -p hl7v2 --dry-run
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 publish -p hl7v2-python --dry-run
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
 ```
 
 `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` is required on this machine because the
@@ -60,6 +65,38 @@ Package verification completed for:
 | `hl7v2-server` | 287.4 KiB | Pass |
 | `hl7v2-cli` | 276.3 KiB | Pass |
 
+## Direct crates.io Dry-Run Check
+
+`cargo +1.93.0 publish -p hl7v2 --dry-run` passed directly against the crates.io
+index:
+
+```text
+Packaging hl7v2 v1.2.0
+Packaged 56 files, 732.2KiB (140.0KiB compressed)
+Verifying hl7v2 v1.2.0
+Finished `dev` profile [unoptimized + debuginfo] target(s)
+Uploading hl7v2 v1.2.0
+warning: aborting upload due to dry run
+```
+
+The dependent crates reached packaging, then stopped at dependency resolution
+because `hl7v2 v1.2.0` is not published yet:
+
+```text
+error: failed to prepare local package for uploading
+
+Caused by:
+  no matching package named `hl7v2` found
+  location searched: crates.io index
+  required by package `hl7v2-python v1.2.0`
+```
+
+`hl7v2-server` and `hl7v2-cli` reported the same registry-resolution blocker.
+This is the expected pre-publish result for dependency-ordered crates.io
+packages, not a package-content failure. Their direct `cargo publish --dry-run`
+checks must be rerun after `hl7v2 v1.2.0` is published and visible in the
+crates.io index.
+
 ## Interpretation
 
 Current status is **package-verified**, not published.
@@ -67,7 +104,8 @@ Current status is **package-verified**, not published.
 The workspace-patched dry run proves the package contents and verification build
 against the current unpublished workspace dependency chain. It is not a claim
 that crates are available in the public crates.io index, and it does not replace
-the final dependency-ordered `cargo publish --dry-run` immediately before a real
-publish.
+the dependency-ordered direct `cargo publish --dry-run` checks during a real
+publish. The first direct dry-run now passes for `hl7v2`; direct dry-runs for
+dependent crates are gated on `hl7v2` being published first.
 
 The real publish sequence has not been executed.


### PR DESCRIPTION
## Summary

- refresh release-readiness docs to current main `aafa0b0`
- record that direct crates.io dry-run passes for `hl7v2`
- document the expected unpublished-root-crate blocker for `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`

## Validation

- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 publish -p hl7v2 --dry-run`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

Expected pre-publish registry blockers were also confirmed:

- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 publish -p hl7v2-python --dry-run`
- `cargo +1.93.0 publish -p hl7v2-server --dry-run`
- `cargo +1.93.0 publish -p hl7v2-cli --dry-run`

Those three package, then stop because `hl7v2 v1.2.0` is not yet present in the crates.io index. They must be rerun after `hl7v2` is published and indexed.