### PR TITLE
docs: remove local shim folder references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,49 +63,41 @@ The policy stack is documented in:
 
 ## Architecture
 
-This is a Cargo workspace with 28 crates in `crates/`, organized in three layers:
+This repository now uses `hl7v2` as the canonical Rust library and keeps SRP
+implementation boundaries as modules inside that crate.
 
-**Microcrates** (minimal dependencies, single-responsibility):
-- `hl7v2-model` — Core data types: Message, Segment, Field, Rep, Comp, Atom, Delims
-- `hl7v2-escape` — HL7v2 escape sequences (\F\, \S\, \R\, \E\, \T\)
-- `hl7v2-mllp` — MLLP framing (VT...FS CR)
-- `hl7v2-parser` — Message parsing from bytes, delimiter discovery from MSH
-- `hl7v2-writer` — Message serialization to HL7 wire format and JSON
-- `hl7v2-json` — JSON serialization/deserialization for HL7 messages
-- `hl7v2-normalize` — Message normalization and delimiter transformation
-- `hl7v2-datetime` — Date/time parsing and validation
-- `hl7v2-datatype` — Data type validation (CX, PN, TS, etc.)
-- `hl7v2-path` — Field path parsing/resolution (e.g., `PID.5[1].1`)
-- `hl7v2-query` — Fast path-based data extraction
-- `hl7v2-batch` — Batch message handling (FHS/BHS/BTS/FTS)
-- `hl7v2-network` — Async TCP/TLS MLLP client and server
-- `hl7v2-stream` — Event-based streaming parser for large messages
-- `hl7v2-validation` — Rule-based message validation engine
-- `hl7v2-ack` — Automatic ACK generation logic
-- `hl7v2-faker` — Realistic synthetic data generation
-- `hl7v2-template` — Template-based message generation
-- `hl7v2-template-values` — Values and generators for templates
-- `hl7v2-corpus` — Pre-defined HL7 sample messages
+**Public Rust product crates**:
+- `hl7v2` — library crate for model, parser, writer, query, transport,
+  conformance, ACK, normalization, synthetic data, lifecycle, and experimental
+  modules.
+- `hl7v2-server` — Axum/Tonic HTTP and gRPC runtime service with metrics,
+  health checks, auth, rate limiting, and deployment config.
+- `hl7v2-cli` — CLI binary (`hl7v2`) with parsing, validation, ACK,
+  normalization, streaming, and generation workflows.
 
-**Mid-level crates**:
-- `hl7v2-core` — Facade re-exporting all microcrates.
-- `hl7v2-prof` — Profile-based validation with inheritance (YAML profiles in `profiles/`)
-- `hl7v2-gen` — Synthetic message generation facade
-- `hl7v2-bench` — High-performance benchmarks for all layers
+**Separate packaging lane**:
+- `hl7v2-python` — PyO3 binding package. It is `publish = false` for crates.io
+  and should be validated with Python/maturin tooling before any PyPI release.
 
-**Application crates**:
-- `hl7v2-cli` — CLI binary (`hl7v2`) with streaming support
-- `hl7v2-server` — Axum HTTP API server with metrics, health checks, rate limiting
+**Internal crates and packages**:
+- `hl7v2-bench` — benchmark harness.
+- `hl7v2-test-utils` — shared testing utilities and fixtures.
+- `hl7v2-e2e-tests` — end-to-end tests for full message pipelines.
+- `xtask` — workspace automation.
+- root `hl7v2-examples` package — examples only; `publish = false`.
 
-**Testing crates**:
-- `hl7v2-test-utils` — Shared testing utilities and fixtures
-- `hl7v2-e2e-tests` — Integration tests for full message pipelines
+Former microcrate package names such as `hl7v2-core`, `hl7v2-model`,
+`hl7v2-parser`, and `hl7v2-prof` have been retired from the local workspace.
+Their implementation now lives under `hl7v2::...` module paths. Historical
+old-name crates.io artifacts may exist, but new code should depend on `hl7v2`.
 
-Dependency flow: microcrates → core → prof/gen → cli/server. All shared dependency versions are declared in the root `[workspace.dependencies]`.
+Dependency flow: `hl7v2` -> `hl7v2-server` / `hl7v2-cli` / wrappers and tests.
+All shared dependency versions are declared in the root `[workspace.dependencies]`.
 
 ## Conventions
 
-- **Rust edition 2024**, MSRV 1.92
-- **Error handling**: Each crate has its own error type using `thiserror`. Errors preserve context with `#[source]` chains.
+- **Rust edition 2024**, MSRV 1.93
+- **Error handling**: Public modules use typed errors with `thiserror` where
+  needed. Errors preserve context with `#[source]` chains.
 - **Tests**: Unit tests in `src/tests.rs` modules (`#[cfg(test)]`), integration tests in `tests/` directories.
