### PR TITLE
refactor: remove shim crates from workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,32 +119,16 @@ jobs:
 
       - name: Run BDD tests
         run: |
-          # Run BDD tests for crates that have them
-          cargo test --test bdd_tests -p hl7v2-core || echo "No BDD tests in hl7v2-core"
+          # Run BDD tests for active crates that have them
           cargo test --test bdd_tests -p hl7v2-cli || echo "No BDD tests in hl7v2-cli"
-          cargo test --test bdd_tests -p hl7v2-validation || echo "No BDD tests in hl7v2-validation"
+          cargo test --test bdd_tests -p hl7v2-server || echo "No BDD tests in hl7v2-server"
         timeout-minutes: 5
 
       - name: Run limited property tests
         env:
           PROPTEST_CASES: 100
         run: |
-          cargo test -p hl7v2-ack --test property_tests
-          cargo test -p hl7v2-batch --test property_tests
-          cargo test -p hl7v2-core --test property_tests
-          cargo test -p hl7v2-corpus --test property_tests
-          cargo test -p hl7v2-datatype --test property_tests
-          cargo test -p hl7v2-datetime --test property_tests
-          cargo test -p hl7v2-escape --test property_tests
-          cargo test -p hl7v2-faker --test property_tests
-          cargo test -p hl7v2-json --test property_tests
-          cargo test -p hl7v2-mllp --test property_tests
-          cargo test -p hl7v2-normalize --test property_tests
-          cargo test -p hl7v2-path --test property_tests
-          cargo test -p hl7v2-prof --test property_tests
-          cargo test -p hl7v2-query --test property_tests
-          cargo test -p hl7v2-template --test property_tests
-          cargo test -p hl7v2-writer --test property_tests
+          cargo test -p hl7v2 --all-features property_tests
         timeout-minutes: 5
 
   # ============================================================================
@@ -224,22 +208,7 @@ jobs:
         env:
           PROPTEST_CASES: 1000
         run: |
-          cargo test -p hl7v2-ack --test property_tests
-          cargo test -p hl7v2-batch --test property_tests
-          cargo test -p hl7v2-core --test property_tests
-          cargo test -p hl7v2-corpus --test property_tests
-          cargo test -p hl7v2-datatype --test property_tests
-          cargo test -p hl7v2-datetime --test property_tests
-          cargo test -p hl7v2-escape --test property_tests
-          cargo test -p hl7v2-faker --test property_tests
-          cargo test -p hl7v2-json --test property_tests
-          cargo test -p hl7v2-mllp --test property_tests
-          cargo test -p hl7v2-normalize --test property_tests
-          cargo test -p hl7v2-path --test property_tests
-          cargo test -p hl7v2-prof --test property_tests
-          cargo test -p hl7v2-query --test property_tests
-          cargo test -p hl7v2-template --test property_tests
-          cargo test -p hl7v2-writer --test property_tests
+          cargo test -p hl7v2 --all-features property_tests
         timeout-minutes: 10
 
   # ============================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,12 +138,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,32 +675,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
