### PR TITLE
feat: add stable validation report contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,8 @@ hl7v2 parse <input.mllp> --mllp --json > output.json
 # Validate against a profile (supports profile inheritance)
 hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml
 
-# (Planned) Emit a JSON validation report
-# hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml --report validation_errors.json
-# See docs/STATUS.md for current CLI flag support.
+# Emit a machine-readable validation report
+hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml --report json
 ```
 
 ### Normalize Messages

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -24,9 +24,9 @@
 use clap::{Parser, Subcommand};
 use hl7v2::synthetic::generate::{Template, generate};
 use hl7v2::{
-    AckCode as GenAckCode, Event, Message, StreamParser, ack, get, is_mllp_framed, load_profile,
-    load_profile_checked, normalize, parse, parse_mllp, to_json, validate, wrap_mllp, write,
-    write_mllp,
+    AckCode as GenAckCode, Event, Message, StreamParser, ValidationReport, ack, get,
+    is_mllp_framed, load_profile, load_profile_checked, normalize, parse, parse_mllp, to_json,
+    validate, wrap_mllp, write, write_mllp,
 };
 use std::fs;
 use std::io::{Read, Write};
@@ -1133,15 +1133,11 @@ fn val_command(
     monitor.record_metric("Message validation", validation_time);
 
     // Build validation report
-    let validation_report = ValidationReport {
-        input_file: input.to_string_lossy().to_string(),
-        profile_file: profile.to_string_lossy().to_string(),
-        file_size,
-        segment_count: message.segments.len(),
-        is_valid: results.is_empty(),
-        issue_count: results.len(),
-        issues: results.iter().map(|r| format!("{:?}", r)).collect(),
-    };
+    let validation_report = ValidationReport::from_issues(
+        &message,
+        Some(profile.to_string_lossy().to_string()),
+        results,
+    );
 
     // Output based on report format
     match report {
@@ -1155,15 +1151,25 @@ fn val_command(
         }
         ReportFormat::Text => {
             // Print validation results in text format
-            if results.is_empty() {
+            if validation_report.valid {
                 println!("Validation passed: No issues found");
             } else if detailed {
                 println!("Validation issues found:");
-                for result in &results {
-                    println!("  - {:?}", result);
+                for issue in &validation_report.issues {
+                    let path = issue.path.as_deref().unwrap_or("message");
+                    println!(
+                        "  - {} {} {}: {}",
+                        issue.severity.as_str(),
+                        issue.code,
+                        path,
+                        issue.message
+                    );
                 }
             } else {
-                println!("Validation failed: {} issues found", results.len());
+                println!(
+                    "Validation failed: {} issues found",
+                    validation_report.issue_count
+                );
             }
         }
     }
@@ -1175,29 +1181,17 @@ fn val_command(
         println!("  Input file: {:?}", input);
         println!("  Profile file: {:?}", profile);
         println!("  File size: {} bytes", file_size);
-        println!("  Segments: {}", message.segments.len());
-        println!("  Issues found: {}", results.len());
+        println!("  Segments: {}", validation_report.segment_count);
+        println!("  Issues found: {}", validation_report.issue_count);
         display_performance_stats(&monitor);
     }
 
     // Exit with error code if validation failed
-    if !results.is_empty() {
+    if !validation_report.valid {
         std::process::exit(1);
     }
 
     Ok(())
-}
-
-/// Validation report structure for JSON/YAML output
-#[derive(serde::Serialize)]
-struct ValidationReport {
-    input_file: String,
-    profile_file: String,
-    file_size: usize,
-    segment_count: usize,
-    is_valid: bool,
-    issue_count: usize,
-    issues: Vec<String>,
 }
 
 /// Statistics report structure for JSON/YAML output

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -7,7 +7,6 @@
     clippy::assertions_on_result_states,
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::uninlined_format_args,
     clippy::unwrap_used,
     reason = "legacy CLI unit tests use static fixtures; cleanup is tracked in policy/clippy-debt.toml"
 )]
@@ -574,20 +573,16 @@ constraints:
             let results = hl7v2::validate(&message, &profile);
 
             // Create a validation report
-            let report = crate::ValidationReport {
-                input_file: "test.hl7".to_string(),
-                profile_file: "profile.yaml".to_string(),
-                file_size: 100,
-                segment_count: message.segments.len(),
-                is_valid: results.is_empty(),
-                issue_count: results.len(),
-                issues: results.iter().map(|r| format!("{:?}", r)).collect(),
-            };
+            let report = hl7v2::ValidationReport::from_issues(
+                &message,
+                Some("profile.yaml".to_string()),
+                results,
+            );
 
             // Verify JSON serialization works
             let json = serde_json::to_string_pretty(&report).expect("Should serialize to JSON");
-            assert!(json.contains("input_file"));
-            assert!(json.contains("is_valid"));
+            assert!(json.contains("message_type"));
+            assert!(json.contains("valid"));
         }
 
         #[test]
@@ -608,20 +603,16 @@ constraints:
             let results = hl7v2::validate(&message, &profile);
 
             // Create a validation report
-            let report = crate::ValidationReport {
-                input_file: "test.hl7".to_string(),
-                profile_file: "profile.yaml".to_string(),
-                file_size: 100,
-                segment_count: message.segments.len(),
-                is_valid: results.is_empty(),
-                issue_count: results.len(),
-                issues: results.iter().map(|r| format!("{:?}", r)).collect(),
-            };
+            let report = hl7v2::ValidationReport::from_issues(
+                &message,
+                Some("profile.yaml".to_string()),
+                results,
+            );
 
             // Verify YAML serialization works
             let yaml = serde_yaml::to_string(&report).expect("Should serialize to YAML");
-            assert!(yaml.contains("input_file"));
-            assert!(yaml.contains("is_valid"));
+            assert!(yaml.contains("message_type"));
+            assert!(yaml.contains("valid"));
         }
 
         // -------------------------------------------------------------------------

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -500,6 +500,61 @@ mod validate_command {
     }
 
     #[test]
+    fn test_validate_json_report_uses_stable_issue_contract() {
+        let dir = create_temp_dir();
+        let hl7_file = create_temp_hl7_with_content(
+            &dir,
+            "missing_pid3.hl7",
+            "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1\r",
+        );
+        let profile_file = create_temp_profile(
+            &dir,
+            "profile.yaml",
+            r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let assert = cmd
+            .args([
+                "val",
+                hl7_file.to_str().unwrap(),
+                "--profile",
+                profile_file.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .assert()
+            .failure();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert_eq!(report["valid"], false);
+        assert_eq!(report["message_type"], "ADT^A01");
+        assert!(
+            report["profile"]
+                .as_str()
+                .unwrap()
+                .ends_with("profile.yaml")
+        );
+        assert_eq!(report["issue_count"], 1);
+        assert_eq!(report["issues"][0]["code"], "missing_required_field");
+        assert_eq!(report["issues"][0]["severity"], "error");
+        assert_eq!(report["issues"][0]["path"], "PID.3");
+        assert_eq!(report["issues"][0]["rule_id"], "missing_required_field");
+        assert_eq!(report["issues"][0]["segment_index"], 1);
+        assert_eq!(report["issues"][0]["field_index"], 3);
+    }
+
+    #[test]
     fn test_validate_missing_hl7_file() {
         let dir = create_temp_dir();
         let profile_file = create_temp_profile(&dir, "profile.yaml", minimal_profile());

--- a/crates/hl7v2/src/conformance/validation.rs
+++ b/crates/hl7v2/src/conformance/validation.rs
@@ -82,6 +82,125 @@ impl Issue {
     }
 }
 
+/// Stable severity values used by machine-readable validation reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationReportSeverity {
+    /// Error-level issue.
+    Error,
+    /// Warning-level issue.
+    Warning,
+}
+
+impl ValidationReportSeverity {
+    /// Return the stable lowercase string representation.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+impl From<&Severity> for ValidationReportSeverity {
+    fn from(value: &Severity) -> Self {
+        match value {
+            Severity::Error => Self::Error,
+            Severity::Warning => Self::Warning,
+        }
+    }
+}
+
+/// Machine-readable validation report shared by CLI and service surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationReport {
+    /// Whether the message passed validation without error-level issues.
+    pub valid: bool,
+    /// HL7 trigger event from `MSH.9`, such as `ADT^A01`.
+    pub message_type: String,
+    /// Profile identifier, usually a path or configured profile name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    /// Number of parsed message segments.
+    pub segment_count: usize,
+    /// Number of reported validation issues.
+    pub issue_count: usize,
+    /// Stable validation issue records.
+    pub issues: Vec<ValidationReportIssue>,
+}
+
+impl ValidationReport {
+    /// Build a report from the message, optional profile label, and validation issues.
+    pub fn from_issues(message: &Message, profile: Option<String>, issues: Vec<Issue>) -> Self {
+        let report_issues: Vec<ValidationReportIssue> = issues
+            .into_iter()
+            .map(|issue| ValidationReportIssue::from_issue(message, issue))
+            .collect();
+        let valid = report_issues
+            .iter()
+            .all(|issue| issue.severity != ValidationReportSeverity::Error);
+
+        Self {
+            valid,
+            message_type: message_type(message),
+            profile,
+            segment_count: message.segments.len(),
+            issue_count: report_issues.len(),
+            issues: report_issues,
+        }
+    }
+}
+
+/// Stable validation issue record used in machine-readable reports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationReportIssue {
+    /// Stable snake_case issue code.
+    pub code: String,
+    /// Error or warning severity.
+    pub severity: ValidationReportSeverity,
+    /// HL7 path associated with the issue, such as `PID.3`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Stable rule identifier. Today this mirrors `code` for profile-generated issues.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_id: Option<String>,
+    /// Human-readable issue message.
+    pub message: String,
+    /// Zero-based segment index when it can be inferred from the issue path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment_index: Option<usize>,
+    /// One-based HL7 field index when it can be inferred from the issue path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_index: Option<usize>,
+}
+
+impl ValidationReportIssue {
+    /// Convert an internal validation issue into a stable report issue.
+    pub fn from_issue(message: &Message, issue: Issue) -> Self {
+        let code = stable_issue_code(&issue.code);
+        let (segment_index, field_index) = issue.path.as_deref().map_or((None, None), |path| {
+            (
+                segment_index_for_path(message, path),
+                field_index_for_path(path),
+            )
+        });
+
+        Self {
+            rule_id: if code.is_empty() {
+                None
+            } else {
+                Some(code.clone())
+            },
+            code,
+            severity: ValidationReportSeverity::from(&issue.severity),
+            path: issue.path,
+            message: issue.detail,
+            segment_index,
+            field_index,
+        }
+    }
+}
+
 /// Validation result type
 pub type ValidationResult = Vec<Issue>;
 
@@ -89,6 +208,53 @@ pub type ValidationResult = Vec<Issue>;
 pub trait Validator {
     /// Validate a message and return any issues found
     fn validate(&self, msg: &Message) -> ValidationResult;
+}
+
+fn stable_issue_code(code: &str) -> String {
+    let mut output = String::new();
+    let mut previous_was_separator = false;
+
+    for character in code.chars() {
+        if character.is_ascii_alphanumeric() {
+            output.push(character.to_ascii_lowercase());
+            previous_was_separator = false;
+        } else if !previous_was_separator && !output.is_empty() {
+            output.push('_');
+            previous_was_separator = true;
+        }
+    }
+
+    if output.ends_with('_') {
+        output.pop();
+    }
+
+    output
+}
+
+fn message_type(message: &Message) -> String {
+    let message_code = crate::query::get(message, "MSH.9.1")
+        .or_else(|| crate::query::get(message, "MSH.9"))
+        .unwrap_or("UNKNOWN");
+    let trigger_event = crate::query::get(message, "MSH.9.2");
+
+    trigger_event.map_or_else(
+        || message_code.to_string(),
+        |event| format!("{}^{}", message_code, event),
+    )
+}
+
+fn segment_index_for_path(message: &Message, path: &str) -> Option<usize> {
+    let segment_id = path.split('.').next()?;
+    message
+        .segments
+        .iter()
+        .position(|segment| segment.id_str() == segment_id)
+}
+
+fn field_index_for_path(path: &str) -> Option<usize> {
+    let field_part = path.split('.').nth(1)?;
+    let field_index = field_part.split('[').next()?;
+    field_index.parse().ok()
 }
 
 // ============================================================================
@@ -991,5 +1157,44 @@ mod legacy_tests {
         assert_eq!(issue.code, "TEST_CODE");
         assert_eq!(issue.severity, Severity::Error);
         assert_eq!(issue.path, Some("PID.5".to_string()));
+    }
+
+    #[test]
+    fn validation_report_normalizes_issue_contract() {
+        let message = crate::parser::parse(
+            b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||\r",
+        )
+        .unwrap_or_default();
+        let report = ValidationReport::from_issues(
+            &message,
+            Some("adt_a01.yaml".to_string()),
+            vec![Issue::error(
+                "MISSING_REQUIRED_FIELD",
+                Some("PID.3".to_string()),
+                "PID.3 is required".to_string(),
+            )],
+        );
+
+        assert!(!report.valid);
+        assert_eq!(report.message_type, "ADT^A01");
+        assert_eq!(report.profile.as_deref(), Some("adt_a01.yaml"));
+        assert_eq!(report.issue_count, 1);
+        assert_eq!(report.issues[0].code, "missing_required_field");
+        assert_eq!(
+            report.issues[0].rule_id.as_deref(),
+            Some("missing_required_field")
+        );
+        assert_eq!(report.issues[0].severity, ValidationReportSeverity::Error);
+        assert_eq!(report.issues[0].path.as_deref(), Some("PID.3"));
+        assert_eq!(report.issues[0].segment_index, Some(1));
+        assert_eq!(report.issues[0].field_index, Some(3));
+    }
+
+    #[test]
+    fn validation_report_severity_serializes_lowercase() {
+        let serialized =
+            serde_json::to_string(&ValidationReportSeverity::Warning).unwrap_or_default();
+
+        assert_eq!(serialized, "\"warning\"");
     }
 }

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -101,7 +101,9 @@ pub use ack::{AckCode, ack, ack_with_error};
 pub use conformance::profile::{Profile, load_profile, load_profile_checked, validate};
 
 #[cfg(feature = "profile")]
-pub use conformance::validation::{Issue, Severity};
+pub use conformance::validation::{
+    Issue, Severity, ValidationReport, ValidationReportIssue, ValidationReportSeverity,
+};
 
 #[cfg(feature = "stream")]
 pub use stream::{AsyncStreamParser, Event, StreamParser, StreamParserBuilder};


### PR DESCRIPTION
## Summary
- add shared `hl7v2::ValidationReport` / `ValidationReportIssue` / `ValidationReportSeverity` types for stable machine-readable validation evidence
- route `hl7v2 val --report json|yaml` through the shared report contract instead of debug-string issue output
- document the implemented JSON report flag and add unit/integration coverage for stable code, severity, path, rule id, and index fields

## Contract Notes
- CLI report output changes from the old private debug-string wrapper to the new typed report contract.
- HTTP/OpenAPI response parity is intentionally not changed here; that remains the next `server/validate-report-parity` lane.

## Validation
- `cargo +1.93.0 test -p hl7v2 --all-features`
- `cargo +1.93.0 test -p hl7v2-cli`
- `cargo +1.93.0 test -p hl7v2 --all-features validation_report`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests validate_json_report_uses_stable_issue_contract`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 check --examples`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

Note: `cargo +1.93.0 run -p xtask -- gate --check --changed` without the PyO3 environment flag still stops on the local Python 3.14 / PyO3 0.24.2 compatibility guard; rerun with the established ABI3 compatibility flag passed.