### PR TITLE
ci: update actions for Node 24 readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,13 @@ jobs:
         rust: [stable]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -96,17 +91,12 @@ jobs:
         rust: [stable]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -156,17 +146,12 @@ jobs:
             rust: '1.93'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -189,15 +174,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: dtolnay/rust-toolchain@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -223,15 +205,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: dtolnay/rust-toolchain@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -245,7 +224,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload benchmark artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: benchmark-results.txt

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -28,12 +28,12 @@ jobs:
     name: Validate OpenAPI Spec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install Spectral
         run: npm install -g @stoplight/spectral-cli
@@ -48,7 +48,7 @@ jobs:
         run: redocly build-docs api/openapi/hl7v2-api-v1.yaml -o docs/api-reference.html
 
       - name: Upload API Docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-docs
           path: docs/api-reference.html
@@ -57,15 +57,15 @@ jobs:
     name: Validate Protocol Buffers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup Buf
-        uses: bufbuild/buf-setup-action@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: '24'
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 'stable'
 
@@ -73,7 +73,7 @@ jobs:
         run: go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
       - name: Lint Protos
-        run: buf lint api/proto
+        run: npx -y @bufbuild/buf lint api/proto
 
       - name: Check Breaking Changes
         if: github.event_name == 'pull_request'
@@ -81,23 +81,23 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          buf breaking api/proto \
+          npx -y @bufbuild/buf breaking api/proto \
             --against "https://github.com/${REPOSITORY}.git#branch=${BASE_REF},subdir=api/proto"
 
       - name: Generate Proto Docs
         run: |
-          buf generate api/proto --template buf.gen.yaml
+          npx -y @bufbuild/buf generate api/proto --template buf.gen.yaml
 
   schema-validation:
     name: Validate Schemas
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install ajv-cli
         run: npm install -g ajv-cli ajv-formats

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,18 +55,13 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: "1.93"
           components: llvm-tools-preview
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use larger target dir
         run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
@@ -133,7 +128,7 @@ jobs:
 
       - name: Upload coverage to Codecov (main)
         if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
@@ -143,7 +138,7 @@ jobs:
 
       - name: Upload coverage to Codecov (advisory)
         if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
@@ -189,7 +184,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,10 +50,12 @@ jobs:
           - escape
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install nightly Rust toolchain (required for fuzzing)
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -82,7 +84,7 @@ jobs:
 
       - name: Collect fuzz artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: fuzz/artifacts/
@@ -99,10 +101,12 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -125,7 +129,7 @@ jobs:
         timeout-minutes: 60
 
       - name: Upload mutation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutation-report
           path: mutants-out/
@@ -151,10 +155,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -180,10 +186,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -214,10 +222,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -231,7 +241,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-docs
           path: target/doc/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,12 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,15 +17,12 @@ jobs:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: dtolnay/rust-toolchain@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -39,7 +36,7 @@ jobs:
 
       - name: Upload Audit Report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: audit-report
           path: audit-report.json
@@ -48,15 +45,12 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: dtolnay/rust-toolchain@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
 
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
@@ -69,14 +63,14 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Semgrep
         run: semgrep --config auto --sarif > semgrep.sarif
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif
 
@@ -84,17 +78,13 @@ jobs:
     name: Clippy Security Lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: stable
           components: clippy
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Clippy with Security Lints
         run: |
@@ -112,7 +102,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   if: github.event_name == 'pull_request'
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #     - name: Dependency Review
   #       uses: actions/dependency-review-action@v4
 
@@ -120,7 +110,7 @@ jobs:
     name: License Regression Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
       - name: Check for stale license references
@@ -143,7 +133,7 @@ jobs:
     name: Secrets Scanning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -178,9 +168,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
## Summary
- update GitHub-hosted actions to Node 24-capable major versions where available
- pin the Trivy workflow from a floating master ref to v0.36.0
- move dtolnay/rust-toolchain usage to the pinned v1 action with explicit toolchains
- remove setup-protoc from Rust workflows because the server build uses protoc-bin-vendored
- replace bufbuild/buf-setup-action with direct npx @bufbuild/buf calls in API Contracts

## Validation
- target/tools/actionlint/actionlint.exe
- npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml
- npx -y @bufbuild/buf lint api/proto
- git diff --check
- cargo +1.93.0 fmt --all -- --check
- cargo +1.93.0 run -p xtask -- publish-plan
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed

## Notes
- actionlint was downloaded from the official rhysd/actionlint GitHub release into target/tools for local validation; it is not committed.
- Workflow files were normalized to LF while editing to satisfy git diff --check.