@@ -716,7 +684,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.8.2",
+ "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -729,16 +697,6 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1559,32 +1517,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hl7v2-ack"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-test-utils",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-batch"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-test-utils",
- "proptest",
- "tokio",
-]
-
-[[package]]
 name = "hl7v2-bench"
 version = "1.2.1"
 dependencies = [
- "criterion 0.8.2",
+ "criterion",
  "futures",
  "hl7v2",
  "rand 0.10.1",
@@ -1610,50 +1546,9 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "hl7v2-core"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-corpus"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
- "proptest",
- "serde_json",
-]
-
-[[package]]
-name = "hl7v2-datatype"
-version = "1.2.1"
-dependencies = [
- "chrono",
- "cucumber",
- "hl7v2",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-datetime"
-version = "1.2.1"
-dependencies = [
- "chrono",
- "cucumber",
- "hl7v2",
- "proptest",
- "tokio",
 ]
 
 [[package]]
@@ -1685,17 +1580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hl7v2-escape"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-test-utils",
- "proptest",
- "tokio",
-]
-
-[[package]]
 name = "hl7v2-examples"
 version = "1.2.1"
 dependencies = [
@@ -1706,162 +1590,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "hl7v2-faker"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "proptest",
- "rand 0.10.1",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-gen"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-normalize",
- "hl7v2-parser",
- "hl7v2-query",
- "proptest",
- "rand 0.10.1",
- "tokio",
- "toml 0.8.23",
-]
-
-[[package]]
-name = "hl7v2-guard"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
-]
-
-[[package]]
-name = "hl7v2-json"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "proptest",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-lifecycle"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
-]
-
-[[package]]
-name = "hl7v2-mllp"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-test-utils",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-model"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
- "serde_json",
-]
-
-[[package]]
-name = "hl7v2-network"
-version = "1.2.1"
-dependencies = [
- "bytes",
- "hl7v2",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "hl7v2-normalize"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-parser"
-version = "1.2.1"
-dependencies = [
- "assert_matches",
- "cucumber",
- "hl7v2",
- "hl7v2-escape",
- "hl7v2-mllp",
- "hl7v2-model",
- "hl7v2-query",
- "hl7v2-test-utils",
- "hl7v2-writer",
- "insta",
- "pretty_assertions",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-path"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-prof"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
- "hl7v2-parser",
- "proptest",
- "serde_yaml_ng",
- "tempfile",
- "tokio",
- "wiremock",
-]
-
-[[package]]
 name = "hl7v2-python"
 version = "1.2.1"
 dependencies = [
  "hl7v2",
  "pyo3",
-]
-
-[[package]]
-name = "hl7v2-query"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-model",
- "hl7v2-parser",
- "proptest",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-redact"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
 ]
 
 [[package]]
