### PR TITLE
fix: add OpenAPI contact email

### DIFF
--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -34,6 +34,7 @@ info:
   contact:
     name: HL7v2-rs Team
     url: https://github.com/EffortlessMetrics/hl7v2-rs
+    email: team@effortlessmetrics.com
   license:
     name: AGPL-3.0-or-later
     url: https://github.com/EffortlessMetrics/hl7v2-rs/blob/main/LICENSE

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -34,6 +34,7 @@ info:
   contact:
     name: HL7v2-rs Team
     url: https://github.com/EffortlessMetrics/hl7v2-rs
+    email: team@effortlessmetrics.com
   license:
     name: AGPL-3.0-or-later
     url: https://github.com/EffortlessMetrics/hl7v2-rs/blob/main/LICENSE


### PR DESCRIPTION
## Summary
- add the project contact email to the source OpenAPI contact object
- sync the packaged hl7v2-server OpenAPI copy so package drift tests stay meaningful
- quiet the Spectral contact-properties warning without changing runtime behavior

## Validation
- npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml
- npx -y @bufbuild/buf lint api/proto
- cargo +1.93.0 test -p hl7v2-server --all-features openapi
- git diff --check
- cargo +1.93.0 fmt --all -- --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed

## Notes
- The first server OpenAPI test run failed because the packaged OpenAPI copy had not yet been synced; after updating crates/hl7v2-server/openapi/hl7v2-api-v1.yaml, the targeted test passed.