### PR TITLE
feat: add profile lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml
 
 # Emit a machine-readable validation report
 hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml --report json
+
+# Lint a profile before using it as an interface contract
+hl7v2 profile lint profiles/oru_r01.yaml --report json
 ```
 
 ### Normalize Messages
@@ -188,6 +191,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
   - Temporal rules for date/time comparisons
   - Contextual rules with if/then logic
 - **Local profile loading**: Load YAML-based profiles from files
+- **Profile linting**: Check profile YAML for ignored keys, malformed paths, invalid regexes, and dangling rule references
 - **Flexible rule composition**: Merge profiles with child precedence
 
 ### Synthetic Message Generation (`hl7v2::synthetic`)
@@ -201,7 +205,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 
 ### CLI Interface (`hl7v2-cli`)
 
-- **Unified command interface**: parse, normalize, validate, acknowledge, generate
+- **Unified command interface**: parse, normalize, validate, lint profiles, acknowledge, generate
 - **Input/output formats**: Raw HL7, JSON, MLLP framing
 - **Interactive mode**: Command-line REPL for exploratory use
 - **File I/O**: Read from files or stdin, write to files or stdout

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -12,4 +12,11 @@ hl7v2 doctor --sample message.hl7 --profile profiles/adt_a01.yaml
 hl7v2 doctor --server-url http://127.0.0.1:8080/health --format json
 ```
 
+Lint a profile before using it as an interface contract:
+
+```bash
+hl7v2 profile lint profiles/adt_a01.yaml
+hl7v2 profile lint profiles/adt_a01.yaml --report json
+```
+
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -24,14 +24,14 @@
 use clap::{Parser, Subcommand};
 use hl7v2::synthetic::generate::{Template, generate};
 use hl7v2::{
-    AckCode as GenAckCode, Event, Message, StreamParser, ValidationReport, ack, get,
-    is_mllp_framed, load_profile, load_profile_checked, normalize, parse, parse_mllp, to_json,
-    validate, wrap_mllp, write, write_mllp,
+    AckCode as GenAckCode, Event, Message, ProfileLintReport, StreamParser, ValidationReport, ack,
+    get, is_mllp_framed, lint_profile_yaml, load_profile, load_profile_checked, normalize, parse,
+    parse_mllp, to_json, validate, wrap_mllp, write, write_mllp,
 };
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 use std::time::Duration;
 mod config;
@@ -173,6 +173,12 @@ enum Commands {
         format: ReportFormat,
     },
 
+    /// Inspect and lint validation profiles
+    Profile {
+        #[command(subcommand)]
+        command: ProfileCommands,
+    },
+
     /// Generate ACK for HL7 v2 message
     Ack {
         /// Input HL7 file
@@ -243,6 +249,19 @@ enum Commands {
 
     /// Interactive mode
     Interactive,
+}
+
+#[derive(Subcommand, Debug)]
+enum ProfileCommands {
+    /// Lint a profile YAML file
+    Lint {
+        /// Profile YAML file
+        profile: PathBuf,
+
+        /// Output lint report format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        report: ReportFormat,
+    },
 }
 
 /// Server mode selection
@@ -381,6 +400,9 @@ async fn main() {
             server_url.as_deref(),
             format,
         ),
+        Commands::Profile { command } => match command {
+            ProfileCommands::Lint { profile, report } => profile_lint_command(profile, report),
+        },
         Commands::Ack {
             input,
             mode,
@@ -1192,6 +1214,66 @@ fn val_command(
     }
 
     Ok(())
+}
+
+fn profile_lint_command(
+    profile: &Path,
+    report: &ReportFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let profile_yaml = fs::read_to_string(profile)?;
+    let lint_report = lint_profile_yaml(&profile_yaml);
+    let output = format_profile_lint_report(profile, &lint_report, report)?;
+    println!("{}", output);
+
+    if !lint_report.valid {
+        return Err(std::io::Error::other("profile lint reported errors").into());
+    }
+
+    Ok(())
+}
+
+fn format_profile_lint_report(
+    profile: &Path,
+    report: &ProfileLintReport,
+    format: &ReportFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        ReportFormat::Json => Ok(serde_json::to_string_pretty(report)?),
+        ReportFormat::Yaml => Ok(serde_yaml::to_string(report)?),
+        ReportFormat::Text => {
+            let mut lines = Vec::new();
+            if report.valid {
+                lines.push(format!("Profile lint passed: {}", profile.display()));
+            } else {
+                lines.push(format!(
+                    "Profile lint failed: {} error(s), {} warning(s)",
+                    report.error_count, report.warning_count
+                ));
+            }
+
+            for issue in &report.issues {
+                let location = issue.path.as_deref().unwrap_or("profile");
+                lines.push(format!(
+                    "  - {} {} {}: {}",
+                    issue.severity.as_str(),
+                    issue.code,
+                    location,
+                    issue.message
+                ));
+            }
+
+            if report.issues.is_empty() {
+                lines.push("  No profile lint issues found".to_string());
+            } else if report.warning_count > 0 && report.error_count == 0 {
+                lines.push(format!(
+                    "  {} warning(s) found; profile can still load",
+                    report.warning_count
+                ));
+            }
+
+            Ok(lines.join("\n"))
+        }
+    }
 }
 
 /// Statistics report structure for JSON/YAML output

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -55,6 +55,22 @@ mod cli_unit_tests {
         }
 
         #[test]