-- **Commit messages**: `<type>(<scope>): <subject>` — types: feat, fix, docs, style, refactor, test, chore; scopes: core, prof, gen, cli, network, etc.
+- **Commit messages**: `<type>(<scope>): <subject>` — types: feat, fix, docs, style, refactor, test, chore; scopes should name the current crate or module, such as `hl7v2`, `parser`, `profile`, `cli`, or `server`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,20 +1,20 @@
 # Development Guide
 
-Get up and running with hl7v2-rs development.
+Get up and running with `hl7v2-rs` development.
 
----
-
-## 🚀 Quick Start
+## Quick Start
 
 ### 1. Setup Environment
 
-We use **Nix** for a reproducible development environment. If you have Nix installed with flakes enabled:
+We use Nix for a reproducible development environment. If you have Nix
+installed with flakes enabled:
 
 ```bash
 nix develop
 ```
 
-This shell includes all necessary tools: `rust`, `cargo-nextest`, `cargo-deny`, `just`, etc.
+This shell includes the expected Rust, Cargo, `cargo-nextest`, `cargo-deny`,
+and `just` tooling.
 
 ### 2. Repository Setup
 
@@ -26,44 +26,41 @@ just setup
 
 ### 3. Verify Everything
 
-Run the "gate" command to verify formatting, lints, and tests:
+Run the gate command to verify formatting, lints, and tests:
 
 ```bash
 just gate
 ```
 
----
+## Unified Development Workflow
 
-## 🛠️ Unified Development Workflow
-
-We use `just` as our primary entry point. It wraps `cargo xtask` for complex automation.
+We use `just` as the primary entry point. It wraps `cargo xtask` for complex
+automation.
 
 ### Basic Loop
 
 | Command | Action |
-|---------|--------|
-| `just lint-fix` | **Mutating**. Auto-formats code and applies safe clippy fixes. |
-| `just gate` | Fast local "CI preview". Checks fmt, clippy, and compiles tests. |
-| `just gate-check` | **Strict**. Exactly what runs in CI. No mutations allowed. |
-| `just gate-changed` | **Fast**. Only runs checks for crates impacted by your changes. |
-| `just test` | Runs all tests using `cargo-nextest` (if available) or `cargo test`. |
+| --- | --- |
+| `just lint-fix` | Mutating. Auto-formats code and applies safe clippy fixes. |
+| `just gate` | Fast local CI preview. Checks fmt, clippy, and compiles tests. |
+| `just gate-check` | Strict CI-parity gate. No mutations allowed. |
+| `just gate-changed` | Faster checks for crates impacted by your changes. |
+| `just test` | Runs all tests using `cargo-nextest` when available, otherwise `cargo test`. |
 
-### Scaffolding New Crates
+### Adding New Implementation
 
-To create a new microcrate with all standard boilerplate (README, CLAUDE.md, Cargo.toml inheritance):
-
-```bash
-just scaffold my-feature "Brief description of the feature"
-```
+Normal feature work should add modules under `crates/hl7v2/src`. Add a new
+workspace crate only when the design needs a separate product, binary, service,
+foreign-language binding, benchmark, test, or tool boundary.
 
 ### Documentation
 
 ```bash
 just docs        # Build and open workspace documentation
-just docs-build  # Build docs without opening (for CI)
+just docs-build  # Build docs without opening, for CI
 ```
 
-### Quality & Security
+### Quality And Security
 
 ```bash
 just audit       # Run security vulnerability scan and license check
@@ -71,53 +68,48 @@ just outdated    # Check for outdated dependencies
 just bench       # Run all benchmarks
 ```
 
----
+## Project Structure
 
-## 🏗️ Project Structure
+The project is a Cargo workspace with one public Rust library crate, two public
+Rust wrapper crates, a separate Python binding lane, and private test/tool
+crates:
 
-The project is a Cargo workspace with 28 specialized crates in `crates/`, organized into layers:
+1. **Library**: `hl7v2`, which owns parser, writer, query, transport,
+   conformance, synthetic, lifecycle, and operational modules.
+2. **Rust products**: `hl7v2-server` and `hl7v2-cli`, which depend on `hl7v2`.
+3. **Python lane**: `hl7v2-python`, kept `publish = false` for crates.io and
+   released through Python packaging tooling.
+4. **Internal support**: `hl7v2-e2e-tests`, `hl7v2-test-utils`, `hl7v2-bench`,
+   `xtask`, and the root examples package.
 
