### PR TITLE
feat: add redacted evidence bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ hl7v2 norm <input.hl7> > output.hl7
 hl7v2 redact <input.hl7> --policy safe-analysis.toml --format json
 ```
 
+### Bundle Evidence
+
+```bash
+# Create a PHI-safe evidence packet for support or replay
+hl7v2 bundle failing.hl7 --profile profiles/oru_r01.yaml --redact-policy safe-analysis.toml --out issue-bundle/
+```
+
 ### Generate Messages
 
 ```bash

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -36,6 +36,7 @@ Redact a message for safe analysis:
 ```bash
 hl7v2 redact message.hl7 --policy safe-analysis.toml --format json
 hl7v2 redact message.hl7 --policy safe-analysis.toml --format hl7 > message.redacted.hl7
+hl7v2 bundle message.hl7 --profile profiles/adt_a01.yaml --redact-policy safe-analysis.toml --out issue-bundle/
 ```
 
 Policy files use explicit rules with required reasons:
@@ -61,5 +62,15 @@ Rules default to fail-closed: `hash` and `drop` rules must match at least one
 field unless `optional = true` is set. Built-in sensitive fields such as
 `PID.3`, `PID.5`, `PID.7`, `PID.11`, `PID.13`, `PID.19`, and next-of-kin
 fields must be protected when present and cannot be retained.
+
+`hl7v2 bundle` writes a redacted evidence packet containing:
+
+- `message.redacted.hl7`
+- `validation-report.json`
+- `field-paths.json`
+- `profile.yaml`
+- `redaction-receipt.json`
+- `environment.json`
+- `replay.sh` and `replay.ps1`
 
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -208,6 +208,24 @@ enum Commands {
         format: RedactFormat,
     },
 
