### PR TITLE
feat: add corpus summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ hl7v2 gen --profile profiles/oru_r01.yaml --seed 1337 --count 100 --out corpus/
 hl7v2 gen --template templates/adt_a01.yaml --seed 42 --count 50 --out test_data/
 ```
 
+### Summarize Corpora
+
+```bash
+# Summarize a directory or single-file corpus of HL7 messages
+hl7v2 corpus summarize corpus/
+
+# Emit a machine-readable corpus summary
+hl7v2 corpus summarize corpus/ --format json
+```
+
 ### Acknowledgment Generation
 
 ```bash
@@ -205,7 +215,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 
 ### CLI Interface (`hl7v2-cli`)
 
-- **Unified command interface**: parse, normalize, validate, lint profiles, acknowledge, generate
+- **Unified command interface**: parse, normalize, validate, lint profiles, acknowledge, generate, summarize corpora
 - **Input/output formats**: Raw HL7, JSON, MLLP framing
 - **Interactive mode**: Command-line REPL for exploratory use
 - **File I/O**: Read from files or stdin, write to files or stdout

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -19,4 +19,11 @@ hl7v2 profile lint profiles/adt_a01.yaml
 hl7v2 profile lint profiles/adt_a01.yaml --report json
 ```
 
+Summarize a directory or file corpus:
+
+```bash
+hl7v2 corpus summarize corpus/
+hl7v2 corpus summarize corpus/ --format json
+```
+
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -22,6 +22,7 @@
 )]
 
 use clap::{Parser, Subcommand};
+use hl7v2::synthetic::corpus::{CorpusSummary, summarize_corpus_path};
 use hl7v2::synthetic::generate::{Template, generate};
 use hl7v2::{
     AckCode as GenAckCode, Event, Message, ProfileLintReport, StreamParser, ValidationReport, ack,
@@ -179,6 +180,12 @@ enum Commands {
         command: ProfileCommands,
     },
 
+    /// Inspect message corpora
+    Corpus {
+        #[command(subcommand)]
+        command: CorpusCommands,
+    },
+
     /// Generate ACK for HL7 v2 message
     Ack {
         /// Input HL7 file
@@ -261,6 +268,19 @@ enum ProfileCommands {
         /// Output lint report format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         report: ReportFormat,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum CorpusCommands {
+    /// Summarize a directory or file corpus of HL7 messages
+    Summarize {
+        /// Corpus directory or single HL7 file
+        path: PathBuf,
+
+        /// Output summary format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        format: ReportFormat,
     },
 }
 
@@ -402,6 +422,9 @@ async fn main() {
         ),
         Commands::Profile { command } => match command {
             ProfileCommands::Lint { profile, report } => profile_lint_command(profile, report),
+        },
+        Commands::Corpus { command } => match command {
+            CorpusCommands::Summarize { path, format } => corpus_summarize_command(path, format),
         },
         Commands::Ack {
             input,
@@ -1447,6 +1470,77 @@ fn stats_command(
     monitor.record_metric("Output", output_time);
 
     Ok(())
+}
+
+fn corpus_summarize_command(
+    path: &PathBuf,
+    format: &ReportFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let summary = summarize_corpus_path(path)?;
+    let output = format_corpus_summary(&summary, format)?;
+    println!("{}", output);
+    Ok(())
+}
+
+fn format_corpus_summary(
+    summary: &CorpusSummary,
+    format: &ReportFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        ReportFormat::Json => Ok(serde_json::to_string_pretty(summary)?),
+        ReportFormat::Yaml => Ok(serde_yaml::to_string(summary)?),
+        ReportFormat::Text => {
+            let mut output = String::new();
+            output.push_str("Corpus Summary:\n");
+            output.push_str(&format!("  Path: {}\n", summary.root));
+            output.push_str(&format!("  Files scanned: {}\n", summary.file_count));
+            output.push_str(&format!("  Parsed messages: {}\n", summary.message_count));
+            output.push_str(&format!("  Parse errors: {}\n", summary.parse_error_count));
+            output.push_str(&format!("  Total bytes: {}\n", summary.total_bytes));
+
+            output.push('\n');
+            output.push_str("Message types:\n");
+            append_counts(&mut output, &summary.message_types);
+
+            output.push('\n');
+            output.push_str("Segments:\n");
+            append_counts(&mut output, &summary.segments);
+
+            output.push('\n');
+            output.push_str("Field presence:\n");
+            if summary.field_presence.is_empty() {
+                output.push_str("  <none>\n");
+            } else {
+                for field in &summary.field_presence {
+                    output.push_str(&format!(
+                        "  {}: {} message(s), {} occurrence(s)\n",
+                        field.path, field.message_count, field.occurrence_count
+                    ));
+                }
+            }
+
+            if !summary.parse_errors.is_empty() {
+                output.push('\n');
+                output.push_str("Parse errors:\n");
+                for error in &summary.parse_errors {
+                    output.push_str(&format!("  {}: {}\n", error.path, error.error));
+                }
+            }
+
+            Ok(output)
+        }
+    }
+}
+
+fn append_counts(output: &mut String, counts: &[hl7v2::synthetic::corpus::CorpusCount]) {
+    if counts.is_empty() {
+        output.push_str("  <none>\n");
+        return;
+    }
+
+    for count in counts {
+        output.push_str(&format!("  {}: {}\n", count.value, count.count));
+    }
 }
 
 fn ack_command(

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -716,6 +716,54 @@ constraints:
         }
 
         #[test]
+        fn test_format_corpus_summary_report_text() {
+            let report = hl7v2::synthetic::corpus::CorpusSummary {
+                root: "corpus".to_string(),
+                file_count: 2,
+                message_count: 1,
+                parse_error_count: 1,
+                total_bytes: 128,
+                message_types: vec![hl7v2::synthetic::corpus::CorpusCount {
+                    value: "ADT^A01".to_string(),
+                    count: 1,
+                }],
+                segments: vec![hl7v2::synthetic::corpus::CorpusCount {
+                    value: "PID".to_string(),
+                    count: 1,
+                }],
+                field_presence: vec![hl7v2::synthetic::corpus::CorpusFieldPresence {
+                    path: "PID.3".to_string(),
+                    message_count: 1,
+                    occurrence_count: 1,
+                }],
+                parse_errors: vec![hl7v2::synthetic::corpus::CorpusParseFailure {
+                    path: "bad.hl7".to_string(),
+                    error: "Invalid segment ID".to_string(),
+                }],
+            };
+
+            let output = crate::format_corpus_summary(&report, &crate::ReportFormat::Text)
+                .expect("Should format as text");
+
+            assert!(output.contains("Corpus Summary:"));
+            assert!(output.contains("Files scanned: 2"));
+            assert!(output.contains("ADT^A01: 1"));
+            assert!(output.contains("PID.3: 1 message(s), 1 occurrence(s)"));
+            assert!(output.contains("bad.hl7: Invalid segment ID"));
+        }
+
+        #[test]
+        fn test_corpus_summarize_command_execution() {
+            use crate::ReportFormat;
+            use crate::corpus_summarize_command;
+            let dir = TempDir::new().expect("Failed to create temp dir");
+            create_temp_hl7_file(&dir, "test.hl7");
+
+            let result = corpus_summarize_command(&dir.path().to_path_buf(), &ReportFormat::Json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
         fn test_stats_command_execution() {
             use crate::ReportFormat;
             use crate::stats_command;
@@ -876,6 +924,24 @@ constraints:
             let schema = Cli::command();
             let stats_cmd = schema.get_subcommands().find(|c| c.get_name() == "stats");
             assert!(stats_cmd.is_some());
+        }
+
+        #[test]
+        fn test_corpus_command_has_summarize_subcommand() {
+            use crate::Cli;
+            use clap::CommandFactory;
+
+            let schema = Cli::command();
+            let corpus_cmd = schema
+                .get_subcommands()
+                .find(|c| c.get_name() == "corpus")
+                .expect("corpus command should exist");
+
+            assert!(
+                corpus_cmd
+                    .get_subcommands()
+                    .any(|c| c.get_name() == "summarize")
+            );
         }
 
         #[test]

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -86,6 +86,26 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_corpus_help() {
+        let mut cmd = cli_command();
+        cmd.args(["corpus", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Inspect message corpora"));
+    }
+
+    #[test]
+    fn test_corpus_summarize_help() {
+        let mut cmd = cli_command();
+        cmd.args(["corpus", "summarize", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Summarize a directory or file corpus",
+            ));
+    }
+
+    #[test]
     fn test_ack_help() {
         let mut cmd = cli_command();
         cmd.args(["ack", "--help"])
@@ -536,6 +556,72 @@ constraints:
                 .unwrap()
                 .iter()
                 .any(|issue| issue["code"] == "invalid_constraint_pattern")
+        );
+    }
+}
+
+// =========================================================================
+// Corpus Command Tests
+// =========================================================================
+
+mod corpus_command {
+    use super::*;
+
+    #[test]
+    fn test_corpus_summarize_text_counts_messages_and_errors() {
+        let dir = create_temp_dir();
+        create_temp_hl7_file(&dir, "adt.hl7");
+        create_temp_hl7_with_content(&dir, "bad.hl7", invalid_hl7_message());
+
+        let mut cmd = cli_command();
+        cmd.args(["corpus", "summarize", dir.path().to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Corpus Summary:"))
+            .stdout(predicate::str::contains("Files scanned: 2"))
+            .stdout(predicate::str::contains("Parsed messages: 1"))
+            .stdout(predicate::str::contains("Parse errors: 1"))
+            .stdout(predicate::str::contains("ADT^A01^ADT_A01: 1"));
+    }
+
+    #[test]
+    fn test_corpus_summarize_json_is_machine_readable() {
+        let dir = create_temp_dir();
+        create_temp_hl7_file(&dir, "adt.hl7");
+        let nested = dir.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("nested corpus dir should be created");
+        create_temp_file(
+            &dir,
+            "nested/oru.hl7",
+            hl7v2_test_utils::fixtures::SampleMessages::oru_r01().as_bytes(),
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "summarize",
+                dir.path().to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute corpus summarize");
+
+        assert!(output.status.success());
+        assert!(is_valid_json(&output.stdout));
+
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("summary output should be JSON");
+        assert_eq!(report["file_count"], 2);
+        assert_eq!(report["message_count"], 2);
+        assert_eq!(report["parse_error_count"], 0);
+        assert!(
+            report["message_types"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["value"] == "ORU^R01" && entry["count"] == 1)
         );
     }
 }

--- a/crates/hl7v2/src/synthetic/corpus.rs
+++ b/crates/hl7v2/src/synthetic/corpus.rs
@@ -32,13 +32,18 @@
 //! assert_eq!(parsed.seed, 42);
 //! ```
 