-1.  **Microcrates** (SRP-focused): Foundational logic like `hl7v2-model`, `hl7v2-parser`, `hl7v2-writer`.
-2.  **Service Crates**: Connectivity and validation like `hl7v2-network`, `hl7v2-validation`, `hl7v2-prof`.
-3.  **Applications**: User-facing tools like `hl7v2-cli` and `hl7v2-server`.
+## Agent Workflow
 
----
+If you are an AI agent, follow this loop:
 
-## 🤖 Agent Workflow (Enforced)
+1. Perform your edits.
+2. Run `just lint-fix` when the lane allows mutating fixes.
+3. Run `just gate-check` before opening a PR.
+4. Do not rely on CI to discover lint or formatting errors.
 
-If you are an AI agent (Claude, Gemini, etc.), you **must** follow this loop:
-
-1.  Perform your edits.
-2.  Run `just lint-fix` to tighten the bolts.
-3.  Run `just gate-check` to ensure no regressions.
-4.  Only then open a PR.
-
-*Do not rely on CI to discover lint or formatting errors.*
-
----
-
-## 🧪 Testing Tips
+## Testing Tips
 
 ### Focused Testing
 
 ```bash
-# Test a specific crate
-cargo test -p hl7v2-core
+# Test the canonical library crate
+cargo test -p hl7v2
 
 # Run a specific test with output
 cargo test test_name -- --nocapture
 ```
 
-### Integration & E2E
+### Integration And E2E
 
-Integration tests are in `tests/` directories within each crate. End-to-end tests involving the CLI and network are in `crates/hl7v2-e2e-tests`.
+Integration tests live in `tests/` directories within retained crates.
+End-to-end tests involving the CLI and network are in
+`crates/hl7v2-e2e-tests`.
 
----
+## ADRs
 
-## 📜 ADRs (Architecture Decision Records)
-
-All major technical decisions are documented in `docs/adr/`. Please review them before proposing significant architectural changes.
-
----
-
-**Happy coding!** 🦀
+All major technical decisions are documented in `docs/adr/`. Review them before
+proposing significant architectural changes.

--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ Implementation boundaries live as modules under `hl7v2`, including
 `hl7v2::transport`, `hl7v2::conformance`, `hl7v2::synthetic`,
 `hl7v2::lifecycle`, and `hl7v2::experimental`.
 
-In this repository, old implementation microcrate names are retained only as
-private deprecated compatibility shims unless a future compatibility release
-deliberately changes that policy. Some historical `1.2.0` artifacts for old
-package names already exist on crates.io; those names are compatibility
-artifacts, not the product surface for new code.
+Old implementation microcrate package names may exist historically on
+crates.io, but their local shim folders have been retired from this repository.
+Those names are compatibility artifacts, not the product surface for new code.
 
 ## Installation
 
@@ -243,9 +241,9 @@ hl7v2-python
   PyO3 binding package; released through the Python packaging lane
 ```
 
-The deprecated compatibility crates re-export `hl7v2` modules and should not
-gain new behavior. See [ADR-015](docs/adr/0015-collapse-public-crate-surface.md)
-and [the module map](docs/architecture/module-map.md) for the migration policy.
+Retired compatibility crate names should not gain new behavior. See
+[ADR-015](docs/adr/0015-collapse-public-crate-surface.md) and
+[the module map](docs/architecture/module-map.md) for the migration policy.
 
 ## Performance Characteristics
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -68,10 +68,15 @@ cargo run -p xtask -- publish-plan
 cargo run -p xtask -- publish --yes
 
 # Resume from a specific crate if crates.io index propagation interrupted the run
-cargo run -p xtask -- publish --yes --from hl7v2-template-values
+cargo run -p xtask -- publish --yes --from hl7v2-server
 ```
 
-The publish sequence excludes non-published workspace members such as `hl7v2-python`, `hl7v2-bench`, `hl7v2-test-utils`, `hl7v2-e2e-tests`, `xtask`, and the root `hl7v2-examples` package.
+The publish sequence is the Rust product graph: `hl7v2`, then `hl7v2-server`,
+then `hl7v2-cli`. It excludes non-published workspace members such as
+`hl7v2-python`, `hl7v2-bench`, `hl7v2-test-utils`, `hl7v2-e2e-tests`, `xtask`,
+and the root `hl7v2-examples` package. Historical old microcrate package names
+are not published again unless a deliberate deprecation-only compatibility
+release is approved.
 
 For GitHub Actions based releases, use the manual `Publish to crates.io` workflow. It prints the derived order first and only publishes when `execute=true` is selected and the `CARGO_REGISTRY_TOKEN` secret is configured.
 

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -39,14 +39,12 @@ hl7v2-cli
 xtask
 ```
 
-The Python binding crate and soon-to-be-collapsed implementation crates are
-staged in `policy/clippy-lints.toml`; the Python binding has an explicit debt
-receipt in `policy/clippy-debt.toml` while its PyO3 packaging lane stays
-isolated:
+The Python binding crate and private test/benchmark crates are staged in
+`policy/clippy-lints.toml`; the Python binding has an explicit debt receipt in
+`policy/clippy-debt.toml` while its PyO3 packaging lane stays isolated:
 
 ```text
 hl7v2-python
