### PR TITLE
feat: align validate endpoint report shape

### DIFF
--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -319,16 +319,40 @@ components:
 
     ValidateResponse:
       type: object
-      required: [valid, metadata]
+      required: [valid, message_type, segment_count, issue_count, issues, metadata]
       properties:
         valid:
           type: boolean
+        message_type:
+          type: string
+          description: HL7 trigger event from MSH.9, such as ADT^A01
+        profile:
+          type: string
+          nullable: true
+          description: Profile identifier used for validation
+        segment_count:
+          type: integer
+          minimum: 0
+          description: Number of parsed message segments
+        issue_count:
+          type: integer
+          minimum: 0
+          description: Number of reported validation issues
+        issues:
+          type: array
+          description: Stable validation issue records shared with CLI reports
+          items:
+            $ref: '#/components/schemas/ValidationReportIssue'
         errors:
           type: array
+          deprecated: true
+          description: Compatibility error array; use issues instead
           items:
             $ref: '#/components/schemas/ValidationError'
         warnings:
           type: array
+          deprecated: true
+          description: Compatibility warning array; use issues instead
           items:
             $ref: '#/components/schemas/ValidationWarning'
         metadata:
@@ -421,6 +445,38 @@ components:
         severity:
           type: string
           enum: [error, warning, info]
+
+    ValidationReportIssue:
+      type: object
+      required: [code, severity, message]
+      properties:
+        code:
+          type: string
+          description: Stable snake_case issue code
+        severity:
+          type: string
+          enum: [error, warning]
+        path:
+          type: string
+          nullable: true
+          description: HL7 path associated with the issue, such as PID.3
+        rule_id:
+          type: string
+          nullable: true
+          description: Stable rule identifier
+        message:
+          type: string
+          description: Human-readable issue message
+        segment_index:
+          type: integer
+          minimum: 0
+          nullable: true
+          description: Zero-based segment index when available
+        field_index:
+          type: integer
+          minimum: 1
+          nullable: true
+          description: One-based HL7 field index when available
 
     ValidationWarning:
       type: object

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -319,16 +319,40 @@ components:
 
     ValidateResponse:
       type: object
-      required: [valid, metadata]
+      required: [valid, message_type, segment_count, issue_count, issues, metadata]
       properties:
         valid:
           type: boolean
+        message_type:
+          type: string
+          description: HL7 trigger event from MSH.9, such as ADT^A01
+        profile:
+          type: string
+          nullable: true
+          description: Profile identifier used for validation
+        segment_count:
+          type: integer
+          minimum: 0
+          description: Number of parsed message segments
+        issue_count:
+          type: integer
+          minimum: 0
+          description: Number of reported validation issues
+        issues:
+          type: array
+          description: Stable validation issue records shared with CLI reports
+          items:
+            $ref: '#/components/schemas/ValidationReportIssue'
         errors:
           type: array
+          deprecated: true
+          description: Compatibility error array; use issues instead
           items:
             $ref: '#/components/schemas/ValidationError'
         warnings:
           type: array
+          deprecated: true
+          description: Compatibility warning array; use issues instead
           items:
             $ref: '#/components/schemas/ValidationWarning'
         metadata:
@@ -421,6 +445,38 @@ components:
         severity:
           type: string
           enum: [error, warning, info]
+
+    ValidationReportIssue:
+      type: object
+      required: [code, severity, message]
+      properties:
+        code:
+          type: string
+          description: Stable snake_case issue code
+        severity:
+          type: string
+          enum: [error, warning]
+        path:
+          type: string
+          nullable: true
+          description: HL7 path associated with the issue, such as PID.3
+        rule_id:
+          type: string
+          nullable: true
+          description: Stable rule identifier
+        message:
+          type: string
+          description: Human-readable issue message
+        segment_index:
+          type: integer
+          minimum: 0
+          nullable: true
+          description: Zero-based segment index when available
+        field_index:
+          type: integer
+          minimum: 1
+          nullable: true
+          description: One-based HL7 field index when available
 
     ValidationWarning:
       type: object

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -66,8 +66,13 @@ pub async fn validate_handler(
 
     // Perform validation using the profile
     let issues = hl7v2::validate(&message, &profile);
+    let report = hl7v2::ValidationReport::from_issues(
+        &message,
+        Some(profile.message_structure.clone()),
+        issues.clone(),
+    );
 
-    // Convert validation issues to response format
+    // Preserve legacy error/warning arrays while exposing the shared report issues.
     let mut errors = Vec::new();
     let mut warnings = Vec::new();
 
@@ -96,10 +101,13 @@ pub async fn validate_handler(
         }
     }
 
