### PR TITLE
test: migrate shim coverage to hl7v2 facade

### DIFF
--- a/crates/hl7v2/tests/ack_facade.rs
+++ b/crates/hl7v2/tests/ack_facade.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "ack")]
+
+use hl7v2::{AckCode, Message, Segment, ack, ack_with_error, get, parse, write};
+use std::error::Error;
+use std::fmt::Debug;
+
+fn require_eq<T>(actual: T, expected: T, label: &str) -> Result<(), Box<dyn Error>>
+where
+    T: PartialEq + Debug,
+{
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("{label}: expected {expected:?}, got {actual:?}")).into())
+    }
+}
+
+fn sample_message() -> Result<Message, hl7v2::Error> {
+    parse(
+        b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r",
+    )
+}
+
+#[test]
+fn ack_facade_preserves_control_id_and_swaps_applications() -> Result<(), Box<dyn Error>> {
+    let original = sample_message()?;
+    let response = ack(&original, AckCode::AA)?;
+
+    require_eq(get(&response, "MSH.3"), Some("RECVAPP"), "ack sender app")?;
+    require_eq(get(&response, "MSH.5"), Some("SENDAPP"), "ack receiver app")?;
+    require_eq(get(&response, "MSA.1"), Some("AA"), "ack code")?;
+    require_eq(get(&response, "MSA.2"), Some("CTRL123"), "ack control id")?;
+
+    Ok(())
+}
+
+#[test]
+fn ack_with_error_roundtrips_with_err_segment() -> Result<(), Box<dyn Error>> {
+    let original = sample_message()?;
+    let response = ack_with_error(&original, AckCode::AE, Some("Application failure"))?;
+    let reparsed = parse(&write(&response))?;
+
+    require_eq(reparsed.segments.len(), 3, "segment count")?;
+    require_eq(get(&reparsed, "MSA.1"), Some("AE"), "ack code")?;
+    require_eq(
+        get(&reparsed, "ERR.3"),
+        Some("Application failure"),
+        "ERR message",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn ack_facade_supports_application_and_commit_codes() -> Result<(), Box<dyn Error>> {
+    let original = sample_message()?;
+
+    for code in [
+        AckCode::AA,
+        AckCode::AE,
+        AckCode::AR,
+        AckCode::CA,
+        AckCode::CE,
+        AckCode::CR,
+    ] {
+        let response = ack(&original, code)?;
+        require_eq(get(&response, "MSA.1"), Some(code.as_str()), "ack code")?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn ack_facade_rejects_messages_without_msh() -> Result<(), Box<dyn Error>> {
+    let invalid = Message::with_segments(vec![Segment {
+        id: *b"PID",
+        fields: Vec::new(),
+    }]);
+
+    let result = ack(&invalid, AckCode::AA);
+    require_eq(result.is_err(), true, "invalid message rejection")?;
+
+    Ok(())
+}

--- a/crates/hl7v2/tests/batch_facade.rs
+++ b/crates/hl7v2/tests/batch_facade.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "batch")]
 
 use hl7v2::batch::{BatchType, parse_batch};
+use std::fmt::Debug;
 
 #[test]
 fn batch_module_parses_single_batch_through_hl7v2() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,6 +27,82 @@ BTS|1|End of batch\r";
         ))
         .into());
     }