-use crate::model::{Atom, Message};
+use crate::model::{Atom, Field, Message};
+use crate::parser::{parse, parse_mllp};
+use crate::transport::mllp::is_mllp_framed;
 use crate::writer::write;
 use chrono::{DateTime, Utc};
 use rand::{RngExt, SeedableRng};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 /// Configuration for corpus generation
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,6 +104,58 @@ pub struct MessageInfo {
     pub message_type: String,
     /// Template index used to generate this message
     pub template_index: usize,
+}
+
+/// Count for a corpus-level string dimension.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusCount {
+    /// Dimension value, such as a message type or segment ID.
+    pub value: String,
+    /// Number of times the value was observed.
+    pub count: usize,
+}
+
+/// Field-presence count across a corpus.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusFieldPresence {
+    /// HL7 path, such as `PID.3` or `OBX.5`.
+    pub path: String,
+    /// Number of parsed messages where this field path was present.
+    pub message_count: usize,
+    /// Number of field occurrences across all parsed messages.
+    pub occurrence_count: usize,
+}
+
+/// Parse failure captured while summarizing a corpus.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusParseFailure {
+    /// File path relative to the summarized root when possible.
+    pub path: String,
+    /// Parser error string for this file.
+    pub error: String,
+}
+
+/// Summary of a directory or file corpus of HL7 v2 messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusSummary {
+    /// Root path that was summarized.
+    pub root: String,
+    /// Number of regular files scanned.
+    pub file_count: usize,
+    /// Number of messages parsed successfully.
+    pub message_count: usize,
+    /// Number of files that could not be parsed as HL7 v2.
+    pub parse_error_count: usize,
+    /// Total input bytes across scanned files.
+    pub total_bytes: usize,
+    /// Message type counts from parsed MSH-9 values.
+    pub message_types: Vec<CorpusCount>,
+    /// Segment ID counts across parsed messages.
+    pub segments: Vec<CorpusCount>,
+    /// Field presence counts across parsed messages.
+    pub field_presence: Vec<CorpusFieldPresence>,
+    /// Per-file parse failures.
+    pub parse_errors: Vec<CorpusParseFailure>,
 }
 
 /// Train/validation/test split information
