### PR TITLE
release: bump package line to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.2.1] - 2026-05-08
+
+### Release
+
+- Moved the package line to `1.2.1` so the final Rust publish can use a fresh
+  release tag instead of reusing the historical `v1.2.0` tag.
+
 ### Documentation
 
 - Clarified the post-collapse public package surface: `hl7v2`, `hl7v2-python`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-lock",
  "bytes",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-ack"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-batch"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-bench"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "criterion 0.8.2",
  "futures",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-corpus"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
  "proptest",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-datatype"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "cucumber",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-datetime"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "cucumber",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-e2e-tests"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-escape"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-examples"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "hl7v2",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-faker"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-gen"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1733,14 +1733,14 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-guard"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
 ]
 
 [[package]]
 name = "hl7v2-json"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1751,14 +1751,14 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-lifecycle"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
 ]
 
 [[package]]
 name = "hl7v2-mllp"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-model"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
  "serde_json",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-network"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bytes",
  "hl7v2",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-normalize"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-parser"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_matches",
  "cucumber",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-path"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-prof"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
  "hl7v2-parser",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-python"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
  "pyo3",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-query"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1859,14 +1859,14 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-redact"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
 ]
 
 [[package]]
 name = "hl7v2-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum 0.8.9",
  "cucumber",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-stream"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "criterion 0.5.1",
  "hl7v2",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-template"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2",
  "proptest",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-template-values"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hl7v2-model",
  "hl7v2-parser",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-validation"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_matches",
  "cucumber",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-writer"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cucumber",
  "hl7v2",
@@ -6011,7 +6011,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.93"
 