+        fn test_profile_command_has_lint_subcommand() {
+            use crate::Cli;
+            let schema = Cli::command();
+            let profile = schema
+                .get_subcommands()
+                .find(|command| command.get_name() == "profile")
+                .expect("profile command should exist");
+
+            assert!(
+                profile
+                    .get_subcommands()
+                    .any(|command| command.get_name() == "lint")
+            );
+        }
+
+        #[test]
         fn test_ack_command_mode_options() {
             // Verify ACK mode options exist
             let modes = vec!["original", "enhanced"];

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -68,6 +68,24 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_profile_help() {
+        let mut cmd = cli_command();
+        cmd.args(["profile", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Inspect and lint"));
+    }
+
+    #[test]
+    fn test_profile_lint_help() {
+        let mut cmd = cli_command();
+        cmd.args(["profile", "lint", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Lint a profile YAML file"));
+    }
+
+    #[test]
     fn test_ack_help() {
         let mut cmd = cli_command();
         cmd.args(["ack", "--help"])
@@ -413,6 +431,112 @@ mod norm_command {
         let normalized_msg = hl7v2::parse(&normalized_content).expect("Normalized should parse");
 
         assert_eq!(original_msg.segments.len(), normalized_msg.segments.len());
+    }
+}
+
+// =========================================================================
+// Profile Command Tests
+// =========================================================================
+
+mod profile_command {
+    use super::*;
+
+    #[test]
+    fn test_profile_lint_passes_minimal_profile() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(&dir, "profile.yaml", minimal_profile());
+
+        let mut cmd = cli_command();
+        cmd.args(["profile", "lint", profile_file.to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Profile lint passed"))
+            .stdout(predicate::str::contains("No profile lint issues found"));
+    }
+
+    #[test]
+    fn test_profile_lint_json_reports_warnings_without_failing() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(
+            &dir,
+            "profile.yaml",
+            r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+rules: []
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "lint",
+                profile_file.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute profile lint");
+
+        assert!(output.status.success());
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("profile lint output should be JSON");
+        assert_eq!(report["valid"], true);
+        assert_eq!(report["warning_count"], 1);
+        assert_eq!(report["issues"][0]["code"], "unknown_top_level_key");
+        assert_eq!(report["issues"][0]["path"], "rules");
+    }
+
+    #[test]
+    fn test_profile_lint_json_reports_errors_and_fails() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(
+            &dir,
+            "profile.yaml",
+            r#"
+message_structure: ""
+version: "2.5"
+segments:
+  - id: ""
+constraints:
+  - path: PID.x
+    pattern: "["
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let assert = cmd
+            .args([
+                "profile",
+                "lint",
+                profile_file.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .assert()
+            .failure();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert_eq!(report["valid"], false);
+        assert!(report["error_count"].as_u64().unwrap() >= 3);
+        assert!(
+            report["issues"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|issue| issue["code"] == "empty_message_structure")
+        );
+        assert!(
+            report["issues"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|issue| issue["code"] == "invalid_constraint_pattern")
+        );
     }
 }
 

--- a/crates/hl7v2/src/conformance/profile/mod.rs
+++ b/crates/hl7v2/src/conformance/profile/mod.rs
@@ -59,6 +59,7 @@ pub use super::validation::{
 use crate::model::{Error, Message};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 /// Profile loading error types.
 ///
@@ -405,6 +406,695 @@ pub struct ExpressionGuardrails {
     /// Whether to allow custom scripts
     #[serde(default)]
     pub allow_custom_scripts: bool,
+}
+
+/// Result of linting a profile definition.
+///
+/// Profile linting checks the profile as configuration, before it is applied to
+/// a message. It reports YAML/load failures plus structural issues that the
+/// runtime validator would otherwise ignore or only reveal during validation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileLintReport {
+    /// Whether the profile has no lint errors.
+    pub valid: bool,
+    /// Number of errors in `issues`.
+    pub error_count: usize,
+    /// Number of warnings in `issues`.
+    pub warning_count: usize,
+    /// Total number of issues.
+    pub issue_count: usize,
+    /// Lint findings.
+    pub issues: Vec<ProfileLintIssue>,
+}
+
+impl ProfileLintReport {
+    fn from_issues(issues: Vec<ProfileLintIssue>) -> Self {
+        let error_count = issues
+            .iter()
+            .filter(|issue| issue.severity == ProfileLintSeverity::Error)
+            .count();
+        let warning_count = issues
+            .iter()
+            .filter(|issue| issue.severity == ProfileLintSeverity::Warning)
+            .count();
+        Self {
+            valid: error_count == 0,
+            error_count,
+            warning_count,
+            issue_count: issues.len(),
+            issues,
+        }
+    }
+}
+
+/// A single profile lint finding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileLintIssue {
+    /// Stable lint code.
+    pub code: String,
+    /// Finding severity.
+    pub severity: ProfileLintSeverity,
+    /// Profile path or YAML location, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+impl ProfileLintIssue {
+    fn error(code: &str, path: Option<String>, message: String) -> Self {
+        Self {
+            code: code.to_string(),
+            severity: ProfileLintSeverity::Error,
+            path,
+            message,
+        }
+    }
+
+    fn warning(code: &str, path: Option<String>, message: String) -> Self {
+        Self {
+            code: code.to_string(),
+            severity: ProfileLintSeverity::Warning,
+            path,
+            message,
+        }
+    }
+}
+
+/// Profile lint finding severity.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProfileLintSeverity {
+    /// Profile should not be used until fixed.
+    Error,
+    /// Profile loads, but contains surprising or ignored configuration.
+    Warning,
+}
+
+impl ProfileLintSeverity {
+    /// Return the lowercase severity string used by text output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+/// Lint a profile YAML document.
+///
+/// This function is intentionally stricter than `load_profile_checked`: it
+/// catches ignored keys, malformed paths, invalid regex patterns, unsupported
+/// rule strings, and dangling value-set/table references.
+pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
+    let root = match serde_yaml::from_str::<serde_yaml::Value>(yaml) {
+        Ok(root) => root,
+        Err(err) => {
+            return ProfileLintReport::from_issues(vec![ProfileLintIssue::error(
+                "yaml_parse_error",
+                None,
+                err.to_string(),
+            )]);
+        }
+    };
+
+    let mut issues = Vec::new();
+    lint_unknown_profile_keys(&root, &mut issues);
+
+    let profile = match serde_yaml::from_value::<Profile>(root) {
+        Ok(profile) => profile,
+        Err(err) => {
+            issues.push(ProfileLintIssue::error(
+                "profile_load_error",
+                None,
+                err.to_string(),
+            ));
+            return ProfileLintReport::from_issues(issues);
+        }
+    };
+
+    lint_profile(&profile, &mut issues);
+    ProfileLintReport::from_issues(issues)
+}
+
+fn lint_unknown_profile_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileLintIssue>) {
+    let Some(mapping) = root.as_mapping() else {
+        return;
+    };
+
+    let known_keys = [
+        "message_structure",
+        "version",
+        "message_type",
+        "parent",
+        "description",
+        "segments",
+        "constraints",
+        "lengths",
+        "valuesets",
+        "datatypes",
+        "advanced_datatypes",
+        "cross_field_rules",
+        "temporal_rules",
+        "contextual_rules",
+        "custom_rules",
+        "hl7_tables",
+        "table_precedence",
+        "expression_guardrails",
+    ];
+
+    for key in mapping.keys().filter_map(serde_yaml::Value::as_str) {
+        if !known_keys.contains(&key) {
+            issues.push(ProfileLintIssue::warning(
+                "unknown_top_level_key",
+                Some(key.to_string()),
+                format!("top-level key '{key}' is ignored by the profile loader"),
+            ));
+        }
+    }
+}
+
+fn lint_profile(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    lint_profile_identity(profile, issues);
+    lint_segments(profile, issues);
+    lint_constraints(profile, issues);
+    lint_lengths(profile, issues);
+    lint_value_sets(profile, issues);
+    lint_datatypes(profile, issues);
+    lint_rules(profile, issues);
+    lint_tables(profile, issues);
+    lint_custom_rules(profile, issues);
+}
+
+fn lint_profile_identity(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    if profile.message_structure.trim().is_empty() {
+        issues.push(ProfileLintIssue::error(
+            "empty_message_structure",
+            Some("message_structure".to_string()),
+            "message_structure must not be empty".to_string(),
+        ));
+    }
+
+    if profile.version.trim().is_empty() {
+        issues.push(ProfileLintIssue::error(
+            "empty_version",
+            Some("version".to_string()),
+            "version must not be empty".to_string(),
+        ));
+    }
+}
+
+fn lint_segments(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    let mut seen = HashSet::new();
+    for (index, segment) in profile.segments.iter().enumerate() {
+        let path = format!("segments[{index}].id");
+        if segment.id.trim().is_empty() {
+            issues.push(ProfileLintIssue::error(
+                "empty_segment_id",
+                Some(path),
+                "segment id must not be empty".to_string(),
+            ));
+        } else if !seen.insert(segment.id.as_str()) {
+            issues.push(ProfileLintIssue::warning(
+                "duplicate_segment_id",
+                Some(path),
+                format!("segment '{}' is listed more than once", segment.id),
+            ));
+        }
+    }
+}
+
+fn lint_constraints(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    for (index, constraint) in profile.constraints.iter().enumerate() {
+        lint_hl7_path(
+            &constraint.path,
+            format!("constraints[{index}].path"),
+            issues,
+        );
+
+        if let Some(components) = &constraint.components
+            && let (Some(min), Some(max)) = (components.min, components.max)
+            && min > max
+        {
+            issues.push(ProfileLintIssue::error(
+                "component_min_exceeds_max",
+                Some(format!("constraints[{index}].components")),
+                format!("component minimum {min} exceeds maximum {max}"),
+            ));
+        }
+
+        if let Some(pattern) = &constraint.pattern {
+            lint_regex(
+                pattern,
+                format!("constraints[{index}].pattern"),
+                "invalid_constraint_pattern",
+                issues,
+            );
+        }
+
+        if let Some(condition) = &constraint.when {
+            lint_condition(condition, format!("constraints[{index}].when"), issues);
+        }
+    }
+}
+
+fn lint_condition(condition: &Condition, base_path: String, issues: &mut Vec<ProfileLintIssue>) {
+    if let Some(eq_conditions) = &condition.eq {
+        if eq_conditions.len() != 2 {
+            issues.push(ProfileLintIssue::error(
+                "invalid_condition_eq",
+                Some(format!("{base_path}.eq")),
+                "condition eq must contain exactly [field_path, expected_value]".to_string(),
+            ));
+        } else if let Some(field_path) = eq_conditions.first() {
+            lint_hl7_path(field_path, format!("{base_path}.eq[0]"), issues);
+        }
+    }
+
+    if let Some(nested_conditions) = &condition.any {
+        for (index, nested) in nested_conditions.iter().enumerate() {
+            lint_condition(nested, format!("{base_path}.any[{index}]"), issues);
+        }
+    }
+}
+
+fn lint_lengths(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    for (index, length) in profile.lengths.iter().enumerate() {
+        lint_hl7_path(&length.path, format!("lengths[{index}].path"), issues);
+
+        if let Some(policy) = &length.policy
+            && policy != "no-truncate"
+            && policy != "may-truncate"
+        {
+            issues.push(ProfileLintIssue::warning(
+                "unknown_length_policy",
+                Some(format!("lengths[{index}].policy")),
+                format!("length policy '{policy}' is not recognized"),
+            ));
+        }
+    }
+}
+
+fn lint_value_sets(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    let table_ids: HashSet<&str> = profile
+        .hl7_tables
+        .iter()
+        .map(|table| table.id.as_str())
+        .collect();
+    let mut names = HashSet::new();
+
+    for (index, valueset) in profile.valuesets.iter().enumerate() {
+        lint_hl7_path(&valueset.path, format!("valuesets[{index}].path"), issues);
+
+        if valueset.name.trim().is_empty() {
+            issues.push(ProfileLintIssue::error(
+                "empty_valueset_name",
+                Some(format!("valuesets[{index}].name")),
+                "value set name must not be empty".to_string(),
+            ));
+        } else if !names.insert(valueset.name.as_str()) {
+            issues.push(ProfileLintIssue::warning(
+                "duplicate_valueset_name",
+                Some(format!("valuesets[{index}].name")),
+                format!("value set '{}' is defined more than once", valueset.name),
+            ));
+        }
+
+        if valueset.codes.is_empty() && !table_ids.contains(valueset.name.as_str()) {
+            issues.push(ProfileLintIssue::warning(
+                "empty_valueset_without_table",
+                Some(format!("valuesets[{index}]")),
+                format!(
+                    "value set '{}' has no inline codes and does not reference an hl7_tables id",
+                    valueset.name
+                ),
+            ));
+        }
+    }
+}
+
+fn lint_datatypes(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    for (index, datatype) in profile.datatypes.iter().enumerate() {
+        lint_hl7_path(&datatype.path, format!("datatypes[{index}].path"), issues);
+        if datatype.r#type.trim().is_empty() {
+            issues.push(ProfileLintIssue::error(
+                "empty_datatype",
+                Some(format!("datatypes[{index}].type")),
+                "datatype must not be empty".to_string(),
+            ));
+        }
+    }
+
+    for (index, datatype) in profile.advanced_datatypes.iter().enumerate() {
+        lint_hl7_path(
+            &datatype.path,
+            format!("advanced_datatypes[{index}].path"),
+            issues,
+        );
+
+        if datatype.r#type.trim().is_empty() {
+            issues.push(ProfileLintIssue::error(
+                "empty_advanced_datatype",
+                Some(format!("advanced_datatypes[{index}].type")),
+                "advanced datatype must not be empty".to_string(),
+            ));
+        }
+
+        if let (Some(min), Some(max)) = (datatype.min_length, datatype.max_length)
+            && min > max
+        {
+            issues.push(ProfileLintIssue::error(
+                "datatype_min_length_exceeds_max",
+                Some(format!("advanced_datatypes[{index}]")),
+                format!("minimum length {min} exceeds maximum length {max}"),
+            ));
+        }
+
+        if let Some(pattern) = &datatype.pattern {
+            lint_regex(
+                pattern,
+                format!("advanced_datatypes[{index}].pattern"),
+                "invalid_datatype_pattern",
+                issues,
+            );
+        }
+
+        if let Some(checksum) = &datatype.checksum
+            && checksum != "luhn"
+            && checksum != "mod10"
+        {
+            issues.push(ProfileLintIssue::warning(
+                "unknown_checksum_algorithm",
+                Some(format!("advanced_datatypes[{index}].checksum")),
+                format!("checksum algorithm '{checksum}' is ignored by validation"),
+            ));
+        }
+    }
+}
+
+fn lint_rules(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    let valueset_names: HashSet<&str> = profile
+        .valuesets
+        .iter()
+        .map(|valueset| valueset.name.as_str())
+        .collect();
+
+    lint_cross_field_rules(profile, &valueset_names, issues);
+    lint_temporal_rules(profile, issues);
+    lint_contextual_rules(profile, &valueset_names, issues);
+}
+
+fn lint_cross_field_rules(
+    profile: &Profile,
+    valueset_names: &HashSet<&str>,
+    issues: &mut Vec<ProfileLintIssue>,
+) {
+    let mut ids = HashSet::new();
+
+    for (index, rule) in profile.cross_field_rules.iter().enumerate() {
+        let base_path = format!("cross_field_rules[{index}]");
+        lint_rule_id(rule.id.as_str(), &mut ids, &base_path, issues);
+
+        if rule.validation_mode != "conditional" && rule.validation_mode != "assert" {
+            issues.push(ProfileLintIssue::error(
+                "unknown_cross_field_validation_mode",
+                Some(format!("{base_path}.validation_mode")),
+                format!(
+                    "cross-field validation mode '{}' is not supported",
+                    rule.validation_mode
+                ),
+            ));
+        }
+
+        for (condition_index, condition) in rule.conditions.iter().enumerate() {
+            lint_rule_condition(
+                condition,
+                format!("{base_path}.conditions[{condition_index}]"),
+                issues,
+            );
+        }
+
+        for (action_index, action) in rule.actions.iter().enumerate() {
+            lint_rule_action(
+                action,
+                format!("{base_path}.actions[{action_index}]"),
+                valueset_names,
+                issues,
+            );
+        }
+    }
+}
+
+fn lint_temporal_rules(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    let mut ids = HashSet::new();
+
+    for (index, rule) in profile.temporal_rules.iter().enumerate() {
+        let base_path = format!("temporal_rules[{index}]");
+        lint_rule_id(rule.id.as_str(), &mut ids, &base_path, issues);
+        lint_hl7_path(&rule.before, format!("{base_path}.before"), issues);
+        lint_hl7_path(&rule.after, format!("{base_path}.after"), issues);
+    }
+}
+
+fn lint_contextual_rules(
+    profile: &Profile,
+    valueset_names: &HashSet<&str>,
+    issues: &mut Vec<ProfileLintIssue>,
+) {
+    let mut ids = HashSet::new();
+
+    for (index, rule) in profile.contextual_rules.iter().enumerate() {
+        let base_path = format!("contextual_rules[{index}]");
+        lint_rule_id(rule.id.as_str(), &mut ids, &base_path, issues);
+        lint_hl7_path(
+            &rule.context_field,
+            format!("{base_path}.context_field"),
+            issues,
+        );
+        lint_hl7_path(
+            &rule.target_field,
+            format!("{base_path}.target_field"),
+            issues,
+        );
+
+        match rule.validation_type.as_str() {
+            "require" | "prohibit" | "validate_datatype" | "validate_valueset" => {}
+            validation_type => issues.push(ProfileLintIssue::error(
+                "unknown_contextual_validation_type",
+                Some(format!("{base_path}.validation_type")),
+                format!("contextual validation type '{validation_type}' is not supported"),
+            )),
+        }
+
+        if rule.validation_type == "validate_datatype" && !rule.parameters.contains_key("datatype")
+        {
+            issues.push(ProfileLintIssue::error(
+                "missing_contextual_datatype_parameter",
+                Some(format!("{base_path}.parameters.datatype")),
+                "validate_datatype requires a datatype parameter".to_string(),
+            ));
+        }
+
+        if rule.validation_type == "validate_valueset" {
+            match rule.parameters.get("valueset") {
+                Some(valueset) if valueset_names.contains(valueset.as_str()) => {}
+                Some(valueset) => issues.push(ProfileLintIssue::error(
+                    "unknown_contextual_valueset",
+                    Some(format!("{base_path}.parameters.valueset")),
+                    format!("contextual rule references undefined value set '{valueset}'"),
+                )),
+                None => issues.push(ProfileLintIssue::error(
+                    "missing_contextual_valueset_parameter",
+                    Some(format!("{base_path}.parameters.valueset")),
+                    "validate_valueset requires a valueset parameter".to_string(),
+                )),
+            }
+        }
+    }
+}
+
+fn lint_rule_id(
+    id: &str,
+    seen: &mut HashSet<String>,
+    base_path: &str,
+    issues: &mut Vec<ProfileLintIssue>,
+) {
+    if id.trim().is_empty() {
+        issues.push(ProfileLintIssue::error(
+            "empty_rule_id",
+            Some(format!("{base_path}.id")),
+            "rule id must not be empty".to_string(),
+        ));
+    } else if !seen.insert(id.to_string()) {
+        issues.push(ProfileLintIssue::warning(
+            "duplicate_rule_id",
+            Some(format!("{base_path}.id")),
+            format!("rule id '{id}' is defined more than once in this rule family"),
+        ));
+    }
+}
+
+fn lint_rule_condition(
+    condition: &RuleCondition,
+    base_path: String,
+    issues: &mut Vec<ProfileLintIssue>,
+) {
+    lint_hl7_path(&condition.field, format!("{base_path}.field"), issues);
+
+    match condition.operator.as_str() {
+        "eq" | "ne" | "contains" | "in" | "exists" | "not_exists" | "is_date" | "before"
+        | "within_range" => {}
+        "matches_regex" => match &condition.value {
+            Some(pattern) => lint_regex(
+                pattern,
+                format!("{base_path}.value"),
+                "invalid_rule_condition_regex",
+                issues,
+            ),
+            None => issues.push(ProfileLintIssue::error(
+                "missing_rule_condition_regex",
+                Some(format!("{base_path}.value")),
+                "matches_regex requires a regex pattern in value".to_string(),
+            )),
+        },
+        operator => issues.push(ProfileLintIssue::error(
+            "unknown_rule_condition_operator",
+            Some(format!("{base_path}.operator")),
+            format!("rule condition operator '{operator}' is not supported"),
+        )),
+    }
+
+    if condition.operator == "within_range" && condition.values.as_ref().map_or(0, Vec::len) != 2 {
+        issues.push(ProfileLintIssue::error(
+            "invalid_within_range_values",
+            Some(format!("{base_path}.values")),
+            "within_range requires exactly two values".to_string(),
+        ));
+    }
+}
+
+fn lint_rule_action(
+    action: &RuleAction,
+    base_path: String,
+    valueset_names: &HashSet<&str>,
+    issues: &mut Vec<ProfileLintIssue>,
+) {
+    lint_hl7_path(&action.field, format!("{base_path}.field"), issues);
+
+    match action.action.as_str() {
+        "require" | "prohibit" | "validate" => {}
+        action_type => issues.push(ProfileLintIssue::error(
+            "unknown_rule_action",
+            Some(format!("{base_path}.action")),
+            format!("rule action '{action_type}' is not supported"),
+        )),
+    }
+
+    if let Some(valueset) = &action.valueset
+        && !valueset_names.contains(valueset.as_str())
+    {
+        issues.push(ProfileLintIssue::error(
+            "unknown_action_valueset",
+            Some(format!("{base_path}.valueset")),
+            format!("rule action references undefined value set '{valueset}'"),
+        ));
+    }
+}
+
+fn lint_tables(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    let mut ids = HashSet::new();
+    let mut table_by_id: HashMap<&str, usize> = HashMap::new();
+
+    for (index, table) in profile.hl7_tables.iter().enumerate() {
+        if table.id.trim().is_empty() {
+            issues.push(ProfileLintIssue::error(
+                "empty_table_id",
+                Some(format!("hl7_tables[{index}].id")),
+                "HL7 table id must not be empty".to_string(),
+            ));
+        } else {
+            table_by_id.insert(table.id.as_str(), index);
+            if !ids.insert(table.id.as_str()) {
+                issues.push(ProfileLintIssue::warning(
+                    "duplicate_table_id",
+                    Some(format!("hl7_tables[{index}].id")),
+                    format!("HL7 table '{}' is defined more than once", table.id),
+                ));
+            }
+        }
+
+        if table.name.trim().is_empty() {
+            issues.push(ProfileLintIssue::warning(
+                "empty_table_name",
+                Some(format!("hl7_tables[{index}].name")),
+                format!("HL7 table '{}' has an empty name", table.id),
+            ));
+        }
+
+        if table.version.trim().is_empty() {
+            issues.push(ProfileLintIssue::warning(
+                "empty_table_version",
+                Some(format!("hl7_tables[{index}].version")),
+                format!("HL7 table '{}' has an empty version", table.id),
+            ));
+        }
+    }
+
+    for (index, table_id) in profile.table_precedence.iter().enumerate() {
+        if !table_by_id.contains_key(table_id.as_str()) {
+            issues.push(ProfileLintIssue::error(
+                "unknown_table_precedence_entry",
+                Some(format!("table_precedence[{index}]")),
+                format!("table precedence references undefined HL7 table '{table_id}'"),
+            ));
+        }
+    }
+}
+
+fn lint_custom_rules(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
+    let mut ids = HashSet::new();
+
+    for (index, rule) in profile.custom_rules.iter().enumerate() {
+        let base_path = format!("custom_rules[{index}]");
+        lint_rule_id(rule.id.as_str(), &mut ids, &base_path, issues);
+
+        if rule.script.trim().is_empty() {
+            issues.push(ProfileLintIssue::error(
+                "empty_custom_rule_script",
+                Some(format!("{base_path}.script")),
+                format!("custom rule '{}' has an empty script", rule.id),
+            ));
+        }
+    }
+
+    if !profile.custom_rules.is_empty() && !profile.expression_guardrails.allow_custom_scripts {
+        issues.push(ProfileLintIssue::warning(
+            "custom_rules_without_script_guardrail",
+            Some("expression_guardrails.allow_custom_scripts".to_string()),
+            "custom_rules are present but expression_guardrails.allow_custom_scripts is false"
+                .to_string(),
+        ));
+    }
+}
+
+fn lint_hl7_path(path: &str, location: String, issues: &mut Vec<ProfileLintIssue>) {
+    if let Err(err) = crate::query::path::parse_path(path) {
+        issues.push(ProfileLintIssue::error(
+            "invalid_hl7_path",
+            Some(location),
+            format!("'{path}' is not a valid HL7 field path: {err}"),
+        ));
+    }
+}
+
+fn lint_regex(pattern: &str, location: String, code: &str, issues: &mut Vec<ProfileLintIssue>) {
+    if let Err(err) = Regex::new(pattern) {
+        issues.push(ProfileLintIssue::error(
+            code,
+            Some(location),
+            format!("regex '{pattern}' failed to compile: {err}"),
+        ));
+    }
 }
 
 /// Load profile from YAML

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -288,3 +288,105 @@ segments:
         assert!(matches!(load_err, ProfileLoadError::Io(_)));
     }
 }
+
+#[cfg(test)]
+mod profile_lint_tests {
+    use super::super::{ProfileLintSeverity, lint_profile_yaml};
+
+    #[test]
+    fn test_lint_profile_yaml_accepts_minimal_profile() {
+        let y = r#"
+message_structure: "ADT_A01"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+constraints:
+  - path: "MSH.9"
+    required: true
+"#;
+
+        let report = lint_profile_yaml(y);
+
+        assert!(report.valid, "unexpected lint report: {report:?}");
+        assert_eq!(report.issue_count, 0);
+    }
+
+    #[test]
+    fn test_lint_profile_yaml_reports_structural_errors() {
+        let y = r#"
+message_structure: ""
+version: "2.5.1"
+segments:
+  - id: ""
+constraints:
+  - path: "PID.x"
+    pattern: "["
+cross_field_rules:
+  - id: "rule-1"
+    validation_mode: "sometimes"
+    description: "invalid mode"
+    conditions:
+      - field: "PID.3"
+        operator: "matches_regex"
+    actions:
+      - field: "PID.5"
+        action: "invent"
+        valueset: "missing"
+table_precedence:
+  - "HL79999"
+"#;
+
+        let report = lint_profile_yaml(y);
+        let codes: Vec<&str> = report
+            .issues
+            .iter()
+            .map(|issue| issue.code.as_str())
+            .collect();
+
+        assert!(!report.valid);
+        assert!(codes.contains(&"empty_message_structure"));
+        assert!(codes.contains(&"empty_segment_id"));
+        assert!(codes.contains(&"invalid_hl7_path"));
+        assert!(codes.contains(&"invalid_constraint_pattern"));
+        assert!(codes.contains(&"unknown_cross_field_validation_mode"));
+        assert!(codes.contains(&"missing_rule_condition_regex"));
+        assert!(codes.contains(&"unknown_rule_action"));
+        assert!(codes.contains(&"unknown_action_valueset"));
+        assert!(codes.contains(&"unknown_table_precedence_entry"));
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.severity == ProfileLintSeverity::Error)
+        );
+    }
+
+    #[test]
+    fn test_lint_profile_yaml_warns_for_ignored_top_level_keys() {
+        let y = r#"
+message_structure: "ADT_A01"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+rules: []
+description: "profile metadata"
+"#;
+
+        let report = lint_profile_yaml(y);
+
+        assert!(report.valid, "warnings should not fail profile lint");
+        assert_eq!(report.warning_count, 1);
+        assert!(
+            report
+                .issues
+                .iter()
+                .all(|issue| issue.severity == ProfileLintSeverity::Warning)
+        );
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.path.as_deref() == Some("rules"))
+        );
+    }
+}

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -98,7 +98,10 @@ pub use normalize::normalize;
 pub use ack::{AckCode, ack, ack_with_error};
 
 #[cfg(feature = "profile")]
-pub use conformance::profile::{Profile, load_profile, load_profile_checked, validate};
+pub use conformance::profile::{
+    Profile, ProfileLintIssue, ProfileLintReport, ProfileLintSeverity, lint_profile_yaml,
+    load_profile, load_profile_checked, validate,
+};
 
 #[cfg(feature = "profile")]
 pub use conformance::validation::{


### PR DESCRIPTION
## Summary
- add `hl7v2::lint_profile_yaml` plus typed profile lint report/issue/severity contracts
- add `hl7v2 profile lint <profile.yaml>` with text/json/yaml output and nonzero exit on lint errors
- cover structural profile checks for ignored keys, malformed paths, invalid regexes, unsupported rule strings, and dangling value-set/table references

## Validation
- `cargo +1.93.0 test -p hl7v2 --all-features`
- `cargo +1.93.0 test -p hl7v2-cli --all-targets`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 check --examples`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p hl7v2-cli -- profile lint profiles/adt_a01.yaml --report json`