### PR TITLE
docs: align public surface references

### DIFF
--- a/crates/hl7v2/src/conformance/profile/mod.rs
+++ b/crates/hl7v2/src/conformance/profile/mod.rs
@@ -1,8 +1,8 @@
 //! Profile validation for HL7 v2 messages.
 //!
-//! This crate provides functionality for loading and applying
-//! conformance profiles to HL7 v2 messages. It builds on the
-//! `hl7v2-validation` crate for core validation logic.
+//! This module provides functionality for loading and applying
+//! conformance profiles to HL7 v2 messages. It builds on
+//! `hl7v2::conformance::validation` for core validation logic.
 
 #![expect(
     clippy::collapsible_if,
@@ -44,7 +44,7 @@
 //! let issues = validate(&message, &profile);
 //! ```
 
-// Re-export validation types for backward compatibility
+// Re-export validation types for compatibility with the old profile facade.
 pub use super::validation::{
     Issue, ParsedTimestamp, RuleAction, RuleCondition, Severity, TimestampPrecision,
     ValidationResult, Validator, check_rule_condition, compare_timestamps_for_before, get_nonempty,

--- a/crates/hl7v2/src/conformance/validation.rs
+++ b/crates/hl7v2/src/conformance/validation.rs
@@ -29,7 +29,7 @@
     clippy::indexing_slicing,
     clippy::string_slice,
     clippy::uninlined_format_args,
-    reason = "Pre-existing validation implementation debt moved from hl7v2-validation; cleanup is separate from this behavior-preserving module collapse."
+    reason = "Pre-existing validation implementation debt moved during module collapse; cleanup is separate from this behavior-preserving change."
 )]
 
 use crate::model::Message;

--- a/crates/hl7v2/src/conformance/validation/tests/mod.rs
+++ b/crates/hl7v2/src/conformance/validation/tests/mod.rs
@@ -1,6 +1,6 @@
-//! Test modules for hl7v2-validation crate.
+//! Test modules for `hl7v2::conformance::validation`.
 //!
-//! This module organizes all unit and property-based tests for the validation crate.
+//! This module organizes all unit and property-based tests for validation.
 
 pub mod property_tests;
 pub mod unit_tests;

--- a/crates/hl7v2/src/conformance/validation/tests/property_tests.rs
+++ b/crates/hl7v2/src/conformance/validation/tests/property_tests.rs
@@ -1,4 +1,4 @@
-//! Property-based tests for hl7v2-validation crate using proptest.
+//! Property-based tests for `hl7v2::conformance::validation` using proptest.
 //!
 //! These tests verify that:
 //! - Valid messages pass validation
@@ -10,7 +10,7 @@
     clippy::arithmetic_side_effects,
     clippy::string_slice,
     clippy::uninlined_format_args,