-current microcrates
 internal test and benchmark crates
 ```
 
@@ -55,9 +53,9 @@ server or CLI lint debt that was not appropriate to clean up in this policy PR
 must be represented by a reasoned `#[expect(...)]` and an expiring
 `policy/clippy-debt.toml` receipt.
 
-Soon-to-be-collapsed implementation microcrates are not required to opt in
-individually during demicrocrating. When their code moves under `hl7v2`, the
-canonical library crate's inherited lint baseline applies.
+Former implementation microcrates have been retired locally. Their code now
+lives under `hl7v2`, so the canonical library crate's inherited lint baseline
+is the enforcement point for that implementation surface.
 
 ## No test carveouts
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -13,7 +13,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
 | `hl7v2-python` | 🟡 Experimental | N/A | PyO3 binding package held out of the crates.io Rust publish graph; validate through the Python/maturin lane before release. |
-| compatibility shims | ✅ Package-frozen | N/A | In the current workspace, old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are private deprecated shims unless explicitly retained for compatibility. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
+| retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
 ## Feature Set (v1.2.1)
 

--- a/docs/TESTING_ANALYSIS.md
+++ b/docs/TESTING_ANALYSIS.md
@@ -3,6 +3,10 @@
 **Generated:** 2026-02-24  
 **Total Crates Analyzed:** 26
 
+> Historical note: this analysis predates the post-1.2.1 crate-surface collapse
+> and local shim-folder retirement. It is retained as a dated testing receipt;
+> current Rust consumers should use `hl7v2` and its module paths.
+
 ## Executive Summary
 
 This document provides a comprehensive analysis of the testing status across all 26 microcrates in the hl7v2-rs workspace. The analysis covers unit tests, integration tests, BDD tests, property-based tests, fuzz tests, snapshot tests, and benchmarks.

--- a/docs/TESTING_SUMMARY.md
+++ b/docs/TESTING_SUMMARY.md
@@ -1,5 +1,9 @@
 # HL7v2-rs Testing Summary
 
+> Historical note: this summary predates the post-1.2.1 crate-surface collapse
+> and local shim-folder retirement. It is retained as a dated testing receipt;
+> current Rust consumers should use `hl7v2` and its module paths.
+
 ## Overview
 - **Total Crates:** 26
 - **Total Tests:** ~1,300+

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -1,194 +1,123 @@
-# HL7v2 Crate Collapse Module Map
+# HL7v2 Module Map
 
-This document is the working map for collapsing implementation microcrates into modules under the canonical `hl7v2` Rust library crate. It implements the policy from [ADR-015](../adr/0015-collapse-public-crate-surface.md).
+This document records the current post-1.2.1 shape after the public crate
+surface collapse described by [ADR-015](../adr/0015-collapse-public-crate-surface.md).
 
 ## Current State
 
-As of 2026-05-07, the implementation modules have been collapsed into
-`hl7v2`, and `cargo run -p xtask -- publish-plan` resolves the final Rust
-package graph:
+As of 2026-05-08, the implementation modules have been collapsed into the
+canonical `hl7v2` Rust library crate. Local compatibility shim crate folders
+were retired after the v1.2.1 release. `cargo run -p xtask -- publish-plan`
+resolves the Rust product graph:
 
-- `hl7v2`
-- `hl7v2-server`
-- `hl7v2-cli`
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
 
-`hl7v2-python` remains an external binding package in the workspace, but it is
-not part of the crates.io Rust publish graph. It is released through the
-separate Python packaging lane.
+`hl7v2-python` remains in the workspace as a separate PyO3 binding lane with
+`publish = false` for crates.io.
 
-The old implementation package names remain in the workspace as private
-deprecated compatibility shims and test harnesses. They are retained only to
-prove old import paths while the compatibility policy is still active. Some old
-package names already have historical `1.2.0` artifacts on crates.io; the
-current workspace keeps those names `publish = false` and does not treat them
-as product surfaces for new code.
+Historical old microcrate package names may exist on crates.io, but those names
+are compatibility artifacts. New Rust code should depend on `hl7v2` and use
+module paths under that crate.
 
 ## Boundary Rule
 
