### PR TITLE
feat: add corpus diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ hl7v2 corpus summarize corpus/
 
 # Emit a machine-readable corpus summary
 hl7v2 corpus summarize corpus/ --format json
+
+# Compare before/after corpora for feed drift
+hl7v2 corpus diff feeds/before feeds/after --format json
 ```
 
 ### Acknowledgment Generation

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -24,6 +24,7 @@ Summarize a directory or file corpus:
 ```bash
 hl7v2 corpus summarize corpus/
 hl7v2 corpus summarize corpus/ --format json
+hl7v2 corpus diff feeds/before feeds/after --format json
 ```
 
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -22,7 +22,10 @@
 )]
 
 use clap::{Parser, Subcommand};
-use hl7v2::synthetic::corpus::{CorpusSummary, summarize_corpus_path};
+use hl7v2::synthetic::corpus::{
+    CorpusCountDiff, CorpusDiffReport, CorpusFieldPresenceDiff, CorpusSummary, diff_corpus_paths,
+    summarize_corpus_path,
+};
 use hl7v2::synthetic::generate::{Template, generate};
 use hl7v2::{
     AckCode as GenAckCode, Event, Message, ProfileLintReport, StreamParser, ValidationReport, ack,
@@ -282,6 +285,19 @@ enum CorpusCommands {
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
     },
+
+    /// Diff two directory or file corpora of HL7 messages
+    Diff {
+        /// Before corpus directory or single HL7 file
+        before: PathBuf,
+
+        /// After corpus directory or single HL7 file
+        after: PathBuf,
+
+        /// Output diff format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        format: ReportFormat,
+    },
 }
 
 /// Server mode selection
@@ -425,6 +441,11 @@ async fn main() {
         },
         Commands::Corpus { command } => match command {
             CorpusCommands::Summarize { path, format } => corpus_summarize_command(path, format),
+            CorpusCommands::Diff {
+                before,
+                after,
+                format,
+            } => corpus_diff_command(before, after, format),
         },
         Commands::Ack {
             input,
@@ -1540,6 +1561,119 @@ fn append_counts(output: &mut String, counts: &[hl7v2::synthetic::corpus::Corpus
 
     for count in counts {
         output.push_str(&format!("  {}: {}\n", count.value, count.count));
+    }
+}
+
+fn corpus_diff_command(
+    before: &PathBuf,
+    after: &PathBuf,
+    format: &ReportFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let diff = diff_corpus_paths(before, after)?;
+    let output = format_corpus_diff(&diff, format)?;
+    println!("{}", output);
+    Ok(())
+}
+
+fn format_corpus_diff(
+    diff: &CorpusDiffReport,
+    format: &ReportFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        ReportFormat::Json => Ok(serde_json::to_string_pretty(diff)?),
+        ReportFormat::Yaml => Ok(serde_yaml::to_string(diff)?),
+        ReportFormat::Text => {
+            let mut output = String::new();
+            output.push_str("Corpus Diff:\n");
+            output.push_str(&format!("  Before: {}\n", diff.before_root));
+            output.push_str(&format!("  After: {}\n", diff.after_root));
+
+            output.push('\n');
+            output.push_str("Totals:\n");
+            output.push_str(&format!(
+                "  Files scanned: {} -> {} ({})\n",
+                diff.file_count.before,
+                diff.file_count.after,
+                format_signed_delta(diff.file_count.delta)
+            ));
+            output.push_str(&format!(
+                "  Parsed messages: {} -> {} ({})\n",
+                diff.message_count.before,
+                diff.message_count.after,
+                format_signed_delta(diff.message_count.delta)
+            ));
+            output.push_str(&format!(
+                "  Parse errors: {} -> {} ({})\n",
+                diff.parse_error_count.before,
+                diff.parse_error_count.after,
+                format_signed_delta(diff.parse_error_count.delta)
+            ));
+            output.push_str(&format!(
+                "  Total bytes: {} -> {} ({})\n",
+                diff.total_bytes.before,
+                diff.total_bytes.after,
+                format_signed_delta(diff.total_bytes.delta)
+            ));
+
+            output.push('\n');
+            output.push_str("Message types:\n");
+            append_count_diffs(&mut output, &diff.message_types);
+
+            output.push('\n');
+            output.push_str("Segments:\n");
+            append_count_diffs(&mut output, &diff.segments);
+
+            output.push('\n');
+            output.push_str("Field presence:\n");
+            append_field_presence_diffs(&mut output, &diff.field_presence);
+
+            Ok(output)
+        }
+    }
+}
+
+fn append_count_diffs(output: &mut String, counts: &[CorpusCountDiff]) {
+    if counts.is_empty() {
+        output.push_str("  <none>\n");
+        return;
+    }
+
+    for count in counts {
+        output.push_str(&format!(
+            "  {}: {} -> {} ({})\n",
+            count.value,
+            count.before,
+            count.after,
+            format_signed_delta(count.delta)
+        ));
+    }
+}
+
+fn append_field_presence_diffs(output: &mut String, fields: &[CorpusFieldPresenceDiff]) {
+    if fields.is_empty() {
+        output.push_str("  <none>\n");
+        return;
+    }
+
+    for field in fields {
+        output.push_str(&format!(
+            "  {}: messages {} -> {} ({}), occurrences {} -> {} ({})\n",
+            field.path,
+            field.before_message_count,
+            field.after_message_count,
+            format_signed_delta(field.message_count_delta),
+            field.before_occurrence_count,
+            field.after_occurrence_count,
+            format_signed_delta(field.occurrence_count_delta)
+        ));
+    }
+}
+
+fn format_signed_delta(delta: i128) -> String {
+    if delta > 0 {
+        format!("+{delta}")
+    } else {
+        delta.to_string()
     }
 }
 

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -764,6 +764,80 @@ constraints:
         }
 
         #[test]
+        fn test_format_corpus_diff_report_text() {
+            let report = hl7v2::synthetic::corpus::CorpusDiffReport {
+                before_root: "before".to_string(),
+                after_root: "after".to_string(),
+                file_count: hl7v2::synthetic::corpus::CorpusTotalDiff {
+                    before: 1,
+                    after: 2,
+                    delta: 1,
+                },
+                message_count: hl7v2::synthetic::corpus::CorpusTotalDiff {
+                    before: 1,
+                    after: 2,
+                    delta: 1,
+                },
+                parse_error_count: hl7v2::synthetic::corpus::CorpusTotalDiff {
+                    before: 0,
+                    after: 1,
+                    delta: 1,
+                },
+                total_bytes: hl7v2::synthetic::corpus::CorpusTotalDiff {
+                    before: 100,
+                    after: 180,
+                    delta: 80,
+                },
+                message_types: vec![hl7v2::synthetic::corpus::CorpusCountDiff {
+                    value: "ORU^R01".to_string(),
+                    before: 0,
+                    after: 1,
+                    delta: 1,
+                }],
+                segments: vec![hl7v2::synthetic::corpus::CorpusCountDiff {
+                    value: "OBX".to_string(),
+                    before: 0,
+                    after: 1,
+                    delta: 1,
+                }],
+                field_presence: vec![hl7v2::synthetic::corpus::CorpusFieldPresenceDiff {
+                    path: "OBX.5".to_string(),
+                    before_message_count: 0,
+                    after_message_count: 1,
+                    message_count_delta: 1,
+                    before_occurrence_count: 0,
+                    after_occurrence_count: 1,
+                    occurrence_count_delta: 1,
+                }],
+            };
+
+            let output = crate::format_corpus_diff(&report, &crate::ReportFormat::Text)
+                .expect("Should format as text");
+
+            assert!(output.contains("Corpus Diff:"));
+            assert!(output.contains("Parsed messages: 1 -> 2 (+1)"));
+            assert!(output.contains("ORU^R01: 0 -> 1 (+1)"));
+            assert!(output.contains("OBX.5: messages 0 -> 1 (+1)"));
+        }
+
+        #[test]
+        fn test_corpus_diff_command_execution() {
+            use crate::ReportFormat;
+            use crate::corpus_diff_command;
+            let before = TempDir::new().expect("Failed to create before temp dir");
+            let after = TempDir::new().expect("Failed to create after temp dir");
+            create_temp_hl7_file(&before, "test.hl7");
+            create_temp_hl7_file(&after, "test.hl7");
+
+            let result = corpus_diff_command(
+                &before.path().to_path_buf(),
+                &after.path().to_path_buf(),
+                &ReportFormat::Json,
+            );
+            assert!(result.is_ok());
+        }
+
+        #[test]
         fn test_stats_command_execution() {
             use crate::ReportFormat;
             use crate::stats_command;
@@ -942,6 +1016,20 @@ constraints:
                     .get_subcommands()
                     .any(|c| c.get_name() == "summarize")
             );
+        }
+
+        #[test]
+        fn test_corpus_command_has_diff_subcommand() {
+            use crate::Cli;
+            use clap::CommandFactory;
+
+            let schema = Cli::command();
+            let corpus_cmd = schema
+                .get_subcommands()
+                .find(|c| c.get_name() == "corpus")
+                .expect("corpus command should exist");
+
+            assert!(corpus_cmd.get_subcommands().any(|c| c.get_name() == "diff"));
         }
 
         #[test]

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -106,6 +106,17 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_corpus_diff_help() {
+        let mut cmd = cli_command();
+        cmd.args(["corpus", "diff", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Diff two directory or file corpora",
+            ));
+    }
+
+    #[test]
     fn test_ack_help() {
         let mut cmd = cli_command();
         cmd.args(["ack", "--help"])
@@ -622,6 +633,76 @@ mod corpus_command {
                 .unwrap()
                 .iter()
                 .any(|entry| entry["value"] == "ORU^R01" && entry["count"] == 1)
+        );
+    }
+
+    #[test]
+    fn test_corpus_diff_text_reports_deltas() {
+        let before = create_temp_dir();
+        let after = create_temp_dir();
+        create_temp_hl7_file(&before, "adt.hl7");
+        create_temp_hl7_file(&after, "adt.hl7");
+        create_temp_file(
+            &after,
+            "oru.hl7",
+            hl7v2_test_utils::fixtures::SampleMessages::oru_r01().as_bytes(),
+        );
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "corpus",
+            "diff",
+            before.path().to_str().unwrap(),
+            after.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Corpus Diff:"))
+        .stdout(predicate::str::contains("Parsed messages: 1 -> 2 (+1)"))
+        .stdout(predicate::str::contains("ORU^R01: 0 -> 1 (+1)"));
+    }
+
+    #[test]
+    fn test_corpus_diff_json_is_machine_readable() {
+        let before = create_temp_dir();
+        let after = create_temp_dir();
+        create_temp_hl7_file(&before, "adt.hl7");
+        create_temp_hl7_file(&after, "adt.hl7");
+        create_temp_file(
+            &after,
+            "oru.hl7",
+            hl7v2_test_utils::fixtures::SampleMessages::oru_r01().as_bytes(),
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "diff",
+                before.path().to_str().unwrap(),
+                after.path().to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute corpus diff");
+
+        assert!(output.status.success());
+        assert!(is_valid_json(&output.stdout));
+
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("diff output should be JSON");
+        assert_eq!(report["file_count"]["delta"], 1);
+        assert_eq!(report["message_count"]["delta"], 1);
+        assert!(
+            report["message_types"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["value"] == "ORU^R01"
+                    && entry["before"] == 0
+                    && entry["after"] == 1
+                    && entry["delta"] == 1)
         );
     }
 }

--- a/crates/hl7v2/src/synthetic/corpus.rs
+++ b/crates/hl7v2/src/synthetic/corpus.rs
@@ -158,6 +158,72 @@ pub struct CorpusSummary {
     pub parse_errors: Vec<CorpusParseFailure>,
 }
 
+/// Before/after total for a corpus-level numeric dimension.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusTotalDiff {
+    /// Value observed in the before corpus.
+    pub before: usize,
+    /// Value observed in the after corpus.
+    pub after: usize,
+    /// `after - before` as a signed delta.
+    pub delta: i128,
+}
+
+/// Before/after count for a corpus-level string dimension.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusCountDiff {
+    /// Dimension value, such as a message type or segment ID.
+    pub value: String,
+    /// Count observed in the before corpus.
+    pub before: usize,
+    /// Count observed in the after corpus.
+    pub after: usize,
+    /// `after - before` as a signed delta.
+    pub delta: i128,
+}
+
+/// Before/after field-presence count for a corpus diff.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusFieldPresenceDiff {
+    /// HL7 path, such as `PID.3` or `OBX.5`.
+    pub path: String,
+    /// Number of before-corpus messages where this path was present.
+    pub before_message_count: usize,
+    /// Number of after-corpus messages where this path was present.
+    pub after_message_count: usize,
+    /// `after_message_count - before_message_count` as a signed delta.
+    pub message_count_delta: i128,
+    /// Number of before-corpus occurrences.
+    pub before_occurrence_count: usize,
+    /// Number of after-corpus occurrences.
+    pub after_occurrence_count: usize,
+    /// `after_occurrence_count - before_occurrence_count` as a signed delta.
+    pub occurrence_count_delta: i128,
+}
+
+/// Difference report for two HL7 v2 corpora.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusDiffReport {
+    /// Root path summarized for the before corpus.
+    pub before_root: String,
+    /// Root path summarized for the after corpus.
+    pub after_root: String,
+    /// Regular file count before/after/delta.
+    pub file_count: CorpusTotalDiff,
+    /// Parsed message count before/after/delta.
+    pub message_count: CorpusTotalDiff,
+    /// Parse error count before/after/delta.
+    pub parse_error_count: CorpusTotalDiff,
+    /// Total byte count before/after/delta.
+    pub total_bytes: CorpusTotalDiff,
+    /// Message type count differences.
+    pub message_types: Vec<CorpusCountDiff>,
+    /// Segment count differences.
+    pub segments: Vec<CorpusCountDiff>,
+    /// Field presence differences.
+    pub field_presence: Vec<CorpusFieldPresenceDiff>,
+}
+
 /// Train/validation/test split information
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CorpusSplits {
@@ -463,6 +529,40 @@ pub fn summarize_corpus_path(path: impl AsRef<Path>) -> Result<CorpusSummary, Co
     })
 }
 
+/// Diff two file or directory corpora of HL7 v2 messages.
+///
+/// This summarizes both inputs using [`summarize_corpus_path`] and returns
+/// before/after counts plus signed deltas for the stable corpus dimensions.
+///
+/// # Errors
+///
+/// Returns [`CorpusError::InvalidConfig`] if either input is neither a regular
+/// file nor a directory. Returns [`CorpusError::IoError`] if traversal or file
+/// reading fails.
+pub fn diff_corpus_paths(
+    before: impl AsRef<Path>,
+    after: impl AsRef<Path>,
+) -> Result<CorpusDiffReport, CorpusError> {
+    let before_summary = summarize_corpus_path(before)?;
+    let after_summary = summarize_corpus_path(after)?;
+    Ok(diff_corpus_summaries(&before_summary, &after_summary))
+}
+
+/// Diff two already-computed corpus summaries.
+pub fn diff_corpus_summaries(before: &CorpusSummary, after: &CorpusSummary) -> CorpusDiffReport {
+    CorpusDiffReport {
+        before_root: before.root.clone(),
+        after_root: after.root.clone(),
+        file_count: total_diff(before.file_count, after.file_count),
+        message_count: total_diff(before.message_count, after.message_count),
+        parse_error_count: total_diff(before.parse_error_count, after.parse_error_count),
+        total_bytes: total_diff(before.total_bytes, after.total_bytes),
+        message_types: diff_counts(&before.message_types, &after.message_types),
+        segments: diff_counts(&before.segments, &after.segments),
+        field_presence: diff_field_presence(&before.field_presence, &after.field_presence),
+    }
+}
+
 fn collect_corpus_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), CorpusError> {
     if path.is_file() {
         files.push(path.to_path_buf());
@@ -550,6 +650,106 @@ fn compare_field_paths(left: &str, right: &str) -> Ordering {
         .cmp(right_segment)
         .then(left_index.cmp(&right_index))
         .then(left.cmp(right))
+}
+
+fn total_diff(before: usize, after: usize) -> CorpusTotalDiff {
+    CorpusTotalDiff {
+        before,
+        after,
+        delta: signed_delta(before, after),
+    }
+}
+
+fn diff_counts(before: &[CorpusCount], after: &[CorpusCount]) -> Vec<CorpusCountDiff> {
+    let before_counts = count_map(before);
+    let after_counts = count_map(after);
+    let mut values = BTreeSet::new();
+
+    for value in before_counts.keys() {
+        values.insert(value.as_str());
+    }
+    for value in after_counts.keys() {
+        values.insert(value.as_str());
+    }
+
+    values
+        .into_iter()
+        .map(|value| {
+            let before = before_counts.get(value).copied().unwrap_or_default();
+            let after = after_counts.get(value).copied().unwrap_or_default();
+            CorpusCountDiff {
+                value: value.to_string(),
+                before,
+                after,
+                delta: signed_delta(before, after),
+            }
+        })
+        .filter(|count| count.delta != 0)
+        .collect()
+}
+
+fn count_map(counts: &[CorpusCount]) -> BTreeMap<String, usize> {
+    counts
+        .iter()
+        .map(|count| (count.value.clone(), count.count))
+        .collect()
+}
+
+fn diff_field_presence(
+    before: &[CorpusFieldPresence],
+    after: &[CorpusFieldPresence],
+) -> Vec<CorpusFieldPresenceDiff> {
+    let before_fields = field_presence_map(before);
+    let after_fields = field_presence_map(after);
+    let mut paths = BTreeSet::new();
+
+    for path in before_fields.keys() {
+        paths.insert(path.as_str());
+    }
+    for path in after_fields.keys() {
+        paths.insert(path.as_str());
+    }
+
+    let mut diffs: Vec<CorpusFieldPresenceDiff> = paths
+        .into_iter()
+        .map(|path| {
+            let before = before_fields.get(path);
+            let after = after_fields.get(path);
+            let before_message_count = before.map_or(0, |field| field.message_count);
+            let after_message_count = after.map_or(0, |field| field.message_count);
+            let before_occurrence_count = before.map_or(0, |field| field.occurrence_count);
+            let after_occurrence_count = after.map_or(0, |field| field.occurrence_count);
+
+            CorpusFieldPresenceDiff {
+                path: path.to_string(),
+                before_message_count,
+                after_message_count,
+                message_count_delta: signed_delta(before_message_count, after_message_count),
+                before_occurrence_count,
+                after_occurrence_count,
+                occurrence_count_delta: signed_delta(
+                    before_occurrence_count,
+                    after_occurrence_count,
+                ),
+            }
+        })
+        .filter(|field| field.message_count_delta != 0 || field.occurrence_count_delta != 0)
+        .collect();
+    diffs.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+    diffs
+}
+
+fn field_presence_map(fields: &[CorpusFieldPresence]) -> BTreeMap<String, &CorpusFieldPresence> {
+    fields
+        .iter()
+        .map(|field| (field.path.clone(), field))
+        .collect()
+}
+
+fn signed_delta(before: usize, after: usize) -> i128 {
+    let before = i128::try_from(before).unwrap_or(i128::MAX);
+    let after = i128::try_from(after).unwrap_or(i128::MAX);
+    after.saturating_sub(before)
 }
 
 fn split_field_path(path: &str) -> (&str, usize) {
@@ -677,6 +877,43 @@ mod summary_tests {
                 .first()
                 .map(|failure| failure.path.as_str()),
             Some("invalid.hl7")
+        );
+    }
+
+    #[test]
+    fn diff_corpus_paths_reports_count_deltas() {
+        let Ok(before) = tempfile::tempdir() else {
+            panic!("before temp dir should be created");
+        };
+        let Ok(after) = tempfile::tempdir() else {
+            panic!("after temp dir should be created");
+        };
+        write_message(&before.path().join("adt.hl7"), ADT_A01);
+        write_message(&after.path().join("adt.hl7"), ADT_A01);
+        write_message(&after.path().join("oru.hl7"), ORU_R01);
+
+        let Ok(diff) = diff_corpus_paths(before.path(), after.path()) else {
+            panic!("corpus diff should be created");
+        };
+
+        assert_eq!(diff.file_count.before, 1);
+        assert_eq!(diff.file_count.after, 2);
+        assert_eq!(diff.file_count.delta, 1);
+        assert_eq!(diff.message_count.delta, 1);
+        assert!(
+            diff.message_types
+                .iter()
+                .any(|count| count.value == "ORU^R01" && count.before == 0 && count.after == 1)
+        );
+        assert!(
+            diff.segments
+                .iter()
+                .any(|count| count.value == "OBX" && count.before == 0 && count.after == 1)
+        );
+        assert!(
+            diff.field_presence
+                .iter()
+                .any(|field| field.path == "OBX.5" && field.message_count_delta == 1)
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `hl7v2 corpus diff <before> <after>` with text, JSON, and YAML output
- derive drift reports from corpus fingerprints with count, field-presence, cardinality, value-shape, and validation issue-code deltas
- support `--profile` to attach profile metadata and compare validation issue-code counts
- document the command in the root and CLI READMEs

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2 --all-features corpus`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli corpus`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests corpus`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`