### PR TITLE
feat: add minimum Python API parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,7 @@ version = "1.2.1"
 dependencies = [
  "hl7v2",
  "pyo3",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -25,3 +25,4 @@ hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "json",
 ] }
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
+serde_json = { workspace = true }

--- a/crates/hl7v2-python/README.md
+++ b/crates/hl7v2-python/README.md
@@ -30,15 +30,36 @@ python tests\python_smoke\smoke.py
 ```python
 import hl7v2
 
-message = hl7v2.PyMessage.parse(
+raw = (
     "MSH|^~\\&|SEND|FAC|RECV|FAC|202605080101||ADT^A01|CTRL1|P|2.5\r"
     "PID|1||123456^^^HOSP^MR||Doe^John||19700101|M"
 )
+profile_yaml = """
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"""
 
 print(hl7v2.__version__)
+
+message = hl7v2.parse(raw)
 print(message.segment_count())
 print(message.to_json())
+
+print(hl7v2.to_json(raw))
+print(hl7v2.normalize(raw))
+
+report = hl7v2.validate(raw, profile_yaml)
+print(report.valid)
+print(report.message_type)
+print(report.to_dict())
 ```
 
-The first stable binding proof is build/install/import plus parse and JSON
-smoke coverage. Broader Python APIs should be added in focused follow-up PRs.
+The current Python surface intentionally starts with the minimum evidence loop:
+parse, JSON export, normalize, and validate. Broader Python APIs should be
+added in focused follow-up PRs.

--- a/crates/hl7v2-python/src/lib.rs
+++ b/crates/hl7v2-python/src/lib.rs
@@ -1,6 +1,9 @@
 //! Python bindings for HL7v2 via PyO3.
 
-use ::hl7v2::{Message, parse as rust_parse, to_json as rust_to_json};
+use ::hl7v2::{
+    Message, ValidationReport, load_profile_checked, normalize as rust_normalize,
+    parse as rust_parse, to_json as rust_to_json, validate as rust_validate,
+};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -32,10 +35,106 @@ impl PyMessage {
     }
 }
 
+/// Stable validation report wrapper for Python.
+#[pyclass]
+pub struct PyValidationReport {
+    inner: ValidationReport,
+}
+
+#[pymethods]
+impl PyValidationReport {
+    /// Whether the message passed validation without error-level issues.
+    #[getter]
+    pub fn valid(&self) -> bool {
+        self.inner.valid
+    }
+
+    /// HL7 trigger event from `MSH.9`, such as `ADT^A01`.
+    #[getter]
+    pub fn message_type(&self) -> String {
+        self.inner.message_type.clone()
+    }
+
+    /// Profile identifier included in the report.
+    #[getter]
+    pub fn profile(&self) -> Option<String> {
+        self.inner.profile.clone()
+    }
+
+    /// Number of parsed message segments.
+    #[getter]
+    pub fn segment_count(&self) -> usize {
+        self.inner.segment_count
+    }
+
+    /// Number of validation issues in the report.
+    #[getter]
+    pub fn issue_count(&self) -> usize {
+        self.inner.issue_count
+    }
+
+    /// Convert the validation report to a JSON string.
+    pub fn to_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner)
+            .map_err(|e| PyValueError::new_err(format!("Report serialization error: {e}")))
+    }
+
+    /// Convert the validation report to a Python dict.
+    pub fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let json = self.to_json()?;
+        py.import("json")?.call_method1("loads", (json,))
+    }
+}
+
+/// Parse an HL7 message from a string.
+#[pyfunction]
+pub fn parse(content: &str) -> PyResult<PyMessage> {
+    PyMessage::parse(content)
+}
+
+/// Parse an HL7 message and convert it to a JSON string.
+#[pyfunction]
+pub fn to_json(content: &str) -> PyResult<String> {
+    let message = rust_parse(content.as_bytes())
+        .map_err(|e| PyValueError::new_err(format!("Parse error: {e}")))?;
+    Ok(rust_to_json(&message).to_string())
+}
+
+/// Normalize an HL7 message.
+#[pyfunction(signature = (content, canonical_delims = false))]
+pub fn normalize(content: &str, canonical_delims: bool) -> PyResult<String> {
+    let normalized = rust_normalize(content.as_bytes(), canonical_delims)
+        .map_err(|e| PyValueError::new_err(format!("Normalize error: {e}")))?;
+    String::from_utf8(normalized)
+        .map_err(|e| PyValueError::new_err(format!("Normalize UTF-8 error: {e}")))
+}
+
+/// Validate an HL7 message against a profile YAML string.
+#[pyfunction]
+pub fn validate(content: &str, profile_yaml: &str) -> PyResult<PyValidationReport> {
+    let message = rust_parse(content.as_bytes())
+        .map_err(|e| PyValueError::new_err(format!("Parse error: {e}")))?;
+    let profile = load_profile_checked(profile_yaml)
+        .map_err(|e| PyValueError::new_err(format!("Profile load error: {e}")))?;
+    let issues = rust_validate(&message, &profile);
+    Ok(PyValidationReport {
+        inner: ValidationReport::from_issues(
+            &message,
+            Some(profile.message_structure.clone()),
+            issues,
+        ),
+    })
+}
+
 /// HL7v2 module for Python
 #[pymodule]
 fn hl7v2(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PyMessage>()?;
+    m.add_class::<PyValidationReport>()?;
+    m.add_function(wrap_pyfunction!(parse, m)?)?;
+    m.add_function(wrap_pyfunction!(to_json, m)?)?;
+    m.add_function(wrap_pyfunction!(normalize, m)?)?;
+    m.add_function(wrap_pyfunction!(validate, m)?)?;
     Ok(())
 }

