### PR TITLE
docs: clarify registry publish boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.0 (Rust 2024). Current `main` is tested and package-verified, but the crates.io publish sequence has not been executed. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.0 package line (Rust 2024). Current `main` is tested and package-verified, but the final four-package crates.io publish sequence has not been executed. Some historical implementation microcrate artifacts already exist on crates.io; they are not the product surface for new code. The existing `v1.2.0` git tag predates the current release head, so tag/version alignment still belongs in the final publish procedure. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -51,9 +51,11 @@ Implementation boundaries live as modules under `hl7v2`, including
 `hl7v2::transport`, `hl7v2::conformance`, `hl7v2::synthetic`,
 `hl7v2::lifecycle`, and `hl7v2::experimental`.
 
-Old implementation microcrate names are retained only as private deprecated
-compatibility shims unless a future compatibility release deliberately changes
-that policy. They are not the product surface for new code.
+In this repository, old implementation microcrate names are retained only as
+private deprecated compatibility shims unless a future compatibility release
+deliberately changes that policy. Some historical `1.2.0` artifacts for old
+package names already exist on crates.io; those names are compatibility
+artifacts, not the product surface for new code.
 
 ## Installation
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-07
-> **Project Status**: v1.2.0 current release; current `main` is tested and package-verified, but the real crates.io publish sequence has not been executed.
+> **Project Status**: v1.2.0 package line; current `main` is tested and package-verified, but the final four-package crates.io publish sequence has not been executed.
 
 ## Core Components
 
@@ -12,7 +12,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2` | ✅ 100% | 92% | Canonical Rust library crate for parsing, writing, validation, transport framing, ACK, normalization, and generation. Foundation model, escape, and MLLP implementations now live here. |
 | `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
-| compatibility shims | ✅ Package-frozen | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are private deprecated shims unless explicitly retained for compatibility. |
+| compatibility shims | ✅ Package-frozen | N/A | In the current workspace, old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are private deprecated shims unless explicitly retained for compatibility. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
 ## Feature Set (v1.2.0)
 
@@ -36,13 +36,15 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, Extended, and Benchmarks are green as of the 2026-05-07 release-readiness verification; API Contracts are unchanged unless contract files are touched.
+- ✅ **Main workflows**: CI, Coverage, Security, Extended, Benchmarks, and API Contracts are green on the 2026-05-07 release-readiness head after manual API Contracts and Coverage dispatches.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-07.md`.
+- ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
+- ⚠️ **Tag alignment**: the existing `v1.2.0` tag points at an older commit, not the current release-readiness head. The final publish procedure must choose whether to retag, move to a new version, or otherwise document the release-head/tag relationship before uploading crates.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Release v1.2.0 is tagged. Current code is tested and package-verified; publish must still run dependency-ordered final dry-runs and wait for each published dependency to appear in the crates.io index before publishing dependents.**
+**Current code is tested and package-verified; publishing the final public package graph must still resolve the tag/version alignment, run dependency-ordered final dry-runs, and wait for each published dependency to appear in the crates.io index before publishing dependents.**

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -15,7 +15,10 @@ package graph:
 
 The old implementation package names remain in the workspace as private
 deprecated compatibility shims and test harnesses. They are retained only to
-prove old import paths while the compatibility policy is still active.
+prove old import paths while the compatibility policy is still active. Some old
+package names already have historical `1.2.0` artifacts on crates.io; the
+current workspace keeps those names `publish = false` and does not treat them
+as product surfaces for new code.
 
 ## Boundary Rule
 

--- a/docs/audits/publish-dry-run-2026-05-07.md
+++ b/docs/audits/publish-dry-run-2026-05-07.md
@@ -4,7 +4,8 @@
 
 This receipt records package verification after the foundation implementation
 carriers were collapsed into `hl7v2` at merge commit `3482fd4`, then refreshed
-after the release-readiness docs sync at `aafa0b0`.
+after the release-readiness docs sync at `aafa0b0` and the manual API Contracts
+release-dispatch gate at `e7ce6ca`.
 
 The old foundation package names are now private deprecated compatibility shims:
 
@@ -13,6 +14,41 @@ The old foundation package names are now private deprecated compatibility shims:
 - `hl7v2-mllp`
 
 They are not part of the crates.io publish plan.
+
+A live crates.io registry check on 2026-05-07 found that some old
+implementation package names already have historical `1.2.0` artifacts. Those
+artifacts predate the final four-package publish plan and cannot be described
+as private registry state. The current workspace keeps those names
+`publish = false` and treats them as compatibility artifacts, not product
+surfaces for new code.
+
+Historical old-name artifacts observed in the registry:
+
+```text
+hl7v2-batch
+hl7v2-datatype
+hl7v2-datetime
+hl7v2-escape
+hl7v2-faker
+hl7v2-json
+hl7v2-mllp
+hl7v2-model
+hl7v2-network
+hl7v2-normalize
+hl7v2-parser
+hl7v2-path
+hl7v2-query
+hl7v2-stream
+hl7v2-writer
+```
+
+The final product package names `hl7v2`, `hl7v2-server`, `hl7v2-cli`, and
+`hl7v2-python` were not present in the registry at the time of that check.
+
+The existing `v1.2.0` git tag points at older commit `1782d9a`, not the current
+release-readiness head `e7ce6ca`. The source tree remains on the `1.2.0`
+package line, but final publication still needs an explicit tag/version
+decision before upload.
 
 ## Commands
 
@@ -99,7 +135,8 @@ crates.io index.
 
 ## Interpretation
 
-Current status is **package-verified**, not published.
+Current status is **package-verified** for the final public package graph, not
+published for the final product package sequence.
 
 The workspace-patched dry run proves the package contents and verification build
 against the current unpublished workspace dependency chain. It is not a claim
@@ -108,4 +145,4 @@ the dependency-ordered direct `cargo publish --dry-run` checks during a real
 publish. The first direct dry-run now passes for `hl7v2`; direct dry-runs for
 dependent crates are gated on `hl7v2` being published first.
 
-The real publish sequence has not been executed.
+The final four-package publish sequence has not been executed.


### PR DESCRIPTION
## Summary
- clarify that the final four-package publish sequence has not run, while historical old microcrate artifacts already exist on crates.io
- document that old package names are compatibility artifacts and remain `publish = false` in the current workspace
- record the stale `v1.2.0` tag boundary so final publish has an explicit tag/version decision

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- live crates.io registry check for final package names and historical old-name artifacts