### PR TITLE
release: separate python binding from crates publish graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.0 package line (Rust 2024). Current `main` is tested and package-verified, but the final four-package crates.io publish sequence has not been executed. Some historical implementation microcrate artifacts already exist on crates.io; they are not the product surface for new code. The existing `v1.2.0` git tag predates the current release head, so tag/version alignment still belongs in the final publish procedure. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.0 package line (Rust 2024). Current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed. Some historical implementation microcrate artifacts already exist on crates.io; they are not the product surface for new code. The existing `v1.2.0` git tag predates the current release head, so tag/version alignment still belongs in the final publish procedure. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -24,7 +24,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Not included in the local Python 3.14/PyO3 validation proof |
-| **Publish Readiness** | Package-verified | Workspace-patched dry-run verifies the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli` |
+| **Publish Readiness** | Package-verified | Workspace-patched dry-run verifies the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`; Python remains a separate binding lane |
 
 ## Features
 
@@ -44,7 +44,7 @@ The public Rust package surface is intentionally small:
 | `hl7v2` | Canonical Rust library crate. Normal Rust users should depend on this crate. |
 | `hl7v2-server` | HTTP/gRPC runtime service with Axum, Tonic, metrics, auth, and deployment behavior. |
 | `hl7v2-cli` | Command-line binary distribution. |
-| `hl7v2-python` | PyO3/Python binding package. |
+| `hl7v2-python` | PyO3/Python binding package; held out of the crates.io Rust publish graph for the Python packaging lane. |
 
 Implementation boundaries live as modules under `hl7v2`, including
 `hl7v2::model`, `hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`,
@@ -240,7 +240,7 @@ hl7v2-cli
   command-line binary
 
 hl7v2-python