--- a/tests/python_smoke/smoke.py
+++ b/tests/python_smoke/smoke.py
@@ -30,6 +30,82 @@ def main() -> int:
         print("message JSON did not decode to an object", file=sys.stderr)
         return 1
 
+    top_level_message = hl7v2.parse(raw)
+    if top_level_message.segment_count() != 2:
+        print("top-level parse did not return a two-segment message", file=sys.stderr)
+        return 1
+
+    top_level_payload = json.loads(hl7v2.to_json(raw))
+    if not isinstance(top_level_payload, dict):
+        print("top-level to_json did not decode to an object", file=sys.stderr)
+        return 1
+
+    normalized = hl7v2.normalize(raw)
+    if "MSH|^~\\&" not in normalized or "PID|" not in normalized:
+        print("normalize did not return expected HL7 content", file=sys.stderr)
+        return 1
+
+    profile_yaml = """
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: MSH.9
+    required: true
+  - path: PID.3
+    required: true
+"""
+    report = hl7v2.validate(raw, profile_yaml)
+    if not report.valid:
+        print("expected validation report to be valid", file=sys.stderr)
+        return 1
+    if report.message_type != "ADT^A01":
+        print(f"unexpected message type: {report.message_type}", file=sys.stderr)
+        return 1
+    report_dict = report.to_dict()
+    if report_dict["valid"] is not True or report_dict["issue_count"] != 0:
+        print("validation report dict did not match expected shape", file=sys.stderr)
+        return 1
+    if report.profile != "ADT_A01" or report_dict["profile"] != "ADT_A01":
+        print("validation report did not preserve profile identity", file=sys.stderr)
+        return 1
+    report_json = json.loads(report.to_json())
+    if report_json["message_type"] != "ADT^A01":
+        print("validation report JSON did not preserve message_type", file=sys.stderr)
+        return 1
+
+    failing_profile_yaml = """
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.13
+    required: true
+"""
+    failing_report = hl7v2.validate(raw, failing_profile_yaml)
+    if failing_report.valid:
+        print("expected missing PID.13 validation to fail", file=sys.stderr)
+        return 1
+    failing_dict = failing_report.to_dict()
+    issue = failing_dict["issues"][0]
+    if issue["code"] != "missing_required_field" or issue["path"] != "PID.13":
+        print(f"unexpected validation issue: {issue}", file=sys.stderr)
+        return 1
+
+    try:
+        hl7v2.parse("not an hl7 message")
+    except ValueError as exc:
+        if "Parse error" not in str(exc):
+            print(f"parse error did not include stable context: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print("expected invalid HL7 parse to raise ValueError", file=sys.stderr)
+        return 1
+
     print(f"hl7v2-python smoke ok version={version} segments={segment_count}")
     return 0
 


### PR DESCRIPTION
## Summary
- add top-level Python binding functions: `parse`, `to_json`, `normalize`, and `validate`
- add `PyValidationReport` with stable report properties plus `to_json()` and `to_dict()`
- expand the Python smoke proof to cover parse/JSON/normalize/validate success, validation issue shape, profile identity, and parse error behavior

## Contract notes
- existing `PyMessage.parse()` remains available for compatibility
- `validate()` returns the shared Rust validation report shape and labels the profile with the loaded `message_structure`, matching server report semantics for inline profiles
- `hl7v2-python` remains `publish = false`; the crates.io publish plan remains Rust-only

## Dependency notes
- add `serde_json` to `hl7v2-python` from the workspace so the binding can serialize the shared validation report without introducing a new third-party package

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check -p hl7v2-python --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 clippy -p hl7v2-python --all-features --all-targets -- -D warnings`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test -p hl7v2-python --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; maturin build -m crates/hl7v2-python/Cargo.toml --out target/python-wheels`
- temporary venv install from `target/python-wheels` and `python tests/python_smoke/smoke.py`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 run -p xtask -- publish-plan`