### PR TITLE
test: add python wheel smoke proof

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,86 @@
+name: Python Wheels
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "pyproject.toml"
+      - "crates/hl7v2/**"
+      - "crates/hl7v2-python/**"
+      - "tests/python_smoke/**"
+      - ".github/workflows/python-wheels.yml"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "pyproject.toml"
+      - "crates/hl7v2/**"
+      - "crates/hl7v2-python/**"
+      - "tests/python_smoke/**"
+      - ".github/workflows/python-wheels.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-wheels-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+jobs:
+  wheel-smoke:
+    name: Wheel smoke (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: python-wheels-${{ matrix.os }}-${{ matrix.python-version }}
+
+      - name: Install maturin
+        run: python -m pip install --upgrade pip "maturin==1.13.1"
+
+      - name: Build wheel
+        run: maturin build --release --out dist
+
+      - name: Install built wheel
+        run: |
+          python -c "import glob, subprocess, sys; wheels = glob.glob('dist/*.whl'); assert len(wheels) == 1, wheels; subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--force-reinstall', wheels[0]])"
+
+      - name: Run import smoke test
+        run: python tests/python_smoke/smoke.py
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/*.whl
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Lifecycle** | Beta | Domain tests exist, but lifecycle is not part of the current HTTP/gRPC contract gate |
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
-| **Python Bindings** | Experimental | Not included in the local Python 3.14/PyO3 validation proof |
+| **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
 | **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published to crates.io; Python remains a separate binding lane |
 
 ## Features
@@ -247,6 +247,21 @@ hl7v2-python
 Retired compatibility crate names should not gain new behavior. See
 [ADR-015](docs/adr/0015-collapse-public-crate-surface.md) and
 [the module map](docs/architecture/module-map.md) for the migration policy.
+
+## Python Binding Lane
+
+`hl7v2-python` is built with maturin and installs as the Python module
+`hl7v2`. It is not part of the Rust crates.io publish graph.
+
+```bash
+python -m pip install "maturin==1.13.1"
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin build --release --out dist
+python -m pip install dist/*.whl
+python tests/python_smoke/smoke.py
+```
+
+The current binding proof covers wheel build, install, import, version
+metadata, parse, segment count, and JSON conversion.
 
 ## Performance Characteristics
 

--- a/crates/hl7v2-python/README.md
+++ b/crates/hl7v2-python/README.md
@@ -1,0 +1,44 @@
+# hl7v2-python
+
+Python bindings for the Rust `hl7v2` toolkit.
+
+This package is intentionally outside the crates.io Rust publish graph. Build
+and validate it through the Python/maturin lane before any PyPI or TestPyPI
+release.
+
+## Build
+
+```bash
+python -m pip install "maturin==1.13.1"
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin build --release --out dist
+python -m pip install dist/*.whl
+python tests/python_smoke/smoke.py
+```
+
+On PowerShell:
+
+```powershell
+python -m pip install "maturin==1.13.1"
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
+maturin build --release --out dist
+python -m pip install (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+python tests\python_smoke\smoke.py
+```
+
+## Current API
+
+```python
+import hl7v2
+
+message = hl7v2.PyMessage.parse(
+    "MSH|^~\\&|SEND|FAC|RECV|FAC|202605080101||ADT^A01|CTRL1|P|2.5\r"
+    "PID|1||123456^^^HOSP^MR||Doe^John||19700101|M"
+)
+
+print(hl7v2.__version__)
+print(message.segment_count())
+print(message.to_json())
+```
+
+The first stable binding proof is build/install/import plus parse and JSON
+smoke coverage. Broader Python APIs should be added in focused follow-up PRs.

--- a/crates/hl7v2-python/src/lib.rs
+++ b/crates/hl7v2-python/src/lib.rs
@@ -35,6 +35,7 @@ impl PyMessage {
 /// HL7v2 module for Python
 #[pymodule]
 fn hl7v2(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PyMessage>()?;
     Ok(())
 }

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -103,6 +103,19 @@ enabled, so this workflow does not add a status check to every PR.
 Full-repository `@droid security --full` scans are not enabled in this first
 pass because they can create branches and need broader write permissions.
 
+### `.github/workflows/python-wheels.yml` - Python Wheel Smoke
+
+Builds the separate `hl7v2-python` maturin package and proves the wheel can be
+installed and imported. This workflow does not publish to PyPI.
+
+#### Jobs:
+
+1. **wheel-smoke** - Python package proof
+   - Builds a wheel with maturin
+   - Installs the built wheel
+   - Runs `tests/python_smoke/smoke.py`
+   - Uploads the wheel as a short-retention smoke artifact
+
 ## Viewing CI Results
 
 ### GitHub Actions
@@ -129,6 +142,7 @@ The following artifacts are generated and available for download:
 | nightly.yml | api-docs | Generated API documentation |
 | coverage.yml | tarpaulin-coverage | Tarpaulin coverage reports |
 | coverage.yml | llvm-coverage | LLVM coverage reports |
+| python-wheels.yml | python-wheel-* | Smoke-test wheels for the Python binding lane |
 
 ## Manual Triggers
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,7 +12,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2` | ✅ 100% | 92% | Canonical Rust library crate for parsing, writing, validation, transport framing, ACK, normalization, and generation. Foundation model, escape, and MLLP implementations now live here. |
 | `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
-| `hl7v2-python` | 🟡 Experimental | N/A | PyO3 binding package held out of the crates.io Rust publish graph; validate through the Python/maturin lane before release. |
+| `hl7v2-python` | 🟡 Experimental | Smoke | PyO3 binding package held out of the crates.io Rust publish graph; validated through the Python/maturin wheel smoke lane before any PyPI release. |
 | retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
 ## Feature Set (v1.2.1)
@@ -41,7 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-08.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-08.md`.
-- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io and should be verified with Python packaging tooling before PyPI or wheel release.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The binding is verified through a maturin wheel build/install/import smoke lane before any PyPI or TestPyPI release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. The fresh `v1.2.1` tag points at the current release head.
 

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -112,6 +112,15 @@ reason = "cargo-make task definitions for local DevEx."
 covered_by = ["cargo make"]
 
 [[allow]]
+path = "pyproject.toml"
+kind = "python_package_config"
+owner = "hl7v2-python"
+surface = "python-binding"
+classification = "production"
+reason = "Maturin build metadata for the hl7v2-python wheel lane; the binding stays outside the Rust crates.io graph."
+covered_by = [".github/workflows/python-wheels.yml"]
+
+[[allow]]
 path = "justfile"
 kind = "build_config"
 owner = "EffortlessMetrics"
@@ -303,6 +312,15 @@ surface = "developer-tooling"
 classification = "tooling"
 reason = "Auxiliary developer scripts (gitignore tests, etc.)."
 covered_by = ["scripts/tests/test_gitignore_nodejs.sh"]
+
+[[allow]]
+glob = "tests/python_smoke/**"
+kind = "python_smoke_test"
+owner = "hl7v2-python"
+surface = "tests"
+classification = "test"
+reason = "Python binding smoke tests verify wheel install, import, parse, and JSON conversion."
+covered_by = [".github/workflows/python-wheels.yml", "python tests/python_smoke/smoke.py"]
 
 # ---------------------------------------------------------------------------
 # Governance receipts (docs/ subtree)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["maturin>=1.13.1,<2"]
+build-backend = "maturin"
+
+[project]
+name = "hl7v2-python"
+dynamic = ["version"]
+description = "Python bindings for the hl7v2 Rust toolkit."
+readme = "crates/hl7v2-python/README.md"
+requires-python = ">=3.10"
+license = { text = "AGPL-3.0-or-later" }
+authors = [
+    { name = "EffortlessMetrics", email = "team@effortlessmetrics.com" },
+]
+keywords = ["hl7", "healthcare", "parser", "validator"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+]
+
+[project.urls]
+Homepage = "https://github.com/EffortlessMetrics/hl7v2-rs"
+Repository = "https://github.com/EffortlessMetrics/hl7v2-rs"
+
+[tool.maturin]
+manifest-path = "crates/hl7v2-python/Cargo.toml"
+module-name = "hl7v2"
+bindings = "pyo3"

--- a/tests/python_smoke/smoke.py
+++ b/tests/python_smoke/smoke.py
@@ -1,0 +1,38 @@
+"""Import and parse smoke test for the hl7v2 Python binding."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import hl7v2
+
+
+def main() -> int:
+    raw = (
+        "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605080101||ADT^A01|CTRL123|P|2.5\r"
+        "PID|1||123456^^^HOSP^MR||Doe^John||19700101|M"
+    )
+
+    version = getattr(hl7v2, "__version__", "")
+    if not isinstance(version, str) or not version:
+        print("hl7v2.__version__ is missing", file=sys.stderr)
+        return 1
+
+    message = hl7v2.PyMessage.parse(raw)
+    segment_count = message.segment_count()
+    if segment_count != 2:
+        print(f"expected 2 segments, got {segment_count}", file=sys.stderr)
+        return 1
+
+    payload = json.loads(message.to_json())
+    if not isinstance(payload, dict):
+        print("message JSON did not decode to an object", file=sys.stderr)
+        return 1
+
+    print(f"hl7v2-python smoke ok version={version} segments={segment_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add root maturin `pyproject.toml` for the `hl7v2-python` binding lane
- add a Python wheel smoke workflow that builds, installs, imports, and parses with the wheel on Ubuntu, Windows, and macOS
- add binding README, smoke script, file-policy entries, and `hl7v2.__version__`

## Validation
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check -p hl7v2-python --all-features --all-targets`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test -p hl7v2-python --all-features`
- `cargo +1.93.0 run -p xtask -- check-lint-policy`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- temp venv proof with `maturin==1.13.1`: `maturin build --release --out dist`, install wheel, `python tests/python_smoke/smoke.py`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Notes
- `hl7v2-python` remains `publish = false` for crates.io.
- This does not publish to PyPI or TestPyPI; it only proves wheel build/install/import behavior.