-Crates are product and distribution surfaces. SRP implementation units are modules unless they require a separate release, package, binary, runtime service, or foreign-language binding boundary.
+Crates are product and distribution surfaces. SRP implementation units are
+modules unless they require a separate release, package, binary, runtime
+service, or foreign-language binding boundary.
 
-## Target Public Crates
-
-| Crate | Role | Migration rule |
-| --- | --- | --- |
-| `hl7v2` | Canonical Rust library crate | Owns the core HL7 API and implementation modules. |
-| `hl7v2-server` | HTTP/gRPC runtime service | Depends on `hl7v2` with runtime features; keeps Axum, Tonic, metrics, auth, CORS, and deployment config. |
-| `hl7v2-cli` | Binary distribution | Depends on `hl7v2` with CLI-needed features. |
-| `hl7v2-python` | Python binding package | Depends on `hl7v2`; keeps PyO3 isolated and uses `publish = false` for the crates.io Rust publish graph. |
-
-## Target Internal Crates
+## Public And Internal Crates
 
 | Crate | Role | Publish policy |
 | --- | --- | --- |
-| `hl7v2-e2e-tests` | End-to-end tests | `publish = false` |
-| `hl7v2-test-utils` | Shared test utilities | `publish = false`; later candidate for `tests/support` |
-| `hl7v2-bench` | Benchmark harness if retained | `publish = false`; prefer root `benches/` if practical |
-| `xtask` | Workspace automation | `publish = false` |
+| `hl7v2` | Canonical Rust library crate and implementation home. | Public crates.io package. |
+| `hl7v2-server` | HTTP/gRPC runtime service with Axum, Tonic, metrics, auth, CORS, and deployment config. | Public crates.io package. |
+| `hl7v2-cli` | Command-line binary distribution. | Public crates.io package. |
+| `hl7v2-python` | Python binding package that depends on `hl7v2`. | `publish = false`; Python/maturin lane. |
+| `hl7v2-e2e-tests` | End-to-end tests. | `publish = false`. |
+| `hl7v2-test-utils` | Shared test utilities. | `publish = false`; later candidate for `tests/support`. |
+| `hl7v2-bench` | Benchmark harness. | `publish = false`; later candidate for root `benches/`. |
+| root `hl7v2-examples` package | Examples. | `publish = false`. |
+| `xtask` | Workspace automation. | `publish = false`. |
 
-## Current Crate to Target Module Map
+## Former Package To Current Module Map
 
