### PR TITLE
ci: allow manual API contract verification

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,6 +1,7 @@
 name: API Contracts
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'api/**'


### PR DESCRIPTION
## Summary

- add `workflow_dispatch` to the API Contracts workflow for release-head verification
- keep existing path-filtered push and PR triggers unchanged
- leave OpenAPI, proto, schemas, profiles, and validation commands untouched

## Validation

- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`