### PR TITLE
docs: audit evidence loop contract gaps

### DIFF
--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -1,0 +1,105 @@
+# Evidence Artifacts
+
+This document maps the current evidence-loop artifacts and their contract
+status. It is a current-state reference for the schema, golden-fixture, CLI
+output-contract, server parity, and Python parity follow-up work.
+
+## Product Loop
+
+The evidence loop is:
+
+```text
+raw feed / message
+  -> profile lint
+  -> profile test / explain
+  -> validation report
+  -> corpus summarize
+  -> corpus fingerprint
+  -> corpus diff
+  -> safe-analysis redact
+  -> redacted evidence bundle
+  -> replay verification
+```
+
+The target is deterministic, machine-readable proof of what arrived, what
+failed, what changed, what was redacted, and how to replay the result.
+
+## Artifact Inventory
+
+| Artifact | Producer | Primary type | Contract status |
+| --- | --- | --- | --- |
+| Doctor report | `hl7v2 doctor --format json|yaml|text` | CLI-local `DoctorReport` | Has tool `version`; no `schema_version`; no JSON Schema. |
+| Validation report | `hl7v2 val --report json|yaml|text`, Rust `ValidationReport`, Python `report.to_dict()` / `report.to_json()`, server `/hl7/validate` fields | `hl7v2::ValidationReport` | Shared across Rust/CLI/Python and embedded in server response; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Profile lint report | `hl7v2 profile lint --report json|yaml|text`, Rust `lint_profile_yaml` | `hl7v2::ProfileLintReport` | Library type; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Profile test report | `hl7v2 profile test --report json|yaml|text` | CLI-local `ProfileTestReport` | Includes validation reports per case; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Profile explain report | `hl7v2 profile explain --format json|yaml|text` | CLI-local `ProfileExplainReport` | Includes profile SHA-256 and loaded profile version; no artifact `schema_version`; no tool version; no JSON Schema. |
+| Corpus summary | `hl7v2 corpus summarize --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusSummary` | Library type; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Corpus fingerprint | `hl7v2 corpus fingerprint --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusFingerprint` | Has `fingerprint_version`, `tool_version`, optional profile SHA-256 metadata; no JSON Schema yet. |
+| Corpus diff report | `hl7v2 corpus diff --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusDiffReport` | Has `diff_version`, `tool_version`, optional profile SHA-256 metadata; no JSON Schema yet. |
+| Redaction output | `hl7v2 redact --format json` | CLI-local `RedactionOutput` | Has input and policy SHA-256 values plus receipt; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Redaction receipt | `hl7v2 redact --format json`, bundle `redaction-receipt.json` | CLI-local `RedactionReceipt` | Captures actions and PHI removal status; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Field path trace | Bundle `field-paths.json` | CLI-local `FieldPathTraceReport` | Captures redacted message field paths and value shapes; no `schema_version`; no JSON Schema. |
+| Evidence bundle summary | `hl7v2 bundle ...` stdout | CLI-local `EvidenceBundleSummary` | Has `bundle_version`; no `tool_version`; no manifest or artifact hashes yet. |
+| Evidence bundle environment | Bundle `environment.json` | CLI-local `EvidenceBundleEnvironment` | Has `bundle_version`, `tool_name`, `tool_version`, input/profile/policy hashes, and replay command. |
+| Evidence replay report | `hl7v2 replay --format json|yaml|text` | CLI-local `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, and optional regenerated validation report; no manifest hash verification yet. |
+
+## Current Parity
+
+| Surface | Current parity |
+| --- | --- |
+| Rust library | Owns the shared `ValidationReport`, `ProfileLintReport`, and corpus summary/fingerprint/diff types. Bundle, replay, profile test, and profile explain report types are currently CLI-local. |
+| CLI | Produces the complete evidence loop today. Most commands support JSON/YAML/text. `redact` supports JSON or HL7 output. `bundle` currently emits JSON summary only. |
+| Server | `/hl7/validate` exposes the shared validation issue fields and preserves legacy `errors` / `warnings`; it does not yet expose redaction, bundle, replay, or corpus artifacts. |
+| Python | Exposes parse, JSON conversion, normalize, and validation report dict/JSON parity. It does not yet expose corpus, redaction, bundle, or replay artifacts. |
+
+One current validation-report parity wrinkle is the profile label. The CLI uses
+the profile file path, while the server and Python binding use the loaded
+profile `message_structure`. The report fields are otherwise shared through
+`hl7v2::ValidationReport`.
+
+## Output Semantics
+
+The CLI has useful machine-readable outputs, but the script contract is not yet
+uniform.
+
+- JSON/YAML output generally goes to stdout.
+- Human text output also goes to stdout.
+- Diagnostics and top-level errors are written to stderr by the global error
+  path.
+- `hl7v2 redact --format hl7` writes the redacted message to stdout and a short
+  receipt to stderr.
+- `hl7v2 val` exits `1` for invalid validation reports.
+- `profile lint`, `profile test`, and `replay` return errors for failed
+  evidence checks, which currently route through the global `exit(1)` handler.
+- Parse/config/profile/policy/IO failures also use the same global `exit(1)`
+  behavior today.
+
+The planned output-contract work should split these into the documented
+automation classes:
+
+```text
+0 = success
+1 = validation/profile/evidence failed
+2 = parse/config/profile/policy input error
+3 = IO/runtime/environment error
+```
+
+## Contract Hardening Gaps
+
+The next contract-hardening work should lock:
+
+- `schema_version` or artifact-specific version naming for every machine
+  artifact.
+- `tool_version` where users need provenance outside an environment file.
+- JSON Schemas under `schemas/evidence/`.
+- Golden fixtures under `fixtures/evidence/`.
+- Explicit null and empty-list behavior for optional fields.
+- Stable stdout/stderr/exit-code behavior across the CLI.
+- Bundle manifest and artifact SHA-256 verification during replay.
+- Redaction leak sentinel tests for synthetic PHI fixtures.
+- Server and Python parity for any artifact promoted beyond CLI-only use.
+
+## Non-Goals
+
+This document does not define new runtime behavior. It records the current
+evidence artifacts and the gaps that should be addressed by follow-up PRs.

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -1,0 +1,125 @@
+# Evidence Loop Current-State Audit
+
+Date: 2026-05-08
+
+## Purpose
+
+This audit records the current evidence-loop state after the product-usefulness
+lane added first-run diagnostics, typed validation reports, profile commands,
+corpus observability, safe redaction, evidence bundle/replay, and Python API
+parity.
+
+The goal is to make the next hardening work concrete: JSON Schemas, golden
+fixtures, CLI output semantics, bundle manifest verification, server parity, and
+Python corpus/redaction APIs should be based on the artifacts that exist now.
+
+## Current Product Loop
+
+The current CLI can run the full evidence path:
+
+```text
+hl7v2 doctor
+hl7v2 profile lint <profile.yaml> --report json
+hl7v2 profile explain <profile.yaml> --format json
+hl7v2 profile test <profile.yaml> <fixtures/> --report json
+hl7v2 val <message.hl7> --profile <profile.yaml> --report json
+hl7v2 corpus summarize <feeds/> --format json
+hl7v2 corpus fingerprint <feeds/> --profile <profile.yaml> --format json
+hl7v2 corpus diff <before/> <after/> --profile <profile.yaml> --format json
+hl7v2 redact <message.hl7> --policy <safe-analysis.toml> --format json
+hl7v2 bundle <message.hl7> --profile <profile.yaml> --redact-policy <safe-analysis.toml> --out <bundle/>
+hl7v2 replay <bundle/> --format json
+```
+
+The server exposes validation report parity through `/hl7/validate`. Python
+exposes parse, JSON conversion, normalization, and validation report dict/JSON
+parity.
+
+## Artifact Status
+
+| Artifact | Current state | Main gap |
+| --- | --- | --- |
+| `ValidationReport` | Shared Rust type used by CLI, Python, and server validation response fields. Includes stable issue code, severity, path, rule ID, message, segment index, and field index. | Missing artifact `schema_version`, `tool_version`, JSON Schema, and golden fixture set. |
+| `ProfileLintReport` | Shared Rust type from profile linting. CLI emits text/JSON/YAML. | Missing version fields and JSON Schema. |
+| `ProfileTestReport` | CLI report with fixture cases, pass/fail status, embedded validation reports, and optional expected-report comparison. | CLI-local type; missing version fields and JSON Schema. |
+| `ProfileExplainReport` | CLI report with profile SHA-256, structure, version, segments, constraints, tables, rules, and lint summary. | CLI-local type; missing artifact version and tool version. |
+| `CorpusSummary` | Shared Rust corpus summary type. CLI emits text/JSON/YAML. | Missing version fields; no JSON Schema. |
+| `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. | Needs JSON Schema and golden fixtures. |
+| `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. | Needs JSON Schema and golden fixtures. |
+| `RedactionReceipt` | CLI receipt records PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | CLI-local type; missing version fields, JSON Schema, and dedicated leak-sentinel fixture family. |
+| `EvidenceBundleSummary` | CLI stdout JSON summary includes `bundle_version`, output directory, message type, validation status, redaction status, and artifact list. | No manifest; no artifact hashes in summary. |
+| Bundle artifacts | `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, and `replay.ps1`. | No `manifest.json`; replay does not verify artifact hashes. |
+| `EvidenceReplayReport` | CLI report with `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, reproduction status, and optional regenerated validation report. | No manifest verification yet; report schema not locked. |
+| Python validation report | `report.valid`, `message_type`, `profile`, `segment_count`, `issue_count`, `to_dict()`, and `to_json()` mirror `ValidationReport`. | Python does not yet expose corpus, redaction, bundle, or replay artifact APIs. |
+
+## Surface Parity
+
+| Surface | Evidence-loop coverage |
+| --- | --- |
+| Rust | Shared validation, profile lint, corpus summary/fingerprint/diff, parse, normalize, write, ACK, and redaction module APIs. Several evidence packet reports remain CLI-local. |
+| CLI | Complete current loop: doctor, profile lint/test/explain, validation, corpus summarize/fingerprint/diff, redact, bundle, and replay. |
+| Server | Validation report parity for `/hl7/validate`; redaction, bundle, replay, corpus, readiness, ACK policy, and quarantine hooks remain follow-up work. |
+| Python | Minimum API parity for parse, `to_json`, normalize, and validation reports. Corpus, redaction, bundle, and replay APIs remain follow-up work. |
+
+One known validation parity detail remains: the CLI report `profile` value is
+the profile path supplied by the user, while the server and Python surfaces use
+the loaded profile message structure. The shape is shared; the profile identity
+semantics still need to be made explicit before schemas are treated as stable.
+
+## CLI Automation Semantics
+
+Current behavior is useful but not fully script-grade:
+
+- Machine-readable JSON/YAML usually goes to stdout.
+- Human text output also goes to stdout.
+- Top-level diagnostics use stderr through the global error handler.
+- `redact --format hl7` sends the redacted HL7 body to stdout and a short
+  receipt to stderr.
+- Validation failure, profile lint failure, profile test failure, replay
+  failure, parse failure, policy failure, config/input failure, and IO failure
+  currently collapse to exit code `1`.
+
+The follow-up `cli/output-contract` PR should make this explicit and split exit
+codes by failure class:
+
+| Exit code | Intended meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Validation/profile/evidence check failed. |
+| `2` | Parse/profile/config/policy input error. |
+| `3` | IO/runtime/environment error. |
+
+## Known Contract Gaps
+
+The evidence loop exists, but it is not yet fully contract-grade. Remaining
+hardening work:
+
+1. Add JSON Schemas for machine-readable evidence artifacts.
+2. Add representative golden fixtures and normalized snapshot comparisons.
+3. Add artifact version and tool version fields consistently.
+4. Document null/empty-list behavior for optional fields.
+5. Add bundle `manifest.json` with artifact SHA-256 values.
+6. Make replay verify artifact integrity, not only validation reproduction.
+7. Add synthetic PHI leak sentinels for redaction, bundle, replay, and later
+   Python wrappers.
+8. Promote shared report types out of CLI-local structs when server or Python
+   parity needs them.
+9. Add consistent `--output`, `--quiet`, and `--no-color` behavior for evidence
+   commands.
+
+## Verification Performed For This Audit
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| Inspected CLI command definitions and formatters | Pass | `doctor`, `profile`, `corpus`, `redact`, `bundle`, and `replay` commands are present. |
+| Inspected shared Rust validation and corpus types | Pass | `ValidationReport`, `ProfileLintReport`, `CorpusSummary`, `CorpusFingerprint`, and `CorpusDiffReport` are library types. |
+| Inspected server validation handler and response model | Pass | `/hl7/validate` builds `ValidationReport` and exposes shared issue records. |
+| Inspected Python binding API | Pass | Python exposes parse, JSON conversion, normalization, and validation report dict/JSON access. |
+| Checked existing integration tests | Pass | CLI tests cover JSON outputs, redaction no-PHI assertions, bundle artifacts, replay success, replay drift failure, and missing-artifact failure. |
+
+## Result
+
+The evidence loop is real enough to harden. The next work should not add broad
+new features first; it should make the existing artifacts stable contracts with
+schemas, goldens, version fields, CLI output semantics, manifest verification,
+and parity plans for server and Python surfaces.


### PR DESCRIPTION
## Summary
- add a current-state audit for the evidence loop after doctor, reports, profile, corpus, redaction, bundle/replay, and Python parity work
- add an architecture reference mapping evidence artifacts, producer surfaces, version-field coverage, and parity gaps
- call out the next hardening targets: evidence JSON Schemas, golden fixtures, CLI output semantics, bundle manifest verification, and server/Python parity follow-ups

## Validation
- `git diff --cached --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 run -p xtask -- gate --check --changed` failed locally without PyO3 override because local Python is 3.14 and PyO3 supports up to 3.13
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`