### PR TITLE
cli: define output exit contract

### DIFF
--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -78,4 +78,19 @@ fields must be protected when present and cannot be retained.
 from `message.redacted.hl7` and `profile.yaml`, and fails if it no longer
 matches `validation-report.json`.
 
+## Automation contract
+
+The CLI keeps primary command output on stdout. For JSON/YAML evidence commands,
+stdout is the machine-readable artifact. Stderr is reserved for diagnostics,
+receipts, and top-level errors.
+
+Exit codes are stable for automation:
+
+| Code | Meaning |
+| ---: | ------- |
+| `0` | Success, or a check/report that passed. |
+| `1` | Validation, profile, doctor, or replay evidence check failed. |
+| `2` | Parse, profile, config, or policy input error. |
+| `3` | IO, runtime, or environment error. |
+
 For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -5,7 +5,6 @@
     clippy::allow_attributes,
     clippy::allow_attributes_without_reason,
     clippy::cast_precision_loss,
-    clippy::exit,
     clippy::indexing_slicing,
     clippy::unchecked_time_subtraction,
     clippy::uninlined_format_args,
@@ -37,6 +36,7 @@ use hl7v2::{
 };
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
@@ -49,6 +49,46 @@ mod monitor;
 mod serve;
 #[cfg(test)]
 mod tests;
