### PR TITLE
feat: add corpus fingerprint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ hl7v2 corpus summarize corpus/
 
 # Emit a machine-readable corpus summary
 hl7v2 corpus summarize corpus/ --format json
+
+# Create a deterministic feed fingerprint
+hl7v2 corpus fingerprint corpus/ --format json
+
+# Include validation issue-code counts in the fingerprint
+hl7v2 corpus fingerprint corpus/ --profile profiles/oru_r01.yaml --format json
 ```
 
 ### Acknowledgment Generation

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -24,6 +24,8 @@ Summarize a directory or file corpus:
 ```bash
 hl7v2 corpus summarize corpus/
 hl7v2 corpus summarize corpus/ --format json
+hl7v2 corpus fingerprint corpus/ --format json
+hl7v2 corpus fingerprint corpus/ --profile profiles/adt_a01.yaml --format json
 ```
 
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -22,7 +22,10 @@
 )]
 
 use clap::{Parser, Subcommand};
-use hl7v2::synthetic::corpus::{CorpusSummary, summarize_corpus_path};
+use hl7v2::synthetic::corpus::{
+    CorpusCount, CorpusFingerprint, CorpusFingerprintProfile, CorpusSummary, compute_sha256,
+    fingerprint_corpus_path, summarize_corpus_path,
+};
 use hl7v2::synthetic::generate::{Template, generate};
 use hl7v2::{
     AckCode as GenAckCode, Event, Message, ProfileLintReport, StreamParser, ValidationReport, ack,
@@ -282,6 +285,20 @@ enum CorpusCommands {
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
     },
+
+    /// Create a deterministic feed fingerprint
+    Fingerprint {
+        /// Corpus directory or single HL7 file
+        path: PathBuf,
+
+        /// Optional profile YAML file for validation issue-code counts
+        #[arg(long)]
+        profile: Option<PathBuf>,
+
+        /// Output fingerprint format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        format: ReportFormat,
+    },
 }
 
 /// Server mode selection
@@ -425,6 +442,11 @@ async fn main() {
         },
         Commands::Corpus { command } => match command {
             CorpusCommands::Summarize { path, format } => corpus_summarize_command(path, format),
+            CorpusCommands::Fingerprint {
+                path,
+                profile,
+                format,
+            } => corpus_fingerprint_command(path, profile.as_ref(), format),
         },
         Commands::Ack {
             input,
@@ -1540,6 +1562,217 @@ fn append_counts(output: &mut String, counts: &[hl7v2::synthetic::corpus::Corpus
 
     for count in counts {
         output.push_str(&format!("  {}: {}\n", count.value, count.count));
+    }
+}
+
+fn corpus_fingerprint_command(
+    path: &PathBuf,
+    profile: Option<&PathBuf>,
+    format: &ReportFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut fingerprint = fingerprint_corpus_path(path)?;
+
+    if let Some(profile_path) = profile {
+        let (profile_metadata, issue_counts) =
+            fingerprint_validation_issue_counts(path, profile_path)?;
+        fingerprint.profile = Some(profile_metadata);
+        fingerprint.validation_issue_code_counts = issue_counts;
+    }
+
+    let output = format_corpus_fingerprint(&fingerprint, format)?;
+    println!("{}", output);
+    Ok(())
+}
+
+fn fingerprint_validation_issue_counts(
+    path: &Path,
+    profile_path: &Path,
+) -> Result<(CorpusFingerprintProfile, Vec<CorpusCount>), Box<dyn std::error::Error>> {
+    let profile_yaml = fs::read_to_string(profile_path)?;
+    let profile = load_profile_checked(&profile_yaml)?;
+    let profile_metadata = CorpusFingerprintProfile {
+        path: profile_path.to_string_lossy().to_string(),
+        sha256: compute_sha256(&profile_yaml),
+        version: profile.version.clone(),
+        message_structure: profile.message_structure.clone(),
+    };
+
+    let mut files = Vec::new();
+    collect_cli_corpus_files(path, &mut files)?;
+    files.sort();
+
+    let mut counts = std::collections::BTreeMap::new();
+    for file in files {
+        let bytes = fs::read(&file)?;
+        let parsed = if is_mllp_framed(&bytes) {
+            parse_mllp(&bytes)
+        } else {
+            parse(&bytes)
+        };
+        let Ok(message) = parsed else {
+            continue;
+        };
+        let issues = validate(&message, &profile);
+        let report = ValidationReport::from_issues(
+            &message,
+            Some(profile_path.to_string_lossy().to_string()),
+            issues,
+        );
+        for issue in report.issues {
+            let count = counts.entry(issue.code).or_insert(0usize);
+            *count = count.saturating_add(1);
+        }
+    }
+
+    Ok((profile_metadata, counts_to_corpus_counts(counts)))
+}
+
+fn collect_cli_corpus_files(
+    path: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if path.is_file() {
+        files.push(path.to_path_buf());
+        return Ok(());
+    }
+
+    if !path.is_dir() {
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} is not a file or directory", path.display()),
+        )));
+    }
+
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let child = entry.path();
+        if child.is_dir() {
+            collect_cli_corpus_files(&child, files)?;
+        } else if child.is_file() {
+            files.push(child);
+        }
+    }
+
+    Ok(())
+}
+
+fn counts_to_corpus_counts(counts: std::collections::BTreeMap<String, usize>) -> Vec<CorpusCount> {
+    counts
+        .into_iter()
+        .map(|(value, count)| CorpusCount { value, count })
+        .collect()
+}
+
+fn format_corpus_fingerprint(
+    fingerprint: &CorpusFingerprint,
+    format: &ReportFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        ReportFormat::Json => Ok(serde_json::to_string_pretty(fingerprint)?),
+        ReportFormat::Yaml => Ok(serde_yaml::to_string(fingerprint)?),
+        ReportFormat::Text => {
+            let mut output = String::new();
+            output.push_str("Corpus Fingerprint:\n");
+            output.push_str(&format!("  Path: {}\n", fingerprint.root));
+            output.push_str(&format!(
+                "  Fingerprint version: {}\n",
+                fingerprint.fingerprint_version
+            ));
+            output.push_str(&format!("  Tool version: {}\n", fingerprint.tool_version));
+            output.push_str(&format!("  Files scanned: {}\n", fingerprint.file_count));
+            output.push_str(&format!(
+                "  Parsed messages: {}\n",
+                fingerprint.message_count
+            ));
+            output.push_str(&format!(
+                "  Parse errors: {}\n",
+                fingerprint.parse_error_count
+            ));
+
+            if let Some(profile) = &fingerprint.profile {
+                output.push('\n');
+                output.push_str("Profile:\n");
+                output.push_str(&format!("  Path: {}\n", profile.path));
+                output.push_str(&format!("  SHA-256: {}\n", profile.sha256));
+                output.push_str(&format!("  Version: {}\n", profile.version));
+                output.push_str(&format!(
+                    "  Message structure: {}\n",
+                    profile.message_structure
+                ));
+            }
+
+            output.push('\n');
+            output.push_str("Message types:\n");
+            append_counts(&mut output, &fingerprint.message_type_counts);
+
+            output.push('\n');
+            output.push_str("Segments:\n");
+            append_counts(&mut output, &fingerprint.segment_counts);
+
+            output.push('\n');
+            output.push_str("Field presence:\n");
+            append_fingerprint_field_presence(&mut output, fingerprint);
+
+            output.push('\n');
+            output.push_str("Value shapes:\n");
+            append_value_shape_stats(&mut output, fingerprint);
+
+            if fingerprint.profile.is_some() {
+                output.push('\n');
+                output.push_str("Validation issue codes:\n");
+                append_counts(&mut output, &fingerprint.validation_issue_code_counts);
+            }
+
+            Ok(output)
+        }
+    }
+}
+
+fn append_fingerprint_field_presence(output: &mut String, fingerprint: &CorpusFingerprint) {
+    if fingerprint.field_presence.is_empty() {
+        output.push_str("  <none>\n");
+        return;
+    }
+
+    for field in &fingerprint.field_presence {
+        if let Some(cardinality) = fingerprint
+            .field_cardinality
+            .iter()
+            .find(|candidate| candidate.path == field.path)
+        {
+            output.push_str(&format!(
+                "  {}: {} message(s), {} occurrence(s), min {}, max {}\n",
+                field.path,
+                field.message_count,
+                field.occurrence_count,
+                cardinality.min_per_message,
+                cardinality.max_per_message
+            ));
+        } else {
+            output.push_str(&format!(
+                "  {}: {} message(s), {} occurrence(s)\n",
+                field.path, field.message_count, field.occurrence_count
+            ));
+        }
+    }
+}
+
+fn append_value_shape_stats(output: &mut String, fingerprint: &CorpusFingerprint) {
+    if fingerprint.value_shape_stats.is_empty() {
+        output.push_str("  <none>\n");
+        return;
+    }
+
+    for stats in &fingerprint.value_shape_stats {
+        output.push_str(&format!(
+            "  {}: coded {}, timestamp {}, numeric {}, null {}, text {}\n",
+            stats.path,
+            stats.coded_count,
+            stats.timestamp_count,
+            stats.numeric_count,
+            stats.null_count,
+            stats.text_count
+        ));
     }
 }
 

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -764,6 +764,77 @@ constraints:
         }
 
         #[test]
+        fn test_format_corpus_fingerprint_report_text() {
+            let report = hl7v2::synthetic::corpus::CorpusFingerprint {
+                fingerprint_version: "1".to_string(),
+                tool_version: "1.2.1".to_string(),
+                root: "corpus".to_string(),
+                profile: Some(hl7v2::synthetic::corpus::CorpusFingerprintProfile {
+                    path: "profile.yaml".to_string(),
+                    sha256: "abc123".to_string(),
+                    version: "2.5.1".to_string(),
+                    message_structure: "ADT_A01".to_string(),
+                }),
+                file_count: 2,
+                message_count: 1,
+                parse_error_count: 1,
+                message_type_counts: vec![hl7v2::synthetic::corpus::CorpusCount {
+                    value: "ADT^A01".to_string(),
+                    count: 1,
+                }],
+                segment_counts: vec![hl7v2::synthetic::corpus::CorpusCount {
+                    value: "PID".to_string(),
+                    count: 1,
+                }],
+                field_presence: vec![hl7v2::synthetic::corpus::CorpusFieldPresence {
+                    path: "PID.3".to_string(),
+                    message_count: 1,
+                    occurrence_count: 1,
+                }],
+                field_cardinality: vec![hl7v2::synthetic::corpus::CorpusFieldCardinality {
+                    path: "PID.3".to_string(),
+                    min_per_message: 0,
+                    max_per_message: 1,
+                    total_occurrences: 1,
+                    message_count: 1,
+                }],
+                value_shape_stats: vec![hl7v2::synthetic::corpus::CorpusValueShapeStats {
+                    path: "PID.3".to_string(),
+                    coded_count: 1,
+                    timestamp_count: 0,
+                    numeric_count: 0,
+                    null_count: 0,
+                    text_count: 0,
+                }],
+                validation_issue_code_counts: vec![hl7v2::synthetic::corpus::CorpusCount {
+                    value: "missing_required_field".to_string(),
+                    count: 1,
+                }],
+            };
+
+            let output = crate::format_corpus_fingerprint(&report, &crate::ReportFormat::Text)
+                .expect("Should format as text");
+
+            assert!(output.contains("Corpus Fingerprint:"));
+            assert!(output.contains("Profile:"));
+            assert!(output.contains("ADT^A01: 1"));
+            assert!(output.contains("PID.3: 1 message(s), 1 occurrence(s), min 0, max 1"));
+            assert!(output.contains("missing_required_field: 1"));
+        }
+
+        #[test]
+        fn test_corpus_fingerprint_command_execution() {
+            use crate::ReportFormat;
+            use crate::corpus_fingerprint_command;
+            let dir = TempDir::new().expect("Failed to create temp dir");
+            create_temp_hl7_file(&dir, "test.hl7");
+
+            let result =
+                corpus_fingerprint_command(&dir.path().to_path_buf(), None, &ReportFormat::Json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
         fn test_stats_command_execution() {
             use crate::ReportFormat;
             use crate::stats_command;
@@ -941,6 +1012,24 @@ constraints:
                 corpus_cmd
                     .get_subcommands()
                     .any(|c| c.get_name() == "summarize")
+            );
+        }
+
+        #[test]
+        fn test_corpus_command_has_fingerprint_subcommand() {
+            use crate::Cli;
+            use clap::CommandFactory;
+
+            let schema = Cli::command();
+            let corpus_cmd = schema
+                .get_subcommands()
+                .find(|c| c.get_name() == "corpus")
+                .expect("corpus command should exist");
+
+            assert!(
+                corpus_cmd
+                    .get_subcommands()
+                    .any(|c| c.get_name() == "fingerprint")
             );
         }
 

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -106,6 +106,17 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_corpus_fingerprint_help() {
+        let mut cmd = cli_command();
+        cmd.args(["corpus", "fingerprint", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Create a deterministic feed fingerprint",
+            ));
+    }
+
+    #[test]
     fn test_ack_help() {
         let mut cmd = cli_command();
         cmd.args(["ack", "--help"])
@@ -622,6 +633,79 @@ mod corpus_command {
                 .unwrap()
                 .iter()
                 .any(|entry| entry["value"] == "ORU^R01" && entry["count"] == 1)
+        );
+    }
+
+    #[test]
+    fn test_corpus_fingerprint_text_reports_shape() {
+        let dir = create_temp_dir();
+        create_temp_hl7_file(&dir, "adt.hl7");
+
+        let mut cmd = cli_command();
+        cmd.args(["corpus", "fingerprint", dir.path().to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Corpus Fingerprint:"))
+            .stdout(predicate::str::contains("Files scanned: 1"))
+            .stdout(predicate::str::contains("ADT^A01^ADT_A01: 1"))
+            .stdout(predicate::str::contains("Field presence:"))
+            .stdout(predicate::str::contains("Value shapes:"));
+    }
+
+    #[test]
+    fn test_corpus_fingerprint_json_with_profile_counts_issue_codes() {
+        let dir = create_temp_dir();
+        let profile_dir = create_temp_dir();
+        create_temp_hl7_with_content(
+            &dir,
+            "missing_pid3.hl7",
+            "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1\r",
+        );
+        let profile = create_temp_profile(
+            &profile_dir,
+            "profile.yaml",
+            r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "fingerprint",
+                dir.path().to_str().unwrap(),
+                "--profile",
+                profile.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute corpus fingerprint");
+
+        assert!(output.status.success());
+        assert!(is_valid_json(&output.stdout));
+
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("fingerprint output should be JSON");
+        assert_eq!(report["fingerprint_version"], "1");
+        assert_eq!(report["file_count"], 1);
+        assert_eq!(report["message_count"], 1);
+        assert_eq!(report["parse_error_count"], 0);
+        assert_eq!(report["profile"]["message_structure"], "ADT_A01");
+        assert!(
+            report["validation_issue_code_counts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["value"] == "missing_required_field" && entry["count"] == 1)
         );
     }
 }

--- a/crates/hl7v2/src/synthetic/corpus.rs
+++ b/crates/hl7v2/src/synthetic/corpus.rs
@@ -158,6 +158,82 @@ pub struct CorpusSummary {
     pub parse_errors: Vec<CorpusParseFailure>,
 }
 
+/// Field cardinality observed across parsed corpus messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusFieldCardinality {
+    /// HL7 path, such as `PID.3` or `OBX.5`.
+    pub path: String,
+    /// Minimum occurrences observed in any parsed message.
+    pub min_per_message: usize,
+    /// Maximum occurrences observed in any parsed message.
+    pub max_per_message: usize,
+    /// Total occurrences across all parsed messages.
+    pub total_occurrences: usize,
+    /// Number of parsed messages where this path was present.
+    pub message_count: usize,
+}
+
+/// Value shape counts for one HL7 field path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusValueShapeStats {
+    /// HL7 path, such as `PID.3` or `OBX.5`.
+    pub path: String,
+    /// Count of coded/component values.
+    pub coded_count: usize,
+    /// Count of timestamp-like values.
+    pub timestamp_count: usize,
+    /// Count of numeric values.
+    pub numeric_count: usize,
+    /// Count of explicit HL7 null values.
+    pub null_count: usize,
+    /// Count of other non-empty text values.
+    pub text_count: usize,
+}
+
+/// Profile metadata attached to a corpus fingerprint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusFingerprintProfile {
+    /// Profile path supplied by the caller.
+    pub path: String,
+    /// SHA-256 hash of the profile content.
+    pub sha256: String,
+    /// Profile version, when loaded.
+    pub version: String,
+    /// Profile message structure, when loaded.
+    pub message_structure: String,
+}
+
+/// Deterministic compact signature for a file or directory corpus.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusFingerprint {
+    /// Fingerprint schema version.
+    pub fingerprint_version: String,
+    /// hl7v2 tool version.
+    pub tool_version: String,
+    /// Root path that was fingerprinted.
+    pub root: String,
+    /// Optional profile metadata.
+    pub profile: Option<CorpusFingerprintProfile>,
+    /// Number of regular files scanned.
+    pub file_count: usize,
+    /// Number of messages parsed successfully.
+    pub message_count: usize,
+    /// Number of files that could not be parsed as HL7 v2.
+    pub parse_error_count: usize,
+    /// Message type counts from parsed MSH-9 values.
+    pub message_type_counts: Vec<CorpusCount>,
+    /// Segment ID counts across parsed messages.
+    pub segment_counts: Vec<CorpusCount>,
+    /// Field presence counts across parsed messages.
+    pub field_presence: Vec<CorpusFieldPresence>,
+    /// Field cardinality observations across parsed messages.
+    pub field_cardinality: Vec<CorpusFieldCardinality>,
+    /// Value shape observations across parsed messages.
+    pub value_shape_stats: Vec<CorpusValueShapeStats>,
+    /// Validation issue code counts when a profile is supplied.
+    pub validation_issue_code_counts: Vec<CorpusCount>,
+}
+
 /// Train/validation/test split information
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CorpusSplits {
@@ -463,6 +539,104 @@ pub fn summarize_corpus_path(path: impl AsRef<Path>) -> Result<CorpusSummary, Co
     })
 }
 
+/// Fingerprint a file or directory of HL7 v2 messages.
+///
+/// The fingerprint is a compact deterministic feed signature derived from the
+/// parsed messages in the corpus. Parse failures are counted but skipped for
+/// shape-level dimensions.
+///
+/// # Errors
+///
+/// Returns [`CorpusError::InvalidConfig`] if the path is neither a regular file
+/// nor a directory. Returns [`CorpusError::IoError`] if traversal or file
+/// reading fails.
+pub fn fingerprint_corpus_path(path: impl AsRef<Path>) -> Result<CorpusFingerprint, CorpusError> {
+    let root = path.as_ref();
+    let summary = summarize_corpus_path(root)?;
+    let (field_cardinality, value_shape_stats) =
+        collect_fingerprint_details(root, summary.message_count)?;
+
+    Ok(CorpusFingerprint {
+        fingerprint_version: "1".to_string(),
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        root: summary.root,
+        profile: None,
+        file_count: summary.file_count,
+        message_count: summary.message_count,
+        parse_error_count: summary.parse_error_count,
+        message_type_counts: summary.message_types,
+        segment_counts: summary.segments,
+        field_presence: summary.field_presence,
+        field_cardinality,
+        value_shape_stats,
+        validation_issue_code_counts: Vec::new(),
+    })
+}
+
+fn collect_fingerprint_details(
+    root: &Path,
+    message_count: usize,
+) -> Result<(Vec<CorpusFieldCardinality>, Vec<CorpusValueShapeStats>), CorpusError> {
+    let mut files = Vec::new();
+    collect_corpus_files(root, &mut files)?;
+    files.sort();
+
+    let mut cardinality: BTreeMap<String, FieldCardinalityAccumulator> = BTreeMap::new();
+    let mut value_shapes: BTreeMap<String, CorpusValueShapeStats> = BTreeMap::new();
+
+    for file in &files {
+        let relative_path = relative_corpus_path(root, file);
+        let bytes =
+            fs::read(file).map_err(|e| CorpusError::IoError(format!("{relative_path}: {e}")))?;
+        let parsed = if is_mllp_framed(&bytes) {
+            parse_mllp(&bytes)
+        } else {
+            parse(&bytes)
+        };
+        let Ok(message) = parsed else {
+            continue;
+        };
+
+        let mut message_occurrences: BTreeMap<String, usize> = BTreeMap::new();
+        record_fingerprint_message_shape(&message, &mut message_occurrences, &mut value_shapes);
+
+        for (path, occurrences) in message_occurrences {
+            let entry = cardinality.entry(path).or_default();
+            entry.present_message_count = entry.present_message_count.saturating_add(1);
+            entry.total_occurrences = entry.total_occurrences.saturating_add(occurrences);
+            entry.max_per_message = entry.max_per_message.max(occurrences);
+            entry.min_present_per_message = match entry.min_present_per_message {
+                Some(current) => Some(current.min(occurrences)),
+                None => Some(occurrences),
+            };
+        }
+    }
+
+    let mut cardinality: Vec<CorpusFieldCardinality> = cardinality
+        .into_iter()
+        .map(|(path, stats)| {
+            let min_per_message = if stats.present_message_count < message_count {
+                0
+            } else {
+                stats.min_present_per_message.unwrap_or_default()
+            };
+            CorpusFieldCardinality {
+                path,
+                min_per_message,
+                max_per_message: stats.max_per_message,
+                total_occurrences: stats.total_occurrences,
+                message_count: stats.present_message_count,
+            }
+        })
+        .collect();
+    cardinality.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+
+    let mut value_shape_stats: Vec<CorpusValueShapeStats> = value_shapes.into_values().collect();
+    value_shape_stats.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+
+    Ok((cardinality, value_shape_stats))
+}
+
 fn collect_corpus_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), CorpusError> {
     if path.is_file() {
         files.push(path.to_path_buf());
@@ -531,6 +705,39 @@ fn record_message_shape(
     }
 }
 
+#[derive(Default)]
+struct FieldCardinalityAccumulator {
+    present_message_count: usize,
+    total_occurrences: usize,
+    max_per_message: usize,
+    min_present_per_message: Option<usize>,
+}
+
+fn record_fingerprint_message_shape(
+    message: &Message,
+    message_occurrences: &mut BTreeMap<String, usize>,
+    value_shapes: &mut BTreeMap<String, CorpusValueShapeStats>,
+) {
+    for segment in &message.segments {
+        let segment_id = segment.id_str().to_string();
+
+        for (field_index, field) in segment.fields.iter().enumerate() {
+            if !field_is_present(field) {
+                continue;
+            }
+
+            let display_index = if segment_id == "MSH" {
+                field_index.saturating_add(2)
+            } else {
+                field_index.saturating_add(1)
+            };
+            let path = format!("{segment_id}.{display_index}");
+            increment_count(message_occurrences, path.clone());
+            record_value_shape(value_shapes, &path, field);
+        }
+    }
+}
+
 fn field_is_present(field: &Field) -> bool {
     field.reps.iter().any(|rep| {
         rep.comps.iter().any(|comp| {
@@ -540,6 +747,87 @@ fn field_is_present(field: &Field) -> bool {
             })
         })
     })
+}
+
+#[derive(Clone, Copy)]
+enum ValueShape {
+    Coded,
+    Timestamp,
+    Numeric,
+    Null,
+    Text,
+}
+
+fn record_value_shape(
+    value_shapes: &mut BTreeMap<String, CorpusValueShapeStats>,
+    path: &str,
+    field: &Field,
+) {
+    let stats = value_shapes
+        .entry(path.to_string())
+        .or_insert_with(|| empty_value_shape_stats(path));
+    for shape in field_value_shapes(field) {
+        match shape {
+            ValueShape::Coded => stats.coded_count = stats.coded_count.saturating_add(1),
+            ValueShape::Timestamp => {
+                stats.timestamp_count = stats.timestamp_count.saturating_add(1);
+            }
+            ValueShape::Numeric => stats.numeric_count = stats.numeric_count.saturating_add(1),
+            ValueShape::Null => stats.null_count = stats.null_count.saturating_add(1),
+            ValueShape::Text => stats.text_count = stats.text_count.saturating_add(1),
+        }
+    }
+}
+
+fn empty_value_shape_stats(path: &str) -> CorpusValueShapeStats {
+    CorpusValueShapeStats {
+        path: path.to_string(),
+        coded_count: 0,
+        timestamp_count: 0,
+        numeric_count: 0,
+        null_count: 0,
+        text_count: 0,
+    }
+}
+
+fn field_value_shapes(field: &Field) -> Vec<ValueShape> {
+    field
+        .reps
+        .iter()
+        .filter_map(repetition_value_shape)
+        .collect()
+}
+
+fn repetition_value_shape(rep: &crate::model::Rep) -> Option<ValueShape> {
+    if rep
+        .comps
+        .iter()
+        .flat_map(|component| component.subs.iter())
+        .any(|atom| matches!(atom, Atom::Null))
+    {
+        return Some(ValueShape::Null);
+    }
+
+    if rep.comps.len() > 1 {
+        return Some(ValueShape::Coded);
+    }
+
+    let text = rep.first_text()?;
+    if text.is_empty() {
+        return None;
+    }
+
+    if is_hl7_timestamp_shape(text) {
+        Some(ValueShape::Timestamp)
+    } else if text.parse::<f64>().is_ok() {
+        Some(ValueShape::Numeric)
+    } else {
+        Some(ValueShape::Text)
+    }
+}
+
+fn is_hl7_timestamp_shape(text: &str) -> bool {
+    matches!(text.len(), 8 | 12 | 14) && text.chars().all(|character| character.is_ascii_digit())
 }
 
 fn compare_field_paths(left: &str, right: &str) -> Ordering {
@@ -677,6 +965,45 @@ mod summary_tests {
                 .first()
                 .map(|failure| failure.path.as_str()),
             Some("invalid.hl7")
+        );
+    }
+
+    #[test]
+    fn fingerprint_corpus_path_reports_shape_and_cardinality() {
+        let Ok(dir) = tempfile::tempdir() else {
+            panic!("test temp dir should be created");
+        };
+        write_message(&dir.path().join("adt.hl7"), ADT_A01);
+        write_message(&dir.path().join("oru.hl7"), ORU_R01);
+        write_message(&dir.path().join("invalid.hl7"), "not an hl7 message");
+
+        let Ok(fingerprint) = fingerprint_corpus_path(dir.path()) else {
+            panic!("corpus should fingerprint");
+        };
+
+        assert_eq!(fingerprint.fingerprint_version, "1");
+        assert_eq!(fingerprint.file_count, 3);
+        assert_eq!(fingerprint.message_count, 2);
+        assert_eq!(fingerprint.parse_error_count, 1);
+        assert!(
+            fingerprint
+                .message_type_counts
+                .iter()
+                .any(|count| count.value == "ORU^R01" && count.count == 1)
+        );
+        assert!(
+            fingerprint
+                .field_cardinality
+                .iter()
+                .any(|field| field.path == "OBX.5"
+                    && field.min_per_message == 0
+                    && field.max_per_message == 1)
+        );
+        assert!(
+            fingerprint
+                .value_shape_stats
+                .iter()
+                .any(|shape| shape.path == "OBX.5" && shape.numeric_count == 1)
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `hl7v2 corpus fingerprint <path>` with text, JSON, and YAML output
- expose deterministic corpus fingerprint data from `hl7v2::synthetic::corpus`
- optionally enrich CLI fingerprints with profile SHA-256 metadata and validation issue-code counts
- document the new command in the root and CLI READMEs

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2 --all-features corpus`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli fingerprint`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests corpus`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`