@@ -220,7 +220,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "crates/hl7v2", features = [
+hl7v2 = { version = "1.2.1", path = "crates/hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.0 package line (Rust 2024). Current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed. Some historical implementation microcrate artifacts already exist on crates.io; they are not the product surface for new code. The existing `v1.2.0` git tag predates the current release head, so tag/version alignment still belongs in the final publish procedure. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.1 package line (Rust 2024). Current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed. Some historical implementation microcrate artifacts already exist on crates.io; they are not the product surface for new code. The existing `v1.2.0` git tag predates the current release head and remains historical; the next release should publish from a fresh `v1.2.1` tag after final dry-runs. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -31,7 +31,7 @@ Update the `version` field in the root `Cargo.toml`. Since we use workspace inhe
 
 ```toml
 [workspace.package]
-version = "1.2.0"
+version = "<version>"
 ```
 
 ### 2. Update Changelog
@@ -52,8 +52,8 @@ cargo build --workspace --release
 Create a git tag for the new version.
 
 ```bash
-git tag -a v1.2.0 -m "Release v1.2.0"
-git push origin v1.2.0
+git tag -a v<version> -m "Release v<version>"
+git push origin v<version>
 ```
 
 ### 5. Publish to Crates.io
@@ -71,7 +71,7 @@ cargo run -p xtask -- publish --yes
 cargo run -p xtask -- publish --yes --from hl7v2-template-values
 ```
 
-The publish sequence excludes non-published workspace members such as `hl7v2-bench`, `hl7v2-test-utils`, `hl7v2-e2e-tests`, `xtask`, and the root `hl7v2-examples` package.
+The publish sequence excludes non-published workspace members such as `hl7v2-python`, `hl7v2-bench`, `hl7v2-test-utils`, `hl7v2-e2e-tests`, `xtask`, and the root `hl7v2-examples` package.
 
 For GitHub Actions based releases, use the manual `Publish to crates.io` workflow. It prints the derived order first and only publishes when `execute=true` is selected and the `CARGO_REGISTRY_TOKEN` secret is configured.
 

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.2.0
+  version: 1.2.1
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-ack/Cargo.toml
+++ b/crates/hl7v2-ack/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "ack",
 ] }
 

--- a/crates/hl7v2-batch/Cargo.toml
+++ b/crates/hl7v2-batch/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "batch", "file", "processing"]
 categories = ["parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "batch",
 ] }
 

--- a/crates/hl7v2-bench/Cargo.toml
+++ b/crates/hl7v2-bench/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "parsing"]
 
 [dependencies]
 # Library surface under benchmark
-hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml.workspace = true
-hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
@@ -26,7 +26,7 @@ hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [
     "network",
     "synthetic",
 ] }
-hl7v2-server = { version = "1.2.0", path = "../hl7v2-server" }
+hl7v2-server = { version = "1.2.1", path = "../hl7v2-server" }
 sysinfo = "0.38.2"
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/hl7v2-core/Cargo.toml
+++ b/crates/hl7v2-core/Cargo.toml
@@ -19,7 +19,7 @@ network = ["hl7v2/network"]
 stream = ["hl7v2/stream"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2" }
+hl7v2 = { version = "1.2.1", path = "../hl7v2" }
 
 [dev-dependencies]
 cucumber = "0.22.1"

--- a/crates/hl7v2-core/README.md
+++ b/crates/hl7v2-core/README.md
@@ -6,7 +6,7 @@ Use the `hl7v2` crate for new Rust code:
 
 ```toml
 [dependencies]
-hl7v2 = "1.2.0"
+hl7v2 = "1.2.1"
 ```
 
 `hl7v2-core` is retained temporarily as a deprecated compatibility shim over

--- a/crates/hl7v2-corpus/Cargo.toml
+++ b/crates/hl7v2-corpus/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "synthetic",
 ] }
 

--- a/crates/hl7v2-datatype/Cargo.toml
+++ b/crates/hl7v2-datatype/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "datatype", "validation"]
 categories = ["parser-implementations", "encoding"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = ["profile"] }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = ["profile"] }
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/crates/hl7v2-datetime/Cargo.toml
+++ b/crates/hl7v2-datetime/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "datetime", "date", "time"]
 categories = ["date-and-time", "parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = ["profile"] }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = ["profile"] }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/hl7v2-e2e-tests/Cargo.toml
+++ b/crates/hl7v2-e2e-tests/Cargo.toml
@@ -12,15 +12,15 @@ repository.workspace = true
 
 [dependencies]
 # Local crates - full system integration
-hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
     "stream",
     "network",
 ] }
-hl7v2-test-utils = { version = "1.2.0", path = "../hl7v2-test-utils" }
-hl7v2-server = { version = "1.2.0", path = "../hl7v2-server" }
+hl7v2-test-utils = { version = "1.2.1", path = "../hl7v2-test-utils" }
+hl7v2-server = { version = "1.2.1", path = "../hl7v2-server" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/hl7v2-escape/Cargo.toml
+++ b/crates/hl7v2-escape/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "escape", "encoding"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }

--- a/crates/hl7v2-faker/Cargo.toml
+++ b/crates/hl7v2-faker/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "faker", "test-data", "mock"]
 categories = ["development-tools::testing", "parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "synthetic",
 ] }
 

--- a/crates/hl7v2-gen/Cargo.toml
+++ b/crates/hl7v2-gen/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "synthetic",
 ] }
 
@@ -24,9 +24,9 @@ rand = "0.10.0"
 cucumber = "0.22.1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
-hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
-hl7v2-normalize = { version = "1.2.0", path = "../hl7v2-normalize" }
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
+hl7v2-query = { version = "1.2.1", path = "../hl7v2-query" }
+hl7v2-normalize = { version = "1.2.1", path = "../hl7v2-normalize" }
+hl7v2-parser = { version = "1.2.1", path = "../hl7v2-parser" }
 
 [[test]]
 name = "bdd_tests"

--- a/crates/hl7v2-guard/Cargo.toml
+++ b/crates/hl7v2-guard/Cargo.toml
@@ -13,4 +13,4 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = ["experimental-guard"] }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = ["experimental-guard"] }

--- a/crates/hl7v2-json/Cargo.toml
+++ b/crates/hl7v2-json/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "json", "serialization"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/hl7v2-lifecycle/Cargo.toml
+++ b/crates/hl7v2-lifecycle/Cargo.toml
@@ -13,4 +13,4 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = ["lifecycle"] }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = ["lifecycle"] }

--- a/crates/hl7v2-mllp/Cargo.toml
+++ b/crates/hl7v2-mllp/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "mllp", "protocol", "framing"]
 categories = ["network-programming", "encoding"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }

--- a/crates/hl7v2-model/Cargo.toml
+++ b/crates/hl7v2-model/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "data-model"]
 categories = ["data-structures", "encoding"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/hl7v2-network/Cargo.toml
+++ b/crates/hl7v2-network/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "network",
 ] }
 

--- a/crates/hl7v2-network/fuzz/Cargo.toml
+++ b/crates/hl7v2-network/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "1.11.1"
 tokio-util = { version = "0.7.18", features = ["codec"] }
 
 # The crate being fuzzed
-hl7v2-network = { version = "1.2.0", path = ".." }
+hl7v2-network = { version = "1.2.1", path = ".." }
 
 [[bin]]
 name = "mllp_codec"

--- a/crates/hl7v2-normalize/Cargo.toml
+++ b/crates/hl7v2-normalize/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "normalize", "canonical"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "normalize",
 ] }
 

--- a/crates/hl7v2-parser/Cargo.toml
+++ b/crates/hl7v2-parser/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["hl7", "healthcare", "parser"]
 categories = ["parser-implementations", "encoding"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
-hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
-hl7v2-escape = { version = "1.2.0", path = "../hl7v2-escape" }
-hl7v2-mllp = { version = "1.2.0", path = "../hl7v2-mllp" }
-hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
+hl7v2-model = { version = "1.2.1", path = "../hl7v2-model" }
+hl7v2-escape = { version = "1.2.1", path = "../hl7v2-escape" }
+hl7v2-mllp = { version = "1.2.1", path = "../hl7v2-mllp" }
+hl7v2-query = { version = "1.2.1", path = "../hl7v2-query" }
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 hl7v2-writer = { path = "../hl7v2-writer" }
 proptest = "1.6"

--- a/crates/hl7v2-parser/fuzz/Cargo.toml
+++ b/crates/hl7v2-parser/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-hl7v2-parser = { version = "1.2.0", path = ".." }
-hl7v2-model = { version = "1.2.0", path = "../../hl7v2-model" }
+hl7v2-parser = { version = "1.2.1", path = ".." }
+hl7v2-model = { version = "1.2.1", path = "../../hl7v2-model" }
 
 [[bin]]
 name = "parse_message"

--- a/crates/hl7v2-path/Cargo.toml
+++ b/crates/hl7v2-path/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hl7", "healthcare", "path", "field", "access"]
 categories = ["parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
 proptest = "1.6"

--- a/crates/hl7v2-prof/Cargo.toml
+++ b/crates/hl7v2-prof/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "profile-core",
 ] }
 
@@ -23,7 +23,7 @@ default = ["persistent-cache"]
 persistent-cache = ["hl7v2/persistent-cache"]
 
 [dev-dependencies]
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
+hl7v2-parser = { version = "1.2.1", path = "../hl7v2-parser" }
 serde_yaml = { workspace = true }
 tempfile = "3.26.0"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "fs"] }

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-query/Cargo.toml
+++ b/crates/hl7v2-query/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["hl7", "healthcare", "query", "path"]
 categories = ["parser-implementations", "encoding"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
-hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
+hl7v2-model = { version = "1.2.1", path = "../hl7v2-model" }
 proptest = "1.6"
 hl7v2-parser = { path = "../hl7v2-parser" }
 cucumber = "0.22.1"

--- a/crates/hl7v2-redact/Cargo.toml
+++ b/crates/hl7v2-redact/Cargo.toml
@@ -13,4 +13,4 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = ["redact"] }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = ["redact"] }

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 
 [dependencies]
 # Local crates
-hl7v2 = { version = "1.2.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.2.0
+  version: 1.2.1
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-stream/Cargo.toml
+++ b/crates/hl7v2-stream/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "stream",
 ] }
 

--- a/crates/hl7v2-template-values/Cargo.toml
+++ b/crates/hl7v2-template-values/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "synthetic",
 ] }
 

--- a/crates/hl7v2-template-values/fuzz/Cargo.toml
+++ b/crates/hl7v2-template-values/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 cargo-fuzz = true
 
 [dependencies]
-hl7v2-template-values = { version = "1.2.0", path = ".." }
+hl7v2-template-values = { version = "1.2.1", path = ".." }
 libfuzzer-sys = "0.4"
 rand = "0.10.0"
 serde_json = "1.0.149"

--- a/crates/hl7v2-template/Cargo.toml
+++ b/crates/hl7v2-template/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "synthetic",
 ] }
 

--- a/crates/hl7v2-test-utils/Cargo.toml
+++ b/crates/hl7v2-test-utils/Cargo.toml
@@ -11,9 +11,9 @@ publish = false  # Dev-only crate
 repository.workspace = true
 
 [dependencies]
-hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
-hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
+hl7v2-model = { version = "1.2.1", path = "../hl7v2-model" }
+hl7v2-parser = { version = "1.2.1", path = "../hl7v2-parser" }
+hl7v2-query = { version = "1.2.1", path = "../hl7v2-query" }
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/hl7v2-validation/Cargo.toml
+++ b/crates/hl7v2-validation/Cargo.toml
@@ -14,18 +14,18 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false, features = [
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false, features = [
     "profile-core",
 ] }
 
 [dev-dependencies]
-hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
-hl7v2-query = { version = "1.2.0", path = "../hl7v2-query" }
+hl7v2-model = { version = "1.2.1", path = "../hl7v2-model" }
+hl7v2-query = { version = "1.2.1", path = "../hl7v2-query" }
 serde = { workspace = true, features = ["derive"] }
 regex = { workspace = true }
 # Test utilities from workspace
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
-hl7v2-parser = { version = "1.2.0", path = "../hl7v2-parser" }
+hl7v2-parser = { version = "1.2.1", path = "../hl7v2-parser" }
 
 # Property-based testing
 proptest = "1.6"

--- a/crates/hl7v2-writer/Cargo.toml
+++ b/crates/hl7v2-writer/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["hl7", "healthcare", "serializer", "writer"]
 categories = ["encoding", "parser-implementations"]
 
 [dependencies]
-hl7v2 = { version = "1.2.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 
 [dev-dependencies]
-hl7v2-model = { version = "1.2.0", path = "../hl7v2-model" }
-hl7v2-mllp = { version = "1.2.0", path = "../hl7v2-mllp" }
+hl7v2-model = { version = "1.2.1", path = "../hl7v2-model" }
+hl7v2-mllp = { version = "1.2.1", path = "../hl7v2-mllp" }
 hl7v2-parser = { path = "../hl7v2-parser" }
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 proptest = "1.6"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,8 +2,8 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-07
-> **Project Status**: v1.2.0 package line; current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed.
+> **Last Updated**: 2026-05-08
+> **Project Status**: v1.2.1 package line; current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed.
 
 ## Core Components
 
@@ -15,7 +15,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2-python` | 🟡 Experimental | N/A | PyO3 binding package held out of the crates.io Rust publish graph; validate through the Python/maturin lane before release. |
 | compatibility shims | ✅ Package-frozen | N/A | In the current workspace, old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are private deprecated shims unless explicitly retained for compatibility. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
-## Feature Set (v1.2.0)
+## Feature Set (v1.2.1)
 
 ### 🚀 Connectivity
 - ✅ **MLLP Over TCP**: Fully implemented async client and server.
@@ -39,14 +39,14 @@ This document provides a transparent view of which features are fully implemente
 
 - ✅ **Main workflows**: CI, Coverage, Security, Extended, Benchmarks, and API Contracts are green on the 2026-05-07 release-readiness head after manual API Contracts and Coverage dispatches.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current Rust package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-07.md`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current Rust package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-08.md`.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io and should be verified with Python packaging tooling before PyPI or wheel release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
-- ⚠️ **Tag alignment**: the existing `v1.2.0` tag points at an older commit, not the current release-readiness head. The final publish procedure must choose whether to retag, move to a new version, or otherwise document the release-head/tag relationship before uploading crates.
+- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. The current release line moves forward as `v1.2.1`; create a fresh `v1.2.1` tag on the release head after final dry-runs and before upload.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current code is tested and package-verified; publishing the final Rust package graph must still resolve the tag/version alignment, run dependency-ordered final dry-runs, and wait for each published dependency to appear in the crates.io index before publishing dependents.**
+**Current code is tested and package-verified; publishing the final Rust package graph must still run dependency-ordered final dry-runs, create the fresh `v1.2.1` release tag, and wait for each published dependency to appear in the crates.io index before publishing dependents.**

--- a/docs/audits/publish-dry-run-2026-05-08.md
+++ b/docs/audits/publish-dry-run-2026-05-08.md
@@ -1,0 +1,107 @@
+# Publish Dry-Run Receipt - 2026-05-08
+
+## Context
+
+This receipt records the release-line correction from `1.2.0` to `1.2.1`.
+The existing `v1.2.0` tag points at historical commit `1782d9a`, so the
+current release line moves forward instead of reusing or moving that tag.
+
+The Rust crates.io publish graph remains:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+`hl7v2-python` remains `publish = false` and belongs to the separate
+Python/maturin binding lane.
+
+## Commands
+
+Run locally on Windows:
+
+```powershell
+cargo +1.93.0 metadata --format-version 1 --no-deps
+git diff --check
+cargo +1.93.0 fmt --all -- --check
+cargo +1.93.0 run -p xtask -- publish-plan
+cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches
+cargo +1.93.0 publish -p hl7v2 --dry-run
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
+npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml
+npx -y @bufbuild/buf lint api/proto
+```
+
+These commands were rerun on a clean version-alignment branch after committing
+the release-prep changes. Run the same dependency-ordered dry-runs again on
+clean `main` immediately before upload.
+
+## Results
+
+`cargo +1.93.0 run -p xtask -- publish-plan` returned:
+
+```text
+1. hl7v2
+2. hl7v2-server
+3. hl7v2-cli
+```
+
+The workspace-patched dry run passed for all three Rust crates:
+
+```text
+Dry-running hl7v2...
+Dry-running hl7v2-server...
+Dry-running hl7v2-cli...
+Publish dry-run checks passed!
+```
+
+Package verification completed for:
+
+| Crate | Version | Package size | Result |
+| --- | --- | ---: | --- |
+| `hl7v2` | `1.2.1` | 732.1 KiB | Pass |
+| `hl7v2-server` | `1.2.1` | 287.3 KiB | Pass |
+| `hl7v2-cli` | `1.2.1` | 276.3 KiB | Pass |
+
+`cargo +1.93.0 publish -p hl7v2 --dry-run` passed directly against the
+crates.io index:
+
+```text
+Packaging hl7v2 v1.2.1
+Packaged 56 files, 732.1KiB (140.0KiB compressed)
+Verifying hl7v2 v1.2.1
+Uploading hl7v2 v1.2.1
+warning: aborting upload due to dry run
+```
+
+The dependent crates reached packaging, then stopped at dependency resolution
+because `hl7v2 v1.2.1` is not published yet:
+
+```text
+no matching package named `hl7v2` found
+location searched: crates.io index
+required by package `hl7v2-server v1.2.1`
+```
+
+`hl7v2-cli` reported the same registry-resolution blocker. This is the
+expected dependency-ordered pre-publish result, not a package-content failure.
+
+OpenAPI lint passed with the existing non-blocking contact warning:
+
+```text
+1 problem (0 errors, 1 warning, 0 infos, 0 hints)
+```
+
+Buf proto lint passed through `npx -y @bufbuild/buf lint api/proto`.
+
+## Status
+
+Current status is **package-verified** for the `1.2.1` Rust publish graph, not
+published. Before real upload:
+
+1. Merge the version-alignment PR.
+2. Verify hosted CI, Coverage, Security, and API Contracts on the release head.
+3. Run dependency-ordered final dry-runs on clean `main`.
+4. Create the fresh `v1.2.1` tag.
+5. Publish `hl7v2`, wait for index propagation, then publish `hl7v2-server`
+   and `hl7v2-cli`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -213,7 +213,7 @@ Some examples require specific features to be enabled:
 ```toml
 # Cargo.toml
 [dependencies]
-hl7v2 = { version = "1.2.0", features = ["network", "stream"] }
+hl7v2 = { version = "1.2.1", features = ["network", "stream"] }
 ```
 
 - `network` - Enables MLLP client/server functionality
@@ -243,7 +243,7 @@ cargo run --package hl7v2-cli -- serve --port 2575
 Enable required features in your `Cargo.toml`:
 
 ```toml
-hl7v2 = { version = "1.2.0", features = ["network"] }
+hl7v2 = { version = "1.2.1", features = ["network"] }
 ```
 
 ## Contributing

--- a/infrastructure/k8s/deployment.yaml
+++ b/infrastructure/k8s/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hl7v2-server
   labels:
     app: hl7v2-server
-    version: v1.2.0
+    version: v1.2.1
 spec:
   replicas: 3
   selector:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         app: hl7v2-server
-        version: v1.2.0
+        version: v1.2.1
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"


### PR DESCRIPTION
## Summary
- bump the workspace release line and internal path dependency requirements from `1.2.0` to `1.2.1`
- keep the historical `v1.2.0` tag intact and document `v1.2.1` as the fresh publish tag
- update shipped OpenAPI metadata, deployment labels, release docs, and the publish dry-run receipt for the three-crate Rust graph

## Validation
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 check -p hl7v2 --all-targets`
- `cargo +1.93.0 test -p xtask`
- `cargo +1.93.0 test -p hl7v2-server --all-features openapi`
- `cargo +1.93.0 check -p hl7v2-cli --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check -p hl7v2-python --all-features`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `cargo +1.93.0 publish -p hl7v2 --dry-run`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml` (passes with existing contact warning)
- `npx -y @bufbuild/buf lint api/proto`

## Expected pre-publish boundary
- `cargo +1.93.0 publish -p hl7v2-server --dry-run` packages, then stops because `hl7v2 v1.2.1` is not in the crates.io index yet
- `cargo +1.93.0 publish -p hl7v2-cli --dry-run` stops for the same dependency-index reason
- rerun those direct dry-runs after `hl7v2 v1.2.1` is published and indexed