### PR TITLE
test: add evidence artifact golden fixtures

### DIFF
--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2194,6 +2194,336 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
 }
 
 // =========================================================================
+// Evidence Golden Fixture Tests
+// =========================================================================
+
+mod evidence_golden_fixtures {
+    use super::*;
+    use serde_json::Value;
+    use std::path::Path;
+
+    const PROFILE: &str = r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"#;
+
+    const LINT_WARNING_PROFILE: &str = r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+rules: []
+"#;
+
+    const MISSING_PID3_MESSAGE: &str = "MSH|^~\\&|||||||ADT^A01|CTRL123|P|2.5\rPID|1\r";
+    const VALID_ADT_MESSAGE: &str =
+        "MSH|^~\\&|||||||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR\r";
+    const CORPUS_ADT_MESSAGE: &str = "MSH|^~\\&|||||||ADT^A01|CTRL123|P|2.5\r";
+    const CORPUS_ORU_MESSAGE: &str = "MSH|^~\\&|||||||ORU^R01|CTRL124|P|2.5\r";
+    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+    const SAFE_ANALYSIS_POLICY: &str = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "date of birth"
+
+[[rules]]
+path = "PID.11"
+action = "drop"
+reason = "patient address"
+
+[[rules]]
+path = "MSH.9"
+action = "retain"
+reason = "message type is needed for analysis"
+
+[[rules]]
+path = "MSH.10"
+action = "retain"
+reason = "control id is needed for replay correlation"
+
+[[rules]]
+path = "OBX.3"
+action = "retain"
+reason = "observation identifier is needed for analysis"
+
+[[rules]]
+path = "OBX.5"
+action = "retain"
+reason = "non-PHI synthetic observation value shape is needed for analysis"
+"#;
+
+    fn fixture(name: &str) -> Value {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("fixtures")
+            .join("evidence")
+            .join(format!("{name}.json"));
+        serde_json::from_slice(&std::fs::read(&path).expect("evidence fixture should be readable"))
+            .expect("evidence fixture should be valid JSON")
+    }
+
+    fn set(value: &mut Value, pointer: &str, replacement: impl Into<Value>) {
+        *value
+            .pointer_mut(pointer)
+            .expect("fixture normalization pointer should exist") = replacement.into();
+    }
+
+    fn command_json(args: &[String], expect_success: bool) -> Value {
+        let mut cmd = cli_command();
+        let output = cmd.args(args).output().expect("CLI command should run");
+        assert_eq!(
+            output.status.success(),
+            expect_success,
+            "stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).expect("CLI stdout should be JSON")
+    }
+
+    fn assert_fixture(name: &str, actual: Value) {
+        assert_eq!(
+            actual,
+            fixture(name),
+            "evidence fixture {name}.json drifted"
+        );
+    }
+
+    #[test]
+    fn test_validation_report_matches_golden_fixture() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "missing_pid3.hl7", MISSING_PID3_MESSAGE);
+        let profile = create_temp_profile(&dir, "profile.yaml", PROFILE);
+        let mut report = command_json(
+            &[
+                "val".to_string(),
+                message.to_string_lossy().into_owned(),
+                "--profile".to_string(),
+                profile.to_string_lossy().into_owned(),
+                "--report".to_string(),
+                "json".to_string(),
+            ],
+            false,
+        );
+        set(&mut report, "/profile", "profile.yaml");
+
+        assert_fixture("validation-report", report);
+    }
+
+    #[test]
+    fn test_profile_reports_match_golden_fixtures() {
+        let dir = create_temp_dir();
+        let profile = create_temp_profile(&dir, "profile.yaml", PROFILE);
+        let lint_profile = create_temp_profile(&dir, "lint.yaml", LINT_WARNING_PROFILE);
+
+        let lint_report = command_json(
+            &[
+                "profile".to_string(),
+                "lint".to_string(),
+                lint_profile.to_string_lossy().into_owned(),
+                "--report".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        assert_fixture("profile-lint-report", lint_report);
+
+        let mut explain_report = command_json(
+            &[
+                "profile".to_string(),
+                "explain".to_string(),
+                profile.to_string_lossy().into_owned(),
+                "--format".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        set(&mut explain_report, "/profile", "profile.yaml");
+        assert_fixture("profile-explain-report", explain_report);
+
+        let fixtures = dir.path().join("fixtures");
+        std::fs::create_dir_all(fixtures.join("valid")).unwrap();
+        std::fs::create_dir_all(fixtures.join("invalid")).unwrap();
+        create_temp_file(
+            &dir,
+            "fixtures/valid/valid.hl7",
+            VALID_ADT_MESSAGE.as_bytes(),
+        );
+        create_temp_hl7_with_content(
+            &dir,
+            "fixtures/invalid/missing_pid3.hl7",
+            MISSING_PID3_MESSAGE,
+        );
+
+        let mut test_report = command_json(
+            &[
+                "profile".to_string(),
+                "test".to_string(),
+                profile.to_string_lossy().into_owned(),
+                fixtures.to_string_lossy().into_owned(),
+                "--report".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        set(&mut test_report, "/profile", "profile.yaml");
+        set(&mut test_report, "/fixtures", "fixtures");
+        set(
+            &mut test_report,
+            "/cases/0/path",
+            "fixtures/valid/valid.hl7",
+        );
+        set(
+            &mut test_report,
+            "/cases/0/validation_report/profile",
+            "profile.yaml",
+        );
+        set(
+            &mut test_report,
+            "/cases/1/path",
+            "fixtures/invalid/missing_pid3.hl7",
+        );
+        set(
+            &mut test_report,
+            "/cases/1/validation_report/profile",
+            "profile.yaml",
+        );
+        assert_fixture("profile-test-report", test_report);
+    }
+
+    #[test]
+    fn test_corpus_reports_match_golden_fixtures() {
+        let dir = create_temp_dir();
+        let site = dir.path().join("site-a");
+        let before = dir.path().join("before");
+        let after = dir.path().join("after");
+        std::fs::create_dir_all(&site).unwrap();
+        std::fs::create_dir_all(&before).unwrap();
+        std::fs::create_dir_all(&after).unwrap();
+        create_temp_file(&dir, "site-a/adt.hl7", CORPUS_ADT_MESSAGE.as_bytes());
+        create_temp_file(&dir, "before/adt.hl7", CORPUS_ADT_MESSAGE.as_bytes());
+        create_temp_file(&dir, "after/oru.hl7", CORPUS_ORU_MESSAGE.as_bytes());
+
+        let mut summary = command_json(
+            &[
+                "corpus".to_string(),
+                "summarize".to_string(),
+                site.to_string_lossy().into_owned(),
+                "--format".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        set(&mut summary, "/root", "site-a");
+        assert_fixture("corpus-summary", summary);
+
+        let mut fingerprint = command_json(
+            &[
+                "corpus".to_string(),
+                "fingerprint".to_string(),
+                site.to_string_lossy().into_owned(),
+                "--format".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        set(&mut fingerprint, "/tool_version", "1.2.1");
+        set(&mut fingerprint, "/root", "site-a");
+        assert_fixture("corpus-fingerprint", fingerprint);
+
+        let mut diff = command_json(
+            &[
+                "corpus".to_string(),
+                "diff".to_string(),
+                before.to_string_lossy().into_owned(),
+                after.to_string_lossy().into_owned(),
+                "--format".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        set(&mut diff, "/tool_version", "1.2.1");
+        set(&mut diff, "/before_root", "before");
+        set(&mut diff, "/after_root", "after");
+        assert_fixture("corpus-diff", diff);
+    }
+
+    #[test]
+    fn test_redaction_bundle_and_replay_reports_match_golden_fixtures() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
+        let profile = create_temp_profile(&dir, "profile.yaml", minimal_profile());
+        let policy = create_temp_file(&dir, "safe-analysis.toml", SAFE_ANALYSIS_POLICY.as_bytes());
+
+        let redact_output = command_json(
+            &[
+                "redact".to_string(),
+                message.to_string_lossy().into_owned(),
+                "--policy".to_string(),
+                policy.to_string_lossy().into_owned(),
+                "--format".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        assert_fixture("redaction-receipt", redact_output["receipt"].clone());
+
+        let bundle = dir.path().join("issue-bundle");
+        let bundle_summary = command_json(
+            &[
+                "bundle".to_string(),
+                message.to_string_lossy().into_owned(),
+                "--profile".to_string(),
+                profile.to_string_lossy().into_owned(),
+                "--redact-policy".to_string(),
+                policy.to_string_lossy().into_owned(),
+                "--out".to_string(),
+                bundle.to_string_lossy().into_owned(),
+            ],
+            true,
+        );
+        assert_fixture("evidence-bundle", bundle_summary);
+
+        let receipt: Value = serde_json::from_slice(
+            &std::fs::read(bundle.join("redaction-receipt.json"))
+                .expect("bundle redaction receipt should be readable"),
+        )
+        .expect("bundle redaction receipt should be JSON");
+        assert_fixture("redaction-receipt", receipt);
+
+        let mut replay = command_json(
+            &[
+                "replay".to_string(),
+                bundle.to_string_lossy().into_owned(),
+                "--format".to_string(),
+                "json".to_string(),
+            ],
+            true,
+        );
+        set(&mut replay, "/tool_version", "1.2.1");
+        assert_fixture("evidence-replay", replay);
+    }
+}
+
+// =========================================================================
 // ACK Generation Command Tests
 // =========================================================================
 

--- a/fixtures/evidence/corpus-diff.json
+++ b/fixtures/evidence/corpus-diff.json
@@ -1,67 +1,35 @@
 {
   "diff_version": "1",
   "tool_version": "1.2.1",
-  "before_root": "fixtures/corpus/before",
-  "after_root": "fixtures/corpus/after",
-  "profile": {
-    "path": "profiles/adt_a01.yaml",
-    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "version": "2.5.1",
-    "message_structure": "ADT_A01"
+  "before_root": "before",
+  "after_root": "after",
+  "profile": null,
+  "file_count": {
+    "before": 1,
+    "after": 1,
+    "delta": 0
   },
-  "file_count": {"before": 2, "after": 3, "delta": 1},
-  "message_count": {"before": 2, "after": 3, "delta": 1},
-  "parse_error_count": {"before": 0, "after": 1, "delta": 1},
-  "new_message_types": ["ORM^O01"],
-  "removed_message_types": [],
-  "new_segments": ["ORC"],
+  "message_count": {
+    "before": 1,
+    "after": 1,
+    "delta": 0
+  },
+  "parse_error_count": {
+    "before": 0,
+    "after": 0,
+    "delta": 0
+  },
+  "new_message_types": ["ORU^R01"],
+  "removed_message_types": ["ADT^A01"],
+  "new_segments": [],
   "removed_segments": [],
   "message_type_counts": [
-    {"value": "ADT^A01", "before": 1, "after": 1, "delta": 0},
-    {"value": "ORM^O01", "before": 0, "after": 1, "delta": 1}
+    {"value": "ADT^A01", "before": 1, "after": 0, "delta": -1},
+    {"value": "ORU^R01", "before": 0, "after": 1, "delta": 1}
   ],
-  "segment_counts": [
-    {"value": "PID", "before": 2, "after": 3, "delta": 1}
-  ],
-  "field_presence": [
-    {
-      "path": "PID.3",
-      "before_message_count": 2,
-      "after_message_count": 3,
-      "message_count_delta": 1,
-      "before_occurrence_count": 2,
-      "after_occurrence_count": 3,
-      "occurrence_count_delta": 1
-    }
-  ],
-  "field_cardinality": [
-    {
-      "path": "PID.3",
-      "before_min_per_message": 1,
-      "after_min_per_message": 1,
-      "min_per_message_delta": 0,
-      "before_max_per_message": 1,
-      "after_max_per_message": 2,
-      "max_per_message_delta": 1,
-      "before_total_occurrences": 2,
-      "after_total_occurrences": 4,
-      "total_occurrences_delta": 2,
-      "before_message_count": 2,
-      "after_message_count": 3,
-      "message_count_delta": 1
-    }
-  ],
-  "value_shape_stats": [
-    {
-      "path": "OBX.5",
-      "coded_count": {"before": 0, "after": 1, "delta": 1},
-      "timestamp_count": {"before": 0, "after": 0, "delta": 0},
-      "numeric_count": {"before": 1, "after": 2, "delta": 1},
-      "null_count": {"before": 0, "after": 0, "delta": 0},
-      "text_count": {"before": 0, "after": 1, "delta": 1}
-    }
-  ],
-  "validation_issue_code_counts": [
-    {"value": "required_field_missing", "before": 0, "after": 1, "delta": 1}
-  ]
+  "segment_counts": [],
+  "field_presence": [],
+  "field_cardinality": [],
+  "value_shape_stats": [],
+  "validation_issue_code_counts": []
 }

--- a/fixtures/evidence/corpus-fingerprint.json
+++ b/fixtures/evidence/corpus-fingerprint.json
@@ -1,41 +1,96 @@
 {
   "fingerprint_version": "1",
   "tool_version": "1.2.1",
-  "root": "fixtures/corpus/site-a",
-  "profile": {
-    "path": "profiles/adt_a01.yaml",
-    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "version": "2.5.1",
-    "message_structure": "ADT_A01"
-  },
-  "file_count": 2,
-  "message_count": 2,
+  "root": "site-a",
+  "profile": null,
+  "file_count": 1,
+  "message_count": 1,
   "parse_error_count": 0,
   "message_type_counts": [
-    {"value": "ADT^A01", "count": 1},
-    {"value": "ORU^R01", "count": 1}
+    {"value": "ADT^A01", "count": 1}
   ],
   "segment_counts": [
-    {"value": "MSH", "count": 2},
-    {"value": "PID", "count": 2},
-    {"value": "OBX", "count": 1}
+    {"value": "MSH", "count": 1}
   ],
   "field_presence": [
-    {"path": "PID.3", "message_count": 2, "occurrence_count": 2},
-    {"path": "OBX.3", "message_count": 1, "occurrence_count": 1}
+    {"path": "MSH.2", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.9", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.10", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.11", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.12", "message_count": 1, "occurrence_count": 1}
   ],
   "field_cardinality": [
     {
-      "path": "PID.3",
+      "path": "MSH.2",
       "min_per_message": 1,
       "max_per_message": 1,
-      "total_occurrences": 2,
-      "message_count": 2
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.9",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.10",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.11",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.12",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
     }
   ],
   "value_shape_stats": [
     {
-      "path": "OBX.5",
+      "path": "MSH.2",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 1
+    },
+    {
+      "path": "MSH.9",
+      "coded_count": 1,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 0
+    },
+    {
+      "path": "MSH.10",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 1
+    },
+    {
+      "path": "MSH.11",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 1
+    },
+    {
+      "path": "MSH.12",
       "coded_count": 0,
       "timestamp_count": 0,
       "numeric_count": 1,
@@ -43,7 +98,5 @@
       "text_count": 0
     }
   ],
-  "validation_issue_code_counts": [
-    {"value": "required_field_missing", "count": 1}
-  ]
+  "validation_issue_code_counts": []
 }

--- a/fixtures/evidence/corpus-summary.json
+++ b/fixtures/evidence/corpus-summary.json
@@ -1,21 +1,21 @@
 {
-  "root": "fixtures/corpus/site-a",
-  "file_count": 2,
-  "message_count": 2,
+  "root": "site-a",
+  "file_count": 1,
+  "message_count": 1,
   "parse_error_count": 0,
-  "total_bytes": 512,
+  "total_bytes": 37,
   "message_types": [
-    {"value": "ADT^A01", "count": 1},
-    {"value": "ORU^R01", "count": 1}
+    {"value": "ADT^A01", "count": 1}
   ],
   "segments": [
-    {"value": "MSH", "count": 2},
-    {"value": "PID", "count": 2},
-    {"value": "OBX", "count": 1}
+    {"value": "MSH", "count": 1}
   ],
   "field_presence": [
-    {"path": "PID.3", "message_count": 2, "occurrence_count": 2},
-    {"path": "OBX.3", "message_count": 1, "occurrence_count": 1}
+    {"path": "MSH.2", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.9", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.10", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.11", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.12", "message_count": 1, "occurrence_count": 1}
   ],
   "parse_errors": []
 }

--- a/fixtures/evidence/evidence-bundle.json
+++ b/fixtures/evidence/evidence-bundle.json
@@ -1,9 +1,9 @@
 {
   "bundle_version": "1",
-  "output_dir": "issue-bundle",
+  "output_dir": ".",
   "message_type": "ADT^A01",
-  "validation_valid": false,
-  "validation_issue_count": 1,
+  "validation_valid": true,
+  "validation_issue_count": 0,
   "redaction_phi_removed": true,
   "artifacts": [
     "message.redacted.hl7",

--- a/fixtures/evidence/evidence-replay.json
+++ b/fixtures/evidence/evidence-replay.json
@@ -1,40 +1,60 @@
 {
   "replay_version": "1",
   "bundle_version": "1",
-  "tool_name": "hl7v2",
+  "tool_name": "hl7v2-cli",
   "tool_version": "1.2.1",
   "message_type": "ADT^A01",
   "reproduced": true,
-  "validation_valid": false,
-  "validation_issue_count": 1,
+  "validation_valid": true,
+  "validation_issue_count": 0,
   "checks": [
     {
-      "name": "required_artifacts",
+      "name": "bundle-layout",
       "status": "pass",
-      "message": "All required bundle artifacts are present."
+      "message": "all expected bundle artifacts are present"
     },
     {
-      "name": "validation_report",
+      "name": "environment",
       "status": "pass",
-      "message": "Regenerated validation report matches the bundle report."
+      "message": "environment.json parsed"
+    },
+    {
+      "name": "stored-validation-report",
+      "status": "pass",
+      "message": "validation-report.json parsed"
+    },
+    {
+      "name": "parse-redacted-message",
+      "status": "pass",
+      "message": "message.redacted.hl7 parsed"
+    },
+    {
+      "name": "load-profile",
+      "status": "pass",
+      "message": "profile.yaml loaded"
+    },
+    {
+      "name": "generate-validation-report",
+      "status": "pass",
+      "message": "validation report regenerated from bundled message and profile"
+    },
+    {
+      "name": "report-match",
+      "status": "pass",
+      "message": "regenerated validation report matches validation-report.json"
+    },
+    {
+      "name": "environment-match",
+      "status": "pass",
+      "message": "environment metadata matches regenerated validation report"
     }
   ],
   "validation_report": {
-    "valid": false,
+    "valid": true,
     "message_type": "ADT^A01",
-    "profile": "profiles/adt_a01.yaml",
+    "profile": "profile.yaml",
     "segment_count": 3,
-    "issue_count": 1,
-    "issues": [
-      {
-        "code": "required_field_missing",
-        "severity": "error",
-        "path": "PID.3",
-        "rule_id": "patient_identifier_required",
-        "message": "PID.3 is required by profile ADT_A01.",
-        "segment_index": 1,
-        "field_index": 3
-      }
-    ]
+    "issue_count": 0,
+    "issues": []
   }
 }

--- a/fixtures/evidence/profile-explain-report.json
+++ b/fixtures/evidence/profile-explain-report.json
@@ -1,102 +1,57 @@
 {
-  "profile": "profiles/adt_a01.yaml",
-  "profile_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "profile": "profile.yaml",
+  "profile_sha256": "3fb926fc70cb562412775c4f91f0ee9e9c4405e120057d7c8ab21f6a6d2526bc",
   "message_structure": "ADT_A01",
-  "version": "2.5.1",
-  "message_type": "ADT^A01",
+  "version": "2.5",
+  "message_type": null,
   "parent": null,
   "summary": {
-    "segment_count": 3,
-    "required_field_count": 2,
-    "field_constraint_count": 2,
-    "length_rule_count": 1,
-    "datatype_rule_count": 1,
-    "advanced_datatype_rule_count": 1,
-    "value_set_count": 1,
-    "cross_field_rule_count": 1,
+    "segment_count": 2,
+    "required_field_count": 1,
+    "field_constraint_count": 1,
+    "length_rule_count": 0,
+    "datatype_rule_count": 0,
+    "advanced_datatype_rule_count": 0,
+    "value_set_count": 0,
+    "cross_field_rule_count": 0,
     "temporal_rule_count": 0,
     "contextual_rule_count": 0,
     "custom_rule_count": 0,
-    "hl7_table_count": 1
+    "hl7_table_count": 0
   },
   "segments": [
     {"id": "MSH"},
-    {"id": "PID"},
-    {"id": "PV1"}
+    {"id": "PID"}
   ],
   "required_fields": [
-    {"path": "PID.3", "conditional": false},
-    {"path": "PID.5", "conditional": false}
+    {"path": "PID.3", "conditional": false}
   ],
   "field_constraints": [
     {
       "path": "PID.3",
       "required": true,
       "conditional": false,
-      "component_min": 1,
+      "component_min": null,
       "component_max": null,
       "allowed_value_count": 0,
       "allowed_values": [],
       "pattern": null
-    },
-    {
-      "path": "PID.8",
-      "required": false,
-      "conditional": false,
-      "component_min": null,
-      "component_max": null,
-      "allowed_value_count": 2,
-      "allowed_values": ["F", "M"],
-      "pattern": null
     }
   ],
-  "length_rules": [
-    {"path": "PID.3", "max": 32, "policy": "warn"}
-  ],
-  "datatype_rules": [
-    {
-      "path": "PID.7",
-      "datatype": "DTM",
-      "kind": "advanced",
-      "pattern": null,
-      "min_length": 8,
-      "max_length": 26,
-      "format": "hl7_ts",
-      "checksum": null
-    }
-  ],
-  "value_sets": [
-    {
-      "name": "Administrative Sex",
-      "path": "PID.8",
-      "source": "inline",
-      "inline_code_count": 2,
-      "table_code_count": 0
-    }
-  ],
+  "length_rules": [],
+  "datatype_rules": [],
+  "value_sets": [],
   "rules": {
-    "cross_field": [
-      {
-        "id": "patient_identifier_required",
-        "description": "PID.3 is required for admitted patients."
-      }
-    ],
+    "cross_field": [],
     "temporal": [],
     "contextual": [],
     "custom": []
   },
-  "hl7_tables": [
-    {
-      "id": "0001",
-      "name": "Administrative Sex",
-      "version": "2.5.1",
-      "code_count": 2
-    }
-  ],
-  "table_precedence": ["inline", "profile", "hl7_table"],
+  "hl7_tables": [],
+  "table_precedence": [],
   "expression_guardrails": {
-    "max_depth": 8,
-    "max_length": 256,
+    "max_depth": null,
+    "max_length": null,
     "allow_custom_scripts": false
   },
   "lint": {

--- a/fixtures/evidence/profile-lint-report.json
+++ b/fixtures/evidence/profile-lint-report.json
@@ -1,20 +1,14 @@
 {
-  "valid": false,
-  "error_count": 1,
+  "valid": true,
+  "error_count": 0,
   "warning_count": 1,
-  "issue_count": 2,
+  "issue_count": 1,
   "issues": [
     {
-      "code": "invalid_path",
-      "severity": "error",
-      "path": "constraints[0].path",
-      "message": "Constraint path PID.X is not a valid HL7 field path."
-    },
-    {
-      "code": "unknown_table_reference",
+      "code": "unknown_top_level_key",
       "severity": "warning",
-      "path": "constraints[1].table",
-      "message": "Table 9999 is not present in the loaded profile tables."
+      "path": "rules",
+      "message": "top-level key 'rules' is ignored by the profile loader"
     }
   ]
 }

--- a/fixtures/evidence/profile-test-report.json
+++ b/fixtures/evidence/profile-test-report.json
@@ -1,54 +1,49 @@
 {
-  "profile": "profiles/adt_a01.yaml",
-  "fixtures": "fixtures/profile/adt_a01",
-  "valid": false,
+  "profile": "profile.yaml",
+  "fixtures": "fixtures",
+  "valid": true,
   "case_count": 2,
-  "passed_count": 1,
-  "failed_count": 1,
+  "passed_count": 2,
+  "failed_count": 0,
   "cases": [
     {
-      "name": "valid/minimal.hl7",
-      "path": "fixtures/profile/adt_a01/valid/minimal.hl7",
+      "name": "valid/valid.hl7",
+      "path": "fixtures/valid/valid.hl7",
       "expectation": "valid",
       "passed": true,
-      "message": "Fixture passed as expected.",
+      "message": "expected valid and report was valid",
       "validation_report": {
         "valid": true,
         "message_type": "ADT^A01",
-        "profile": "profiles/adt_a01.yaml",
-        "segment_count": 3,
+        "profile": "profile.yaml",
+        "segment_count": 2,
         "issue_count": 0,
         "issues": []
       }
     },
     {
       "name": "invalid/missing_pid3.hl7",
-      "path": "fixtures/profile/adt_a01/invalid/missing_pid3.hl7",
+      "path": "fixtures/invalid/missing_pid3.hl7",
       "expectation": "invalid",
-      "passed": false,
-      "message": "Expected report did not match actual validation issues.",
+      "passed": true,
+      "message": "expected invalid and report was invalid",
       "validation_report": {
         "valid": false,
         "message_type": "ADT^A01",
-        "profile": "profiles/adt_a01.yaml",
-        "segment_count": 3,
+        "profile": "profile.yaml",
+        "segment_count": 2,
         "issue_count": 1,
         "issues": [
           {
-            "code": "required_field_missing",
+            "code": "missing_required_field",
             "severity": "error",
             "path": "PID.3",
-            "rule_id": "patient_identifier_required",
-            "message": "PID.3 is required by profile ADT_A01.",
+            "rule_id": "missing_required_field",
+            "message": "Required field PID.3 is missing",
             "segment_index": 1,
             "field_index": 3
           }
         ]
-      },
-      "expected_report": {
-        "path": "fixtures/profile/adt_a01/expected/missing_pid3.report.json",
-        "matched": false,
-        "message": "Expected report was missing required_field_missing at PID.3."
       }
     }
   ]

--- a/fixtures/evidence/redaction-receipt.json
+++ b/fixtures/evidence/redaction-receipt.json
@@ -5,7 +5,7 @@
     {
       "path": "PID.3",
       "action": "hash",
-      "reason": "Patient identifier is direct PHI.",
+      "reason": "patient identifier",
       "matched_count": 1,
       "optional": false,
       "status": "applied"
@@ -13,15 +13,55 @@
     {
       "path": "PID.5",
       "action": "drop",
-      "reason": "Patient name is direct PHI.",
+      "reason": "patient name",
       "matched_count": 1,
       "optional": false,
       "status": "applied"
     },
     {
+      "path": "PID.7",
+      "action": "drop",
+      "reason": "date of birth",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "PID.11",
+      "action": "drop",
+      "reason": "patient address",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "MSH.9",
+      "action": "retain",
+      "reason": "message type is needed for analysis",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    },
+    {
+      "path": "MSH.10",
+      "action": "retain",
+      "reason": "control id is needed for replay correlation",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    },
+    {
       "path": "OBX.3",
       "action": "retain",
-      "reason": "Observation identifier is needed for support analysis.",
+      "reason": "observation identifier is needed for analysis",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    },
+    {
+      "path": "OBX.5",
+      "action": "retain",
+      "reason": "non-PHI synthetic observation value shape is needed for analysis",
       "matched_count": 1,
       "optional": false,
       "status": "retained"

--- a/fixtures/evidence/validation-report.json
+++ b/fixtures/evidence/validation-report.json
@@ -1,16 +1,16 @@
 {
   "valid": false,
   "message_type": "ADT^A01",
-  "profile": "profiles/adt_a01.yaml",
-  "segment_count": 3,
+  "profile": "profile.yaml",
+  "segment_count": 2,
   "issue_count": 1,
   "issues": [
     {
-      "code": "required_field_missing",
+      "code": "missing_required_field",
       "severity": "error",
       "path": "PID.3",
-      "rule_id": "patient_identifier_required",
-      "message": "PID.3 is required by profile ADT_A01.",
+      "rule_id": "missing_required_field",
+      "message": "Required field PID.3 is missing",
       "segment_index": 1,
       "field_index": 3
     }


### PR DESCRIPTION
## Summary
- add CLI integration coverage that regenerates evidence artifact JSON and compares it to checked-in golden fixtures
- refresh evidence fixtures from illustrative samples to normalized current CLI outputs
- cover validation, profile lint/test/explain, corpus summarize/fingerprint/diff, redaction receipt, bundle summary, and replay report artifacts

## Validation
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests evidence_golden_fixtures -- --nocapture`
- `Get-ChildItem schemas\evidence\*-v1.schema.json | ForEach-Object { $name = $_.Name -replace '-v1\.schema\.json$',''; npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s $_.FullName -d "fixtures/evidence/$name.json" --spec=draft7; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } }`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`