-| Current crate | Target location | Public status | Notes |
-| --- | --- | --- | --- |
-| `hl7v2` | `hl7v2` crate root | Public | Becomes the real facade and implementation crate. |
-| `hl7v2-core` | temporary compatibility shim or removed | Temporary | Do not keep as a second facade. |
-| `hl7v2-model` | `hl7v2::model` | Module | Foundation data structures. |
-| `hl7v2-escape` | `hl7v2::escape` | Module | Small standalone escaping helpers. |
-| `hl7v2-mllp` | `hl7v2::transport::mllp` | Module | Core MLLP framing; not async networking. |
-| `hl7v2-network` | `hl7v2::transport::network` | Feature-gated module | Async MLLP client/server behind `network`. |
-| `hl7v2-path` | `hl7v2::query::path` | Module | Path parsing belongs with query. |
-| `hl7v2-query` | `hl7v2::query` | Module | Field/query access and presence semantics. |
-| `hl7v2-json` | `hl7v2::writer::json` | Module | JSON serialization folds into writer unless a later PR proves otherwise. |
-| `hl7v2-parser` | `hl7v2::parser` | Module | Also exposes top-level `parse`, `parse_mllp`, `parse_batch`, `parse_file_batch`. |
-| `hl7v2-writer` | `hl7v2::writer` | Module | Also exposes top-level `write`, `write_mllp`, and JSON helpers. |
-| `hl7v2-normalize` | `hl7v2::normalize` | Module | Top-level `normalize` remains stable. |
-| `hl7v2-batch` | `hl7v2::batch` | Collapsed as leaf feature module | Batch file parsing/writing; `hl7v2-batch` remains a compatibility shim. |
-| `hl7v2-stream` | `hl7v2::stream` | Feature-gated module | Event parser behind `stream`. |
-| `hl7v2-prof` | `hl7v2::conformance::profile` | Module | Profile loading, inheritance, cache, and profile-backed validation. |
-| `hl7v2-validation` | `hl7v2::conformance::validation` | Module | Issues, severity, validators, and validation engine helpers. |
-| `hl7v2-datatype` | `hl7v2::conformance::datatype` | Collapsed as leaf conformance module | Primitive/composite data type validation; `hl7v2-datatype` remains a compatibility shim. |
-| `hl7v2-datetime` | `hl7v2::conformance::datatype::datetime` | Collapsed as leaf conformance module | Datetime parsing is part of datatype validation; `hl7v2-datetime` remains a compatibility shim. |
-| `hl7v2-ack` | `hl7v2::ack` | Collapsed as ACK feature module | First-class runtime HL7 behavior; `hl7v2-ack` remains a compatibility shim. |
-| `hl7v2-faker` | `hl7v2::synthetic::faker` | Collapsed as synthetic feature module | Test/synthetic data generation behind `synthetic`; `hl7v2-faker` remains a compatibility shim. |
-| `hl7v2-corpus` | `hl7v2::synthetic::corpus` | Collapsed as synthetic feature module | Corpus manifest and lock behavior behind `synthetic`; `hl7v2-corpus` remains a compatibility shim. |
-| `hl7v2-template` | `hl7v2::synthetic::template` | Collapsed as synthetic feature module | Template model/rendering behind `synthetic`; `hl7v2-template` remains a compatibility shim. |
-| `hl7v2-template-values` | `hl7v2::synthetic::values` | Collapsed as synthetic feature module | Value distributions/sources behind `synthetic`; `hl7v2-template-values` remains a compatibility shim. |
-| `hl7v2-gen` | `hl7v2::synthetic::generate` | Collapsed as synthetic feature module | Generation facade behind `synthetic`; ACK remains in `hl7v2::ack`; `hl7v2-gen` remains a compatibility shim. |
-| `hl7v2-redact` | `hl7v2::redact` | Feature-gated module | Collapsed as a leaf feature module; `hl7v2-redact` is a compatibility shim. |
-| `hl7v2-lifecycle` | `hl7v2::lifecycle` | Collapsed as leaf feature module | `hl7v2-lifecycle` remains a compatibility shim. |
-| `hl7v2-guard` | `hl7v2::experimental::guard` | Collapsed as leaf experimental feature module | `hl7v2-guard` remains a compatibility shim; do not present guard as stable until semantics are proven. |
-| `hl7v2-server` | `crates/hl7v2-server` | Public crate | Keep external. |
-| `hl7v2-cli` | `crates/hl7v2-cli` | Public crate | Keep external. |
-| `hl7v2-python` | `crates/hl7v2-python` | Separate binding lane | Keep external; release with Python packaging tooling, not crates.io by default. |
-| `hl7v2-bench` | root `benches/` or private crate | Internal | Prefer root benches; keep private crate only if needed. |
-| `hl7v2-e2e-tests` | `crates/hl7v2-e2e-tests` | Internal | Keep or later move to workspace tests. |
-| `hl7v2-test-utils` | `crates/hl7v2-test-utils` or `tests/support` | Internal | Keep until shared helpers can move safely. |
-| `xtask` | `xtask` | Internal | Keep. |
-
-## Target Feature Flags
-
-| Feature | Dependencies | Modules |
+| Former package | Current location | Notes |
 | --- | --- | --- |
