### PR TITLE
docs: record 1.2.1 crates publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved the package line to `1.2.1` so the final Rust publish can use a fresh
   release tag instead of reusing the historical `v1.2.0` tag.
+- Published the final Rust package graph to crates.io: `hl7v2`,
+  `hl7v2-server`, and `hl7v2-cli`.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.1 package line (Rust 2024). Current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed. Some historical implementation microcrate artifacts already exist on crates.io; they are not the product surface for new code. The existing `v1.2.0` git tag predates the current release head and remains historical; the next release should publish from a fresh `v1.2.1` tag after final dry-runs. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -24,7 +24,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Not included in the local Python 3.14/PyO3 validation proof |
-| **Publish Readiness** | Package-verified | Workspace-patched dry-run verifies the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`; Python remains a separate binding lane |
+| **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published to crates.io; Python remains a separate binding lane |
 
 ## Features
 
@@ -67,7 +67,7 @@ cd hl7v2-rs
 cargo install --path crates/hl7v2-cli
 ```
 
-### From crates.io (when published)
+### From crates.io
 
 ```bash
 cargo install hl7v2-cli

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-08
-> **Project Status**: v1.2.1 package line; current `main` is tested and package-verified, but the final Rust crates.io publish sequence has not been executed.
+> **Project Status**: v1.2.1 published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 
 ## Core Components
 
@@ -37,16 +37,17 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, Extended, Benchmarks, and API Contracts are green on the 2026-05-07 release-readiness head after manual API Contracts and Coverage dispatches.
+- ✅ **Main workflows**: CI, Coverage, Security, Extended, Benchmarks, and API Contracts are green on the 2026-05-08 `v1.2.1` release head after manual API Contracts and Coverage dispatches.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification proves the current Rust package graph while the dependency chain is still unpublished. Direct crates.io dry-run passes for `hl7v2`; dependent crates must be dry-run again after `hl7v2` is published and available in the crates.io index. See `docs/audits/publish-dry-run-2026-05-08.md`.
+- ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-08.md`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-08.md`.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io and should be verified with Python packaging tooling before PyPI or wheel release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
-- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. The current release line moves forward as `v1.2.1`; create a fresh `v1.2.1` tag on the release head after final dry-runs and before upload.
+- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. The fresh `v1.2.1` tag points at the current release head.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current code is tested and package-verified; publishing the final Rust package graph must still run dependency-ordered final dry-runs, create the fresh `v1.2.1` release tag, and wait for each published dependency to appear in the crates.io index before publishing dependents.**
+**Current code is tested, package-verified, tagged as `v1.2.1`, and published to crates.io for the final Rust package graph.**

--- a/docs/audits/publish-2026-05-08.md
+++ b/docs/audits/publish-2026-05-08.md
@@ -1,0 +1,84 @@
+# Publish Receipt - 2026-05-08
+
+## Context
+
+This receipt records the actual crates.io publication for `hl7v2-rs` v1.2.1.
+The release used a fresh `v1.2.1` tag because the existing `v1.2.0` tag points
+at a historical commit.
+
+The published Rust package graph is:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+`hl7v2-python` remains `publish = false` and is intentionally held for the
+separate Python/maturin binding lane.
+
+## Release Head
+
+```text
+7777af2 release: bump package line to 1.2.1 (#441)
+```
+
+The `v1.2.1` tag points at this release head and was pushed to GitHub.
+
+## Pre-Publish Verification
+
+Local verification on clean `main`:
+
+```powershell
+git diff --check
+cargo +1.93.0 fmt --all -- --check
+cargo +1.93.0 run -p xtask -- publish-plan
+cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches
+cargo +1.93.0 publish -p hl7v2 --dry-run
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
+```
+
+The dependent direct dry-runs were rerun after each dependency became visible
+in the crates.io index.
+
+Hosted release-head verification on commit `7777af2`:
+
+- CI: success
+- Coverage: success through manual dispatch
+- Security: success
+- API Contracts: success through push and manual dispatch
+- Extended Tests: success inside CI
+- Benchmarks: success inside CI
+
+## Publish Commands
+
+```powershell
+cargo +1.93.0 publish -p hl7v2
+cargo +1.93.0 publish -p hl7v2-server
+cargo +1.93.0 publish -p hl7v2-cli
+```
+
+## Results
+
+Cargo reported successful upload and index availability for:
+
+| Crate | Version | Result |
+| --- | --- | --- |
+| `hl7v2` | `1.2.1` | Published |
+| `hl7v2-server` | `1.2.1` | Published |
+| `hl7v2-cli` | `1.2.1` | Published |
+
+Registry verification:
+
+```text
+hl7v2 = "1.2.1"
+hl7v2-server = "1.2.1"
+hl7v2-cli = "1.2.1"
+```
+
+`cargo +1.93.0 info` also resolved each package at version `1.2.1`.
+
+## Status
+
+The final Rust package graph is published to crates.io. Historical old
+implementation package names that already exist at `1.2.0` remain
+compatibility artifacts and are not the product surface for new code.

--- a/docs/audits/publish-dry-run-2026-05-08.md
+++ b/docs/audits/publish-dry-run-2026-05-08.md
@@ -1,5 +1,8 @@
 # Publish Dry-Run Receipt - 2026-05-08
 
+This dry-run receipt was followed by the actual `v1.2.1` crates.io publish.
+See `docs/audits/publish-2026-05-08.md` for the upload receipt.
+
 ## Context
 
 This receipt records the release-line correction from `1.2.0` to `1.2.1`.
@@ -96,12 +99,5 @@ Buf proto lint passed through `npx -y @bufbuild/buf lint api/proto`.
 
 ## Status
 
-Current status is **package-verified** for the `1.2.1` Rust publish graph, not
-published. Before real upload:
-
-1. Merge the version-alignment PR.
-2. Verify hosted CI, Coverage, Security, and API Contracts on the release head.
-3. Run dependency-ordered final dry-runs on clean `main`.
-4. Create the fresh `v1.2.1` tag.
-5. Publish `hl7v2`, wait for index propagation, then publish `hl7v2-server`
-   and `hl7v2-cli`.
+This receipt established **package verification** for the `1.2.1` Rust publish
+graph. The follow-up publish receipt records the actual upload.


### PR DESCRIPTION
## Summary
- record that `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are now published to crates.io
- add a publish receipt with tag, hosted-check, dry-run, publish, and registry evidence
- update status wording so `hl7v2-python` remains the separate Python binding lane and old microcrates stay compatibility artifacts

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 info hl7v2`
- `cargo +1.93.0 info hl7v2-server`
- `cargo +1.93.0 info hl7v2-cli`
- `cargo +1.93.0 search hl7v2 --limit 8`
- `cargo +1.93.0 search hl7v2-server --limit 3`
- `cargo +1.93.0 search hl7v2-cli --limit 3`