+
+    Ok(())
+}
+
+fn require_eq<T>(actual: T, expected: T, label: &str) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: PartialEq + Debug,
+{
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("{label}: expected {expected:?}, got {actual:?}")).into())
+    }
+}
+
+fn require(condition: bool, message: &'static str) -> Result<(), Box<dyn std::error::Error>> {
+    if condition {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(message).into())
+    }
+}
+
+#[test]
+fn batch_module_parses_multi_batch_file_through_hl7v2() -> Result<(), Box<dyn std::error::Error>> {
+    let data = b"FHS|^~\\&|HIS|HOSPITAL|||20250128120000\r\
+BHS|^~\\&|HIS|HOSPITAL|LAB|LABHOST|20250128120000|||LAB_BATCH\r\
+MSH|^~\\&|HIS|HOSPITAL|LAB|LABHOST|20250128120100||ORM^O01|ORD001|P|2.5.1\r\
+PID|1||MRN001^^^HOSP^MR||Patient^One\r\
+MSH|^~\\&|HIS|HOSPITAL|LAB|LABHOST|20250128120200||ORM^O01|ORD002|P|2.5.1\r\
+PID|1||MRN002^^^HOSP^MR||Patient^Two\r\
+BTS|2\r\
+BHS|^~\\&|HIS|HOSPITAL|RAD|RADHOST|20250128130000|||RAD_BATCH\r\
+MSH|^~\\&|HIS|HOSPITAL|RAD|RADHOST|20250128130100||ORM^O01|RAD001|P|2.5.1\r\
+PID|1||MRN003^^^HOSP^MR||Patient^Three\r\
+BTS|1\r\
+FTS|3\r";
+
+    let batch = parse_batch(data)?;
+
+    require_eq(batch.info.batch_type, BatchType::File, "batch type")?;
+    require_eq(batch.batches.len(), 2, "nested batch count")?;
+    require_eq(batch.total_message_count(), 3, "message count")?;
+    require_eq(
+        batch.info.message_count,
+        Some(3),
+        "file trailer message count",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn batch_module_accepts_messages_without_batch_headers() -> Result<(), Box<dyn std::error::Error>> {
+    let data = b"MSH|^~\\&|APP|FAC|RECV|RECVFAC|20250128120000||ADT^A01|MSG001|P|2.5.1\r\
+PID|1||MRN001^^^HOSP^MR||Patient^One\r\
+MSH|^~\\&|APP|FAC|RECV|RECVFAC|20250128120100||ADT^A01|MSG002|P|2.5.1\r\
+PID|1||MRN002^^^HOSP^MR||Patient^Two\r";
+
+    let batch = parse_batch(data)?;
+
+    require_eq(batch.total_message_count(), 2, "message count")?;
+    require_eq(batch.batches.len(), 1, "implicit batch count")?;
+
+    Ok(())
+}
+
+#[test]
+fn batch_module_reports_trailer_count_mismatch() -> Result<(), Box<dyn std::error::Error>> {
+    let data = b"BHS|^~\\&|APP|FAC\r\
+MSH|^~\\&|APP|FAC|RECV|RECVFAC|||ADT^A01|MSG|P|2.5.1\r\
+BTS|5\r";
+
+    let result = parse_batch(data);
+
+    require(result.is_err(), "expected count mismatch")?;
 
     Ok(())
 }

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "profile")]
+
+use chrono::{Datelike, Timelike};
+use hl7v2::conformance::datatype::datetime::{
+    DateTimeError, TimestampPrecision, parse_hl7_dt, parse_hl7_tm, parse_hl7_ts,
+    parse_hl7_ts_with_precision,
+};
+use hl7v2::{Severity, load_profile_checked, parse, validate};
+use std::error::Error;
+use std::fmt::Debug;
+
+fn require_eq<T>(actual: T, expected: T, label: &str) -> Result<(), Box<dyn Error>>
+where
+    T: PartialEq + Debug,
+{
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("{label}: expected {expected:?}, got {actual:?}")).into())
+    }
+}
+
+fn require(condition: bool, message: &'static str) -> Result<(), Box<dyn Error>> {
+    if condition {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(message).into())
+    }
+}
+
+#[test]
+fn datetime_facade_preserves_precision_and_fractional_seconds() -> Result<(), Box<dyn Error>> {
+    let timestamp = parse_hl7_ts_with_precision("20250128152312.123456")?;
+
+    require_eq(
+        timestamp.precision,
+        TimestampPrecision::FractionalSecond,
+        "timestamp precision",
+    )?;
+    require_eq(
+        timestamp.fractional_seconds,
+        Some(123456),
+        "fractional seconds",
+    )?;
+    require_eq(timestamp.datetime.year(), 2025, "year")?;
+    require_eq(timestamp.datetime.month(), 1, "month")?;
+    require_eq(timestamp.datetime.day(), 28, "day")?;
+    require_eq(timestamp.datetime.hour(), 15, "hour")?;
+
+    Ok(())
+}
+
+#[test]
+fn datetime_facade_reports_specific_error_variants() -> Result<(), Box<dyn Error>> {
+    require(
+        matches!(
+            parse_hl7_dt("notadate"),
+            Err(DateTimeError::InvalidDateFormat(_))
+        ),
+        "expected InvalidDateFormat",
+    )?;
+    require(
+        matches!(parse_hl7_tm("2500"), Err(DateTimeError::TimeOutOfRange(_))),
+        "expected TimeOutOfRange",
+    )?;
+    require(
+        matches!(
+            parse_hl7_ts("bad"),
+            Err(DateTimeError::InvalidTimestampFormat(_))
+        ),
+        "expected InvalidTimestampFormat",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn profile_facade_rejects_invalid_valueset_values() -> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+valuesets:
+  - path: "PID.8"
+    name: "AdministrativeSex"
+    codes: ["M", "F"]
+"#,
+    )?;
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR||Doe^John||19700101|X\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("PID.8")
+                && issue.code == "VALUE_NOT_IN_SET"
+        }),
+        "expected PID.8 value set violation",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn profile_facade_reports_length_constraint_failures() -> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+lengths:
+  - path: "PID.5.1"
+    max: 3
+    policy: "no-truncate"
+"#,
+    )?;
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR||Longname^John||19700101|M\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        issues
+            .iter()
+            .any(|issue| issue.path.as_deref() == Some("PID.5.1")),
+        "expected PID.5.1 length issue",
+    )?;
+
+    Ok(())
+}