-  PyO3 binding package
+  PyO3 binding package; released through the Python packaging lane
 ```
 
 The deprecated compatibility crates re-export `hl7v2` modules and should not

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [lib]
 name = "hl7v2"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-07
-> **Project Status**: v1.2.0 package line; current `main` is tested and package-verified, but the final four-package crates.io publish sequence has not been executed.
+> **Project Status**: v1.2.0 package line; current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed.
 
 ## Core Components
 
@@ -12,6 +12,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2` | ✅ 100% | 92% | Canonical Rust library crate for parsing, writing, validation, transport framing, ACK, normalization, and generation. Foundation model, escape, and MLLP implementations now live here. |
 | `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
+| `hl7v2-python` | 🟡 Experimental | N/A | PyO3 binding package held out of the crates.io Rust publish graph; validate through the Python/maturin lane before release. |
 | compatibility shims | ✅ Package-frozen | N/A | In the current workspace, old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are private deprecated shims unless explicitly retained for compatibility. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
 ## Feature Set (v1.2.0)
@@ -37,8 +38,9 @@ This document provides a transparent view of which features are fully implemente
 ## Release and Publish Readiness
 
 - ✅ **Main workflows**: CI, Coverage, Security, Extended, Benchmarks, and API Contracts are green on the 2026-05-07 release-readiness head after manual API Contracts and Coverage dispatches.
-- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final public package graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current public package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-07.md`.
+- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current Rust package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-07.md`.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io and should be verified with Python packaging tooling before PyPI or wheel release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ⚠️ **Tag alignment**: the existing `v1.2.0` tag points at an older commit, not the current release-readiness head. The final publish procedure must choose whether to retag, move to a new version, or otherwise document the release-head/tag relationship before uploading crates.
 
@@ -47,4 +49,4 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current code is tested and package-verified; publishing the final public package graph must still resolve the tag/version alignment, run dependency-ordered final dry-runs, and wait for each published dependency to appear in the crates.io index before publishing dependents.**
+**Current code is tested and package-verified; publishing the final Rust package graph must still resolve the tag/version alignment, run dependency-ordered final dry-runs, and wait for each published dependency to appear in the crates.io index before publishing dependents.**

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -5,13 +5,16 @@ This document is the working map for collapsing implementation microcrates into 
 ## Current State
 
 As of 2026-05-07, the implementation modules have been collapsed into
-`hl7v2`, and `cargo run -p xtask -- publish-plan` resolves the final public
+`hl7v2`, and `cargo run -p xtask -- publish-plan` resolves the final Rust
 package graph:
 
 - `hl7v2`
-- `hl7v2-python`
 - `hl7v2-server`
 - `hl7v2-cli`
+
+`hl7v2-python` remains an external binding package in the workspace, but it is
+not part of the crates.io Rust publish graph. It is released through the
+separate Python packaging lane.
 
 The old implementation package names remain in the workspace as private
 deprecated compatibility shims and test harnesses. They are retained only to
@@ -31,7 +34,7 @@ Crates are product and distribution surfaces. SRP implementation units are modul
 | `hl7v2` | Canonical Rust library crate | Owns the core HL7 API and implementation modules. |
 | `hl7v2-server` | HTTP/gRPC runtime service | Depends on `hl7v2` with runtime features; keeps Axum, Tonic, metrics, auth, CORS, and deployment config. |
 | `hl7v2-cli` | Binary distribution | Depends on `hl7v2` with CLI-needed features. |
-| `hl7v2-python` | Python binding package | Depends on `hl7v2`; keeps PyO3 isolated. |
+| `hl7v2-python` | Python binding package | Depends on `hl7v2`; keeps PyO3 isolated and uses `publish = false` for the crates.io Rust publish graph. |
 
 ## Target Internal Crates
 
@@ -75,7 +78,7 @@ Crates are product and distribution surfaces. SRP implementation units are modul
 | `hl7v2-guard` | `hl7v2::experimental::guard` | Collapsed as leaf experimental feature module | `hl7v2-guard` remains a compatibility shim; do not present guard as stable until semantics are proven. |
 | `hl7v2-server` | `crates/hl7v2-server` | Public crate | Keep external. |
 | `hl7v2-cli` | `crates/hl7v2-cli` | Public crate | Keep external. |
-| `hl7v2-python` | `crates/hl7v2-python` | Public crate | Keep external. |
+| `hl7v2-python` | `crates/hl7v2-python` | Separate binding lane | Keep external; release with Python packaging tooling, not crates.io by default. |
 | `hl7v2-bench` | root `benches/` or private crate | Internal | Prefer root benches; keep private crate only if needed. |
 | `hl7v2-e2e-tests` | `crates/hl7v2-e2e-tests` | Internal | Keep or later move to workspace tests. |
 | `hl7v2-test-utils` | `crates/hl7v2-test-utils` or `tests/support` | Internal | Keep until shared helpers can move safely. |

--- a/docs/audits/publish-dry-run-2026-05-07.md
+++ b/docs/audits/publish-dry-run-2026-05-07.md
@@ -4,8 +4,8 @@
 
 This receipt records package verification after the foundation implementation
 carriers were collapsed into `hl7v2` at merge commit `3482fd4`, then refreshed
-after the release-readiness docs sync at `aafa0b0` and the manual API Contracts
-release-dispatch gate at `e7ce6ca`.
+after the release-readiness docs sync, the manual API Contracts release-dispatch
+gate, and the Python binding lane separation.
 
 The old foundation package names are now private deprecated compatibility shims:
 
@@ -17,8 +17,8 @@ They are not part of the crates.io publish plan.
 
 A live crates.io registry check on 2026-05-07 found that some old
 implementation package names already have historical `1.2.0` artifacts. Those
-artifacts predate the final four-package publish plan and cannot be described
-as private registry state. The current workspace keeps those names
+artifacts predate the final Rust publish plan and cannot be described as
+private registry state. The current workspace keeps those names
 `publish = false` and treats them as compatibility artifacts, not product
 surfaces for new code.
 
@@ -42,13 +42,15 @@ hl7v2-stream
 hl7v2-writer
 ```
 
-The final product package names `hl7v2`, `hl7v2-server`, `hl7v2-cli`, and
-`hl7v2-python` were not present in the registry at the time of that check.
+The final Rust product package names `hl7v2`, `hl7v2-server`, and `hl7v2-cli`
+were not present in the registry at the time of that check. `hl7v2-python` was
+also absent, and is now held out of the crates.io Rust publish graph for the
+separate Python binding lane.
 
 The existing `v1.2.0` git tag points at older commit `1782d9a`, not the current
-release-readiness head `e7ce6ca`. The source tree remains on the `1.2.0`
-package line, but final publication still needs an explicit tag/version
-decision before upload.
+release-readiness head. The source tree remains on the `1.2.0` package line,
+but final publication still needs an explicit tag/version decision before
+upload.
 
 ## Commands
 
@@ -56,37 +58,33 @@ Run locally on Windows:
 
 ```powershell
 cargo +1.93.0 run -p xtask -- publish-plan
-$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
-cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches --allow-dirty
+cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches
 cargo +1.93.0 publish -p hl7v2 --dry-run
-$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 publish -p hl7v2-python --dry-run
 cargo +1.93.0 publish -p hl7v2-server --dry-run
 cargo +1.93.0 publish -p hl7v2-cli --dry-run
 ```
 