+
+const EXIT_CHECK_FAILED: i32 = 1;
+const EXIT_INPUT_ERROR: i32 = 2;
+const EXIT_RUNTIME_ERROR: i32 = 3;
+
+#[derive(Debug)]
+struct CliFailure {
+    code: i32,
+    message: String,
+}
+
+impl CliFailure {
+    fn check_failed(message: impl Into<String>) -> Box<dyn std::error::Error> {
+        Box::new(Self {
+            code: EXIT_CHECK_FAILED,
+            message: message.into(),
+        })
+    }
+}
+
+impl fmt::Display for CliFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CliFailure {}
+
+fn classify_cli_error(error: &(dyn std::error::Error + 'static)) -> i32 {
+    if let Some(failure) = error.downcast_ref::<CliFailure>() {
+        failure.code
+    } else if let Some(error) = error.downcast_ref::<std::io::Error>() {
+        match error.kind() {
+            std::io::ErrorKind::InvalidInput | std::io::ErrorKind::Other => EXIT_INPUT_ERROR,
+            _ => EXIT_RUNTIME_ERROR,
+        }
+    } else {
+        EXIT_INPUT_ERROR
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -913,7 +953,7 @@ async fn main() {
 
     if let Err(e) = result {
         eprintln!("Error: {}", e);
-        process::exit(1);
+        process::exit(classify_cli_error(e.as_ref()));
     }
 }
 
@@ -973,7 +1013,7 @@ fn doctor_command(
     println!("{}", output);
 
     if report.has_errors() {
-        return Err(std::io::Error::other("doctor reported failed checks").into());
+        return Err(CliFailure::check_failed("doctor reported failed checks"));
     }
 
     Ok(())
@@ -1694,7 +1734,7 @@ fn val_command(
 
     // Exit with error code if validation failed
     if !validation_report.valid {
-        std::process::exit(1);
+        return Err(CliFailure::check_failed("validation failed"));
     }
 
     Ok(())
@@ -1825,7 +1865,9 @@ fn replay_command(bundle: &Path, format: &ReportFormat) -> Result<(), Box<dyn st
     if report.reproduced {
         Ok(())
     } else {
-        Err(std::io::Error::other("bundle replay did not reproduce stored evidence").into())
+        Err(CliFailure::check_failed(
+            "bundle replay did not reproduce stored evidence",
+        ))
     }
 }
 
@@ -2498,7 +2540,7 @@ fn profile_lint_command(
     println!("{}", output);
 
     if !lint_report.valid {
-        return Err(std::io::Error::other("profile lint reported errors").into());
+        return Err(CliFailure::check_failed("profile lint reported errors"));
     }
 
     Ok(())
@@ -2738,7 +2780,7 @@ fn profile_test_command(
     println!("{}", output);
 
     if !test_report.valid {
-        return Err(std::io::Error::other("profile test reported failures").into());
+        return Err(CliFailure::check_failed("profile test reported failures"));
     }
 
     Ok(())

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2851,7 +2851,7 @@ mod exit_codes {
         let mut cmd = cli_command();
         cmd.args(["parse", invalid_file.to_str().unwrap()])
             .assert()
-            .code(predicate::ne(0));
+            .code(2);
     }
 
     #[test]
@@ -2859,7 +2859,273 @@ mod exit_codes {
         let mut cmd = cli_command();
         cmd.args(["parse", "/nonexistent/file.hl7"])
             .assert()
-            .code(predicate::ne(0));
+            .code(3);
+    }
+}
+
+// =========================================================================
+// CLI Output Contract Tests
+// =========================================================================
+
+mod output_contract {
+    use super::*;
+
+    const PROFILE_REQUIRING_PID3: &str = r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"#;
+
+    const MISSING_PID3_MESSAGE: &str = "MSH|^~\\&|||||||ADT^A01|CTRL123|P|2.5\rPID|1\r";
+    const VALID_ADT_MESSAGE: &str =
+        "MSH|^~\\&|||||||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR\r";
+    const SAFE_ANALYSIS_POLICY: &str = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+"#;
+
+    fn output_text(bytes: &[u8]) -> String {
+        String::from_utf8_lossy(bytes).to_string()
+    }
+
+    #[test]
+    fn test_machine_readable_success_uses_stdout_and_exit_zero() {
+        let dir = create_temp_dir();
+        let corpus = dir.path().join("corpus");
+        std::fs::create_dir_all(&corpus).unwrap();
+        create_temp_file(&dir, "corpus/adt.hl7", VALID_ADT_MESSAGE.as_bytes());
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "summarize",
+                corpus.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("corpus summarize should run");
+
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stderr.is_empty());
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+        assert_eq!(report["message_count"], 1);
+    }
+
+    #[test]
+    fn test_validation_failure_returns_one_with_report_on_stdout() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "missing_pid3.hl7", MISSING_PID3_MESSAGE);
+        let profile = create_temp_profile(&dir, "profile.yaml", PROFILE_REQUIRING_PID3);
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "val",
+                message.to_str().unwrap(),
+                "--profile",
+                profile.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .output()
+            .expect("validation command should run");
+
+        assert_eq!(output.status.code(), Some(1));
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("stdout should be JSON report");
+        assert_eq!(report["valid"], false);
+        assert!(output_text(&output.stderr).contains("Error: validation failed"));
+    }
+
+    #[test]
+    fn test_profile_check_failure_returns_one_with_report_on_stdout() {
+        let dir = create_temp_dir();
+        let profile = create_temp_profile(
+            &dir,
+            "profile.yaml",
+            r#"
+message_structure: ""
+version: "2.5"
+segments:
+  - id: ""
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "lint",
+                profile.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .output()
+            .expect("profile lint should run");
+
+        assert_eq!(output.status.code(), Some(1));
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("stdout should be JSON report");
+        assert_eq!(report["valid"], false);
+        assert!(output_text(&output.stderr).contains("profile lint reported errors"));
+    }
+
+    #[test]
+    fn test_profile_fixture_failure_returns_one_with_report_on_stdout() {
+        let dir = create_temp_dir();
+        let profile = create_temp_profile(&dir, "profile.yaml", PROFILE_REQUIRING_PID3);
+        let fixtures = dir.path().join("fixtures");
+        std::fs::create_dir_all(fixtures.join("valid")).unwrap();
+        std::fs::create_dir_all(fixtures.join("invalid")).unwrap();
+        create_temp_file(
+            &dir,
+            "fixtures/valid/missing_pid3.hl7",
+            MISSING_PID3_MESSAGE.as_bytes(),
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "test",
+                profile.to_str().unwrap(),
+                fixtures.to_str().unwrap(),
+                "--report",
+                "json",
+            ])
+            .output()
+            .expect("profile test should run");
+
+        assert_eq!(output.status.code(), Some(1));
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("stdout should be JSON report");
+        assert_eq!(report["valid"], false);
+        assert!(output_text(&output.stderr).contains("profile test reported failures"));
+    }
+
+    #[test]
+    fn test_replay_failure_returns_one_with_report_on_stdout() {
+        let dir = create_temp_dir();
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", dir.path().to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("replay should run");
+
+        assert_eq!(output.status.code(), Some(1));
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("stdout should be JSON report");
+        assert_eq!(report["reproduced"], false);
+        assert!(output_text(&output.stderr).contains("bundle replay did not reproduce"));
+    }
+
+    #[test]
+    fn test_parse_input_error_returns_two_with_diagnostic_on_stderr() {
+        let dir = create_temp_dir();
+        let invalid = create_temp_file(&dir, "invalid.hl7", invalid_hl7_message().as_bytes());
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["parse", invalid.to_str().unwrap()])
+            .output()
+            .expect("parse should run");
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert!(output_text(&output.stderr).contains("Error:"));
+    }
+
+    #[test]
+    fn test_policy_input_error_returns_two_without_primary_output() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "message.hl7", VALID_ADT_MESSAGE);
+        let policy = create_temp_profile(
+            &dir,
+            "policy.toml",
+            r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message.to_str().unwrap(),
+                "--policy",
+                policy.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("redact should run");
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert!(output_text(&output.stderr).contains("must include a reason"));
+    }
+
+    #[test]
+    fn test_io_runtime_error_returns_three_with_diagnostic_on_stderr() {
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["parse", "/nonexistent/file.hl7"])
+            .output()
+            .expect("parse should run");
+
+        assert_eq!(output.status.code(), Some(3));
+        assert!(output.stdout.is_empty());
+        assert!(output_text(&output.stderr).contains("Error:"));
+    }
+
+    #[test]
+    fn test_doctor_failed_check_returns_one_with_report_on_stdout() {
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["doctor", "--server-url", "https://example.com/health"])
+            .output()
+            .expect("doctor should run");
+
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output_text(&output.stdout).contains("[error] server"));
+        assert!(output_text(&output.stderr).contains("doctor reported failed checks"));
+    }
+
+    #[test]
+    fn test_redact_hl7_keeps_primary_output_on_stdout_and_receipt_on_stderr() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "message.hl7", VALID_ADT_MESSAGE);
+        let policy = create_temp_profile(&dir, "policy.toml", SAFE_ANALYSIS_POLICY);
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message.to_str().unwrap(),
+                "--policy",
+                policy.to_str().unwrap(),
+                "--format",
+                "hl7",
+            ])
+            .output()
+            .expect("redact should run");
+
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output_text(&output.stdout).contains("hash:sha256:"));
+        assert!(output_text(&output.stderr).contains("Redaction receipt"));
     }
 }
 

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -59,23 +59,14 @@ profile `message_structure`. The report fields are otherwise shared through
 
 ## Output Semantics
 
