### PR TITLE
contracts: add evidence artifact JSON schemas

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -7,6 +7,7 @@ on:
       - 'api/**'
       - 'schemas/**'
       - 'profiles/**'
+      - 'fixtures/evidence/**'
       - 'config.example.toml'
       - 'config/**'
       - '.spectral.yml'
@@ -17,6 +18,7 @@ on:
       - 'api/**'
       - 'schemas/**'
       - 'profiles/**'
+      - 'fixtures/evidence/**'
       - 'config.example.toml'
       - 'config/**'
       - '.spectral.yml'
@@ -140,6 +142,19 @@ jobs:
             -s schemas/config/hl7v2-config-v1.schema.json \
             -d 'target/contracts/config/*.json' \
             --spec=draft7
+
+      - name: Validate Evidence Fixtures
+        run: |
+          for schema in schemas/evidence/*-v1.schema.json; do
+            name="$(basename "$schema")"
+            name="${name%-v1.schema.json}"
+            data="fixtures/evidence/${name}.json"
+            echo "Validating $data against $schema"
+            ajv validate -c ajv-formats \
+              -s "$schema" \
+              -d "$data" \
+              --spec=draft7
+          done
 
       - name: Validate Test Data
         run: |

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -29,19 +29,19 @@ failed, what changed, what was redacted, and how to replay the result.
 | Artifact | Producer | Primary type | Contract status |
 | --- | --- | --- | --- |
 | Doctor report | `hl7v2 doctor --format json|yaml|text` | CLI-local `DoctorReport` | Has tool `version`; no `schema_version`; no JSON Schema. |
-| Validation report | `hl7v2 val --report json|yaml|text`, Rust `ValidationReport`, Python `report.to_dict()` / `report.to_json()`, server `/hl7/validate` fields | `hl7v2::ValidationReport` | Shared across Rust/CLI/Python and embedded in server response; no `schema_version`; no `tool_version`; no JSON Schema. |
-| Profile lint report | `hl7v2 profile lint --report json|yaml|text`, Rust `lint_profile_yaml` | `hl7v2::ProfileLintReport` | Library type; no `schema_version`; no `tool_version`; no JSON Schema. |
-| Profile test report | `hl7v2 profile test --report json|yaml|text` | CLI-local `ProfileTestReport` | Includes validation reports per case; no `schema_version`; no `tool_version`; no JSON Schema. |
-| Profile explain report | `hl7v2 profile explain --format json|yaml|text` | CLI-local `ProfileExplainReport` | Includes profile SHA-256 and loaded profile version; no artifact `schema_version`; no tool version; no JSON Schema. |
-| Corpus summary | `hl7v2 corpus summarize --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusSummary` | Library type; no `schema_version`; no `tool_version`; no JSON Schema. |
-| Corpus fingerprint | `hl7v2 corpus fingerprint --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusFingerprint` | Has `fingerprint_version`, `tool_version`, optional profile SHA-256 metadata; no JSON Schema yet. |
-| Corpus diff report | `hl7v2 corpus diff --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusDiffReport` | Has `diff_version`, `tool_version`, optional profile SHA-256 metadata; no JSON Schema yet. |
-| Redaction output | `hl7v2 redact --format json` | CLI-local `RedactionOutput` | Has input and policy SHA-256 values plus receipt; no `schema_version`; no `tool_version`; no JSON Schema. |
-| Redaction receipt | `hl7v2 redact --format json`, bundle `redaction-receipt.json` | CLI-local `RedactionReceipt` | Captures actions and PHI removal status; no `schema_version`; no `tool_version`; no JSON Schema. |
+| Validation report | `hl7v2 val --report json|yaml|text`, Rust `ValidationReport`, Python `report.to_dict()` / `report.to_json()`, server `/hl7/validate` fields | `hl7v2::ValidationReport` | Shared across Rust/CLI/Python and embedded in server response; JSON Schema exists at `schemas/evidence/validation-report-v1.schema.json`; no `schema_version`; no `tool_version`. |
+| Profile lint report | `hl7v2 profile lint --report json|yaml|text`, Rust `lint_profile_yaml` | `hl7v2::ProfileLintReport` | Library type; JSON Schema exists at `schemas/evidence/profile-lint-report-v1.schema.json`; no `schema_version`; no `tool_version`. |
+| Profile test report | `hl7v2 profile test --report json|yaml|text` | CLI-local `ProfileTestReport` | Includes validation reports per case; JSON Schema exists at `schemas/evidence/profile-test-report-v1.schema.json`; no `schema_version`; no `tool_version`. |
+| Profile explain report | `hl7v2 profile explain --format json|yaml|text` | CLI-local `ProfileExplainReport` | Includes profile SHA-256 and loaded profile version; JSON Schema exists at `schemas/evidence/profile-explain-report-v1.schema.json`; no artifact `schema_version`; no tool version. |
+| Corpus summary | `hl7v2 corpus summarize --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusSummary` | Library type; JSON Schema exists at `schemas/evidence/corpus-summary-v1.schema.json`; no `schema_version`; no `tool_version`. |
+| Corpus fingerprint | `hl7v2 corpus fingerprint --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusFingerprint` | Has `fingerprint_version`, `tool_version`, optional profile SHA-256 metadata, and JSON Schema at `schemas/evidence/corpus-fingerprint-v1.schema.json`. |
+| Corpus diff report | `hl7v2 corpus diff --format json|yaml|text`, Rust corpus module | `hl7v2::synthetic::corpus::CorpusDiffReport` | Has `diff_version`, `tool_version`, optional profile SHA-256 metadata, and JSON Schema at `schemas/evidence/corpus-diff-v1.schema.json`. |
+| Redaction output | `hl7v2 redact --format json` | CLI-local `RedactionOutput` | Has input and policy SHA-256 values plus receipt; no `schema_version`; no `tool_version`; only the nested receipt has a JSON Schema today. |
+| Redaction receipt | `hl7v2 redact --format json`, bundle `redaction-receipt.json` | CLI-local `RedactionReceipt` | Captures actions and PHI removal status; JSON Schema exists at `schemas/evidence/redaction-receipt-v1.schema.json`; no `schema_version`; no `tool_version`. |
 | Field path trace | Bundle `field-paths.json` | CLI-local `FieldPathTraceReport` | Captures redacted message field paths and value shapes; no `schema_version`; no JSON Schema. |
-| Evidence bundle summary | `hl7v2 bundle ...` stdout | CLI-local `EvidenceBundleSummary` | Has `bundle_version`; no `tool_version`; no manifest or artifact hashes yet. |
+| Evidence bundle summary | `hl7v2 bundle ...` stdout | CLI-local `EvidenceBundleSummary` | Has `bundle_version`; JSON Schema exists at `schemas/evidence/evidence-bundle-v1.schema.json`; no `tool_version`; no manifest or artifact hashes yet. |
 | Evidence bundle environment | Bundle `environment.json` | CLI-local `EvidenceBundleEnvironment` | Has `bundle_version`, `tool_name`, `tool_version`, input/profile/policy hashes, and replay command. |
-| Evidence replay report | `hl7v2 replay --format json|yaml|text` | CLI-local `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, and optional regenerated validation report; no manifest hash verification yet. |
+| Evidence replay report | `hl7v2 replay --format json|yaml|text` | CLI-local `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, optional regenerated validation report, and JSON Schema at `schemas/evidence/evidence-replay-v1.schema.json`; no manifest hash verification yet. |
 
 ## Current Parity
 
@@ -91,8 +91,8 @@ The next contract-hardening work should lock:
 - `schema_version` or artifact-specific version naming for every machine
   artifact.
 - `tool_version` where users need provenance outside an environment file.
-- JSON Schemas under `schemas/evidence/`.
-- Golden fixtures under `fixtures/evidence/`.
+- Golden command-output tests that compare live commands to the representative
+  fixtures under `fixtures/evidence/`.
 - Explicit null and empty-list behavior for optional fields.
 - Stable stdout/stderr/exit-code behavior across the CLI.
 - Bundle manifest and artifact SHA-256 verification during replay.

--- a/fixtures/evidence/corpus-diff.json
+++ b/fixtures/evidence/corpus-diff.json
@@ -1,0 +1,67 @@
+{
+  "diff_version": "1",
+  "tool_version": "1.2.1",
+  "before_root": "fixtures/corpus/before",
+  "after_root": "fixtures/corpus/after",
+  "profile": {
+    "path": "profiles/adt_a01.yaml",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "version": "2.5.1",
+    "message_structure": "ADT_A01"
+  },
+  "file_count": {"before": 2, "after": 3, "delta": 1},
+  "message_count": {"before": 2, "after": 3, "delta": 1},
+  "parse_error_count": {"before": 0, "after": 1, "delta": 1},
+  "new_message_types": ["ORM^O01"],
+  "removed_message_types": [],
+  "new_segments": ["ORC"],
+  "removed_segments": [],
+  "message_type_counts": [
+    {"value": "ADT^A01", "before": 1, "after": 1, "delta": 0},
+    {"value": "ORM^O01", "before": 0, "after": 1, "delta": 1}
+  ],
+  "segment_counts": [
+    {"value": "PID", "before": 2, "after": 3, "delta": 1}
+  ],
+  "field_presence": [
+    {
+      "path": "PID.3",
+      "before_message_count": 2,
+      "after_message_count": 3,
+      "message_count_delta": 1,
+      "before_occurrence_count": 2,
+      "after_occurrence_count": 3,
+      "occurrence_count_delta": 1
+    }
+  ],
+  "field_cardinality": [
+    {
+      "path": "PID.3",
+      "before_min_per_message": 1,
+      "after_min_per_message": 1,
+      "min_per_message_delta": 0,
+      "before_max_per_message": 1,
+      "after_max_per_message": 2,
+      "max_per_message_delta": 1,
+      "before_total_occurrences": 2,
+      "after_total_occurrences": 4,
+      "total_occurrences_delta": 2,
+      "before_message_count": 2,
+      "after_message_count": 3,
+      "message_count_delta": 1
+    }
+  ],
+  "value_shape_stats": [
+    {
+      "path": "OBX.5",
+      "coded_count": {"before": 0, "after": 1, "delta": 1},
+      "timestamp_count": {"before": 0, "after": 0, "delta": 0},
+      "numeric_count": {"before": 1, "after": 2, "delta": 1},
+      "null_count": {"before": 0, "after": 0, "delta": 0},
+      "text_count": {"before": 0, "after": 1, "delta": 1}
+    }
+  ],
+  "validation_issue_code_counts": [
+    {"value": "required_field_missing", "before": 0, "after": 1, "delta": 1}
+  ]
+}

--- a/fixtures/evidence/corpus-fingerprint.json
+++ b/fixtures/evidence/corpus-fingerprint.json
@@ -1,0 +1,49 @@
+{
+  "fingerprint_version": "1",
+  "tool_version": "1.2.1",
+  "root": "fixtures/corpus/site-a",
+  "profile": {
+    "path": "profiles/adt_a01.yaml",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "version": "2.5.1",
+    "message_structure": "ADT_A01"
+  },
+  "file_count": 2,
+  "message_count": 2,
+  "parse_error_count": 0,
+  "message_type_counts": [
+    {"value": "ADT^A01", "count": 1},
+    {"value": "ORU^R01", "count": 1}
+  ],
+  "segment_counts": [
+    {"value": "MSH", "count": 2},
+    {"value": "PID", "count": 2},
+    {"value": "OBX", "count": 1}
+  ],
+  "field_presence": [
+    {"path": "PID.3", "message_count": 2, "occurrence_count": 2},
+    {"path": "OBX.3", "message_count": 1, "occurrence_count": 1}
+  ],
+  "field_cardinality": [
+    {
+      "path": "PID.3",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 2,
+      "message_count": 2
+    }
+  ],
+  "value_shape_stats": [
+    {
+      "path": "OBX.5",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 1,
+      "null_count": 0,
+      "text_count": 0
+    }
+  ],
+  "validation_issue_code_counts": [
+    {"value": "required_field_missing", "count": 1}
+  ]
+}

--- a/fixtures/evidence/corpus-summary.json
+++ b/fixtures/evidence/corpus-summary.json
@@ -1,0 +1,21 @@
+{
+  "root": "fixtures/corpus/site-a",
+  "file_count": 2,
+  "message_count": 2,
+  "parse_error_count": 0,
+  "total_bytes": 512,
+  "message_types": [
+    {"value": "ADT^A01", "count": 1},
+    {"value": "ORU^R01", "count": 1}
+  ],
+  "segments": [
+    {"value": "MSH", "count": 2},
+    {"value": "PID", "count": 2},
+    {"value": "OBX", "count": 1}
+  ],
+  "field_presence": [
+    {"path": "PID.3", "message_count": 2, "occurrence_count": 2},
+    {"path": "OBX.3", "message_count": 1, "occurrence_count": 1}
+  ],
+  "parse_errors": []
+}

--- a/fixtures/evidence/evidence-bundle.json
+++ b/fixtures/evidence/evidence-bundle.json
@@ -1,0 +1,18 @@
+{
+  "bundle_version": "1",
+  "output_dir": "issue-bundle",
+  "message_type": "ADT^A01",
+  "validation_valid": false,
+  "validation_issue_count": 1,
+  "redaction_phi_removed": true,
+  "artifacts": [
+    "message.redacted.hl7",
+    "validation-report.json",
+    "field-paths.json",
+    "profile.yaml",
+    "redaction-receipt.json",
+    "environment.json",
+    "replay.sh",
+    "replay.ps1"
+  ]
+}

--- a/fixtures/evidence/evidence-replay.json
+++ b/fixtures/evidence/evidence-replay.json
@@ -1,0 +1,40 @@
+{
+  "replay_version": "1",
+  "bundle_version": "1",
+  "tool_name": "hl7v2",
+  "tool_version": "1.2.1",
+  "message_type": "ADT^A01",
+  "reproduced": true,
+  "validation_valid": false,
+  "validation_issue_count": 1,
+  "checks": [
+    {
+      "name": "required_artifacts",
+      "status": "pass",
+      "message": "All required bundle artifacts are present."
+    },
+    {
+      "name": "validation_report",
+      "status": "pass",
+      "message": "Regenerated validation report matches the bundle report."
+    }
+  ],
+  "validation_report": {
+    "valid": false,
+    "message_type": "ADT^A01",
+    "profile": "profiles/adt_a01.yaml",
+    "segment_count": 3,
+    "issue_count": 1,
+    "issues": [
+      {
+        "code": "required_field_missing",
+        "severity": "error",
+        "path": "PID.3",
+        "rule_id": "patient_identifier_required",
+        "message": "PID.3 is required by profile ADT_A01.",
+        "segment_index": 1,
+        "field_index": 3
+      }
+    ]
+  }
+}

--- a/fixtures/evidence/profile-explain-report.json
+++ b/fixtures/evidence/profile-explain-report.json
@@ -1,0 +1,109 @@
+{
+  "profile": "profiles/adt_a01.yaml",
+  "profile_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "message_structure": "ADT_A01",
+  "version": "2.5.1",
+  "message_type": "ADT^A01",
+  "parent": null,
+  "summary": {
+    "segment_count": 3,
+    "required_field_count": 2,
+    "field_constraint_count": 2,
+    "length_rule_count": 1,
+    "datatype_rule_count": 1,
+    "advanced_datatype_rule_count": 1,
+    "value_set_count": 1,
+    "cross_field_rule_count": 1,
+    "temporal_rule_count": 0,
+    "contextual_rule_count": 0,
+    "custom_rule_count": 0,
+    "hl7_table_count": 1
+  },
+  "segments": [
+    {"id": "MSH"},
+    {"id": "PID"},
+    {"id": "PV1"}
+  ],
+  "required_fields": [
+    {"path": "PID.3", "conditional": false},
+    {"path": "PID.5", "conditional": false}
+  ],
+  "field_constraints": [
+    {
+      "path": "PID.3",
+      "required": true,
+      "conditional": false,
+      "component_min": 1,
+      "component_max": null,
+      "allowed_value_count": 0,
+      "allowed_values": [],
+      "pattern": null
+    },
+    {
+      "path": "PID.8",
+      "required": false,
+      "conditional": false,
+      "component_min": null,
+      "component_max": null,
+      "allowed_value_count": 2,
+      "allowed_values": ["F", "M"],
+      "pattern": null
+    }
+  ],
+  "length_rules": [
+    {"path": "PID.3", "max": 32, "policy": "warn"}
+  ],
+  "datatype_rules": [
+    {
+      "path": "PID.7",
+      "datatype": "DTM",
+      "kind": "advanced",
+      "pattern": null,
+      "min_length": 8,
+      "max_length": 26,
+      "format": "hl7_ts",
+      "checksum": null
+    }
+  ],
+  "value_sets": [
+    {
+      "name": "Administrative Sex",
+      "path": "PID.8",
+      "source": "inline",
+      "inline_code_count": 2,
+      "table_code_count": 0
+    }
+  ],
+  "rules": {
+    "cross_field": [
+      {
+        "id": "patient_identifier_required",
+        "description": "PID.3 is required for admitted patients."
+      }
+    ],
+    "temporal": [],
+    "contextual": [],
+    "custom": []
+  },
+  "hl7_tables": [
+    {
+      "id": "0001",
+      "name": "Administrative Sex",
+      "version": "2.5.1",
+      "code_count": 2
+    }
+  ],
+  "table_precedence": ["inline", "profile", "hl7_table"],
+  "expression_guardrails": {
+    "max_depth": 8,
+    "max_length": 256,
+    "allow_custom_scripts": false
+  },
+  "lint": {
+    "valid": true,
+    "error_count": 0,
+    "warning_count": 0,
+    "issue_count": 0,
+    "ignored_or_unsupported": []
+  }
+}

--- a/fixtures/evidence/profile-lint-report.json
+++ b/fixtures/evidence/profile-lint-report.json
@@ -1,0 +1,20 @@
+{
+  "valid": false,
+  "error_count": 1,
+  "warning_count": 1,
+  "issue_count": 2,
+  "issues": [
+    {
+      "code": "invalid_path",
+      "severity": "error",
+      "path": "constraints[0].path",
+      "message": "Constraint path PID.X is not a valid HL7 field path."
+    },
+    {
+      "code": "unknown_table_reference",
+      "severity": "warning",
+      "path": "constraints[1].table",
+      "message": "Table 9999 is not present in the loaded profile tables."
+    }
+  ]
+}

--- a/fixtures/evidence/profile-test-report.json
+++ b/fixtures/evidence/profile-test-report.json
@@ -1,0 +1,55 @@
+{
+  "profile": "profiles/adt_a01.yaml",
+  "fixtures": "fixtures/profile/adt_a01",
+  "valid": false,
+  "case_count": 2,
+  "passed_count": 1,
+  "failed_count": 1,
+  "cases": [
+    {
+      "name": "valid/minimal.hl7",
+      "path": "fixtures/profile/adt_a01/valid/minimal.hl7",
+      "expectation": "valid",
+      "passed": true,
+      "message": "Fixture passed as expected.",
+      "validation_report": {
+        "valid": true,
+        "message_type": "ADT^A01",
+        "profile": "profiles/adt_a01.yaml",
+        "segment_count": 3,
+        "issue_count": 0,
+        "issues": []
+      }
+    },
+    {
+      "name": "invalid/missing_pid3.hl7",
+      "path": "fixtures/profile/adt_a01/invalid/missing_pid3.hl7",
+      "expectation": "invalid",
+      "passed": false,
+      "message": "Expected report did not match actual validation issues.",
+      "validation_report": {
+        "valid": false,
+        "message_type": "ADT^A01",
+        "profile": "profiles/adt_a01.yaml",
+        "segment_count": 3,
+        "issue_count": 1,
+        "issues": [
+          {
+            "code": "required_field_missing",
+            "severity": "error",
+            "path": "PID.3",
+            "rule_id": "patient_identifier_required",
+            "message": "PID.3 is required by profile ADT_A01.",
+            "segment_index": 1,
+            "field_index": 3
+          }
+        ]
+      },
+      "expected_report": {
+        "path": "fixtures/profile/adt_a01/expected/missing_pid3.report.json",
+        "matched": false,
+        "message": "Expected report was missing required_field_missing at PID.3."
+      }
+    }
+  ]
+}

--- a/fixtures/evidence/redaction-receipt.json
+++ b/fixtures/evidence/redaction-receipt.json
@@ -1,0 +1,30 @@
+{
+  "phi_removed": true,
+  "hash_algorithm": "sha256",
+  "actions": [
+    {
+      "path": "PID.3",
+      "action": "hash",
+      "reason": "Patient identifier is direct PHI.",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "PID.5",
+      "action": "drop",
+      "reason": "Patient name is direct PHI.",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "OBX.3",
+      "action": "retain",
+      "reason": "Observation identifier is needed for support analysis.",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    }
+  ]
+}

--- a/fixtures/evidence/validation-report.json
+++ b/fixtures/evidence/validation-report.json
@@ -1,0 +1,18 @@
+{
+  "valid": false,
+  "message_type": "ADT^A01",
+  "profile": "profiles/adt_a01.yaml",
+  "segment_count": 3,
+  "issue_count": 1,
+  "issues": [
+    {
+      "code": "required_field_missing",
+      "severity": "error",
+      "path": "PID.3",
+      "rule_id": "patient_identifier_required",
+      "message": "PID.3 is required by profile ADT_A01.",
+      "segment_index": 1,
+      "field_index": 3
+    }
+  ]
+}

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -253,6 +253,15 @@ classification = "test"
 reason = "Repository-wide HL7, MLLP, and template fixtures used by CLI and integration tests."
 covered_by = ["cargo test --workspace --all-features"]
 
+[[allow]]
+glob = "fixtures/evidence/**"
+kind = "fixture_input"
+owner = "api"
+surface = "tests"
+classification = "test"
+reason = "Representative evidence artifact fixtures validated against public JSON schemas."
+covered_by = [".github/workflows/contracts.yml"]
+
 # ---------------------------------------------------------------------------
 # Profiles (HL7 message profile YAML)
 # ---------------------------------------------------------------------------

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -45,6 +45,13 @@ CLI and server configuration (hl7v2.toml):
 - CLI defaults
 - Logging defaults
 
+### Evidence (`evidence/*-v1.schema.json`)
+Machine-readable evidence artifacts emitted by the CLI, library, server, and
+Python lanes:
+- Validation reports and profile lint/test/explain reports
+- Corpus summary, fingerprint, and diff reports
+- Redaction receipts and evidence bundle/replay summaries
+
 ## Usage
 
 ### Validate YAML Against Schema
@@ -70,6 +77,12 @@ Path("target/contracts/config").mkdir(parents=True, exist_ok=True)
 Path("target/contracts/config/config.example.json").write_text(json.dumps(data), encoding="utf-8")
 PY
 ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d target/contracts/config/config.example.json --spec=draft7
+
+# Validate a representative evidence artifact fixture
+ajv validate -c ajv-formats \
+  -s schemas/evidence/validation-report-v1.schema.json \
+  -d fixtures/evidence/validation-report.json \
+  --spec=draft7
 ```
 
 ### In Rust Code
@@ -98,7 +111,7 @@ fn main() {
 ### CI Integration
 
 The API Contracts workflow validates profiles, converted config fixtures, and
-schema syntax:
+evidence fixtures, then compiles every schema:
 
 ```yaml
 # .github/workflows/contracts.yml
@@ -116,6 +129,11 @@ schema syntax:
     Path("target/contracts/config/config.example.json").write_text(json.dumps(data), encoding="utf-8")
     PY
     ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d 'target/contracts/config/*.json' --spec=draft7
+    for schema in schemas/evidence/*-v1.schema.json; do
+      name="$(basename "$schema")"
+      name="${name%-v1.schema.json}"
+      ajv validate -c ajv-formats -s "$schema" -d "fixtures/evidence/${name}.json" --spec=draft7
+    done
 ```
 
 ## Schema Versioning

--- a/schemas/evidence/corpus-diff-v1.schema.json
+++ b/schemas/evidence/corpus-diff-v1.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/corpus-diff/v1",
+  "title": "HL7v2 Corpus Diff Report",
+  "description": "Difference report for two HL7 v2 corpora.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "diff_version",
+    "tool_version",
+    "before_root",
+    "after_root",
+    "profile",
+    "file_count",
+    "message_count",
+    "parse_error_count",
+    "new_message_types",
+    "removed_message_types",
+    "new_segments",
+    "removed_segments",
+    "message_type_counts",
+    "segment_counts",
+    "field_presence",
+    "field_cardinality",
+    "value_shape_stats",
+    "validation_issue_code_counts"
+  ],
+  "properties": {
+    "diff_version": {"type": "string"},
+    "tool_version": {"type": "string"},
+    "before_root": {"type": "string"},
+    "after_root": {"type": "string"},
+    "profile": {"anyOf": [{"$ref": "#/definitions/profile"}, {"type": "null"}]},
+    "file_count": {"$ref": "#/definitions/total_diff"},
+    "message_count": {"$ref": "#/definitions/total_diff"},
+    "parse_error_count": {"$ref": "#/definitions/total_diff"},
+    "new_message_types": {"type": "array", "items": {"type": "string"}},
+    "removed_message_types": {"type": "array", "items": {"type": "string"}},
+    "new_segments": {"type": "array", "items": {"type": "string"}},
+    "removed_segments": {"type": "array", "items": {"type": "string"}},
+    "message_type_counts": {"type": "array", "items": {"$ref": "#/definitions/count_diff"}},
+    "segment_counts": {"type": "array", "items": {"$ref": "#/definitions/count_diff"}},
+    "field_presence": {"type": "array", "items": {"$ref": "#/definitions/field_presence_diff"}},
+    "field_cardinality": {"type": "array", "items": {"$ref": "#/definitions/field_cardinality_diff"}},
+    "value_shape_stats": {"type": "array", "items": {"$ref": "#/definitions/value_shape_stats_diff"}},
+    "validation_issue_code_counts": {"type": "array", "items": {"$ref": "#/definitions/count_diff"}}
+  },
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "version", "message_structure"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "version": {"type": "string"},
+        "message_structure": {"type": "string"}
+      }
+    },
+    "total_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before", "after", "delta"],
+      "properties": {
+        "before": {"type": "integer", "minimum": 0},
+        "after": {"type": "integer", "minimum": 0},
+        "delta": {"type": "integer"}
+      }
+    },
+    "count_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "before", "after", "delta"],
+      "properties": {
+        "value": {"type": "string"},
+        "before": {"type": "integer", "minimum": 0},
+        "after": {"type": "integer", "minimum": 0},
+        "delta": {"type": "integer"}
+      }
+    },
+    "field_presence_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "before_message_count",
+        "after_message_count",
+        "message_count_delta",
+        "before_occurrence_count",
+        "after_occurrence_count",
+        "occurrence_count_delta"
+      ],
+      "properties": {
+        "path": {"type": "string"},
+        "before_message_count": {"type": "integer", "minimum": 0},
+        "after_message_count": {"type": "integer", "minimum": 0},
+        "message_count_delta": {"type": "integer"},
+        "before_occurrence_count": {"type": "integer", "minimum": 0},
+        "after_occurrence_count": {"type": "integer", "minimum": 0},
+        "occurrence_count_delta": {"type": "integer"}
+      }
+    },
+    "field_cardinality_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "before_min_per_message",
+        "after_min_per_message",
+        "min_per_message_delta",
+        "before_max_per_message",
+        "after_max_per_message",
+        "max_per_message_delta",
+        "before_total_occurrences",
+        "after_total_occurrences",
+        "total_occurrences_delta",
+        "before_message_count",
+        "after_message_count",
+        "message_count_delta"
+      ],
+      "properties": {
+        "path": {"type": "string"},
+        "before_min_per_message": {"type": "integer", "minimum": 0},
+        "after_min_per_message": {"type": "integer", "minimum": 0},
+        "min_per_message_delta": {"type": "integer"},
+        "before_max_per_message": {"type": "integer", "minimum": 0},
+        "after_max_per_message": {"type": "integer", "minimum": 0},
+        "max_per_message_delta": {"type": "integer"},
+        "before_total_occurrences": {"type": "integer", "minimum": 0},
+        "after_total_occurrences": {"type": "integer", "minimum": 0},
+        "total_occurrences_delta": {"type": "integer"},
+        "before_message_count": {"type": "integer", "minimum": 0},
+        "after_message_count": {"type": "integer", "minimum": 0},
+        "message_count_delta": {"type": "integer"}
+      }
+    },
+    "value_shape_stats_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "coded_count", "timestamp_count", "numeric_count", "null_count", "text_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "coded_count": {"$ref": "#/definitions/total_diff"},
+        "timestamp_count": {"$ref": "#/definitions/total_diff"},
+        "numeric_count": {"$ref": "#/definitions/total_diff"},
+        "null_count": {"$ref": "#/definitions/total_diff"},
+        "text_count": {"$ref": "#/definitions/total_diff"}
+      }
+    }
+  }
+}

--- a/schemas/evidence/corpus-fingerprint-v1.schema.json
+++ b/schemas/evidence/corpus-fingerprint-v1.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/corpus-fingerprint/v1",
+  "title": "HL7v2 Corpus Fingerprint",
+  "description": "Deterministic compact signature for a file or directory corpus.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "fingerprint_version",
+    "tool_version",
+    "root",
+    "profile",
+    "file_count",
+    "message_count",
+    "parse_error_count",
+    "message_type_counts",
+    "segment_counts",
+    "field_presence",
+    "field_cardinality",
+    "value_shape_stats",
+    "validation_issue_code_counts"
+  ],
+  "properties": {
+    "fingerprint_version": {"type": "string"},
+    "tool_version": {"type": "string"},
+    "root": {"type": "string"},
+    "profile": {"anyOf": [{"$ref": "#/definitions/profile"}, {"type": "null"}]},
+    "file_count": {"type": "integer", "minimum": 0},
+    "message_count": {"type": "integer", "minimum": 0},
+    "parse_error_count": {"type": "integer", "minimum": 0},
+    "message_type_counts": {"type": "array", "items": {"$ref": "#/definitions/count"}},
+    "segment_counts": {"type": "array", "items": {"$ref": "#/definitions/count"}},
+    "field_presence": {"type": "array", "items": {"$ref": "#/definitions/field_presence"}},
+    "field_cardinality": {"type": "array", "items": {"$ref": "#/definitions/field_cardinality"}},
+    "value_shape_stats": {"type": "array", "items": {"$ref": "#/definitions/value_shape_stats"}},
+    "validation_issue_code_counts": {"type": "array", "items": {"$ref": "#/definitions/count"}}
+  },
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "version", "message_structure"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "version": {"type": "string"},
+        "message_structure": {"type": "string"}
+      }
+    },
+    "count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "count"],
+      "properties": {
+        "value": {"type": "string"},
+        "count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "message_count", "occurrence_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "message_count": {"type": "integer", "minimum": 0},
+        "occurrence_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "field_cardinality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "min_per_message", "max_per_message", "total_occurrences", "message_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "min_per_message": {"type": "integer", "minimum": 0},
+        "max_per_message": {"type": "integer", "minimum": 0},
+        "total_occurrences": {"type": "integer", "minimum": 0},
+        "message_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "value_shape_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "coded_count", "timestamp_count", "numeric_count", "null_count", "text_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "coded_count": {"type": "integer", "minimum": 0},
+        "timestamp_count": {"type": "integer", "minimum": 0},
+        "numeric_count": {"type": "integer", "minimum": 0},
+        "null_count": {"type": "integer", "minimum": 0},
+        "text_count": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/schemas/evidence/corpus-summary-v1.schema.json
+++ b/schemas/evidence/corpus-summary-v1.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/corpus-summary/v1",
+  "title": "HL7v2 Corpus Summary",
+  "description": "Summary of a directory or file corpus of HL7 v2 messages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["root", "file_count", "message_count", "parse_error_count", "total_bytes", "message_types", "segments", "field_presence", "parse_errors"],
+  "properties": {
+    "root": {"type": "string"},
+    "file_count": {"type": "integer", "minimum": 0},
+    "message_count": {"type": "integer", "minimum": 0},
+    "parse_error_count": {"type": "integer", "minimum": 0},
+    "total_bytes": {"type": "integer", "minimum": 0},
+    "message_types": {"type": "array", "items": {"$ref": "#/definitions/count"}},
+    "segments": {"type": "array", "items": {"$ref": "#/definitions/count"}},
+    "field_presence": {"type": "array", "items": {"$ref": "#/definitions/field_presence"}},
+    "parse_errors": {"type": "array", "items": {"$ref": "#/definitions/parse_failure"}}
+  },
+  "definitions": {
+    "count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "count"],
+      "properties": {
+        "value": {"type": "string"},
+        "count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "message_count", "occurrence_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "message_count": {"type": "integer", "minimum": 0},
+        "occurrence_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "parse_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "error"],
+      "properties": {
+        "path": {"type": "string"},
+        "error": {"type": "string"}
+      }
+    }
+  }
+}

--- a/schemas/evidence/evidence-bundle-v1.schema.json
+++ b/schemas/evidence/evidence-bundle-v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/evidence-bundle/v1",
+  "title": "HL7v2 Evidence Bundle Summary",
+  "description": "Current machine-readable stdout summary emitted after creating an evidence bundle.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bundle_version",
+    "output_dir",
+    "message_type",
+    "validation_valid",
+    "validation_issue_count",
+    "redaction_phi_removed",
+    "artifacts"
+  ],
+  "properties": {
+    "bundle_version": {
+      "type": "string"
+    },
+    "output_dir": {
+      "type": "string",
+      "description": "Bundle output directory reported by the command."
+    },
+    "message_type": {
+      "type": "string"
+    },
+    "validation_valid": {
+      "type": "boolean"
+    },
+    "validation_issue_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "redaction_phi_removed": {
+      "type": "boolean"
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/evidence/evidence-replay-v1.schema.json
+++ b/schemas/evidence/evidence-replay-v1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/evidence-replay/v1",
+  "title": "HL7v2 Evidence Replay Report",
+  "description": "Machine-readable report emitted when replaying an evidence bundle.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "replay_version",
+    "bundle_version",
+    "tool_name",
+    "tool_version",
+    "message_type",
+    "reproduced",
+    "validation_valid",
+    "validation_issue_count",
+    "checks"
+  ],
+  "properties": {
+    "replay_version": {
+      "type": "string"
+    },
+    "bundle_version": {
+      "type": ["string", "null"]
+    },
+    "tool_name": {
+      "type": "string"
+    },
+    "tool_version": {
+      "type": "string"
+    },
+    "message_type": {
+      "type": ["string", "null"]
+    },
+    "reproduced": {
+      "type": "boolean"
+    },
+    "validation_valid": {
+      "type": ["boolean", "null"]
+    },
+    "validation_issue_count": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/replay_check"
+      }
+    },
+    "validation_report": {
+      "$ref": "#/definitions/validation_report"
+    }
+  },
+  "definitions": {
+    "replay_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "message"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pass", "fail"]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "validation_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid", "message_type", "segment_count", "issue_count", "issues"],
+      "properties": {
+        "valid": {"type": "boolean"},
+        "message_type": {"type": "string"},
+        "profile": {"type": "string"},
+        "segment_count": {"type": "integer", "minimum": 0},
+        "issue_count": {"type": "integer", "minimum": 0},
+        "issues": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/validation_issue"}
+        }
+      }
+    },
+    "validation_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message"],
+      "properties": {
+        "code": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+        "severity": {"type": "string", "enum": ["error", "warning"]},
+        "path": {"type": "string"},
+        "rule_id": {"type": "string"},
+        "message": {"type": "string"},
+        "segment_index": {"type": "integer", "minimum": 0},
+        "field_index": {"type": "integer", "minimum": 1}
+      }
+    }
+  }
+}

--- a/schemas/evidence/profile-explain-report-v1.schema.json
+++ b/schemas/evidence/profile-explain-report-v1.schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/profile-explain-report/v1",
+  "title": "HL7v2 Profile Explain Report",
+  "description": "Machine-readable profile explanation report.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "profile",
+    "profile_sha256",
+    "message_structure",
+    "version",
+    "message_type",
+    "parent",
+    "summary",
+    "segments",
+    "required_fields",
+    "field_constraints",
+    "length_rules",
+    "datatype_rules",
+    "value_sets",
+    "rules",
+    "hl7_tables",
+    "table_precedence",
+    "expression_guardrails",
+    "lint"
+  ],
+  "properties": {
+    "profile": {"type": "string"},
+    "profile_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "message_structure": {"type": "string"},
+    "version": {"type": "string"},
+    "message_type": {"type": ["string", "null"]},
+    "parent": {"type": ["string", "null"]},
+    "summary": {"$ref": "#/definitions/summary"},
+    "segments": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/segment"}
+    },
+    "required_fields": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/required_field"}
+    },
+    "field_constraints": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/field_constraint"}
+    },
+    "length_rules": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/length_rule"}
+    },
+    "datatype_rules": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/datatype_rule"}
+    },
+    "value_sets": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/value_set"}
+    },
+    "rules": {"$ref": "#/definitions/rules"},
+    "hl7_tables": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/hl7_table"}
+    },
+    "table_precedence": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "expression_guardrails": {"$ref": "#/definitions/expression_guardrails"},
+    "lint": {"$ref": "#/definitions/lint_summary"}
+  },
+  "definitions": {
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "segment_count",
+        "required_field_count",
+        "field_constraint_count",
+        "length_rule_count",
+        "datatype_rule_count",
+        "advanced_datatype_rule_count",
+        "value_set_count",
+        "cross_field_rule_count",
+        "temporal_rule_count",
+        "contextual_rule_count",
+        "custom_rule_count",
+        "hl7_table_count"
+      ],
+      "properties": {
+        "segment_count": {"type": "integer", "minimum": 0},
+        "required_field_count": {"type": "integer", "minimum": 0},
+        "field_constraint_count": {"type": "integer", "minimum": 0},
+        "length_rule_count": {"type": "integer", "minimum": 0},
+        "datatype_rule_count": {"type": "integer", "minimum": 0},
+        "advanced_datatype_rule_count": {"type": "integer", "minimum": 0},
+        "value_set_count": {"type": "integer", "minimum": 0},
+        "cross_field_rule_count": {"type": "integer", "minimum": 0},
+        "temporal_rule_count": {"type": "integer", "minimum": 0},
+        "contextual_rule_count": {"type": "integer", "minimum": 0},
+        "custom_rule_count": {"type": "integer", "minimum": 0},
+        "hl7_table_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {"id": {"type": "string"}}
+    },
+    "required_field": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "conditional"],
+      "properties": {
+        "path": {"type": "string"},
+        "conditional": {"type": "boolean"}
+      }
+    },
+    "field_constraint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "required",
+        "conditional",
+        "component_min",
+        "component_max",
+        "allowed_value_count",
+        "allowed_values",
+        "pattern"
+      ],
+      "properties": {
+        "path": {"type": "string"},
+        "required": {"type": "boolean"},
+        "conditional": {"type": "boolean"},
+        "component_min": {"type": ["integer", "null"], "minimum": 0},
+        "component_max": {"type": ["integer", "null"], "minimum": 0},
+        "allowed_value_count": {"type": "integer", "minimum": 0},
+        "allowed_values": {"type": "array", "items": {"type": "string"}},
+        "pattern": {"type": ["string", "null"]}
+      }
+    },
+    "length_rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "max", "policy"],
+      "properties": {
+        "path": {"type": "string"},
+        "max": {"type": ["integer", "null"], "minimum": 0},
+        "policy": {"type": ["string", "null"]}
+      }
+    },
+    "datatype_rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "datatype", "kind", "pattern", "min_length", "max_length", "format", "checksum"],
+      "properties": {
+        "path": {"type": "string"},
+        "datatype": {"type": "string"},
+        "kind": {"type": "string", "enum": ["simple", "advanced"]},
+        "pattern": {"type": ["string", "null"]},
+        "min_length": {"type": ["integer", "null"], "minimum": 0},
+        "max_length": {"type": ["integer", "null"], "minimum": 0},
+        "format": {"type": ["string", "null"]},
+        "checksum": {"type": ["string", "null"]}
+      }
+    },
+    "value_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path", "source", "inline_code_count", "table_code_count"],
+      "properties": {
+        "name": {"type": "string"},
+        "path": {"type": "string"},
+        "source": {"type": "string", "enum": ["inline", "hl7_table", "empty"]},
+        "inline_code_count": {"type": "integer", "minimum": 0},
+        "table_code_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cross_field", "temporal", "contextual", "custom"],
+      "properties": {
+        "cross_field": {"type": "array", "items": {"$ref": "#/definitions/rule"}},
+        "temporal": {"type": "array", "items": {"$ref": "#/definitions/rule"}},
+        "contextual": {"type": "array", "items": {"$ref": "#/definitions/rule"}},
+        "custom": {"type": "array", "items": {"$ref": "#/definitions/rule"}}
+      }
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description"],
+      "properties": {
+        "id": {"type": "string"},
+        "description": {"type": "string"}
+      }
+    },
+    "hl7_table": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "version", "code_count"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "version": {"type": "string"},
+        "code_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "expression_guardrails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_depth", "max_length", "allow_custom_scripts"],
+      "properties": {
+        "max_depth": {"type": ["integer", "null"], "minimum": 0},
+        "max_length": {"type": ["integer", "null"], "minimum": 0},
+        "allow_custom_scripts": {"type": "boolean"}
+      }
+    },
+    "lint_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid", "error_count", "warning_count", "issue_count", "ignored_or_unsupported"],
+      "properties": {
+        "valid": {"type": "boolean"},
+        "error_count": {"type": "integer", "minimum": 0},
+        "warning_count": {"type": "integer", "minimum": 0},
+        "issue_count": {"type": "integer", "minimum": 0},
+        "ignored_or_unsupported": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/profile_lint_issue"}
+        }
+      }
+    },
+    "profile_lint_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message"],
+      "properties": {
+        "code": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+        "severity": {"type": "string", "enum": ["error", "warning"]},
+        "path": {"type": "string"},
+        "message": {"type": "string"}
+      }
+    }
+  }
+}

--- a/schemas/evidence/profile-lint-report-v1.schema.json
+++ b/schemas/evidence/profile-lint-report-v1.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/profile-lint-report/v1",
+  "title": "HL7v2 Profile Lint Report",
+  "description": "Machine-readable profile lint report.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["valid", "error_count", "warning_count", "issue_count", "issues"],
+  "properties": {
+    "valid": {
+      "type": "boolean"
+    },
+    "error_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "warning_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "issue_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/profile_lint_issue"
+      }
+    }
+  },
+  "definitions": {
+    "profile_lint_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning"]
+        },
+        "path": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/evidence/profile-test-report-v1.schema.json
+++ b/schemas/evidence/profile-test-report-v1.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/profile-test-report/v1",
+  "title": "HL7v2 Profile Test Report",
+  "description": "Machine-readable report for profile fixture tests.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "fixtures", "valid", "case_count", "passed_count", "failed_count", "cases"],
+  "properties": {
+    "profile": {
+      "type": "string"
+    },
+    "fixtures": {
+      "type": "string"
+    },
+    "valid": {
+      "type": "boolean"
+    },
+    "case_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "passed_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/profile_test_case"
+      }
+    }
+  },
+  "definitions": {
+    "profile_test_case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path", "expectation", "passed", "message"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "expectation": {
+          "type": "string",
+          "enum": ["valid", "invalid"]
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "validation_report": {
+          "$ref": "#/definitions/validation_report"
+        },
+        "expected_report": {
+          "$ref": "#/definitions/expected_report_comparison"
+        }
+      }
+    },
+    "expected_report_comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "matched"],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "matched": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "validation_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid", "message_type", "segment_count", "issue_count", "issues"],
+      "properties": {
+        "valid": {"type": "boolean"},
+        "message_type": {"type": "string"},
+        "profile": {"type": "string"},
+        "segment_count": {"type": "integer", "minimum": 0},
+        "issue_count": {"type": "integer", "minimum": 0},
+        "issues": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/validation_issue"}
+        }
+      }
+    },
+    "validation_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message"],
+      "properties": {
+        "code": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+        "severity": {"type": "string", "enum": ["error", "warning"]},
+        "path": {"type": "string"},
+        "rule_id": {"type": "string"},
+        "message": {"type": "string"},
+        "segment_index": {"type": "integer", "minimum": 0},
+        "field_index": {"type": "integer", "minimum": 1}
+      }
+    }
+  }
+}

--- a/schemas/evidence/redaction-receipt-v1.schema.json
+++ b/schemas/evidence/redaction-receipt-v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/redaction-receipt/v1",
+  "title": "HL7v2 Redaction Receipt",
+  "description": "Machine-readable receipt describing safe-analysis redaction actions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["phi_removed", "hash_algorithm", "actions"],
+  "properties": {
+    "phi_removed": {
+      "type": "boolean",
+      "description": "Whether any configured PHI-bearing path was removed or hashed."
+    },
+    "hash_algorithm": {
+      "type": "string",
+      "enum": ["sha256"],
+      "description": "Hash algorithm used by hash redaction actions."
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redaction_action"
+      }
+    }
+  },
+  "definitions": {
+    "redaction_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "action", "reason", "matched_count", "optional", "status"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "HL7 path covered by this policy action."
+        },
+        "action": {
+          "type": "string",
+          "enum": ["hash", "drop", "retain"]
+        },
+        "reason": {
+          "type": "string",
+          "description": "Policy reason for the action."
+        },
+        "matched_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of matching values affected by the action."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether missing matches are acceptable for this policy rule."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["applied", "retained", "not_found"]
+        }
+      }
+    }
+  }
+}

--- a/schemas/evidence/validation-report-v1.schema.json
+++ b/schemas/evidence/validation-report-v1.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/validation-report/v1",
+  "title": "HL7v2 Validation Report",
+  "description": "Machine-readable validation report shared by CLI, Rust, server, and Python surfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["valid", "message_type", "segment_count", "issue_count", "issues"],
+  "properties": {
+    "valid": {
+      "type": "boolean",
+      "description": "Whether the message passed validation without error-level issues."
+    },
+    "message_type": {
+      "type": "string",
+      "description": "HL7 trigger event from MSH.9, such as ADT^A01."
+    },
+    "profile": {
+      "type": "string",
+      "description": "Profile identifier, usually a path or loaded message structure."
+    },
+    "segment_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of parsed message segments."
+    },
+    "issue_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of validation issues in this report."
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/validation_issue"
+      }
+    }
+  },
+  "definitions": {
+    "validation_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Stable snake_case issue code."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning"]
+        },
+        "path": {
+          "type": "string",
+          "description": "HL7 path associated with the issue, such as PID.3."
+        },
+        "rule_id": {
+          "type": "string",
+          "description": "Stable validation rule identifier."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable issue message."
+        },
+        "segment_index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based segment index when known."
+        },
+        "field_index": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "One-based HL7 field index when known."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add draft-07 JSON Schemas for current evidence artifacts under `schemas/evidence/`
- add representative PHI-free evidence fixtures under `fixtures/evidence/`
- wire evidence fixture validation into API Contracts and file-policy governance
- update schema/evidence artifact docs to point at the new contract files

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `npx -y @bufbuild/buf lint api/proto`
- `npx -y -p ajv-cli -p ajv-formats ajv validate ...` for every `schemas/evidence/*-v1.schema.json` / `fixtures/evidence/*.json` pair
- `npx -y -p ajv-cli -p ajv-formats ajv compile ...` for every checked-in schema
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

Note: the same changed gate without `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` reaches the known local Python 3.14 / PyO3 3.13 ceiling before the repo checks complete.