@@ -328,6 +385,193 @@ pub enum CorpusError {
     InvalidSplitRatios,
 }
 
+/// Summarize a file or directory of HL7 v2 messages.
+///
+/// Directories are scanned recursively. Each regular file is read and parsed as
+/// plain HL7 unless it is MLLP framed. Files that fail to parse are recorded in
+/// the returned summary rather than failing the whole operation.
+///
+/// # Errors
+///
+/// Returns [`CorpusError::InvalidConfig`] if the path is neither a regular file
+/// nor a directory. Returns [`CorpusError::IoError`] if directory traversal or
+/// file reading fails.
+pub fn summarize_corpus_path(path: impl AsRef<Path>) -> Result<CorpusSummary, CorpusError> {
+    let root = path.as_ref();
+    let mut files = Vec::new();
+    collect_corpus_files(root, &mut files)?;
+    files.sort();
+
+    let mut message_type_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut segment_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut field_message_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut field_occurrence_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut parse_errors = Vec::new();
+    let mut total_bytes = 0usize;
+    let mut message_count = 0usize;
+
+    for file in &files {
+        let relative_path = relative_corpus_path(root, file);
+        let bytes =
+            fs::read(file).map_err(|e| CorpusError::IoError(format!("{relative_path}: {e}")))?;
+        total_bytes = total_bytes.saturating_add(bytes.len());
+
+        let parsed = if is_mllp_framed(&bytes) {
+            parse_mllp(&bytes)
+        } else {
+            parse(&bytes)
+        };
+
+        match parsed {
+            Ok(message) => {
+                message_count = message_count.saturating_add(1);
+                increment_count(&mut message_type_counts, extract_message_type(&message));
+                record_message_shape(
+                    &message,
+                    &mut segment_counts,
+                    &mut field_message_counts,
+                    &mut field_occurrence_counts,
+                );
+            }
+            Err(error) => parse_errors.push(CorpusParseFailure {
+                path: relative_path,
+                error: error.to_string(),
+            }),
+        }
+    }
+
+    let mut field_presence: Vec<CorpusFieldPresence> = field_occurrence_counts
+        .into_iter()
+        .map(|(path, occurrence_count)| CorpusFieldPresence {
+            message_count: field_message_counts.get(&path).copied().unwrap_or_default(),
+            path,
+            occurrence_count,
+        })
+        .collect();
+    field_presence.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+
+    Ok(CorpusSummary {
+        root: root.to_string_lossy().to_string(),
+        file_count: files.len(),
+        message_count,
+        parse_error_count: parse_errors.len(),
+        total_bytes,
+        message_types: counts_to_vec(message_type_counts),
+        segments: counts_to_vec(segment_counts),
+        field_presence,
+        parse_errors,
+    })
+}
+
+fn collect_corpus_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), CorpusError> {
+    if path.is_file() {
+        files.push(path.to_path_buf());
+        return Ok(());
+    }
+
+    if !path.is_dir() {
+        return Err(CorpusError::InvalidConfig(format!(
+            "{} is not a file or directory",
+            path.display()
+        )));
+    }
+
+    for entry in fs::read_dir(path).map_err(|e| CorpusError::IoError(e.to_string()))? {
+        let entry = entry.map_err(|e| CorpusError::IoError(e.to_string()))?;
+        let child = entry.path();
+        if child.is_dir() {
+            collect_corpus_files(&child, files)?;
+        } else if child.is_file() {
+            files.push(child);
+        }
+    }
+
+    Ok(())
+}
+
+fn relative_corpus_path(root: &Path, file: &Path) -> String {
+    let relative = if root.is_dir() {
+        file.strip_prefix(root).unwrap_or(file)
+    } else {
+        file.file_name().map(Path::new).unwrap_or(file)
+    };
+    relative.to_string_lossy().replace('\\', "/")
+}
+
+fn record_message_shape(
+    message: &Message,
+    segment_counts: &mut BTreeMap<String, usize>,
+    field_message_counts: &mut BTreeMap<String, usize>,
+    field_occurrence_counts: &mut BTreeMap<String, usize>,
+) {
+    let mut message_field_paths = BTreeSet::new();
+
+    for segment in &message.segments {
+        let segment_id = segment.id_str().to_string();
+        increment_count(segment_counts, segment_id.clone());
+
+        for (field_index, field) in segment.fields.iter().enumerate() {
+            if !field_is_present(field) {
+                continue;
+            }
+
+            let display_index = if segment_id == "MSH" {
+                field_index.saturating_add(2)
+            } else {
+                field_index.saturating_add(1)
+            };
+            let path = format!("{segment_id}.{display_index}");
+            increment_count(field_occurrence_counts, path.clone());
+            message_field_paths.insert(path);
+        }
+    }
+
+    for path in message_field_paths {
+        increment_count(field_message_counts, path);
+    }
+}
+
+fn field_is_present(field: &Field) -> bool {
+    field.reps.iter().any(|rep| {
+        rep.comps.iter().any(|comp| {
+            comp.subs.iter().any(|atom| match atom {
+                Atom::Text(text) => !text.is_empty(),
+                Atom::Null => true,
+            })
+        })
+    })
+}
+
+fn compare_field_paths(left: &str, right: &str) -> Ordering {
+    let (left_segment, left_index) = split_field_path(left);
+    let (right_segment, right_index) = split_field_path(right);
+
+    left_segment
+        .cmp(right_segment)
+        .then(left_index.cmp(&right_index))
+        .then(left.cmp(right))
+}
+
+fn split_field_path(path: &str) -> (&str, usize) {
+    let Some((segment, field)) = path.split_once('.') else {
+        return (path, usize::MAX);
+    };
+    let index = field.parse::<usize>().unwrap_or(usize::MAX);
+    (segment, index)
+}
+
+fn increment_count(counts: &mut BTreeMap<String, usize>, value: String) {
+    let count = counts.entry(value).or_insert(0);
+    *count = count.saturating_add(1);
+}
+
+fn counts_to_vec(counts: BTreeMap<String, usize>) -> Vec<CorpusCount> {
+    counts
+        .into_iter()
+        .map(|(value, count)| CorpusCount { value, count })
+        .collect()
+}
+
 /// Extract message type from a message's MSH.9 field
 pub fn extract_message_type(message: &Message) -> String {
     // Find MSH segment
@@ -352,4 +596,87 @@ pub fn extract_message_type(message: &Message) -> String {
         }
     }
     "UNKNOWN".to_string()
