### PR TITLE
feat: add profile fixture test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml --report json
 
 # Lint a profile before using it as an interface contract
 hl7v2 profile lint profiles/oru_r01.yaml --report json
+
+# Test profile fixtures as executable interface contracts
+hl7v2 profile test profiles/oru_r01.yaml fixtures/oru_r01/ --report json
 ```
 
 ### Normalize Messages

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -17,6 +17,7 @@ Lint a profile before using it as an interface contract:
 ```bash
 hl7v2 profile lint profiles/adt_a01.yaml
 hl7v2 profile lint profiles/adt_a01.yaml --report json
+hl7v2 profile test profiles/adt_a01.yaml fixtures/adt_a01/ --report json
 ```
 
 Summarize a directory or file corpus:

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -30,10 +30,13 @@ use hl7v2::synthetic::corpus::{
 };
 use hl7v2::synthetic::generate::{Template, generate};
 use hl7v2::{
-    AckCode as GenAckCode, Event, Message, ProfileLintReport, StreamParser, ValidationReport, ack,
-    get, is_mllp_framed, lint_profile_yaml, load_profile, load_profile_checked, normalize, parse,
-    parse_mllp, to_json, validate, wrap_mllp, write, write_mllp,
+    AckCode as GenAckCode, Event, Message, Profile, ProfileLintReport, StreamParser,
+    ValidationReport, ack, get, is_mllp_framed, lint_profile_yaml, load_profile,
+    load_profile_checked, normalize, parse, parse_mllp, to_json, validate, wrap_mllp, write,
+    write_mllp,
 };
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -274,6 +277,19 @@ enum ProfileCommands {
         #[arg(long, value_enum, default_value = "text")]
         report: ReportFormat,
     },
+
+    /// Test a profile against valid/invalid HL7 fixture directories
+    Test {
+        /// Profile YAML file
+        profile: PathBuf,
+
+        /// Fixture root containing valid/, invalid/, and optional expected/
+        fixtures: PathBuf,
+
+        /// Output test report format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        report: ReportFormat,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -386,6 +402,59 @@ enum DoctorStatus {
     Error,
 }
 
+#[derive(serde::Serialize)]
+struct ProfileTestReport {
+    profile: String,
+    fixtures: String,
+    valid: bool,
+    case_count: usize,
+    passed_count: usize,
+    failed_count: usize,
+    cases: Vec<ProfileTestCaseReport>,
+}
+
+#[derive(serde::Serialize)]
+struct ProfileTestCaseReport {
+    name: String,
+    path: String,
+    expectation: ProfileFixtureExpectation,
+    passed: bool,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    validation_report: Option<ValidationReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expected_report: Option<ExpectedReportComparison>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum ProfileFixtureExpectation {
+    Valid,
+    Invalid,
+}
+
+impl ProfileFixtureExpectation {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Valid => "valid",
+            Self::Invalid => "invalid",
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct ExpectedReportComparison {
+    path: String,
+    matched: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+enum ExpectedReportCandidate {
+    File(PathBuf),
+    Ambiguous(PathBuf),
+}
+
 #[tokio::main]
 async fn main() {
     // Initialize tracing for server mode
@@ -458,6 +527,11 @@ async fn main() {
         ),
         Commands::Profile { command } => match command {
             ProfileCommands::Lint { profile, report } => profile_lint_command(profile, report),
+            ProfileCommands::Test {
+                profile,
+                fixtures,
+                report,
+            } => profile_test_command(profile, fixtures, report),
         },
         Commands::Corpus { command } => match command {
             CorpusCommands::Summarize { path, format } => corpus_summarize_command(path, format),
@@ -1300,6 +1374,466 @@ fn profile_lint_command(
     }
 
     Ok(())
+}
+
+fn profile_test_command(
+    profile: &Path,
+    fixtures: &Path,
+    report: &ReportFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let profile_yaml = fs::read_to_string(profile)?;
+    let loaded_profile = load_profile_checked(&profile_yaml)?;
+    let test_report = run_profile_fixture_tests(profile, fixtures, &loaded_profile)?;
+    let output = format_profile_test_report(&test_report, report)?;
+    println!("{}", output);
+
+    if !test_report.valid {
+        return Err(std::io::Error::other("profile test reported failures").into());
+    }
+
+    Ok(())
+}
+
+fn run_profile_fixture_tests(
+    profile_path: &Path,
+    fixtures: &Path,
+    profile: &Profile,
+) -> Result<ProfileTestReport, Box<dyn std::error::Error>> {
+    let valid_root = fixtures.join("valid");
+    let invalid_root = fixtures.join("invalid");
+    let expected_root = fixtures.join("expected");
+    let valid_files = collect_hl7_fixture_files(&valid_root)?;
+    let invalid_files = collect_hl7_fixture_files(&invalid_root)?;
+    let expected_reports =
+        build_expected_report_lookup(fixtures, &expected_root, [&valid_files, &invalid_files]);
+
+    let mut cases = Vec::new();
+    cases.extend(run_profile_fixture_group(
+        profile_path,
+        fixtures,
+        &valid_files,
+        &expected_reports,
+        ProfileFixtureExpectation::Valid,
+        profile,
+    )?);
+    cases.extend(run_profile_fixture_group(
+        profile_path,
+        fixtures,
+        &invalid_files,
+        &expected_reports,
+        ProfileFixtureExpectation::Invalid,
+        profile,
+    )?);
+
+    if cases.is_empty() {
+        return Err(std::io::Error::other(format!(
+            "no .hl7 fixtures found under {}",
+            fixtures.display()
+        ))
+        .into());
+    }
+
+    let passed_count = cases.iter().filter(|case| case.passed).count();
+    let case_count = cases.len();
+    let failed_count = case_count.saturating_sub(passed_count);
+
+    Ok(ProfileTestReport {
+        profile: profile_path.to_string_lossy().to_string(),
+        fixtures: fixtures.to_string_lossy().to_string(),
+        valid: failed_count == 0,
+        case_count,
+        passed_count,
+        failed_count,
+        cases,
+    })
+}
+
+fn run_profile_fixture_group(
+    profile_path: &Path,
+    fixture_root: &Path,
+    files: &[PathBuf],
+    expected_reports: &BTreeMap<PathBuf, ExpectedReportCandidate>,
+    expectation: ProfileFixtureExpectation,
+    profile: &Profile,
+) -> Result<Vec<ProfileTestCaseReport>, Box<dyn std::error::Error>> {
+    let mut cases = Vec::new();
+    for path in files {
+        cases.push(run_profile_fixture_case(
+            profile_path,
+            fixture_root,
+            expected_reports,
+            path,
+            expectation,
+            profile,
+        ));
+    }
+    Ok(cases)
+}
+
+fn run_profile_fixture_case(
+    profile_path: &Path,
+    fixture_root: &Path,
+    expected_reports: &BTreeMap<PathBuf, ExpectedReportCandidate>,
+    path: &Path,
+    expectation: ProfileFixtureExpectation,
+    profile: &Profile,
+) -> ProfileTestCaseReport {
+    let name = relative_display_path(fixture_root, path);
+
+    let contents = match fs::read(path) {
+        Ok(contents) => contents,
+        Err(err) => {
+            return ProfileTestCaseReport {
+                name,
+                path: path.to_string_lossy().to_string(),
+                expectation,
+                passed: false,
+                message: format!("fixture could not be read: {err}"),
+                validation_report: None,
+                expected_report: None,
+            };
+        }
+    };
+
+    let message = match parse(&contents) {
+        Ok(message) => message,
+        Err(err) => {
+            return ProfileTestCaseReport {
+                name,
+                path: path.to_string_lossy().to_string(),
+                expectation,
+                passed: false,
+                message: format!("fixture did not parse as HL7: {err}"),
+                validation_report: None,
+                expected_report: None,
+            };
+        }
+    };
+
+    let issues = validate(&message, profile);
+    let validation_report = ValidationReport::from_issues(
+        &message,
+        Some(profile_path.to_string_lossy().to_string()),
+        issues,
+    );
+    let expected_valid = expectation == ProfileFixtureExpectation::Valid;
+    let mut passed = validation_report.valid == expected_valid;
+    let mut message = if passed {
+        format!(
+            "expected {} and report was {}",
+            expectation.as_str(),
+            if validation_report.valid {
+                "valid"
+            } else {
+                "invalid"
+            }
+        )
+    } else {
+        format!(
+            "expected {} but report was {}",
+            expectation.as_str(),
+            if validation_report.valid {
+                "valid"
+            } else {
+                "invalid"
+            }
+        )
+    };
+
+    let expected_report = expected_reports
+        .get(path)
+        .map(|candidate| compare_expected_report_candidate(candidate, &validation_report));
+    if let Some(comparison) = &expected_report {
+        if comparison.matched {
+            message.push_str("; expected report matched");
+        } else {
+            passed = false;
+            let detail = comparison
+                .message
+                .as_deref()
+                .unwrap_or("expected report did not match");
+            message.push_str(&format!("; {detail}"));
+        }
+    }
+
+    ProfileTestCaseReport {
+        name,
+        path: path.to_string_lossy().to_string(),
+        expectation,
+        passed,
+        message,
+        validation_report: Some(validation_report),
+        expected_report,
+    }
+}
+
+fn collect_hl7_fixture_files(root: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut files = Vec::new();
+    if !root.exists() {
+        return Ok(files);
+    }
+
+    collect_hl7_fixture_files_recursive(root, &mut files)?;
+    files.sort_by(|left, right| compare_paths_case_stable(left, right));
+    Ok(files)
+}
+
+fn compare_paths_case_stable(left: &Path, right: &Path) -> Ordering {
+    let left_display = left.to_string_lossy();
+    let right_display = right.to_string_lossy();
+    left_display
+        .to_lowercase()
+        .cmp(&right_display.to_lowercase())
+        .then_with(|| left_display.cmp(&right_display))
+}
+
+fn collect_hl7_fixture_files_recursive(
+    root: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_hl7_fixture_files_recursive(&path, files)?;
+        } else if file_type.is_file()
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("hl7"))
+        {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn build_expected_report_lookup<'a>(
+    fixture_root: &Path,
+    expected_root: &Path,
+    fixture_groups: impl IntoIterator<Item = &'a Vec<PathBuf>>,
+) -> BTreeMap<PathBuf, ExpectedReportCandidate> {
+    let fixtures: Vec<&PathBuf> = fixture_groups
+        .into_iter()
+        .flat_map(|group| group.iter())
+        .collect();
+    let mut fallback_counts = BTreeMap::new();
+    for fixture_path in &fixtures {
+        let fallback = fallback_expected_report_path(expected_root, fixture_path);
+        if fallback.exists() {
+            let count = fallback_counts.entry(fallback).or_insert(0_usize);
+            *count = count.saturating_add(1);
+        }
+    }
+
+    let mut lookup = BTreeMap::new();
+    for fixture_path in fixtures {
+        let primary = primary_expected_report_path(expected_root, fixture_root, fixture_path);
+        if primary.exists() {
+            lookup.insert(fixture_path.clone(), ExpectedReportCandidate::File(primary));
+            continue;
+        }
+
+        let fallback = fallback_expected_report_path(expected_root, fixture_path);
+        match fallback_counts.get(&fallback).copied() {
+            Some(1) => {
+                lookup.insert(
+                    fixture_path.clone(),
+                    ExpectedReportCandidate::File(fallback),
+                );
+            }
+            Some(_) => {
+                lookup.insert(
+                    fixture_path.clone(),
+                    ExpectedReportCandidate::Ambiguous(fallback),
+                );
+            }
+            None => {}
+        }
+    }
+    lookup
+}
+
+fn primary_expected_report_path(
+    expected_root: &Path,
+    fixture_root: &Path,
+    fixture_path: &Path,
+) -> PathBuf {
+    let relative = fixture_path
+        .strip_prefix(fixture_root)
+        .unwrap_or(fixture_path);
+    let mut path = expected_root.join(relative);
+    path.set_extension("report.json");
+    path
+}
+
+fn fallback_expected_report_path(expected_root: &Path, fixture_path: &Path) -> PathBuf {
+    let stem = fixture_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("fixture");
+    expected_root.join(format!("{stem}.report.json"))
+}
+
+fn compare_expected_report_candidate(
+    candidate: &ExpectedReportCandidate,
+    actual_report: &ValidationReport,
+) -> ExpectedReportComparison {
+    match candidate {
+        ExpectedReportCandidate::File(path) => {
+            compare_expected_report(path, actual_report).unwrap_or_else(|| ExpectedReportComparison {
+                path: path.to_string_lossy().to_string(),
+                matched: false,
+                message: Some("expected report path was registered but no longer exists".to_string()),
+            })
+        }
+        ExpectedReportCandidate::Ambiguous(path) => ExpectedReportComparison {
+            path: path.to_string_lossy().to_string(),
+            matched: false,
+            message: Some(
+                "ambiguous basename expected report; use expected/valid/... or expected/invalid/..."
+                    .to_string(),
+            ),
+        },
+    }
+}
+
+fn compare_expected_report(
+    expected_path: &Path,
+    actual_report: &ValidationReport,
+) -> Option<ExpectedReportComparison> {
+    if !expected_path.exists() {
+        return None;
+    }
+
+    let path = expected_path.to_string_lossy().to_string();
+    let expected = match fs::read_to_string(expected_path)
+        .map_err(|err| format!("expected report could not be read: {err}"))
+        .and_then(|contents| {
+            serde_json::from_str::<serde_json::Value>(&contents)
+                .map_err(|err| format!("expected report is not valid JSON: {err}"))
+        }) {
+        Ok(expected) => expected,
+        Err(message) => {
+            return Some(ExpectedReportComparison {
+                path,
+                matched: false,
+                message: Some(message),
+            });
+        }
+    };
+
+    let actual = match serde_json::to_value(actual_report) {
+        Ok(actual) => actual,
+        Err(err) => {
+            return Some(ExpectedReportComparison {
+                path,
+                matched: false,
+                message: Some(format!("actual report could not be serialized: {err}")),
+            });
+        }
+    };
+
+    match json_subset_matches(&expected, &actual, "$") {
+        Ok(()) => Some(ExpectedReportComparison {
+            path,
+            matched: true,
+            message: None,
+        }),
+        Err(message) => Some(ExpectedReportComparison {
+            path,
+            matched: false,
+            message: Some(message),
+        }),
+    }
+}
+
+fn json_subset_matches(
+    expected: &serde_json::Value,
+    actual: &serde_json::Value,
+    path: &str,
+) -> Result<(), String> {
+    match (expected, actual) {
+        (serde_json::Value::Object(expected), serde_json::Value::Object(actual)) => {
+            for (key, expected_value) in expected {
+                let actual_value = actual
+                    .get(key)
+                    .ok_or_else(|| format!("{path}.{key} was missing from actual report"))?;
+                json_subset_matches(expected_value, actual_value, &format!("{path}.{key}"))?;
+            }
+            Ok(())
+        }
+        (serde_json::Value::Array(expected), serde_json::Value::Array(actual)) => {
+            for (index, expected_value) in expected.iter().enumerate() {
+                let matched = actual.iter().any(|actual_value| {
+                    json_subset_matches(expected_value, actual_value, &format!("{path}[{index}]"))
+                        .is_ok()
+                });
+                if !matched {
+                    return Err(format!(
+                        "{path}[{index}] did not match any actual report item"
+                    ));
+                }
+            }
+            Ok(())
+        }
+        _ if expected == actual => Ok(()),
+        _ => Err(format!(
+            "{path} expected {} but actual report had {}",
+            expected, actual
+        )),
+    }
+}
+
+fn relative_display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn format_profile_test_report(
+    report: &ProfileTestReport,
+    format: &ReportFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        ReportFormat::Json => Ok(serde_json::to_string_pretty(report)?),
+        ReportFormat::Yaml => Ok(serde_yaml::to_string(report)?),
+        ReportFormat::Text => {
+            let mut lines = Vec::new();
+            if report.valid {
+                lines.push(format!(
+                    "Profile test passed: {} against {}",
+                    report.profile, report.fixtures
+                ));
+            } else {
+                lines.push(format!(
+                    "Profile test failed: {} failure(s) across {} case(s)",
+                    report.failed_count, report.case_count
+                ));
+            }
+            lines.push(format!(
+                "  Cases: {} passed, {} failed",
+                report.passed_count, report.failed_count
+            ));
+
+            for case in &report.cases {
+                let status = if case.passed { "PASS" } else { "FAIL" };
+                lines.push(format!(
+                    "  - {} {} expected {}: {}",
+                    status,
+                    case.name,
+                    case.expectation.as_str(),
+                    case.message
+                ));
+            }
+
+            Ok(lines.join("\n"))
+        }
+    }
 }
 
 fn format_profile_lint_report(

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -71,6 +71,22 @@ mod cli_unit_tests {
         }
 
         #[test]
+        fn test_profile_command_has_test_subcommand() {
+            use crate::Cli;
+            let schema = Cli::command();
+            let profile = schema
+                .get_subcommands()
+                .find(|command| command.get_name() == "profile")
+                .expect("profile command should exist");
+
+            assert!(
+                profile
+                    .get_subcommands()
+                    .any(|command| command.get_name() == "test")
+            );
+        }
+
+        #[test]
         fn test_ack_command_mode_options() {
             // Verify ACK mode options exist
             let modes = vec!["original", "enhanced"];
@@ -713,6 +729,136 @@ constraints:
 
             assert!(output.contains("input_file: test.hl7"));
             assert!(output.contains("segment_count: 1"));
+        }
+
+        #[test]
+        fn test_expected_report_array_matching_allows_issue_subset_out_of_order() {
+            let expected = serde_json::json!({
+                "issues": [
+                    {
+                        "code": "missing_required_field",
+                        "severity": "error",
+                        "path": "PID.3"
+                    }
+                ]
+            });
+            let actual = serde_json::json!({
+                "valid": false,
+                "issues": [
+                    {
+                        "code": "datatype_violation",
+                        "severity": "warning",
+                        "path": "PID.7"
+                    },
+                    {
+                        "code": "missing_required_field",
+                        "severity": "error",
+                        "path": "PID.3",
+                        "message": "PID.3 is required"
+                    }
+                ]
+            });
+
+            assert!(crate::json_subset_matches(&expected, &actual, "$").is_ok());
+        }
+
+        #[test]
+        fn test_expected_report_lookup_uses_mirrored_paths_for_duplicate_stems() {
+            let dir = TempDir::new().expect("Failed to create temp dir");
+            let fixture_root = dir.path().join("fixtures");
+            let expected_root = fixture_root.join("expected");
+            let valid_root = fixture_root.join("valid");
+            let invalid_root = fixture_root.join("invalid");
+            std::fs::create_dir_all(expected_root.join("valid")).unwrap();
+            std::fs::create_dir_all(expected_root.join("invalid")).unwrap();
+            std::fs::create_dir_all(&valid_root).unwrap();
+            std::fs::create_dir_all(&invalid_root).unwrap();
+
+            let valid_file = valid_root.join("same.hl7");
+            let invalid_file = invalid_root.join("same.hl7");
+            std::fs::write(&valid_file, b"valid").unwrap();
+            std::fs::write(&invalid_file, b"invalid").unwrap();
+            std::fs::write(expected_root.join("valid/same.report.json"), b"{}").unwrap();
+            std::fs::write(expected_root.join("invalid/same.report.json"), b"{}").unwrap();
+
+            let valid_files = vec![valid_file.clone()];
+            let invalid_files = vec![invalid_file.clone()];
+            let lookup = crate::build_expected_report_lookup(
+                &fixture_root,
+                &expected_root,
+                [&valid_files, &invalid_files],
+            );
+
+            let valid_expected = match lookup.get(&valid_file) {
+                Some(crate::ExpectedReportCandidate::File(path)) => Some(path),
+                _ => None,
+            };
+            let invalid_expected = match lookup.get(&invalid_file) {
+                Some(crate::ExpectedReportCandidate::File(path)) => Some(path),
+                _ => None,
+            };
+            assert_eq!(
+                valid_expected,
+                Some(&expected_root.join("valid/same.report.json"))
+            );
+            assert_eq!(
+                invalid_expected,
+                Some(&expected_root.join("invalid/same.report.json"))
+            );
+        }
+
+        #[test]
+        fn test_expected_report_lookup_flags_ambiguous_basename_fallback() {
+            let dir = TempDir::new().expect("Failed to create temp dir");
+            let fixture_root = dir.path().join("fixtures");
+            let expected_root = fixture_root.join("expected");
+            let valid_root = fixture_root.join("valid");
+            let invalid_root = fixture_root.join("invalid");
+            std::fs::create_dir_all(&expected_root).unwrap();
+            std::fs::create_dir_all(&valid_root).unwrap();
+            std::fs::create_dir_all(&invalid_root).unwrap();
+
+            let valid_file = valid_root.join("same.hl7");
+            let invalid_file = invalid_root.join("same.hl7");
+            std::fs::write(&valid_file, b"valid").unwrap();
+            std::fs::write(&invalid_file, b"invalid").unwrap();
+            std::fs::write(expected_root.join("same.report.json"), b"{}").unwrap();
+
+            let valid_files = vec![valid_file.clone()];
+            let invalid_files = vec![invalid_file.clone()];
+            let lookup = crate::build_expected_report_lookup(
+                &fixture_root,
+                &expected_root,
+                [&valid_files, &invalid_files],
+            );
+
+            let valid_ambiguous = match lookup.get(&valid_file) {
+                Some(crate::ExpectedReportCandidate::Ambiguous(path)) => Some(path),
+                _ => None,
+            };
+            let invalid_ambiguous = match lookup.get(&invalid_file) {
+                Some(crate::ExpectedReportCandidate::Ambiguous(path)) => Some(path),
+                _ => None,
+            };
+            assert_eq!(
+                valid_ambiguous,
+                Some(&expected_root.join("same.report.json"))
+            );
+            assert_eq!(
+                invalid_ambiguous,
+                Some(&expected_root.join("same.report.json"))
+            );
+        }
+
+        #[test]
+        fn test_fixture_file_order_uses_case_stable_tie_breaker() {
+            let upper = PathBuf::from("fixtures/CASE.hl7");
+            let lower = PathBuf::from("fixtures/case.hl7");
+
+            assert_eq!(
+                crate::compare_paths_case_stable(&upper, &lower),
+                std::cmp::Ordering::Less
+            );
         }
 
         #[test]

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -86,6 +86,17 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_profile_test_help() {
+        let mut cmd = cli_command();
+        cmd.args(["profile", "test", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Test a profile against valid/invalid",
+            ));
+    }
+
+    #[test]
     fn test_corpus_help() {
         let mut cmd = cli_command();
         cmd.args(["corpus", "--help"])
@@ -483,6 +494,19 @@ mod norm_command {
 mod profile_command {
     use super::*;
 
+    const PID3_REQUIRED_PROFILE: &str = r#"
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"#;
+
+    const MISSING_PID3_MESSAGE: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL124|P|2.5\rPID|1||||Doe^John||19700101|M\r";
+
     #[test]
     fn test_profile_lint_passes_minimal_profile() {
         let dir = create_temp_dir();
@@ -578,6 +602,145 @@ constraints:
                 .unwrap()
                 .iter()
                 .any(|issue| issue["code"] == "invalid_constraint_pattern")
+        );
+    }
+
+    #[test]
+    fn test_profile_test_passes_valid_and_invalid_fixtures() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(&dir, "profile.yaml", PID3_REQUIRED_PROFILE);
+        let fixtures = dir.path().join("fixtures");
+        let valid_dir = fixtures.join("valid");
+        let invalid_dir = fixtures.join("invalid");
+        let expected_dir = fixtures.join("expected");
+        std::fs::create_dir_all(&valid_dir).unwrap();
+        std::fs::create_dir_all(&invalid_dir).unwrap();
+        std::fs::create_dir_all(&expected_dir).unwrap();
+        create_temp_file(
+            &dir,
+            "fixtures/valid/adt.hl7",
+            hl7v2_test_utils::fixtures::SampleMessages::adt_a01().as_bytes(),
+        );
+        create_temp_hl7_with_content(
+            &dir,
+            "fixtures/invalid/missing_pid3.hl7",
+            MISSING_PID3_MESSAGE,
+        );
+        create_temp_file(
+            &dir,
+            "fixtures/expected/missing_pid3.report.json",
+            br#"{
+  "valid": false,
+  "issues": [
+    {
+      "code": "missing_required_field",
+      "severity": "error",
+      "path": "PID.3"
+    }
+  ]
+}"#,
+        );
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "profile",
+            "test",
+            profile_file.to_str().unwrap(),
+            fixtures.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Profile test passed"))
+        .stdout(predicate::str::contains(
+            "PASS valid/adt.hl7 expected valid",
+        ))
+        .stdout(predicate::str::contains("expected report matched"));
+    }
+
+    #[test]
+    fn test_profile_test_json_reports_case_results() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(&dir, "profile.yaml", PID3_REQUIRED_PROFILE);
+        let fixtures = dir.path().join("fixtures");
+        std::fs::create_dir_all(fixtures.join("valid")).unwrap();
+        std::fs::create_dir_all(fixtures.join("invalid")).unwrap();
+        create_temp_file(
+            &dir,
+            "fixtures/valid/adt.hl7",
+            hl7v2_test_utils::fixtures::SampleMessages::adt_a01().as_bytes(),
+        );
+        create_temp_hl7_with_content(
+            &dir,
+            "fixtures/invalid/missing_pid3.hl7",
+            MISSING_PID3_MESSAGE,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "test",
+                profile_file.to_str().unwrap(),
+                fixtures.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute profile test");
+
+        assert!(output.status.success());
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("profile test output should be JSON");
+        assert_eq!(report["valid"], true);
+        assert_eq!(report["case_count"], 2);
+        assert_eq!(report["passed_count"], 2);
+        assert_eq!(report["failed_count"], 0);
+        assert!(
+            report["cases"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|case| case["expectation"] == "invalid"
+                    && case["validation_report"]["issues"][0]["code"] == "missing_required_field")
+        );
+    }
+
+    #[test]
+    fn test_profile_test_fails_when_invalid_fixture_validates() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(&dir, "profile.yaml", PID3_REQUIRED_PROFILE);
+        let fixtures = dir.path().join("fixtures");
+        std::fs::create_dir_all(fixtures.join("valid")).unwrap();
+        std::fs::create_dir_all(fixtures.join("invalid")).unwrap();
+        create_temp_file(
+            &dir,
+            "fixtures/invalid/actually_valid.hl7",
+            hl7v2_test_utils::fixtures::SampleMessages::adt_a01().as_bytes(),
+        );
+
+        let mut cmd = cli_command();
+        let assert = cmd
+            .args([
+                "profile",
+                "test",
+                profile_file.to_str().unwrap(),
+                fixtures.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .assert()
+            .failure();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let report: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+        assert_eq!(report["valid"], false);
+        assert_eq!(report["failed_count"], 1);
+        assert_eq!(report["cases"][0]["passed"], false);
+        assert!(
+            report["cases"][0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("expected invalid but report was valid")
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `hl7v2 profile test <profile> <fixtures>` for valid/invalid profile fixture suites
- emit text, JSON, and YAML reports with per-case validation reports and stable pass/fail counts
- support optional expected report JSON files, including mirrored `expected/valid/...` / `expected/invalid/...` paths and unique basename fallback
- make expected report comparisons subset-oriented for arrays and fail ambiguous basename fallbacks explicitly
- document the new command in the root and CLI READMEs

## Fixture contract
- `valid/*.hl7` fixtures must validate successfully
- `invalid/*.hl7` fixtures must fail validation
- optional expected reports live under `expected/valid/...` or `expected/invalid/...` with `.report.json` suffix; unique `expected/<stem>.report.json` files are accepted as a compatibility shortcut

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli profile`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli expected_report`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli fixture_file_order`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests profile`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-cli --all-targets`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`