### PR TITLE
ci: add hardened manual Droid workflow

### DIFF
--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,70 @@
+# Manual-first Factory Droid integration.
+#
+# Required setup before use:
+# - Install the Factory Droid GitHub App for this repository.
+# - Add FACTORY_API_KEY as a repository or organization Actions secret.
+#
+# This workflow responds only to explicit @droid commands in pull request
+# comments or review text. Full-repository security scans are intentionally not
+# enabled in this first pass because they can create branches and need broader
+# write permissions.
+#
+# Automatic PR review is intentionally deferred until the manual path is proven
+# stable, so this workflow does not add pull_request status checks to every PR.
+name: Droid Manual
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: droid-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  droid:
+    name: Respond to @droid
+    if: >-
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@droid') &&
+      !contains(github.event.comment.body, '@droid security --full')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+      contains(github.event.comment.body, '@droid') &&
+      !contains(github.event.comment.body, '@droid security --full')) ||
+      (github.event_name == 'pull_request_review' &&
+      contains(github.event.review.body, '@droid') &&
+      !contains(github.event.review.body, '@droid security --full'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Factory API key
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          if [ -z "$FACTORY_API_KEY" ]; then
+            echo "::error::FACTORY_API_KEY secret is not configured. Add it under repository or organization Actions secrets before using @droid."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Droid
+        uses: Factory-AI/droid-action@v5
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          allowed_bots: ""
+          use_sticky_comment: true
+          show_full_output: false

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -87,6 +87,22 @@ Dedicated workflow for code coverage analysis.
 3. **coverage-diff** - PR coverage comparison
    - Compares PR coverage against base branch
 
+### `.github/workflows/droid.yml` - Factory Droid Manual Review
+
+Optional Factory Droid review automation. It responds only to explicit `@droid`
+commands in pull request comments or review text. Automatic PR review is not
+enabled, so this workflow does not add a status check to every PR.
+
+#### Setup:
+
+1. Install the Factory Droid GitHub App for this repository.
+2. Add `FACTORY_API_KEY` under repository or organization Actions secrets.
+3. Ask a repository writer to comment `@droid review`, `@droid fill`, or
+   `@droid security` on a pull request.
+
+Full-repository `@droid security --full` scans are not enabled in this first
+pass because they can create branches and need broader write permissions.
+
 ## Viewing CI Results
 
 ### GitHub Actions
@@ -173,6 +189,7 @@ The following jobs use `continue-on-error: true`:
 | Secret | Purpose | Required For |
 |--------|---------|--------------|
 | `CODECOV_TOKEN` | Upload coverage to Codecov | Coverage uploads |
+| `FACTORY_API_KEY` | Authenticate Factory Droid sessions | Optional Droid manual review workflow |
 | `GITHUB_TOKEN` | GitHub API access | Built-in, automatic |
 
 ## Best Practices


### PR DESCRIPTION
## Summary
- closes the stale generated Factory Droid PR (#380) and replaces it from current `main`
- adds a manual-first Droid workflow that responds only to explicit `@droid` commands in PR comments or review text
- pins Droid to `Factory-AI/droid-action@v5`, keeps repository contents read-only, and documents the required `FACTORY_API_KEY` setup
- keeps automatic PR review and full-repository security scans disabled until the manual path is proven stable

## Security posture
- uses `pull_request` comment/review events only; no `pull_request_target`
- requires Factory's OIDC-backed app token path with `id-token: write`
- grants only `contents: read`, `pull-requests: write`, `issues: write`, and `actions: read` plus OIDC
- does not allow non-writer users or bot triggers beyond the action defaults

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `actionlint .github/workflows/droid.yml`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Notes
Hosted workflow syntax validation still needs to run on this PR. The Droid workflow itself will not run on PR open because automatic review is intentionally deferred.