-`PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` is required on this machine because the
-local Python toolchain is newer than the PyO3 version in this workspace expects
-by default.
+`PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` is required on this machine only when
+checking the Python binding lane, because the local Python toolchain is newer
+than the PyO3 version in this workspace expects by default.
 
 ## Publish Order
 
-`cargo +1.93.0 run -p xtask -- publish-plan` returned the final public package
+`cargo +1.93.0 run -p xtask -- publish-plan` returned the final Rust package
 graph:
 
 | Order | Crate |
 | --- | --- |
 | 1 | `hl7v2` |
-| 2 | `hl7v2-python` |
-| 3 | `hl7v2-server` |
-| 4 | `hl7v2-cli` |
+| 2 | `hl7v2-server` |
+| 3 | `hl7v2-cli` |
 
 ## Dry-Run Result
 
-The workspace-patched dry run passed for all four packages:
+The workspace-patched dry run passed for the Rust publish graph:
 
 ```text
 Dry-running hl7v2...
-Dry-running hl7v2-python...
 Dry-running hl7v2-server...
 Dry-running hl7v2-cli...
 Publish dry-run checks passed!
@@ -96,9 +94,8 @@ Package verification completed for:
 
 | Crate | Package size | Result |
 | --- | ---: | --- |
-| `hl7v2` | 732.2 KiB | Pass |
-| `hl7v2-python` | 69.1 KiB | Pass |
-| `hl7v2-server` | 287.4 KiB | Pass |
+| `hl7v2` | 732.1 KiB | Pass |
+| `hl7v2-server` | 287.3 KiB | Pass |
 | `hl7v2-cli` | 276.3 KiB | Pass |
 
 ## Direct crates.io Dry-Run Check
@@ -124,10 +121,10 @@ error: failed to prepare local package for uploading
 Caused by:
   no matching package named `hl7v2` found
   location searched: crates.io index
-  required by package `hl7v2-python v1.2.0`
+  required by package `hl7v2-server v1.2.0`
 ```
 
-`hl7v2-server` and `hl7v2-cli` reported the same registry-resolution blocker.
+`hl7v2-cli` reported the same registry-resolution blocker.
 This is the expected pre-publish result for dependency-ordered crates.io
 packages, not a package-content failure. Their direct `cargo publish --dry-run`
 checks must be rerun after `hl7v2 v1.2.0` is published and visible in the
@@ -135,7 +132,7 @@ crates.io index.
 
 ## Interpretation
 
-Current status is **package-verified** for the final public package graph, not
+Current status is **package-verified** for the final Rust package graph, not
 published for the final product package sequence.
 
 The workspace-patched dry run proves the package contents and verification build
@@ -145,4 +142,4 @@ the dependency-ordered direct `cargo publish --dry-run` checks during a real
 publish. The first direct dry-run now passes for `hl7v2`; direct dry-runs for
 dependent crates are gated on `hl7v2` being published first.
 
-The final four-package publish sequence has not been executed.
+The final Rust publish sequence has not been executed.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2780,9 +2780,10 @@ mod tests {
     fn publish_order_uses_workspace_dependency_order() -> Result<()> {
         let ordered = publish_order(None)?;
 
-        for public_surface in ["hl7v2", "hl7v2-server", "hl7v2-cli", "hl7v2-python"] {
+        for public_surface in ["hl7v2", "hl7v2-server", "hl7v2-cli"] {
             ensure_contains(&ordered, public_surface)?;
         }
+        ensure_not_contains(&ordered, "hl7v2-python")?;
         for frozen_shim in [
             "hl7v2-ack",
             "hl7v2-batch",
@@ -2819,7 +2820,6 @@ mod tests {
 
         assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-server")?;
         assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-cli")?;
-        assert_dependency_precedes(&ordered, "hl7v2", "hl7v2-python")?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- mark `hl7v2-python` as `publish = false` so the crates.io publish graph is Rust-only
- update xtask publish-order tests to expect `hl7v2`, `hl7v2-server`, and `hl7v2-cli`
- update README/status/module-map/publish receipt language to treat Python as a separate binding lane

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 test -p xtask`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check -p hl7v2-python --all-features`
- `cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `cargo +1.93.0 publish -p hl7v2 --dry-run`
- `cargo +1.93.0 publish -p hl7v2-server --dry-run` stops at expected pre-index `hl7v2` dependency boundary
- `cargo +1.93.0 publish -p hl7v2-cli --dry-run` stops at expected pre-index `hl7v2` dependency boundary