-| `default` | `std`, `serde`, `json`, `profile`, `ack`, `normalize` | Normal parse/inspect/validate/ACK/normalize/serialize workflow. |
-| `std` | none | Standard-library support. |
-| `serde` | `serde` | Serialization derives and models. |
-| `json` | `serde`, `serde_json` | JSON writer helpers. |
-| `profile` | `serde`, `serde_yaml`, `regex` | Profile loading and validation. |
-| `ack` | none | ACK generation. |
-| `normalize` | none | Normalization helpers. |
-| `batch` | none unless later proven needed | Batch parsing/writing. |
-| `stream` | `tokio` if async stream support remains in the same feature | Streaming parser APIs. |
-| `network` | `stream`, `tokio`, `tokio-util`, `futures`, `bytes` | Async MLLP networking. |
-| `synthetic` | `ack`, `serde`, `chrono`, `rand`, `rand_distr`, `serde_json`, `serde_yaml`, `sha2`, `uuid` | Faker, corpus, templates, values, generation. |
-| `redact` | none | Redaction rules/policies. |
-| `lifecycle` | `chrono`, `serde`, `sha2` | Retention/archive lifecycle. |
-| `experimental-guard` | `serde` | Experimental guard/anomaly detection. |
+| `hl7v2-core` | Removed locally | `hl7v2` is the only canonical Rust facade. |
+| `hl7v2-model` | `hl7v2::model` | Foundation data structures. |
+| `hl7v2-escape` | `hl7v2::escape` | HL7 v2 escape and unescape helpers. |
+| `hl7v2-mllp` | `hl7v2::transport::mllp` | Core MLLP framing. |
+| `hl7v2-network` | `hl7v2::transport::network` | Async MLLP client/server behind `network`. |
+| `hl7v2-path` | `hl7v2::query::path` | Path parsing belongs with query. |
+| `hl7v2-query` | `hl7v2::query` | Field/query access and presence semantics. |
+| `hl7v2-json` | `hl7v2::writer::json` | JSON serialization lives with writer. |
+| `hl7v2-parser` | `hl7v2::parser` | Also exposes top-level `parse`, `parse_mllp`, `parse_batch`, and `parse_file_batch`. |
+| `hl7v2-writer` | `hl7v2::writer` | Also exposes top-level `write`, `write_mllp`, and JSON helpers. |
+| `hl7v2-normalize` | `hl7v2::normalize` | Top-level `normalize` remains stable. |
+| `hl7v2-batch` | `hl7v2::batch` | Batch file parsing/writing. |
+| `hl7v2-stream` | `hl7v2::stream` | Event parser behind `stream`. |
+| `hl7v2-prof` | `hl7v2::conformance::profile` | Profile loading, inheritance, cache, and profile-backed validation. |
+| `hl7v2-validation` | `hl7v2::conformance::validation` | Issues, severity, validators, and validation engine helpers. |
+| `hl7v2-datatype` | `hl7v2::conformance::datatype` | Primitive/composite data type validation. |
+| `hl7v2-datetime` | `hl7v2::conformance::datatype::datetime` | Datetime parsing is part of datatype validation. |
+| `hl7v2-ack` | `hl7v2::ack` | First-class runtime HL7 ACK behavior. |
+| `hl7v2-faker` | `hl7v2::synthetic::faker` | Test/synthetic data generation behind `synthetic`. |
+| `hl7v2-corpus` | `hl7v2::synthetic::corpus` | Corpus manifest and lock behavior behind `synthetic`. |
+| `hl7v2-template` | `hl7v2::synthetic::template` | Template model/rendering behind `synthetic`. |
+| `hl7v2-template-values` | `hl7v2::synthetic::values` | Value distributions/sources behind `synthetic`. |
+| `hl7v2-gen` | `hl7v2::synthetic::generate` | Generation facade behind `synthetic`; ACK remains in `hl7v2::ack`. |
+| `hl7v2-redact` | `hl7v2::redact` | Redaction rules and policies. |
+| `hl7v2-lifecycle` | `hl7v2::lifecycle` | Retention/archive lifecycle. |
+| `hl7v2-guard` | `hl7v2::experimental::guard` | Experimental guard/anomaly detection. |
 
-## Dependency-Order Migration
+## Feature Flags
 
-Move from the dependency floor upward:
+| Feature | Modules |
+| --- | --- |
+| `default` | Normal parse/inspect/validate/ACK/normalize/serialize workflow. |
+| `json` | JSON writer helpers. |
+| `profile` | Profile loading and validation. |
+| `ack` | ACK generation. |
+| `normalize` | Normalization helpers. |
+| `batch` | Batch parsing/writing. |
+| `stream` | Streaming parser APIs. |
+| `network` | Async MLLP networking. |
+| `synthetic` | Faker, corpus, templates, values, and generation. |
+| `redact` | Redaction rules/policies. |
+| `lifecycle` | Retention/archive lifecycle. |
+| `experimental-guard` | Experimental guard/anomaly detection. |
 
-1. `path`
-2. `model`
-3. `escape` and MLLP framing
-4. `query`
-5. `parser`
-6. `writer`, `json`, and `normalize`
-7. `validation`, `datatype`, and `datetime`
-8. `profile`
-9. `ack`
-10. `synthetic`
-11. `batch`, `stream`, and `network`
-12. `redact`, `lifecycle`, and `experimental::guard`
-13. server, CLI, Python, examples, e2e tests, and test-utils imports
-14. workspace member removal
-15. compatibility shim removal or freeze
+## Import Rules
 
-`path` is intentionally split out first because it has no implementation-crate
-dependencies. Moving `model`, `escape`, or MLLP while parser/writer/query still
-depend on those crates would force compatibility shims to depend back on
-`hl7v2` and create Cargo cycles.
-
-Leaf feature crates with no remaining implementation-crate dependents can also
-collapse before the foundation block is fully resolved. Those PRs must be
-narrow, keep compatibility shims, and state why they do not introduce cycles.
-`hl7v2-redact`, `hl7v2-guard`, `hl7v2-lifecycle`, `hl7v2-datatype`,
-`hl7v2-datetime`, and `hl7v2-batch` used that path: their implementations now
-live under `hl7v2`, and the old crates are compatibility shims.
-
-The synthetic crates collapsed as one cluster instead of one crate per PR.
-`hl7v2-faker`, `hl7v2-corpus`, `hl7v2-template-values`, `hl7v2-template`, and
-`hl7v2-gen` depend on each other enough that collapsing only one would make its
-shim depend back on `hl7v2` while another synthetic implementation crate still
-depended on the shim. Moving the cluster together preserves behavior without
-introducing Cargo cycles.
-
-## Import Conversion Rules
-
-Moved implementation code should use crate-internal paths:
-
-```rust
-use crate::model::{Message, Segment};
-use crate::parser::parse;
-use crate::writer::write;
-```
-
-Application, wrapper, and public API tests should use the public product crate:
+Public consumers should use `hl7v2`:
 
 ```rust
 use hl7v2::{ack, get, load_profile_checked, parse, validate, write};
 ```
 