+    /// Create a redacted support/debug evidence bundle
+    Bundle {
+        /// Input HL7 file
+        input: PathBuf,
+
+        /// Profile YAML file
+        #[arg(long)]
+        profile: PathBuf,
+
+        /// Safe-analysis redaction policy TOML file
+        #[arg(long)]
+        redact_policy: PathBuf,
+
+        /// Output bundle directory, which must not already exist
+        #[arg(long)]
+        out: PathBuf,
+    },
+
     /// Generate ACK for HL7 v2 message
     Ack {
         /// Input HL7 file
@@ -671,6 +689,58 @@ enum RedactionActionStatus {
     NotFound,
 }
 
+#[derive(serde::Serialize)]
+struct EvidenceBundleSummary {
+    bundle_version: &'static str,
+    output_dir: String,
+    message_type: String,
+    validation_valid: bool,
+    validation_issue_count: usize,
+    redaction_phi_removed: bool,
+    artifacts: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct EvidenceBundleEnvironment {
+    bundle_version: &'static str,
+    tool_name: &'static str,
+    tool_version: &'static str,
+    message_type: String,
+    input_sha256: String,
+    profile_sha256: String,
+    redaction_policy_sha256: String,
+    validation_valid: bool,
+    validation_issue_count: usize,
+    replay_command: &'static str,
+}
+
+#[derive(serde::Serialize)]
+struct FieldPathTraceReport {
+    message_type: String,
+    field_count: usize,
+    fields: Vec<FieldPathTrace>,
+}
+
+#[derive(serde::Serialize)]
+struct FieldPathTrace {
+    path: String,
+    canonical_path: String,
+    segment_index: usize,
+    field_index: usize,
+    present: bool,
+    value_shape: FieldValueShape,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    redaction_action: Option<RedactionAction>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum FieldValueShape {
+    Empty,
+    Present,
+    HashedSha256,
+}
+
 #[tokio::main]
 async fn main() {
     // Initialize tracing for server mode
@@ -771,6 +841,12 @@ async fn main() {
             policy,
             format,
         } => redact_command(input, policy, format),
+        Commands::Bundle {
+            input,
+            profile,
+            redact_policy,
+            out,
+        } => bundle_command(input, profile, redact_policy, out),
         Commands::Ack {
             input,
             mode,
@@ -1621,6 +1697,103 @@ fn redact_command(
     Ok(())
 }
 
+fn bundle_command(
+    input: &Path,
+    profile: &Path,
+    redact_policy: &Path,
+    out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if out.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!("bundle output directory already exists: {}", out.display()),
+        )
+        .into());
+    }
+
+    let contents = fs::read(input)?;
+    let message = parse(&contents)?;
+    let profile_yaml = fs::read_to_string(profile)?;
+    let loaded_profile = load_profile_checked(&profile_yaml)?;
+    let policy_text = fs::read_to_string(redact_policy)?;
+    let redaction_policy = load_safe_analysis_policy(&policy_text)?;
+
+    let mut redacted_message = message.clone();
+    let redaction_receipt = apply_safe_analysis_policy(&mut redacted_message, &redaction_policy)?;
+    let redacted_hl7 = String::from_utf8(write(&redacted_message))?;
+    let field_trace = build_field_path_trace(&redacted_message, &redaction_receipt);
+    let validation_report = ValidationReport::from_issues(
+        &redacted_message,
+        Some("profile.yaml".to_string()),
+        validate(&redacted_message, &loaded_profile),
+    );
+    let message_type = message_field_text(&message, "MSH", 9).unwrap_or_else(|| "unknown".into());
+    let environment = EvidenceBundleEnvironment {
+        bundle_version: "1",
+        tool_name: "hl7v2-cli",
+        tool_version: env!("CARGO_PKG_VERSION"),
+        message_type: message_type.clone(),
+        input_sha256: compute_sha256(&String::from_utf8_lossy(&contents)),
+        profile_sha256: compute_sha256(&profile_yaml),
+        redaction_policy_sha256: compute_sha256(&policy_text),
+        validation_valid: validation_report.valid,
+        validation_issue_count: validation_report.issue_count,
+        replay_command: "hl7v2 val message.redacted.hl7 --profile profile.yaml --report json",
+    };
+
+    fs::create_dir(out)?;
+    fs::write(out.join("message.redacted.hl7"), redacted_hl7)?;
+    fs::write(out.join("profile.yaml"), profile_yaml)?;
+    write_json_file(&out.join("validation-report.json"), &validation_report)?;
+    write_json_file(&out.join("redaction-receipt.json"), &redaction_receipt)?;
+    write_json_file(&out.join("field-paths.json"), &field_trace)?;
+    write_json_file(&out.join("environment.json"), &environment)?;
+    fs::write(out.join("replay.sh"), replay_shell_script())?;
+    fs::write(out.join("replay.ps1"), replay_powershell_script())?;
+
+    let artifacts = [
+        "message.redacted.hl7",
+        "validation-report.json",
+        "field-paths.json",
+        "profile.yaml",
+        "redaction-receipt.json",
+        "environment.json",
+        "replay.sh",
+        "replay.ps1",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    let summary = EvidenceBundleSummary {
+        bundle_version: "1",
+        output_dir: ".".to_string(),
+        message_type,
+        validation_valid: validation_report.valid,
+        validation_issue_count: validation_report.issue_count,
+        redaction_phi_removed: redaction_receipt.phi_removed,
+        artifacts,
+    };
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+
+    Ok(())
+}
+
+fn write_json_file<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fs::write(path, serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+fn replay_shell_script() -> &'static str {
+    "#!/usr/bin/env sh\nset -eu\ncd \"$(dirname \"$0\")\"\nhl7v2 val message.redacted.hl7 --profile profile.yaml --report json > validation-report.replayed.json\n"
+}
+
+fn replay_powershell_script() -> &'static str {
+    "$ErrorActionPreference = 'Stop'\nSet-Location $PSScriptRoot\nhl7v2 val .\\message.redacted.hl7 --profile .\\profile.yaml --report json > .\\validation-report.replayed.json\n"
+}
+
 fn load_safe_analysis_policy(
     policy_text: &str,
 ) -> Result<SafeAnalysisPolicy, Box<dyn std::error::Error>> {
@@ -1854,6 +2027,57 @@ fn message_has_nonempty_field(message: &Message, segment_id: &str, field_index: 
         .filter(|segment| segment.id_str() == segment_id)
         .filter_map(|segment| segment.fields.get(field_index))
         .any(|field| !field_to_text(field, &message.delims).is_empty())
+}
+
+fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> FieldPathTraceReport {
+    let redaction_actions: BTreeMap<&str, RedactionAction> = receipt
+        .actions
+        .iter()
+        .map(|action| (action.path.as_str(), action.action))
+        .collect();
+    let mut fields = Vec::new();
+
+    for (segment_position, segment) in message.segments.iter().enumerate() {
+        let segment_index = segment_position.saturating_add(1);
+        for (modeled_index, field) in segment.fields.iter().enumerate() {
+            let field_index = hl7_field_index(segment.id_str(), modeled_index);
+            let canonical_path = format!("{}.{}", segment.id_str(), field_index);
+            let field_text = field_to_text(field, &message.delims);
+            fields.push(FieldPathTrace {
+                path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
+                canonical_path: canonical_path.clone(),
+                segment_index,
+                field_index,
+                present: !field_text.is_empty(),
+                value_shape: field_value_shape(&field_text),
+                redaction_action: redaction_actions.get(canonical_path.as_str()).copied(),
+            });
+        }
+    }
+
+    FieldPathTraceReport {
+        message_type: message_field_text(message, "MSH", 9).unwrap_or_else(|| "unknown".into()),
+        field_count: fields.len(),
+        fields,
+    }
+}
+
+fn hl7_field_index(segment_id: &str, modeled_index: usize) -> usize {
+    if segment_id == "MSH" {
+        modeled_index.saturating_add(2)
+    } else {
+        modeled_index.saturating_add(1)
+    }
+}
+
+fn field_value_shape(field_text: &str) -> FieldValueShape {
+    if field_text.is_empty() {
+        FieldValueShape::Empty
+    } else if field_text.starts_with("hash:sha256:") {
+        FieldValueShape::HashedSha256
+    } else {
+        FieldValueShape::Present
+    }
 }
 
 fn modeled_field_index(segment_id: &str, field_index: usize) -> Option<usize> {

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -132,6 +132,17 @@ mod cli_unit_tests {
                     .any(|command| command.get_name() == "redact")
             );
         }
+
+        #[test]
+        fn test_bundle_command_exists() {
+            use crate::Cli;
+            let schema = Cli::command();
+            assert!(
+                schema
+                    .get_subcommands()
+                    .any(|command| command.get_name() == "bundle")
+            );
+        }
     }
 
     // =========================================================================

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -159,6 +159,17 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_bundle_help() {
+        let mut cmd = cli_command();
+        cmd.args(["bundle", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Create a redacted support/debug evidence bundle",
+            ));
+    }
+
+    #[test]
     fn test_ack_help() {
         let mut cmd = cli_command();
         cmd.args(["ack", "--help"])
@@ -1752,6 +1763,250 @@ action = "drop"
         .assert()
         .failure()
         .stderr(predicate::str::contains("must include a reason"));
+    }
+}
+
+// =========================================================================
+// Evidence Bundle Command Tests
+// =========================================================================
+
+mod bundle_command {
+    use super::*;
+
+    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+    const PID5_CONSTRAINT_PROFILE: &str = r#"
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: MSH.9
+    required: true
+  - path: PID.5
+    in:
+      - Allowed^Name
+"#;
+    const SAFE_ANALYSIS_POLICY: &str = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "date of birth"
+
+[[rules]]
+path = "PID.11"
+action = "drop"
+reason = "patient address"
+
+[[rules]]
+path = "MSH.9"
+action = "retain"
+reason = "message type is needed for analysis"
+
+[[rules]]
+path = "MSH.10"
+action = "retain"
+reason = "control id is needed for replay correlation"
+
+[[rules]]
+path = "OBX.3"
+action = "retain"
+reason = "observation identifier is needed for analysis"
+
+[[rules]]
+path = "OBX.5"
+action = "retain"
+reason = "non-PHI synthetic observation value shape is needed for analysis"
+"#;
+
+    #[test]
+    fn test_bundle_writes_redacted_replayable_evidence_artifacts() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
+        let profile_file = create_temp_profile(&dir, "profile.yaml", minimal_profile());
+        let policy_file =
+            create_temp_file(&dir, "safe-analysis.toml", SAFE_ANALYSIS_POLICY.as_bytes());
+        let bundle_dir = dir.path().join("issue-bundle");
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "bundle",
+                message_file.to_str().unwrap(),
+                "--profile",
+                profile_file.to_str().unwrap(),
+                "--redact-policy",
+                policy_file.to_str().unwrap(),
+                "--out",
+                bundle_dir.to_str().unwrap(),
+            ])
+            .output()
+            .expect("Failed to execute bundle");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let summary: serde_json::Value =
+            serde_json::from_str(&stdout).expect("bundle summary should be JSON");
+        assert_eq!(summary["bundle_version"], "1");
+        assert_eq!(summary["output_dir"], ".");
+        assert_eq!(summary["message_type"], "ADT^A01");
+        assert_eq!(summary["validation_valid"], true);
+        assert_eq!(summary["redaction_phi_removed"], true);
+
+        for artifact in [
+            "message.redacted.hl7",
+            "validation-report.json",
+            "field-paths.json",
+            "profile.yaml",
+            "redaction-receipt.json",
+            "environment.json",
+            "replay.sh",
+            "replay.ps1",
+        ] {
+            assert!(
+                bundle_dir.join(artifact).exists(),
+                "missing bundle artifact {artifact}"
+            );
+        }
+
+        let redacted_message =
+            std::fs::read_to_string(bundle_dir.join("message.redacted.hl7")).unwrap();
+        assert!(redacted_message.contains("hash:sha256:"));
+        assert!(!redacted_message.contains("Doe^John"));
+        assert!(!redacted_message.contains("123456^^^HOSP^MR"));
+        assert!(!redacted_message.contains("19700101"));
+        assert!(!redacted_message.contains("123 Main St"));
+
+        for artifact in [
+            "validation-report.json",
+            "field-paths.json",
+            "redaction-receipt.json",
+            "environment.json",
+            "replay.sh",
+            "replay.ps1",
+        ] {
+            let content = std::fs::read_to_string(bundle_dir.join(artifact)).unwrap();
+            assert!(
+                !content.contains("Doe^John"),
+                "{artifact} leaked patient name"
+            );
+            assert!(
+                !content.contains("123456^^^HOSP^MR"),
+                "{artifact} leaked patient identifier"
+            );
+            assert!(!content.contains("19700101"), "{artifact} leaked DOB");
+            assert!(
+                !content.contains("123 Main St"),
+                "{artifact} leaked address"
+            );
+        }
+
+        let validation_report: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("validation-report.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(validation_report["profile"], "profile.yaml");
+
+        let field_paths: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("field-paths.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(field_paths["fields"].as_array().unwrap().iter().any(
+            |field| field["canonical_path"] == "PID.3"
+                && field["redaction_action"] == "hash"
+                && field["value_shape"] == "hashed_sha256"
+        ));
+
+        let receipt: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("redaction-receipt.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(receipt["phi_removed"], true);
+
+        let environment: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("environment.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(environment["tool_name"], "hl7v2-cli");
+        assert_eq!(
+            environment["replay_command"],
+            "hl7v2 val message.redacted.hl7 --profile profile.yaml --report json"
+        );
+    }
+
+    #[test]
+    fn test_bundle_validation_report_uses_redacted_message_without_phi() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
+        let profile_file = create_temp_profile(&dir, "profile.yaml", PID5_CONSTRAINT_PROFILE);
+        let hash_name_policy = SAFE_ANALYSIS_POLICY.replace(
+            "path = \"PID.5\"\naction = \"drop\"",
+            "path = \"PID.5\"\naction = \"hash\"",
+        );
+        let policy_file = create_temp_file(&dir, "safe-analysis.toml", hash_name_policy.as_bytes());
+        let bundle_dir = dir.path().join("issue-bundle");
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "bundle",
+            message_file.to_str().unwrap(),
+            "--profile",
+            profile_file.to_str().unwrap(),
+            "--redact-policy",
+            policy_file.to_str().unwrap(),
+            "--out",
+            bundle_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"validation_valid\": false"));
+
+        let validation_report =
+            std::fs::read_to_string(bundle_dir.join("validation-report.json")).unwrap();
+        assert!(validation_report.contains("value_not_in_constraint"));
+        assert!(validation_report.contains("hash:sha256:"));
+        assert!(!validation_report.contains("Doe^John"));
+        assert!(!validation_report.contains("123456^^^HOSP^MR"));
+        assert!(!validation_report.contains("19700101"));
+        assert!(!validation_report.contains("123 Main St"));
+    }
+
+    #[test]
+    fn test_bundle_rejects_existing_output_directory() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
+        let profile_file = create_temp_profile(&dir, "profile.yaml", minimal_profile());
+        let policy_file =
+            create_temp_file(&dir, "safe-analysis.toml", SAFE_ANALYSIS_POLICY.as_bytes());
+        let bundle_dir = dir.path().join("issue-bundle");
+        std::fs::create_dir(&bundle_dir).unwrap();
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "bundle",
+            message_file.to_str().unwrap(),
+            "--profile",
+            profile_file.to_str().unwrap(),
+            "--redact-policy",
+            policy_file.to_str().unwrap(),
+            "--out",
+            bundle_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "bundle output directory already exists",
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary
- add `hl7v2 bundle <input> --profile <profile.yaml> --redact-policy <safe-analysis.toml> --out <dir>`
- write a redacted evidence packet with `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, and replay scripts
- generate the bundled validation report from the redacted message so replay validates the same artifact and report details do not leak original PHI values
- document the bundle workflow in the root and CLI READMEs

## Safety Notes
- refuses an existing output directory before writing artifacts
- stores hashes for original input/profile/policy provenance, not raw input or policy file paths
- field-path traces store path, presence, value shape, and redaction action only, not raw field values
- regression coverage proves validation details use redacted values when a sensitive field fails a profile constraint

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests bundle`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli bundle`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-cli --all-targets`
- `cargo +1.93.0 check --examples`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`