@@ -1901,41 +1634,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hl7v2-stream"
-version = "1.2.1"
-dependencies = [
- "criterion 0.5.1",
- "hl7v2",
- "hl7v2-test-utils",
-]
-
-[[package]]
-name = "hl7v2-template"
-version = "1.2.1"
-dependencies = [
- "hl7v2",
- "proptest",
-]
-
-[[package]]
-name = "hl7v2-template-values"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "proptest",
- "rand 0.10.1",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "hl7v2-test-utils"
 version = "1.2.1"
 dependencies = [
- "hl7v2-model",
- "hl7v2-parser",
- "hl7v2-query",
+ "hl7v2",
  "insta",
  "pretty_assertions",
  "proptest",
@@ -1945,40 +1647,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "hl7v2-validation"
-version = "1.2.1"
-dependencies = [
- "assert_matches",
- "cucumber",
- "hl7v2",
- "hl7v2-model",
- "hl7v2-parser",
- "hl7v2-query",
- "hl7v2-test-utils",
- "insta",
- "pretty_assertions",
- "proptest",
- "regex",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "hl7v2-writer"
-version = "1.2.1"
-dependencies = [
- "cucumber",
- "hl7v2",
- "hl7v2-mllp",
- "hl7v2-model",
- "hl7v2-parser",
- "hl7v2-test-utils",
- "proptest",
- "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -2336,8 +2004,6 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
- "pest",
- "pest_derive",
  "serde",
  "similar",
  "tempfile",
@@ -2369,30 +2035,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2984,49 +2630,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -4054,15 +3657,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4774,38 +4368,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -4818,33 +4391,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5122,12 +4675,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -5870,15 +5417,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,35 +2,8 @@
 members = [
     # Public library crate
     "crates/hl7v2",
-    # Private deprecated compatibility shims for collapsed implementation modules
-    "crates/hl7v2-model",
-    "crates/hl7v2-escape",
-    "crates/hl7v2-mllp",
-    "crates/hl7v2-query",
-    "crates/hl7v2-json",
-    "crates/hl7v2-parser",
-    "crates/hl7v2-writer",
-    "crates/hl7v2-normalize",
-    "crates/hl7v2-network",
-    "crates/hl7v2-batch",
-    "crates/hl7v2-stream",
-    "crates/hl7v2-validation",
-    "crates/hl7v2-datatype",
-    "crates/hl7v2-datetime",
-    "crates/hl7v2-path",
-    "crates/hl7v2-faker",
-    "crates/hl7v2-corpus",
-    # Private compatibility shims and feature-module test harnesses
-    "crates/hl7v2-core",
+    # Internal benchmark harness
     "crates/hl7v2-bench",
-    "crates/hl7v2-prof",
-    "crates/hl7v2-redact",
-    "crates/hl7v2-lifecycle",
-    "crates/hl7v2-guard",
-    "crates/hl7v2-template",
-    "crates/hl7v2-template-values",
-    "crates/hl7v2-gen",
-    "crates/hl7v2-ack",
     # Public wrapper and binding crates
     "crates/hl7v2-python",
     "crates/hl7v2-cli",

--- a/crates/hl7v2-test-utils/Cargo.toml
+++ b/crates/hl7v2-test-utils/Cargo.toml
@@ -11,9 +11,7 @@ publish = false  # Dev-only crate
 repository.workspace = true
 
 [dependencies]
-hl7v2-model = { version = "1.2.1", path = "../hl7v2-model" }
-hl7v2-parser = { version = "1.2.1", path = "../hl7v2-parser" }
-hl7v2-query = { version = "1.2.1", path = "../hl7v2-query" }
+hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -25,4 +23,3 @@ tracing.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4"
-

--- a/crates/hl7v2-test-utils/src/assertions.rs
+++ b/crates/hl7v2-test-utils/src/assertions.rs
@@ -28,9 +28,8 @@
 //! assert_field_equals(&parsed, "MSH.9.2", "A01");
 //! ```
 
-use hl7v2_model::Message;
-use hl7v2_parser::parse;
-use hl7v2_query::get;
+use hl7v2::model::{Atom, Comp, Delims, Field, Message, Rep, Segment};
+use hl7v2::{get, parse};
 
 /// Assert that a message is valid and parseable.
 ///
@@ -142,7 +141,7 @@ pub fn assert_segment_equals(message: &Message, segment_name: &str, expected: &s
                 message
                     .segments
                     .iter()
-                    .map(hl7v2_model::Segment::id_str)
+                    .map(Segment::id_str)
                     .collect::<Vec<_>>()
                     .join(", ")
             )
@@ -260,7 +259,7 @@ pub fn assert_field_exists(message: &Message, path: &str) {
             message
                 .segments
                 .iter()
-                .map(hl7v2_model::Segment::id_str)
+                .map(Segment::id_str)
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -323,7 +322,7 @@ pub fn assert_segment_exists(message: &Message, segment_name: &str) {
         message
             .segments
             .iter()
-            .map(hl7v2_model::Segment::id_str)
+            .map(Segment::id_str)
             .collect::<Vec<_>>()
             .join(", ")
     );
@@ -466,7 +465,7 @@ pub fn assert_segment_count(message: &Message, expected_count: usize) {
         message
             .segments
             .iter()
-            .map(hl7v2_model::Segment::id_str)
+            .map(Segment::id_str)
             .collect::<Vec<_>>()
             .join(", ")
     );
@@ -511,7 +510,7 @@ pub fn assert_segment_type_count(message: &Message, segment_name: &str, expected
 // Helper functions
 
 /// Write a segment to a string.
-fn write_segment_to_string(segment: &hl7v2_model::Segment, delims: &hl7v2_model::Delims) -> String {
+fn write_segment_to_string(segment: &Segment, delims: &Delims) -> String {
     let mut result = segment.id_str().to_string();
 
     for field in &segment.fields {
@@ -523,7 +522,7 @@ fn write_segment_to_string(segment: &hl7v2_model::Segment, delims: &hl7v2_model:
 }
 
 /// Write a field to a string.
-fn write_field_to_string(field: &hl7v2_model::Field, delims: &hl7v2_model::Delims) -> String {
+fn write_field_to_string(field: &Field, delims: &Delims) -> String {
     let reps: Vec<String> = field
         .reps
         .iter()
@@ -533,7 +532,7 @@ fn write_field_to_string(field: &hl7v2_model::Field, delims: &hl7v2_model::Delim
 }
 
 /// Write a repetition to a string.
-fn write_rep_to_string(rep: &hl7v2_model::Rep, delims: &hl7v2_model::Delims) -> String {
+fn write_rep_to_string(rep: &Rep, delims: &Delims) -> String {
     let comps: Vec<String> = rep
         .comps
         .iter()
@@ -543,16 +542,16 @@ fn write_rep_to_string(rep: &hl7v2_model::Rep, delims: &hl7v2_model::Delims) -> 
 }
 
 /// Write a component to a string.
-fn write_comp_to_string(comp: &hl7v2_model::Comp, delims: &hl7v2_model::Delims) -> String {
+fn write_comp_to_string(comp: &Comp, delims: &Delims) -> String {
     let subs: Vec<String> = comp.subs.iter().map(write_atom_to_string).collect();
     subs.join(&delims.sub.to_string())
 }
 
 /// Write an atom to a string.
-fn write_atom_to_string(atom: &hl7v2_model::Atom) -> String {
+fn write_atom_to_string(atom: &Atom) -> String {
     match atom {
-        hl7v2_model::Atom::Text(t) => t.clone(),
-        hl7v2_model::Atom::Null => String::new(),
+        Atom::Text(t) => t.clone(),
+        Atom::Null => String::new(),
     }
 }
 

--- a/crates/hl7v2-test-utils/src/builders.rs
+++ b/crates/hl7v2-test-utils/src/builders.rs
@@ -16,11 +16,11 @@
 //!     .build_bytes();
 //!
 //! // Parse and verify
-//! let message = hl7v2_parser::parse(&bytes).unwrap();
+//! let message = hl7v2::parse(&bytes).unwrap();
 //! assert_eq!(message.segments.len(), 3);
 //! ```
 
-use hl7v2_model::{Comp, Delims, Field, Message, Rep, Segment};
+use hl7v2::model::{Atom, Comp, Delims, Field, Message, Rep, Segment};
 
 /// Builder for creating test HL7 messages.
 ///
@@ -751,7 +751,7 @@ impl SegmentBuilder {
             let mut rep = Rep::new();
             let mut comp = Comp::new();
             for value in *rep_components {
-                comp.subs.push(hl7v2_model::Atom::text(*value));
+                comp.subs.push(Atom::text(*value));
             }
             rep.comps.push(comp);
             field.reps.push(rep);
@@ -823,7 +823,7 @@ fn chrono_timestamp() -> String {
 fn make_component_field(components: &[&str]) -> Field {
     let mut comp = Comp::new();
     for value in components {
-        comp.subs.push(hl7v2_model::Atom::text(*value));
+        comp.subs.push(Atom::text(*value));
     }
     let mut rep = Rep::new();
     rep.comps.push(comp);
@@ -897,10 +897,10 @@ fn write_comp(comp: &Comp, delims: &Delims) -> String {
 }
 
 /// Write a subcomponent to an HL7-formatted string.
-fn write_atom(atom: &hl7v2_model::Atom) -> String {
+fn write_atom(atom: &Atom) -> String {
     match atom {
-        hl7v2_model::Atom::Text(t) => t.clone(),
-        hl7v2_model::Atom::Null => String::new(),
+        Atom::Text(t) => t.clone(),
+        Atom::Null => String::new(),
     }
 }
 
@@ -940,9 +940,9 @@ fn parse_raw_field(field_str: &str, delims: &Delims) -> Field {
             let mut comp = Comp::new();
             for sub_str in comp_str.split(delims.sub) {
                 if sub_str.is_empty() {
-                    comp.subs.push(hl7v2_model::Atom::Null);
+                    comp.subs.push(Atom::Null);
                 } else {
-                    comp.subs.push(hl7v2_model::Atom::text(sub_str));
+                    comp.subs.push(Atom::text(sub_str));
                 }
             }
             rep.comps.push(comp);
@@ -956,6 +956,7 @@ fn parse_raw_field(field_str: &str, delims: &Delims) -> Field {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hl7v2::parse;
 
     #[test]
     fn test_message_builder_new() {
@@ -969,7 +970,7 @@ mod tests {
             .with_pid("MRN123", "Doe", "John")
             .build_bytes();
 
-        let message = hl7v2_parser::parse(&bytes).unwrap();
+        let message = parse(&bytes).unwrap();
         assert_eq!(message.segments.len(), 2);
     }
 
@@ -981,7 +982,7 @@ mod tests {
             .with_pv1("I", "ICU^101")
             .build_bytes();
 
-        let message = hl7v2_parser::parse(&bytes).unwrap();
+        let message = parse(&bytes).unwrap();
         assert_eq!(message.segments.len(), 3);
     }
 
@@ -993,7 +994,7 @@ mod tests {
             .with_obx("1", "NM", "WBC^White Blood Count", "7.5", "10^9/L")
             .build_bytes();
 
-        let message = hl7v2_parser::parse(&bytes).unwrap();
+        let message = parse(&bytes).unwrap();
         assert_eq!(message.segments.len(), 4);
     }
 
@@ -1004,7 +1005,7 @@ mod tests {
             .with_message_control_id("CUSTOM123")
             .build_bytes();
 
-        let message = hl7v2_parser::parse(&bytes).unwrap();
+        let message = parse(&bytes).unwrap();
         // Verify the message was created successfully
         assert_eq!(message.segments.len(), 1);
     }
@@ -1040,7 +1041,7 @@ mod tests {
             .with_raw_segment("ZPV|1|Custom|Value")
             .build_bytes();
 
-        let message = hl7v2_parser::parse(&bytes).unwrap();
+        let message = parse(&bytes).unwrap();
         assert_eq!(message.segments.len(), 2);
         assert_eq!(message.segments[1].id_str(), "ZPV");
     }

--- a/crates/hl7v2-test-utils/src/mocks.rs
+++ b/crates/hl7v2-test-utils/src/mocks.rs
@@ -34,7 +34,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use hl7v2_model::{Error, Message};
+use hl7v2::model::{Error, Message};
 use tokio::net::TcpListener;
 use tokio::sync::{RwLock, mpsc};
 use tokio::time::timeout;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -580,7 +580,7 @@ fn scaffold(name: &str, description: Option<String>) -> Result<()> {
         format!("hl7v2-{name}")
     };
 
-    println!("🏗️  Scaffolding new microcrate: {crate_name}...");
+    println!("🏗️  Scaffolding new crate: {crate_name}...");
 
     let root = env::current_dir()?;
     let crate_path = root.join("crates").join(&crate_name);
@@ -609,7 +609,7 @@ keywords = ["hl7", "healthcare"]
 categories = ["parser-implementations"]
 
 [dependencies]
-hl7v2-model = {{ path = "../hl7v2-model" }}
+hl7v2 = {{ path = "../hl7v2", default-features = false }}
 thiserror = {{ workspace = true }}
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- remove retired shim crate folders from `workspace.members` without deleting the directories yet
- move active `hl7v2-test-utils` imports/dependency from old shim crates to the canonical `hl7v2` facade
- prune retired shim packages from `Cargo.lock` and update the active xtask scaffold to depend on `hl7v2`
- update CI BDD/property-test steps so hosted jobs no longer target retired shim package names

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check --workspace --all-features --all-targets`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test --workspace --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test --doc --workspace`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check --examples`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test --test bdd_tests -p hl7v2-cli`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test --test bdd_tests -p hl7v2-server`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; $env:PROPTEST_CASES='100'; cargo +1.93.0 test -p hl7v2 --all-features property_tests`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; $env:PROPTEST_CASES='1000'; cargo +1.93.0 test -p hl7v2 --all-features property_tests`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check`

Expected publish plan remains:
1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`