-    reason = "Pre-existing validation property test debt moved from hl7v2-validation; cleanup is separate from this behavior-preserving module collapse."
+    reason = "Pre-existing validation property test debt moved during module collapse; cleanup is separate from this behavior-preserving change."
 )]
 
 use super::super::{

--- a/crates/hl7v2/src/conformance/validation/tests/unit_tests.rs
+++ b/crates/hl7v2/src/conformance/validation/tests/unit_tests.rs
@@ -1,4 +1,4 @@
-//! Comprehensive unit tests for hl7v2-validation crate.
+//! Comprehensive unit tests for `hl7v2::conformance::validation`.
 //!
 //! Tests cover:
 //! - Data type validation (ST, ID, DT, TM, TS, NM, etc.)
@@ -11,7 +11,7 @@
 #![expect(
     clippy::expect_used,
     clippy::unwrap_used,
-    reason = "Pre-existing validation unit test panic-family debt moved from hl7v2-validation; cleanup is separate from this behavior-preserving module collapse."
+    reason = "Pre-existing validation unit test panic-family debt moved during module collapse; cleanup is separate from this behavior-preserving change."
 )]
 
 use super::super::{

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -3,9 +3,8 @@
 //! Canonical Rust API for HL7 v2 parsing, writing, validation, transport,
 //! acknowledgement, normalization, and generation.
 //!
-//! The implementation still lives in focused workspace crates during the
-//! crate-surface migration, but public Rust consumers should depend on this
-//! crate and import through `hl7v2`.
+//! The implementation lives in this crate as focused modules. Public Rust
+//! consumers should depend on this crate and import through `hl7v2`.
 //!
 //! ## Quick start
 //!

--- a/crates/hl7v2/src/transport/network/tests.rs
+++ b/crates/hl7v2/src/transport/network/tests.rs
@@ -1,4 +1,4 @@
-//! Comprehensive unit tests for hl7v2-network crate.
+//! Comprehensive unit tests for `hl7v2::transport::network`.
 //!
 //! This module contains unit tests for:
 //! - MLLP codec encoding/decoding

--- a/docs/MICROCRATE_ANALYSIS.md
+++ b/docs/MICROCRATE_ANALYSIS.md
@@ -1,5 +1,10 @@
 # HL7v2 Rust Project - SRP Microcrate Analysis
 
+> Historical note: this analysis records the earlier SRP microcrate extraction
+> phase. The current architecture has collapsed implementation crates back into
+> modules under the canonical `hl7v2` crate; see
+> [the module map](architecture/module-map.md) for the current public surface.
+
 ## Executive Summary
 
 This analysis identifies opportunities to extract microcrates from the existing HL7v2 Rust project to better adhere to the Single Responsibility Principle (SRP). The project already has a good foundation with 14 crates, but several crates contain multiple responsibilities that could be further decomposed.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -36,7 +36,7 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green on current `main` at `aafa0b0`; API Contracts are unchanged unless contract files are touched.
+- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green as of the 2026-05-07 release-readiness verification; API Contracts are unchanged unless contract files are touched.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-07.md`.
 

--- a/docs/TESTING_ARCHITECTURE.md
+++ b/docs/TESTING_ARCHITECTURE.md
@@ -2,7 +2,12 @@
 
 **Version:** 1.0  
 **Created:** 2026-02-24  
-**Status:** Design Document
+**Status:** Historical Design Document
+
+> Historical note: this document predates the crate-surface collapse and still
+> discusses the former microcrate topology. Current Rust examples should import
+> through the canonical `hl7v2` crate and module paths; see
+> [the module map](architecture/module-map.md) for the current public surface.
 
 ## Table of Contents
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ cargo run --example parsing_basics
 - Access segments and fields using path-based queries
 - Handle parsing errors properly
 
-**Dependencies:** `hl7v2-parser`, `hl7v2-core`
+**Dependencies:** `hl7v2`
 
 ```bash
 cargo run --example parsing_basics
@@ -37,7 +37,7 @@ cargo run --example parsing_basics
 - Set custom delimiters
 - Serialize the message to bytes
 
-**Dependencies:** `hl7v2-core`
+**Dependencies:** `hl7v2`
 
 ```bash
 cargo run --example message_building
@@ -51,7 +51,7 @@ cargo run --example message_building
 - Handle timeouts and errors
 - Configure connection parameters
 
-**Dependencies:** `hl7v2-mllp`, `hl7v2-network`, `hl7v2-parser`
+**Dependencies:** `hl7v2` with the `network` feature
 
 ```bash
 # Note: Requires a running MLLP server
@@ -70,7 +70,7 @@ cargo run --example mllp_client
 - Handle validation errors
 - Work with validation results
 
-**Dependencies:** `hl7v2-validation`, `hl7v2-prof`
+**Dependencies:** `hl7v2` with the `profile` feature
 
 ```bash
 cargo run --example validation_basics
@@ -84,7 +84,7 @@ cargo run --example validation_basics
 - Write results
 - Handle batch headers/trailers (FHS/BHS/FTS/BTS)
 
-**Dependencies:** `hl7v2-batch`, `hl7v2-parser`
+**Dependencies:** `hl7v2` with the `batch` feature
 
 ```bash
 cargo run --example batch_processing
@@ -98,7 +98,7 @@ cargo run --example batch_processing
 - Process messages as they're parsed
 - Memory-efficient processing
 
-**Dependencies:** `hl7v2-stream`, `hl7v2-parser`
+**Dependencies:** `hl7v2` with the `stream` feature
 
 ```bash
 cargo run --example streaming_parser
@@ -112,7 +112,7 @@ cargo run --example streaming_parser
 - Use various value sources (fixed, random, UUID, etc.)
 - Batch generation with deterministic seeds
 
-**Dependencies:** `hl7v2-template`, `hl7v2-template-values`
+**Dependencies:** `hl7v2` with the `synthetic` feature
 
 ```bash
 cargo run --example template_generation
@@ -126,7 +126,7 @@ cargo run --example template_generation
 - Include error details in rejection ACKs
 - All ACK code types (AA, AE, AR, CA, CE, CR)
 
-**Dependencies:** `hl7v2-ack`, `hl7v2-parser`
+**Dependencies:** `hl7v2` with the `ack` feature
 
 ```bash
 cargo run --example ack_generation
@@ -159,7 +159,7 @@ cargo run --example ack_generation
 All examples follow proper error handling practices. The recommended pattern is:
 
 ```rust
-use hl7v2_core::{parse, Error};
+use hl7v2::{parse, Error};
 
 fn process_message(bytes: &[u8]) -> Result<String, Error> {
     let message = parse(bytes)?;
@@ -173,7 +173,7 @@ fn process_message(bytes: &[u8]) -> Result<String, Error> {
 ### Path-Based Field Access
 
 ```rust
-use hl7v2_core::{parse, get};
+use hl7v2::{get, parse};
 
 let message = parse(hl7_bytes)?;
 let patient_name = get(&message, "PID.5.1");  // Family name
@@ -183,8 +183,7 @@ let mrn = get(&message, "PID.3.1");           // Patient ID
 ### ACK Generation
 
 ```rust
-use hl7v2_core::parse;
-use hl7v2_ack::{ack, AckCode};
+use hl7v2::{ack, parse, AckCode};
 
 let original = parse(hl7_bytes)?;
 let ack_message = ack(&original, AckCode::AA)?;
@@ -214,7 +213,7 @@ Some examples require specific features to be enabled:
 ```toml
 # Cargo.toml
 [dependencies]
-hl7v2-core = { version = "1.2.0", features = ["network", "stream"] }
+hl7v2 = { version = "1.2.0", features = ["network", "stream"] }
 ```
 
 - `network` - Enables MLLP client/server functionality
@@ -244,7 +243,7 @@ cargo run --package hl7v2-cli -- serve --port 2575
 Enable required features in your `Cargo.toml`:
 
 ```toml
-hl7v2-core = { version = "1.2.0", features = ["network"] }
+hl7v2 = { version = "1.2.0", features = ["network"] }
 ```
 
 ## Contributing

--- a/examples/mllp_client.rs
+++ b/examples/mllp_client.rs
@@ -1,7 +1,7 @@
 //! HL7 v2 MLLP Client Example
 //!
 //! This example demonstrates how to:
-//! - Connect to an MLLP server using the hl7v2-network crate
+//! - Connect to an MLLP server using `hl7v2::transport::network`
 //! - Send an HL7 message and receive an ACK response
 //! - Handle timeouts and connection errors
 //!

--- a/examples/profiles/README.md
+++ b/examples/profiles/README.md
@@ -1,6 +1,6 @@
 # HL7v2 Conformance Profile Examples
 
-This directory contains reference conformance profiles demonstrating the capabilities of the hl7v2-prof validation engine.
+This directory contains reference conformance profiles demonstrating the capabilities of the `hl7v2` conformance validation APIs.
 
 ## Quick Start
 
@@ -23,8 +23,7 @@ curl -X POST http://localhost:8080/hl7/validate \
 ### Using in Rust Code
 
 ```rust
-use hl7v2_prof::{load_profile, validate};
-use hl7v2_core::parse;
+use hl7v2::{load_profile, parse, validate};
 
 // Load profile
 let profile_yaml = std::fs::read_to_string("examples/profiles/ADT_A01.yaml")?;


### PR DESCRIPTION
## Summary

- update live examples and profile docs to point at the canonical `hl7v2` crate instead of old microcrate names
- refresh `hl7v2` crate/module comments now that implementations live under `hl7v2`
- mark old microcrate analysis/testing architecture docs as historical so they do not read as current topology guidance

## Validation

- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 check --examples`
- `cargo +1.93.0 run -p xtask -- check-lint-policy`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 publish -p hl7v2 --dry-run --allow-dirty`