--- a/crates/hl7v2/tests/json_facade.rs
+++ b/crates/hl7v2/tests/json_facade.rs
@@ -1,0 +1,81 @@
+#![cfg(feature = "json")]
+
+use hl7v2::{Comp, Delims, Field, Message, Rep, Segment, to_json, to_json_string_pretty};
+use std::error::Error;
+use std::fmt::Debug;
+
+fn require_eq<T>(actual: T, expected: T, label: &str) -> Result<(), Box<dyn Error>>
+where
+    T: PartialEq + Debug,
+{
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("{label}: expected {expected:?}, got {actual:?}")).into())
+    }
+}
+
+fn require(condition: bool, message: &'static str) -> Result<(), Box<dyn Error>> {
+    if condition {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(message).into())
+    }
+}
+
+#[test]
+fn json_facade_preserves_charsets_segments_and_nested_fields() -> Result<(), Box<dyn Error>> {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![Segment {
+            id: *b"PID",
+            fields: vec![
+                Field::from_text("1"),
+                Field {
+                    reps: vec![Rep {
+                        comps: vec![Comp::from_text("Doe"), Comp::from_text("John")],
+                    }],
+                },
+            ],
+        }],
+        charsets: vec!["ASCII".to_string(), "UTF-8".to_string()],
+    };
+
+    let json = to_json(&message);
+    let segments = json
+        .get("segments")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| std::io::Error::other("missing segments"))?;
+    let meta = json
+        .get("meta")
+        .ok_or_else(|| std::io::Error::other("missing meta"))?;
+    let charsets = meta
+        .get("charsets")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| std::io::Error::other("missing charsets"))?;
+
+    require_eq(segments.len(), 1, "segment count")?;
+    require_eq(charsets.len(), 2, "charset count")?;
+    require(
+        serde_json::to_string(&json)?.contains("Doe"),
+        "expected nested family name in JSON",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn json_facade_pretty_output_is_valid_json() -> Result<(), Box<dyn Error>> {
+    let message = Message::with_segments(vec![Segment {
+        id: *b"MSH",
+        fields: vec![Field::from_text("^~\\&")],
+    }]);
+
+    let json = to_json_string_pretty(&message);
+    let parsed: serde_json::Value = serde_json::from_str(&json)?;
+
+    require(json.contains('\n'), "expected pretty JSON newlines")?;
+    require(parsed.is_object(), "expected object JSON")?;
+
+    Ok(())
+}

--- a/crates/hl7v2/tests/model_facade.rs
+++ b/crates/hl7v2/tests/model_facade.rs
@@ -1,0 +1,115 @@
+use hl7v2::model::{Batch, FileBatch};
+use hl7v2::{Atom, Comp, Delims, Field, Message, Rep, Segment};
+use std::error::Error;
+use std::fmt::Debug;
+
+fn require_eq<T>(actual: T, expected: T, label: &str) -> Result<(), Box<dyn Error>>
+where
+    T: PartialEq + Debug,
+{
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("{label}: expected {expected:?}, got {actual:?}")).into())
+    }
+}
+
+fn require_some<T>(value: Option<T>, label: &str) -> Result<T, Box<dyn Error>> {
+    value.ok_or_else(|| std::io::Error::other(format!("missing {label}")).into())
+}
+
+#[test]
+fn model_roundtrips_complex_message_through_public_facade() -> Result<(), Box<dyn Error>> {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![Segment {
+            id: *b"PID",
+            fields: vec![
+                Field::from_text("1"),
+                Field {
+                    reps: vec![
+                        Rep {
+                            comps: vec![
+                                Comp::from_text("123456"),
+                                Comp::from_text(""),
+                                Comp::from_text(""),
+                                Comp::from_text("HOSP"),
+                                Comp::from_text("MR"),
+                            ],
+                        },
+                        Rep {
+                            comps: vec![Comp::from_text("ALT999"), Comp::from_text("ALT")],
+                        },
+                    ],
+                },
+                Field {
+                    reps: vec![Rep {
+                        comps: vec![Comp {
+                            subs: vec![Atom::text("Doe"), Atom::text("John")],
+                        }],
+                    }],
+                },
+            ],
+        }],
+        charsets: vec!["ASCII".to_string()],
+    };
+
+    let json = serde_json::to_string(&message)?;
+    let decoded: Message = serde_json::from_str(&json)?;
+    let pid = require_some(decoded.segments.first(), "PID segment")?;
+
+    require_eq(pid.id, *b"PID", "segment id")?;
+    require_eq(pid.fields.len(), 3, "field count")?;
+    require_eq(decoded.charsets, vec!["ASCII".to_string()], "charsets")?;
+
+    let repeating_identifier = require_some(pid.fields.get(1), "PID-2 repeating identifier")?;
+    require_eq(
+        repeating_identifier.reps.len(),
+        2,
+        "identifier repetition count",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn model_file_batch_preserves_nested_batch_counts() -> Result<(), Box<dyn Error>> {
+    let mut file_batch = FileBatch::default();
+    let mut first_batch = Batch::default();
+    let mut second_batch = Batch::default();
+
+    first_batch
+        .messages
+        .push(Message::with_segments(vec![Segment {
+            id: *b"MSH",
+            fields: vec![Field::from_text("^~\\&")],
+        }]));
+    second_batch
+        .messages
+        .push(Message::with_segments(vec![Segment {
+            id: *b"MSH",
+            fields: vec![Field::from_text("^~\\&")],
+        }]));
+    second_batch
+        .messages
+        .push(Message::with_segments(vec![Segment {
+            id: *b"MSH",
+            fields: vec![Field::from_text("^~\\&")],
+        }]));
+
+    file_batch.batches.push(first_batch);
+    file_batch.batches.push(second_batch);
+
+    require_eq(file_batch.batches.len(), 2, "batch count")?;
+    require_eq(
+        file_batch
+            .batches
+            .iter()
+            .map(|batch| batch.messages.len())
+            .sum::<usize>(),
+        3,
+        "nested message count",
+    )?;
+
+    Ok(())
+}

--- a/crates/hl7v2/tests/query_facade.rs
+++ b/crates/hl7v2/tests/query_facade.rs
@@ -1,0 +1,55 @@
+use hl7v2::{Presence, get, get_presence, parse};
+use std::error::Error;
+use std::fmt::Debug;
+
+fn require_eq<T>(actual: T, expected: T, label: &str) -> Result<(), Box<dyn Error>>
+where
+    T: PartialEq + Debug,
+{
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("{label}: expected {expected:?}, got {actual:?}")).into())
+    }
+}
+
+fn require(condition: bool, message: &'static str) -> Result<(), Box<dyn Error>> {
+    if condition {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(message).into())
+    }
+}
+
+#[test]
+fn query_facade_reads_real_adt_components_and_repetitions() -> Result<(), Box<dyn Error>> {
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR~ALT999^^^ALT^MR||Doe^John^A||19700101|M\r",
+    )?;
+
+    require_eq(get(&message, "MSH.10"), Some("CTRL123"), "control id")?;
+    require_eq(get(&message, "PID.3.1"), Some("123456"), "primary MRN")?;
+    require_eq(get(&message, "PID.3[2].1"), Some("ALT999"), "alternate MRN")?;
+    require_eq(get(&message, "PID.5.1"), Some("Doe"), "family name")?;
+    require_eq(get(&message, "PID.5.2"), Some("John"), "given name")?;
+
+    Ok(())
+}
+
+#[test]
+fn query_facade_distinguishes_empty_and_missing_presence() -> Result<(), Box<dyn Error>> {
+    let message =
+        parse(b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||\r")?;
+
+    require(
+        matches!(get_presence(&message, "PID.3"), Presence::Empty),
+        "expected empty PID-3",
+    )?;
+    require(
+        matches!(get_presence(&message, "PID.9"), Presence::Missing),
+        "expected missing PID-9",
+    )?;
+
+    Ok(())
+}

--- a/crates/hl7v2/tests/stream_facade.rs
+++ b/crates/hl7v2/tests/stream_facade.rs
@@ -101,3 +101,56 @@ fn stream_parser_reports_message_size_limit() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn stream_parser_emits_field_content_through_hl7v2() -> Result<(), Box<dyn Error>> {
+    let hl7 =
+        b"MSH|^~\\&|SEND|FAC|RECV|FAC|202605070101||ADT^A01|CTRL|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John\r";
+    let cursor = Cursor::new(hl7.as_slice());
+    let reader = BufReader::with_capacity(16, cursor);
+    let mut parser = StreamParser::new(reader);
+
+    let events = collect_events(&mut parser)?;
+
+    require(
+        events.iter().any(
+            |event| matches!(event, Event::Field { raw, .. } if raw.as_slice() == b"Doe^John"),
+        ),
+        "expected patient name field event",
+    )?;
+    require(
+        events.iter().any(|event| {
+            matches!(event, Event::Field { raw, .. } if raw.as_slice() == b"123456^^^HOSP^MR")
+        }),
+        "expected MRN field event",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn stream_parser_preserves_segment_order_through_hl7v2() -> Result<(), Box<dyn Error>> {
+    let hl7 = b"MSH|^~\\&|SEND|FAC|RECV|FAC|202605070101||ADT^A01|CTRL|P|2.5\rEVN|A01|202605070101\rPID|1||123456^^^HOSP^MR||Doe^John\rPV1|1|I|ICU^101\r";
+    let cursor = Cursor::new(hl7.as_slice());
+    let reader = BufReader::new(cursor);
+    let mut parser = StreamParser::new(reader);
+
+    let events = collect_events(&mut parser)?;
+    let segment_ids: Vec<&[u8]> = events
+        .iter()
+        .filter_map(|event| {
+            if let Event::Segment { id } = event {
+                Some(id.as_slice())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    require(
+        segment_ids.as_slice() == [b"EVN".as_slice(), b"PID".as_slice(), b"PV1".as_slice()],
+        "expected EVN/PID/PV1 segment order",
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add canonical `hl7v2` facade tests for ACK, model serialization, query, JSON, and conformance/datetime behavior
- expand existing batch and stream facade tests with multi-batch, headerless-message, trailer-mismatch, field-content, and segment-order coverage
- keep retired shim folders untouched; the migrated tests exercise the current product API, not old crate imports

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check --cached`
- `cargo +1.93.0 test -p hl7v2 --all-features`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 check --examples`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check --workspace --all-features --all-targets`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test --workspace --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test --doc --workspace`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check --examples`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check`