+}
+
+#[cfg(test)]
+mod summary_tests {
+    #![expect(
+        clippy::panic,
+        reason = "Corpus summary tests fail explicitly on test setup errors."
+    )]
+
+    use super::*;
+
+    const ADT_A01: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605080101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M";
+    const ORU_R01: &str = "MSH|^~\\&|LAB|LAB|EHR|HOSP|202605080101||ORU^R01|CTRL456|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\rOBR|1|ORD1|FILL1|CBC^Complete Blood Count\rOBX|1|NM|718-7^Hemoglobin||13.2|g/dL";
+
+    fn write_message(path: &Path, contents: &str) {
+        let result = fs::write(path, contents);
+        assert!(result.is_ok(), "test message should be written: {result:?}");
+    }
+
+    #[test]
+    fn summarize_corpus_path_counts_messages_segments_and_fields() {
+        let Ok(dir) = tempfile::tempdir() else {
+            panic!("test temp dir should be created");
+        };
+        write_message(&dir.path().join("adt.hl7"), ADT_A01);
+        write_message(&dir.path().join("oru.hl7"), ORU_R01);
+
+        let Ok(summary) = summarize_corpus_path(dir.path()) else {
+            panic!("corpus should summarize");
+        };
+
+        assert_eq!(summary.file_count, 2);
+        assert_eq!(summary.message_count, 2);
+        assert_eq!(summary.parse_error_count, 0);
+        assert!(
+            summary
+                .message_types
+                .iter()
+                .any(|count| count.value == "ADT^A01" && count.count == 1)
+        );
+        assert!(
+            summary
+                .message_types
+                .iter()
+                .any(|count| count.value == "ORU^R01" && count.count == 1)
+        );
+        assert!(
+            summary
+                .segments
+                .iter()
+                .any(|count| count.value == "PID" && count.count == 2)
+        );
+        assert!(
+            summary
+                .field_presence
+                .iter()
+                .any(|field| field.path == "PID.3" && field.message_count == 2)
+        );
+    }
+
+    #[test]
+    fn summarize_corpus_path_records_parse_failures() {
+        let Ok(dir) = tempfile::tempdir() else {
+            panic!("test temp dir should be created");
+        };
+        write_message(&dir.path().join("valid.hl7"), ADT_A01);
+        write_message(&dir.path().join("invalid.hl7"), "not an hl7 message");
+
+        let Ok(summary) = summarize_corpus_path(dir.path()) else {
+            panic!("corpus should summarize");
+        };
+
+        assert_eq!(summary.file_count, 2);
+        assert_eq!(summary.message_count, 1);
+        assert_eq!(summary.parse_error_count, 1);
+        assert_eq!(
+            summary
+                .parse_errors
+                .first()
+                .map(|failure| failure.path.as_str()),
+            Some("invalid.hl7")
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add `hl7v2::synthetic::corpus::summarize_corpus_path` with a typed, serializable corpus summary
- add `hl7v2 corpus summarize <path> --format text|json|yaml`
- document the corpus summary command in the root and CLI READMEs

## Behavior
- scans a directory recursively or a single regular file
- parses plain HL7 or MLLP-framed input
- reports message type counts, segment counts, field presence, bytes scanned, and per-file parse failures
- keeps parse failures in the summary instead of failing the whole corpus scan

## Validation
- `cargo +1.93.0 test -p hl7v2 --all-features summarize_corpus_path`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli corpus`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests test_corpus`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- manual smoke: `cargo +1.93.0 run -p hl7v2-cli --quiet -- corpus summarize <temp-corpus> --format json`