### PR TITLE
feat: add evidence bundle replay command

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ hl7v2 redact <input.hl7> --policy safe-analysis.toml --format json
 ```bash
 # Create a PHI-safe evidence packet for support or replay
 hl7v2 bundle failing.hl7 --profile profiles/oru_r01.yaml --redact-policy safe-analysis.toml --out issue-bundle/
+
+# Re-run the redacted bundle and verify the stored validation report reproduces
+hl7v2 replay issue-bundle/ --format json
 ```
 
 ### Generate Messages

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -37,6 +37,7 @@ Redact a message for safe analysis:
 hl7v2 redact message.hl7 --policy safe-analysis.toml --format json
 hl7v2 redact message.hl7 --policy safe-analysis.toml --format hl7 > message.redacted.hl7
 hl7v2 bundle message.hl7 --profile profiles/adt_a01.yaml --redact-policy safe-analysis.toml --out issue-bundle/
+hl7v2 replay issue-bundle/ --format json
 ```
 
 Policy files use explicit rules with required reasons:
@@ -72,5 +73,9 @@ fields must be protected when present and cannot be retained.
 - `redaction-receipt.json`
 - `environment.json`
 - `replay.sh` and `replay.ps1`
+
+`hl7v2 replay` reads the bundle directly, regenerates the validation report
+from `message.redacted.hl7` and `profile.yaml`, and fails if it no longer
+matches `validation-report.json`.
 
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -226,6 +226,16 @@ enum Commands {
         out: PathBuf,
     },
 
+    /// Replay a redacted evidence bundle and verify it reproduces
+    Replay {
+        /// Evidence bundle directory
+        bundle: PathBuf,
+
+        /// Output replay report format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        format: ReportFormat,
+    },
+
     /// Generate ACK for HL7 v2 message
     Ack {
         /// Input HL7 file
@@ -715,6 +725,35 @@ struct EvidenceBundleEnvironment {
 }
 
 #[derive(serde::Serialize)]
+struct EvidenceReplayReport {
+    replay_version: &'static str,
+    bundle_version: Option<String>,
+    tool_name: &'static str,
+    tool_version: &'static str,
+    message_type: Option<String>,
+    reproduced: bool,
+    validation_valid: Option<bool>,
+    validation_issue_count: Option<usize>,
+    checks: Vec<EvidenceReplayCheck>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    validation_report: Option<ValidationReport>,
+}
+
+#[derive(serde::Serialize)]
+struct EvidenceReplayCheck {
+    name: &'static str,
+    status: EvidenceReplayCheckStatus,
+    message: String,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EvidenceReplayCheckStatus {
+    Pass,
+    Fail,
+}
+
+#[derive(serde::Serialize)]
 struct FieldPathTraceReport {
     message_type: String,
     field_count: usize,
@@ -847,6 +886,7 @@ async fn main() {
             redact_policy,
             out,
         } => bundle_command(input, profile, redact_policy, out),
+        Commands::Replay { bundle, format } => replay_command(bundle, format),
         Commands::Ack {
             input,
             mode,
@@ -1776,6 +1816,342 @@ fn bundle_command(
     println!("{}", serde_json::to_string_pretty(&summary)?);
 
     Ok(())
+}
+
+fn replay_command(bundle: &Path, format: &ReportFormat) -> Result<(), Box<dyn std::error::Error>> {
+    let report = build_replay_report(bundle);
+    println!("{}", render_replay_report(&report, format)?);
+
+    if report.reproduced {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("bundle replay did not reproduce stored evidence").into())
+    }
+}
+
+fn build_replay_report(bundle: &Path) -> EvidenceReplayReport {
+    let mut checks = Vec::new();
+    let required_artifacts = [
+        "message.redacted.hl7",
+        "validation-report.json",
+        "field-paths.json",
+        "profile.yaml",
+        "redaction-receipt.json",
+        "environment.json",
+        "replay.sh",
+        "replay.ps1",
+    ];
+
+    let missing_artifacts: Vec<&str> = required_artifacts
+        .iter()
+        .copied()
+        .filter(|artifact| !bundle.join(artifact).is_file())
+        .collect();
+    if missing_artifacts.is_empty() {
+        checks.push(replay_check(
+            "bundle-layout",
+            EvidenceReplayCheckStatus::Pass,
+            "all expected bundle artifacts are present",
+        ));
+    } else {
+        checks.push(replay_check(
+            "bundle-layout",
+            EvidenceReplayCheckStatus::Fail,
+            format!(
+                "missing expected bundle artifact(s): {}",
+                missing_artifacts.join(", ")
+            ),
+        ));
+    }
+
+    let environment = match read_bundle_json_value(bundle, "environment.json") {
+        Ok(environment) => {
+            checks.push(replay_check(
+                "environment",
+                EvidenceReplayCheckStatus::Pass,
+                "environment.json parsed",
+            ));
+            Some(environment)
+        }
+        Err(error) => {
+            checks.push(replay_check(
+                "environment",
+                EvidenceReplayCheckStatus::Fail,
+                error,
+            ));
+            None
+        }
+    };
+
+    let stored_report = match read_bundle_validation_report(bundle, "validation-report.json") {
+        Ok(report) => {
+            checks.push(replay_check(
+                "stored-validation-report",
+                EvidenceReplayCheckStatus::Pass,
+                "validation-report.json parsed",
+            ));
+            Some(report)
+        }
+        Err(error) => {
+            checks.push(replay_check(
+                "stored-validation-report",
+                EvidenceReplayCheckStatus::Fail,
+                error,
+            ));
+            None
+        }
+    };
+
+    let redacted_message = match read_bundle_artifact(bundle, "message.redacted.hl7") {
+        Ok(contents) => match parse(&contents) {
+            Ok(message) => {
+                checks.push(replay_check(
+                    "parse-redacted-message",
+                    EvidenceReplayCheckStatus::Pass,
+                    "message.redacted.hl7 parsed",
+                ));
+                Some(message)
+            }
+            Err(error) => {
+                checks.push(replay_check(
+                    "parse-redacted-message",
+                    EvidenceReplayCheckStatus::Fail,
+                    format!("message.redacted.hl7 did not parse: {error}"),
+                ));
+                None
+            }
+        },
+        Err(error) => {
+            checks.push(replay_check(
+                "parse-redacted-message",
+                EvidenceReplayCheckStatus::Fail,
+                error,
+            ));
+            None
+        }
+    };
+
+    let loaded_profile = match read_bundle_string(bundle, "profile.yaml") {
+        Ok(profile_yaml) => match load_profile_checked(&profile_yaml) {
+            Ok(profile) => {
+                checks.push(replay_check(
+                    "load-profile",
+                    EvidenceReplayCheckStatus::Pass,
+                    "profile.yaml loaded",
+                ));
+                Some(profile)
+            }
+            Err(error) => {
+                checks.push(replay_check(
+                    "load-profile",
+                    EvidenceReplayCheckStatus::Fail,
+                    format!("profile.yaml did not load: {error}"),
+                ));
+                None
+            }
+        },
+        Err(error) => {
+            checks.push(replay_check(
+                "load-profile",
+                EvidenceReplayCheckStatus::Fail,
+                error,
+            ));
+            None
+        }
+    };
+
+    let actual_report = match (redacted_message.as_ref(), loaded_profile.as_ref()) {
+        (Some(message), Some(profile)) => {
+            let report = ValidationReport::from_issues(
+                message,
+                Some("profile.yaml".to_string()),
+                validate(message, profile),
+            );
+            checks.push(replay_check(
+                "generate-validation-report",
+                EvidenceReplayCheckStatus::Pass,
+                "validation report regenerated from bundled message and profile",
+            ));
+            Some(report)
+        }
+        _ => {
+            checks.push(replay_check(
+                "generate-validation-report",
+                EvidenceReplayCheckStatus::Fail,
+                "validation report could not be regenerated",
+            ));
+            None
+        }
+    };
+
+    match (actual_report.as_ref(), stored_report.as_ref()) {
+        (Some(actual), Some(stored)) if actual == stored => checks.push(replay_check(
+            "report-match",
+            EvidenceReplayCheckStatus::Pass,
+            "regenerated validation report matches validation-report.json",
+        )),
+        (Some(_), Some(_)) => checks.push(replay_check(
+            "report-match",
+            EvidenceReplayCheckStatus::Fail,
+            "regenerated validation report differs from validation-report.json",
+        )),
+        _ => checks.push(replay_check(
+            "report-match",
+            EvidenceReplayCheckStatus::Fail,
+            "validation report comparison could not be completed",
+        )),
+    }
+
+    if let (Some(environment), Some(actual)) = (environment.as_ref(), actual_report.as_ref()) {
+        let mut mismatches = Vec::new();
+        if json_string(environment, "message_type").as_deref() != Some(actual.message_type.as_str())
+        {
+            mismatches.push("message_type");
+        }
+        if json_bool(environment, "validation_valid") != Some(actual.valid) {
+            mismatches.push("validation_valid");
+        }
+        if json_usize(environment, "validation_issue_count") != Some(actual.issue_count) {
+            mismatches.push("validation_issue_count");
+        }
+
+        if mismatches.is_empty() {
+            checks.push(replay_check(
+                "environment-match",
+                EvidenceReplayCheckStatus::Pass,
+                "environment metadata matches regenerated validation report",
+            ));
+        } else {
+            checks.push(replay_check(
+                "environment-match",
+                EvidenceReplayCheckStatus::Fail,
+                format!("environment metadata mismatch: {}", mismatches.join(", ")),
+            ));
+        }
+    } else {
+        checks.push(replay_check(
+            "environment-match",
+            EvidenceReplayCheckStatus::Fail,
+            "environment metadata comparison could not be completed",
+        ));
+    }
+
+    let reproduced = checks
+        .iter()
+        .all(|check| check.status == EvidenceReplayCheckStatus::Pass);
+    let bundle_version = environment
+        .as_ref()
+        .and_then(|value| json_string(value, "bundle_version"));
+    let message_type = actual_report
+        .as_ref()
+        .map(|report| report.message_type.clone())
+        .or_else(|| {
+            stored_report
+                .as_ref()
+                .map(|report| report.message_type.clone())
+        })
+        .or_else(|| {
+            environment
+                .as_ref()
+                .and_then(|value| json_string(value, "message_type"))
+        });
+    let validation_valid = actual_report.as_ref().map(|report| report.valid);
+    let validation_issue_count = actual_report.as_ref().map(|report| report.issue_count);
+
+    EvidenceReplayReport {
+        replay_version: "1",
+        bundle_version,
+        tool_name: "hl7v2-cli",
+        tool_version: env!("CARGO_PKG_VERSION"),
+        message_type,
+        reproduced,
+        validation_valid,
+        validation_issue_count,
+        checks,
+        validation_report: actual_report,
+    }
+}
+
+fn replay_check(
+    name: &'static str,
+    status: EvidenceReplayCheckStatus,
+    message: impl Into<String>,
+) -> EvidenceReplayCheck {
+    EvidenceReplayCheck {
+        name,
+        status,
+        message: message.into(),
+    }
+}
+
+fn read_bundle_artifact(bundle: &Path, artifact: &str) -> Result<Vec<u8>, String> {
+    fs::read(bundle.join(artifact)).map_err(|error| format!("could not read {artifact}: {error}"))
+}
+
+fn read_bundle_string(bundle: &Path, artifact: &str) -> Result<String, String> {
+    fs::read_to_string(bundle.join(artifact))
+        .map_err(|error| format!("could not read {artifact}: {error}"))
+}
+
+fn read_bundle_json_value(bundle: &Path, artifact: &str) -> Result<serde_json::Value, String> {
+    let contents = read_bundle_string(bundle, artifact)?;
+    serde_json::from_str(&contents).map_err(|error| format!("{artifact} is invalid JSON: {error}"))
+}
+
+fn read_bundle_validation_report(
+    bundle: &Path,
+    artifact: &str,
+) -> Result<ValidationReport, String> {
+    let contents = read_bundle_string(bundle, artifact)?;
+    serde_json::from_str(&contents).map_err(|error| format!("{artifact} is invalid JSON: {error}"))
+}
+
+fn json_string(value: &serde_json::Value, key: &str) -> Option<String> {
+    value.get(key)?.as_str().map(ToOwned::to_owned)
+}
+
+fn json_bool(value: &serde_json::Value, key: &str) -> Option<bool> {
+    value.get(key)?.as_bool()
+}
+
+fn json_usize(value: &serde_json::Value, key: &str) -> Option<usize> {
+    value
+        .get(key)?
+        .as_u64()
+        .and_then(|count| usize::try_from(count).ok())
+}
+
+fn render_replay_report(
+    report: &EvidenceReplayReport,
+    format: &ReportFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        ReportFormat::Json => Ok(serde_json::to_string_pretty(report)?),
+        ReportFormat::Yaml => Ok(serde_yaml::to_string(report)?),
+        ReportFormat::Text => {
+            let mut output = String::new();
+            output.push_str("Evidence Replay\n");
+            output.push_str(&format!("  Reproduced: {}\n", report.reproduced));
+            if let Some(message_type) = &report.message_type {
+                output.push_str(&format!("  Message type: {message_type}\n"));
+            }
+            if let Some(valid) = report.validation_valid {
+                output.push_str(&format!("  Validation valid: {valid}\n"));
+            }
+            if let Some(issue_count) = report.validation_issue_count {
+                output.push_str(&format!("  Validation issues: {issue_count}\n"));
+            }
+            output.push_str("Checks:\n");
+            for check in &report.checks {
+                let status = match check.status {
+                    EvidenceReplayCheckStatus::Pass => "PASS",
+                    EvidenceReplayCheckStatus::Fail => "FAIL",
+                };
+                output.push_str(&format!("  {status} {} - {}\n", check.name, check.message));
+            }
+            Ok(output)
+        }
+    }
 }
 
 fn write_json_file<T: serde::Serialize>(

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -143,6 +143,17 @@ mod cli_unit_tests {
                     .any(|command| command.get_name() == "bundle")
             );
         }
+
+        #[test]
+        fn test_replay_command_exists() {
+            use crate::Cli;
+            let schema = Cli::command();
+            assert!(
+                schema
+                    .get_subcommands()
+                    .any(|command| command.get_name() == "replay")
+            );
+        }
     }
 
     // =========================================================================

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -170,6 +170,17 @@ mod help_and_version {
     }
 
     #[test]
+    fn test_replay_help() {
+        let mut cmd = cli_command();
+        cmd.args(["replay", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Replay a redacted evidence bundle",
+            ));
+    }
+
+    #[test]
     fn test_ack_help() {
         let mut cmd = cli_command();
         cmd.args(["ack", "--help"])
@@ -2007,6 +2018,178 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
         .stderr(predicate::str::contains(
             "bundle output directory already exists",
         ));
+    }
+}
+
+// =========================================================================
+// Evidence Replay Command Tests
+// =========================================================================
+
+mod replay_command {
+    use super::*;
+
+    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+    const SAFE_ANALYSIS_POLICY: &str = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "date of birth"
+
+[[rules]]
+path = "PID.11"
+action = "drop"
+reason = "patient address"
+
+[[rules]]
+path = "MSH.9"
+action = "retain"
+reason = "message type is needed for analysis"
+
+[[rules]]
+path = "MSH.10"
+action = "retain"
+reason = "control id is needed for replay correlation"
+
+[[rules]]
+path = "OBX.3"
+action = "retain"
+reason = "observation identifier is needed for analysis"
+
+[[rules]]
+path = "OBX.5"
+action = "retain"
+reason = "non-PHI synthetic observation value shape is needed for analysis"
+"#;
+
+    fn create_replayable_bundle(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let message_file = create_temp_hl7_with_content(dir, "message.hl7", PHI_MESSAGE);
+        let profile_file = create_temp_profile(dir, "profile.yaml", minimal_profile());
+        let policy_file =
+            create_temp_file(dir, "safe-analysis.toml", SAFE_ANALYSIS_POLICY.as_bytes());
+        let bundle_dir = dir.path().join("issue-bundle");
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "bundle",
+            message_file.to_str().unwrap(),
+            "--profile",
+            profile_file.to_str().unwrap(),
+            "--redact-policy",
+            policy_file.to_str().unwrap(),
+            "--out",
+            bundle_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+        bundle_dir
+    }
+
+    #[test]
+    fn test_replay_reproduces_bundle_report_without_raw_phi() {
+        let dir = create_temp_dir();
+        let bundle_dir = create_replayable_bundle(&dir);
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", bundle_dir.to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("Failed to execute replay");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains("Doe^John"));
+        assert!(!stdout.contains("123456^^^HOSP^MR"));
+        assert!(!stdout.contains("19700101"));
+        assert!(!stdout.contains("123 Main St"));
+
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("replay output should be JSON");
+        assert_eq!(report["replay_version"], "1");
+        assert_eq!(report["bundle_version"], "1");
+        assert_eq!(report["message_type"], "ADT^A01");
+        assert_eq!(report["reproduced"], true);
+        assert_eq!(report["validation_valid"], true);
+        assert_eq!(report["validation_issue_count"], 0);
+        assert_eq!(report["validation_report"]["profile"], "profile.yaml");
+        assert!(
+            report["checks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|check| check["status"] == "pass")
+        );
+    }
+
+    #[test]
+    fn test_replay_fails_when_stored_validation_report_drifts() {
+        let dir = create_temp_dir();
+        let bundle_dir = create_replayable_bundle(&dir);
+        let report_path = bundle_dir.join("validation-report.json");
+        let mut stored_report: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&report_path).unwrap()).unwrap();
+        stored_report["issue_count"] = serde_json::json!(42);
+        std::fs::write(
+            &report_path,
+            serde_json::to_vec_pretty(&stored_report).unwrap(),
+        )
+        .unwrap();
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", bundle_dir.to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("Failed to execute replay");
+
+        assert!(!output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("replay failure output should be JSON");
+        assert_eq!(report["reproduced"], false);
+        assert!(
+            report["checks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|check| check["name"] == "report-match" && check["status"] == "fail")
+        );
+    }
+
+    #[test]
+    fn test_replay_fails_when_bundle_artifact_is_missing() {
+        let dir = create_temp_dir();
+        let bundle_dir = create_replayable_bundle(&dir);
+        std::fs::remove_file(bundle_dir.join("field-paths.json")).unwrap();
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", bundle_dir.to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("Failed to execute replay");
+
+        assert!(!output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("replay failure output should be JSON");
+        assert_eq!(report["reproduced"], false);
+        assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+            check["name"] == "bundle-layout"
+                && check["status"] == "fail"
+                && check["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("field-paths.json")
+        }));
     }
 }
 


### PR DESCRIPTION
## Summary
- add `hl7v2 replay <bundle> --format json|yaml|text` for redacted evidence bundles
- validate expected bundle artifacts, parse `message.redacted.hl7`, load `profile.yaml`, regenerate the validation report, and compare it to `validation-report.json`
- document the replay step in the root and CLI READMEs

## Security / PHI notes
- replay reads the redacted bundle artifacts directly and does not execute generated shell scripts
- the positive replay test verifies the JSON replay report does not include the raw synthetic PHI from the original message
- replay is not a sanitizer for arbitrary user-authored profile or bundle content; it verifies the bundle it is given

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests replay`
- `cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli replay`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-cli --all-targets`
- `cargo +1.93.0 check --examples`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`