-    let valid = errors.is_empty();
-
     let response = ValidateResponse {
-        valid,
+        valid: report.valid,
+        message_type: report.message_type,
+        profile: report.profile,
+        segment_count: report.segment_count,
+        issue_count: report.issue_count,
+        issues: report.issues,
         errors,
         warnings,
         metadata,

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use hl7v2::ValidationReportIssue;
+
 /// Health check response
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HealthResponse {
@@ -105,6 +107,17 @@ pub struct ValidateRequest {
 pub struct ValidateResponse {
     /// Whether validation passed
     pub valid: bool,
+    /// HL7 trigger event from `MSH.9`, such as `ADT^A01`.
+    pub message_type: String,
+    /// Profile identifier, usually the loaded profile message structure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    /// Number of parsed message segments.
+    pub segment_count: usize,
+    /// Number of reported validation issues.
+    pub issue_count: usize,
+    /// Stable validation issue records.
+    pub issues: Vec<ValidationReportIssue>,
     /// Validation errors
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub errors: Vec<ValidationError>,

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -50,6 +50,11 @@ async fn test_validate_with_minimal_profile() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(body_json["valid"], true);
+    assert_eq!(body_json["message_type"], "ADT^A01");
+    assert_eq!(body_json["profile"], "MINIMAL");
+    assert_eq!(body_json["segment_count"], 1);
+    assert_eq!(body_json["issue_count"], 0);
+    assert_eq!(body_json["issues"].as_array().unwrap().len(), 0);
 }
 
 #[tokio::test]
@@ -168,6 +173,19 @@ constraints:
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(body_json["valid"], false);
+    assert_eq!(body_json["message_type"], "ADT^A01");
+    assert_eq!(body_json["profile"], "ADT_A01");
+    assert_eq!(body_json["segment_count"], 1);
+    assert_eq!(body_json["issue_count"], 1);
+    assert_eq!(body_json["issues"][0]["code"], "missing_required_field");
+    assert_eq!(body_json["issues"][0]["severity"], "error");
+    assert_eq!(body_json["issues"][0]["path"], "PID.3");
+    assert_eq!(body_json["issues"][0]["rule_id"], "missing_required_field");
+    assert_eq!(
+        body_json["issues"][0]["message"],
+        "Required field PID.3 is missing"
+    );
+    assert_eq!(body_json["issues"][0]["field_index"], 3);
     assert_eq!(body_json["errors"][0]["code"], "MISSING_REQUIRED_FIELD");
 }
 

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -60,6 +60,37 @@ Validates an HL7 v2 message against a provided conformance profile.
 }
 ```
 
+**Response Body:**
+```json
+{
+  "valid": false,
+  "message_type": "ADT^A01",
+  "profile": "ADT_A01",
+  "segment_count": 2,
+  "issue_count": 1,
+  "issues": [
+    {
+      "code": "missing_required_field",
+      "severity": "error",
+      "path": "PID.3",
+      "rule_id": "missing_required_field",
+      "message": "Required field PID.3 is missing",
+      "segment_index": 1,
+      "field_index": 3
+    }
+  ],
+  "metadata": {
+    "message_type": "ADT^A01",
+    "version": "2.5",
+    "sending_application": "SENDER",
+    "sending_facility": "FAC",
+    "message_control_id": "123",
+    "segment_count": 2,
+    "charsets": []
+  }
+}
+```
+
 **cURL Example:**
 ```bash
 # Using a local profile file


### PR DESCRIPTION
## Summary
- add the shared typed validation report fields to `POST /hl7/validate`: `message_type`, `profile`, `segment_count`, `issue_count`, and stable `issues`
- preserve legacy `errors` / `warnings` arrays as compatibility fields while pointing OpenAPI callers to `issues`
- update OpenAPI source + packaged server copy, API guide response example, and endpoint tests for valid/invalid report shapes

## Contract Notes
- This is additive for HTTP clients: the new `issues` contract matches the library/CLI validation report semantics, while existing `errors` and `warnings` remain serialized when present.
- The gRPC proto response shape is unchanged in this PR; existing gRPC contract tests still pass.

## Validation
- `cargo +1.93.0 test -p hl7v2-server --test validate_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test proto_packaging_test packaged_openapi_matches_workspace_contract`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `npx -y @bufbuild/buf lint api/proto`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 clippy -p hl7v2-server --all-features --all-targets -- -D warnings`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/profile/profile-v1.schema.json -d "profiles/*.yaml" --spec=draft7`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d "config/*.toml" --spec=draft7`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`