-Module-specific tests can use module paths when they are testing that module directly:
+Module-specific tests and implementers can use module paths:
 
 ```rust
 use hl7v2::conformance::datatype::parse_hl7_ts;
 ```
 
-## PR Sequence
+Inside `crates/hl7v2`, implementation code should use crate-internal module
+paths such as `crate::model`, `crate::parser`, and `crate::writer`.
 
-| PR lane | Branch | Scope |
-| --- | --- | --- |
-| 1 | `docs/crate-surface-collapse-adr` | ADR and module map only. |
-| 2 | `refactor/hl7v2-canonical-facade` | Make `hl7v2` re-export the stable API directly from current crates; no file moves. |
-| 3 | `refactor/collapse-path-module` | Move `hl7v2-path` into `hl7v2::query::path`; keep a temporary shim. |
-| 4 | `refactor/collapse-foundation-modules` | Move `model`, `escape`, and MLLP framing once their downstream users can be handled without cycles. |
-| 5 | `refactor/collapse-query-modules` | Move query access/presence after path is already internal. |
-| 6 | `refactor/collapse-parse-write-modules` | Move parser, writer, JSON, and normalize. |
-| 7 | `refactor/collapse-conformance-modules` | Move validation, datatype, datetime, and profile. |
-| 8 | `refactor/collapse-ack-synthetic-modules` | Move ACK and synthetic modules. |
-| 9 | `refactor/collapse-transport-processing-modules` | Move batch, stream, and network. |
-| 10 | `refactor/collapse-operational-modules` | Move redact, lifecycle, and experimental guard. |
-| 11 | `refactor/update-app-crates-to-hl7v2` | Make server, CLI, Python, examples, e2e tests, and test-utils import through `hl7v2`. |
-| 12 | `refactor/remove-microcrate-workspace-members` | Shrink `[workspace].members`. |
-| 13 | `refactor/remove-compat-shims` | Remove or freeze compatibility shims. |
+## Historical Migration
 
-## Per-PR Rules
+The collapse sequence was completed in stages: facade inversion, first-party
+consumer migration, module collapse by dependency layer, workspace membership
+cleanup, canonical facade tests, and local shim-folder deletion. The historical
+planning details remain in ADR-015 and dated audit documents; this file now
+describes the active repository shape.
 
-- One layer per PR.
-- Preserve behavior.
-- Do not weaken tests.
+## Rules For Future Changes
+
+- Do not reintroduce implementation microcrates for ordinary SRP boundaries.
 - Do not collapse `hl7v2-server`, `hl7v2-cli`, or `hl7v2-python` into `hl7v2`.
 - Do not keep `hl7v2-core` as a second facade.
-- Do not merge #380 as part of this migration.
-- State whether a PR adds, keeps, or removes compatibility shims.
-- Run focused tests for the moved layer plus a workspace check before merge.
+- Add new workspace crates only for product, runtime, binary, binding, test,
+  benchmark, or tool boundaries.

--- a/docs/audits/post-1.2.1-crate-retirement.md
+++ b/docs/audits/post-1.2.1-crate-retirement.md
@@ -1,5 +1,9 @@
 # Post-1.2.1 Crate Retirement Audit
 
+> Completion note: PR #447 deleted the retired local shim crate directories
+> after workspace membership cleanup and facade coverage migration. This
+> document is retained as the dated retirement plan and evidence trail.
+
 ## Context
 
 `hl7v2-rs` v1.2.1 has been published to crates.io for the final Rust package


### PR DESCRIPTION
## Summary
- update current-facing docs to describe the post-#447 workspace shape after local shim folder deletion
- replace stale microcrate/scaffold guidance in contributor and agent docs with the current `hl7v2` module-first model
- refresh the module map as the active former-package-to-module map
- mark old testing analysis/summary docs and the crate-retirement audit as historical receipts instead of current topology guidance

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 run -p xtask -- check-file-policy`

Publish plan remains:
1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`