-The CLI has useful machine-readable outputs, but the script contract is not yet
-uniform.
+The CLI output contract is stable enough for CI and automation:
 
-- JSON/YAML output generally goes to stdout.
+- JSON/YAML output goes to stdout as the primary machine-readable artifact.
 - Human text output also goes to stdout.
 - Diagnostics and top-level errors are written to stderr by the global error
   path.
 - `hl7v2 redact --format hl7` writes the redacted message to stdout and a short
   receipt to stderr.
-- `hl7v2 val` exits `1` for invalid validation reports.
-- `profile lint`, `profile test`, and `replay` return errors for failed
-  evidence checks, which currently route through the global `exit(1)` handler.
-- Parse/config/profile/policy/IO failures also use the same global `exit(1)`
-  behavior today.
-
-The planned output-contract work should split these into the documented
-automation classes:
 
 ```text
 0 = success
@@ -91,10 +82,7 @@ The next contract-hardening work should lock:
 - `schema_version` or artifact-specific version naming for every machine
   artifact.
 - `tool_version` where users need provenance outside an environment file.
-- Golden command-output tests that compare live commands to the representative
-  fixtures under `fixtures/evidence/`.
 - Explicit null and empty-list behavior for optional fields.
-- Stable stdout/stderr/exit-code behavior across the CLI.
 - Bundle manifest and artifact SHA-256 verification during replay.
 - Redaction leak sentinel tests for synthetic PHI fixtures.
 - Server and Python parity for any artifact promoted beyond CLI-only use.

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -68,19 +68,13 @@ semantics still need to be made explicit before schemas are treated as stable.
 
 ## CLI Automation Semantics
 
-Current behavior is useful but not fully script-grade:
+Current behavior is script-grade:
 
-- Machine-readable JSON/YAML usually goes to stdout.
+- Machine-readable JSON/YAML goes to stdout as the primary artifact.
 - Human text output also goes to stdout.
 - Top-level diagnostics use stderr through the global error handler.
 - `redact --format hl7` sends the redacted HL7 body to stdout and a short
   receipt to stderr.
-- Validation failure, profile lint failure, profile test failure, replay
-  failure, parse failure, policy failure, config/input failure, and IO failure
-  currently collapse to exit code `1`.
-
-The follow-up `cli/output-contract` PR should make this explicit and split exit
-codes by failure class:
 
 | Exit code | Intended meaning |
 | --- | --- |


### PR DESCRIPTION
## Summary
- define CLI exit classes for automation: 0 success, 1 evidence/check failure, 2 parse/profile/config/policy input error, 3 IO/runtime/environment error
- route validation, doctor, profile lint/test, and replay failures through typed check-failure errors instead of collapsing everything through one generic exit path
- add output-contract integration tests for stdout/stderr behavior and exit codes across validation, profile, replay, redaction, doctor, parse, and IO cases
- document the automation contract in the CLI README and current evidence artifact docs

## Validation
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests output_contract -- --nocapture`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`