### PR TITLE
cli: add evidence output file flags

### DIFF
--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -84,6 +84,12 @@ The CLI keeps primary command output on stdout. For JSON/YAML evidence commands,
 stdout is the machine-readable artifact. Stderr is reserved for diagnostics,
 receipts, and top-level errors.
 
+Evidence commands that produce reports accept `--output <path>`, `--quiet`, and
+`--no-color`. Without `--output`, the report is written to stdout. With
+`--output`, the same artifact is written to the requested file and stdout stays
+quiet. `--quiet` suppresses non-error diagnostics, while top-level errors still
+go to stderr.
+
 Exit codes are stable for automation:
 
 | Code | Meaning |

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -183,6 +183,18 @@ enum Commands {
         /// Show summary statistics
         #[arg(long)]
         summary: bool,
+
+        /// Write the validation report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Show statistics for HL7 v2 message
@@ -246,6 +258,18 @@ enum Commands {
         /// Output format (json or hl7)
         #[arg(long, value_enum, default_value = "json")]
         format: RedactFormat,
+
+        /// Write the redaction output to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Create a redacted support/debug evidence bundle
@@ -264,6 +288,18 @@ enum Commands {
         /// Output bundle directory, which must not already exist
         #[arg(long)]
         out: PathBuf,
+
+        /// Write the bundle summary JSON to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Replay a redacted evidence bundle and verify it reproduces
@@ -274,6 +310,18 @@ enum Commands {
         /// Output replay report format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
+
+        /// Write the replay report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Generate ACK for HL7 v2 message
@@ -358,6 +406,18 @@ enum ProfileCommands {
         /// Output lint report format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         report: ReportFormat,
+
+        /// Write the lint report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Explain the loaded profile contract
@@ -368,6 +428,18 @@ enum ProfileCommands {
         /// Output explain report format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
+
+        /// Write the explain report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Test a profile against valid/invalid HL7 fixture directories
@@ -381,6 +453,18 @@ enum ProfileCommands {
         /// Output test report format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         report: ReportFormat,
+
+        /// Write the test report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 }
 
@@ -394,6 +478,18 @@ enum CorpusCommands {
         /// Output summary format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
+
+        /// Write the summary report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Create a deterministic feed fingerprint
@@ -408,6 +504,18 @@ enum CorpusCommands {
         /// Output fingerprint format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
+
+        /// Write the fingerprint report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Diff two directory or file corpora of HL7 messages
@@ -425,6 +533,18 @@ enum CorpusCommands {
         /// Output diff format (json, yaml, text)
         #[arg(long, value_enum, default_value = "text")]
         format: ReportFormat,
+
+        /// Write the diff report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 }
 
@@ -469,6 +589,49 @@ enum RedactFormat {
     #[default]
     Json,
     Hl7,
+}
+
+struct OutputOptions<'a> {
+    output: Option<&'a PathBuf>,
+    quiet: bool,
+    no_color: bool,
+}
+
+impl<'a> OutputOptions<'a> {
+    const fn new(output: Option<&'a PathBuf>, quiet: bool, no_color: bool) -> Self {
+        Self {
+            output,
+            quiet,
+            no_color,
+        }
+    }
+
+    fn emit(&self, output: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let _colors_enabled = !self.no_color;
+        if let Some(path) = self.output {
+            fs::write(path, output)?;
+        } else {
+            println!("{}", output);
+        }
+        Ok(())
+    }
+
+    fn emit_raw(&self, output: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let _colors_enabled = !self.no_color;
+        if let Some(path) = self.output {
+            fs::write(path, output)?;
+        } else {
+            print!("{output}");
+        }
+        Ok(())
+    }
+
+    fn diagnostic(&self, message: impl fmt::Display) {
+        let _colors_enabled = !self.no_color;
+        if !self.quiet {
+            eprintln!("{message}");
+        }
+    }
 }
 
 const DOCTOR_BUILTIN_SAMPLE: &[u8] = b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
@@ -872,7 +1035,18 @@ async fn main() {
             detailed,
             report,
             summary,
-        } => val_command(input, profile, *mllp, *detailed, report, *summary),
+            output,
+            quiet,
+            no_color,
+        } => val_command(
+            input,
+            profile,
+            *mllp,
+            *detailed,
+            report,
+            *summary,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+        ),
         Commands::Stats {
             input,
             mllp,
@@ -891,42 +1065,122 @@ async fn main() {
             format,
         ),
         Commands::Profile { command } => match command {
-            ProfileCommands::Lint { profile, report } => profile_lint_command(profile, report),
-            ProfileCommands::Explain { profile, format } => {
-                profile_explain_command(profile, format)
-            }
+            ProfileCommands::Lint {
+                profile,
+                report,
+                output,
+                quiet,
+                no_color,
+            } => profile_lint_command(
+                profile,
+                report,
+                &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+            ),
+            ProfileCommands::Explain {
+                profile,
+                format,
+                output,
+                quiet,
+                no_color,
+            } => profile_explain_command(
+                profile,
+                format,
+                &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+            ),
             ProfileCommands::Test {
                 profile,
                 fixtures,
                 report,
-            } => profile_test_command(profile, fixtures, report),
+                output,
+                quiet,
+                no_color,
+            } => profile_test_command(
+                profile,
+                fixtures,
+                report,
+                &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+            ),
         },
         Commands::Corpus { command } => match command {
-            CorpusCommands::Summarize { path, format } => corpus_summarize_command(path, format),
+            CorpusCommands::Summarize {
+                path,
+                format,
+                output,
+                quiet,
+                no_color,
+            } => corpus_summarize_command(
+                path,
+                format,
+                &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+            ),
             CorpusCommands::Fingerprint {
                 path,
                 profile,
                 format,
-            } => corpus_fingerprint_command(path, profile.as_ref(), format),
+                output,
+                quiet,
+                no_color,
+            } => corpus_fingerprint_command(
+                path,
+                profile.as_ref(),
+                format,
+                &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+            ),
             CorpusCommands::Diff {
                 before,
                 after,
                 profile,
                 format,
-            } => corpus_diff_command(before, after, profile.as_ref(), format),
+                output,
+                quiet,
+                no_color,
+            } => corpus_diff_command(
+                before,
+                after,
+                profile.as_ref(),
+                format,
+                &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+            ),
         },
         Commands::Redact {
             input,
             policy,
             format,
-        } => redact_command(input, policy, format),
+            output,
+            quiet,
+            no_color,
+        } => redact_command(
+            input,
+            policy,
+            format,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+        ),
         Commands::Bundle {
             input,
             profile,
             redact_policy,
             out,
-        } => bundle_command(input, profile, redact_policy, out),
-        Commands::Replay { bundle, format } => replay_command(bundle, format),
+            output,
+            quiet,
+            no_color,
+        } => bundle_command(
+            input,
+            profile,
+            redact_policy,
+            out,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+        ),
+        Commands::Replay {
+            bundle,
+            format,
+            output,
+            quiet,
+            no_color,
+        } => replay_command(
+            bundle,
+            format,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+        ),
         Commands::Ack {
             input,
             mode,
@@ -959,32 +1213,48 @@ async fn main() {
 
 /// Display performance statistics
 fn display_performance_stats(monitor: &monitor::PerformanceMonitor) {
-    println!();
-    println!("Performance Statistics:");
-    println!("  Total execution time: {:?}", monitor.elapsed());
+    print!("{}", format_performance_stats(monitor));
+}
+
+fn format_performance_stats(monitor: &monitor::PerformanceMonitor) -> String {
+    let mut output = String::new();
+    output.push('\n');
+    output.push_str("Performance Statistics:\n");
+    output.push_str(&format!(
+        "  Total execution time: {:?}\n",
+        monitor.elapsed()
+    ));
 
     let metrics = monitor.get_metrics();
     if !metrics.is_empty() {
-        println!("  Detailed metrics:");
+        output.push_str("  Detailed metrics:\n");
         for (name, duration) in metrics {
-            println!("    {}: {:?}", name, duration);
+            output.push_str(&format!("    {name}: {duration:?}\n"));
         }
     }
 
     // System information
     let system_info = monitor::get_system_info();
-    println!("  System information:");
+    output.push_str("  System information:\n");
     if let Some(cpu_usage) = system_info.cpu.cpu_usage_percent {
-        println!("    CPU usage: {:.2}%", cpu_usage);
+        output.push_str(&format!("    CPU usage: {cpu_usage:.2}%\n"));
     }
-    println!("    Total memory: {} bytes", system_info.total_memory);
-    println!("    Used memory: {} bytes", system_info.used_memory);
+    output.push_str(&format!(
+        "    Total memory: {} bytes\n",
+        system_info.total_memory
+    ));
+    output.push_str(&format!(
+        "    Used memory: {} bytes\n",
+        system_info.used_memory
+    ));
     if let Some(rss) = system_info.memory.resident_set_size {
-        println!("    Process memory (RSS): {} bytes", rss);
+        output.push_str(&format!("    Process memory (RSS): {rss} bytes\n"));
     }
     if let Some(vms) = system_info.memory.virtual_memory_size {
-        println!("    Process memory (VMS): {} bytes", vms);
+        output.push_str(&format!("    Process memory (VMS): {vms} bytes\n"));
     }
+
+    output
 }
 
 fn doctor_command(
@@ -1639,6 +1909,7 @@ fn val_command(
     detailed: bool,
     report: &ReportFormat,
     summary: bool,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut monitor = monitor::PerformanceMonitor::new();
 
@@ -1685,51 +1956,59 @@ fn val_command(
         results,
     );
 
-    // Output based on report format
-    match report {
-        ReportFormat::Json => {
-            let json_output = serde_json::to_string_pretty(&validation_report)?;
-            println!("{}", json_output);
-        }
-        ReportFormat::Yaml => {
-            let yaml_output = serde_yaml::to_string(&validation_report)?;
-            println!("{}", yaml_output);
-        }
+    let output = match report {
+        ReportFormat::Json => serde_json::to_string_pretty(&validation_report)?,
+        ReportFormat::Yaml => serde_yaml::to_string(&validation_report)?,
         ReportFormat::Text => {
             // Print validation results in text format
             if validation_report.valid {
-                println!("Validation passed: No issues found");
+                "Validation passed: No issues found".to_string()
             } else if detailed {
-                println!("Validation issues found:");
+                let mut output = String::from("Validation issues found:");
                 for issue in &validation_report.issues {
                     let path = issue.path.as_deref().unwrap_or("message");
-                    println!(
-                        "  - {} {} {}: {}",
+                    output.push_str(&format!(
+                        "\n  - {} {} {}: {}",
                         issue.severity.as_str(),
                         issue.code,
                         path,
                         issue.message
-                    );
+                    ));
                 }
+                output
             } else {
-                println!(
+                format!(
                     "Validation failed: {} issues found",
                     validation_report.issue_count
-                );
+                )
             }
         }
-    }
+    };
+    output_options.emit(&output)?;
 
     // Show summary if requested (only for text format to avoid mixing output)
     if summary && *report == ReportFormat::Text {
-        println!();
-        println!("Validation Summary:");
-        println!("  Input file: {:?}", input);
-        println!("  Profile file: {:?}", profile);
-        println!("  File size: {} bytes", file_size);
-        println!("  Segments: {}", validation_report.segment_count);
-        println!("  Issues found: {}", validation_report.issue_count);
-        display_performance_stats(&monitor);
+        let mut summary_output = String::new();
+        summary_output.push('\n');
+        summary_output.push_str("Validation Summary:\n");
+        summary_output.push_str(&format!("  Input file: {:?}\n", input));
+        summary_output.push_str(&format!("  Profile file: {:?}\n", profile));
+        summary_output.push_str(&format!("  File size: {file_size} bytes\n"));
+        summary_output.push_str(&format!(
+            "  Segments: {}\n",
+            validation_report.segment_count
+        ));
+        summary_output.push_str(&format!(
+            "  Issues found: {}\n",
+            validation_report.issue_count
+        ));
+        summary_output.push_str(&format_performance_stats(&monitor));
+
+        if output_options.output.is_some() || output_options.quiet {
+            output_options.diagnostic(summary_output.trim_end());
+        } else {
+            print!("{summary_output}");
+        }
     }
 
     // Exit with error code if validation failed
@@ -1744,6 +2023,7 @@ fn redact_command(
     input: &Path,
     policy: &Path,
     format: &RedactFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let contents = fs::read(input)?;
     let mut message = parse(&contents)?;
@@ -1762,15 +2042,15 @@ fn redact_command(
                 redacted_hl7,
                 receipt,
             };
-            println!("{}", serde_json::to_string_pretty(&output)?);
+            output_options.emit(&serde_json::to_string_pretty(&output)?)?;
         }
         RedactFormat::Hl7 => {
-            eprintln!(
+            output_options.diagnostic(format!(
                 "Redaction receipt: {} action(s), PHI removed: {}",
                 receipt.actions.len(),
                 receipt.phi_removed
-            );
-            print!("{redacted_hl7}");
+            ));
+            output_options.emit_raw(&redacted_hl7)?;
         }
     }
 
@@ -1782,6 +2062,7 @@ fn bundle_command(
     profile: &Path,
     redact_policy: &Path,
     out: &Path,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if out.exists() {
         return Err(std::io::Error::new(
@@ -1853,14 +2134,18 @@ fn bundle_command(
         redaction_phi_removed: redaction_receipt.phi_removed,
         artifacts,
     };
-    println!("{}", serde_json::to_string_pretty(&summary)?);
+    output_options.emit(&serde_json::to_string_pretty(&summary)?)?;
 
     Ok(())
 }
 
-fn replay_command(bundle: &Path, format: &ReportFormat) -> Result<(), Box<dyn std::error::Error>> {
+fn replay_command(
+    bundle: &Path,
+    format: &ReportFormat,
+    output_options: &OutputOptions<'_>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let report = build_replay_report(bundle);
-    println!("{}", render_replay_report(&report, format)?);
+    output_options.emit(&render_replay_report(&report, format)?)?;
 
     if report.reproduced {
         Ok(())
@@ -2533,11 +2818,12 @@ fn field_to_text(field: &Field, delims: &hl7v2::Delims) -> String {
 fn profile_lint_command(
     profile: &Path,
     report: &ReportFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let profile_yaml = fs::read_to_string(profile)?;
     let lint_report = lint_profile_yaml(&profile_yaml);
     let output = format_profile_lint_report(profile, &lint_report, report)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
 
     if !lint_report.valid {
         return Err(CliFailure::check_failed("profile lint reported errors"));
@@ -2549,6 +2835,7 @@ fn profile_lint_command(
 fn profile_explain_command(
     profile: &Path,
     format: &ReportFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let profile_yaml = fs::read_to_string(profile)?;
     let loaded_profile = load_profile_checked(&profile_yaml)?;
@@ -2556,7 +2843,7 @@ fn profile_explain_command(
     let explain_report =
         build_profile_explain_report(profile, &profile_yaml, &loaded_profile, &lint_report);
     let output = format_profile_explain_report(&explain_report, format)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
     Ok(())
 }
 
@@ -2772,12 +3059,13 @@ fn profile_test_command(
     profile: &Path,
     fixtures: &Path,
     report: &ReportFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let profile_yaml = fs::read_to_string(profile)?;
     let loaded_profile = load_profile_checked(&profile_yaml)?;
     let test_report = run_profile_fixture_tests(profile, fixtures, &loaded_profile)?;
     let output = format_profile_test_report(&test_report, report)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
 
     if !test_report.valid {
         return Err(CliFailure::check_failed("profile test reported failures"));
@@ -3550,10 +3838,11 @@ fn stats_command(
 fn corpus_summarize_command(
     path: &PathBuf,
     format: &ReportFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let summary = summarize_corpus_path(path)?;
     let output = format_corpus_summary(&summary, format)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
     Ok(())
 }
 
@@ -3623,6 +3912,7 @@ fn corpus_diff_command(
     after: &PathBuf,
     profile: Option<&PathBuf>,
     format: &ReportFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let diff = if let Some(profile_path) = profile {
         let mut before_fingerprint = fingerprint_corpus_path(before)?;
@@ -3639,7 +3929,7 @@ fn corpus_diff_command(
         diff_corpus_paths(before, after)?
     };
     let output = format_corpus_diff(&diff, format)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
     Ok(())
 }
 
@@ -3647,6 +3937,7 @@ fn corpus_fingerprint_command(
     path: &PathBuf,
     profile: Option<&PathBuf>,
     format: &ReportFormat,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut fingerprint = fingerprint_corpus_path(path)?;
 
@@ -3658,7 +3949,7 @@ fn corpus_fingerprint_command(
     }
 
     let output = format_corpus_fingerprint(&fingerprint, format)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
     Ok(())
 }
 
@@ -4310,7 +4601,15 @@ fn handle_val_command(input: &str) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    val_command(&file_path, &profile_path, mllp, detailed, &report, summary)
+    val_command(
+        &file_path,
+        &profile_path,
+        mllp,
+        detailed,
+        &report,
+        summary,
+        &OutputOptions::new(None, false, false),
+    )
 }
 
 /// Handle ack command in interactive mode

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -949,12 +949,17 @@ constraints:
 
         #[test]
         fn test_corpus_summarize_command_execution() {
+            use crate::OutputOptions;
             use crate::ReportFormat;
             use crate::corpus_summarize_command;
             let dir = TempDir::new().expect("Failed to create temp dir");
             create_temp_hl7_file(&dir, "test.hl7");
 
-            let result = corpus_summarize_command(&dir.path().to_path_buf(), &ReportFormat::Json);
+            let result = corpus_summarize_command(
+                &dir.path().to_path_buf(),
+                &ReportFormat::Json,
+                &OutputOptions::new(None, false, false),
+            );
             assert!(result.is_ok());
         }
 
@@ -1063,6 +1068,7 @@ constraints:
 
         #[test]
         fn test_corpus_diff_command_execution() {
+            use crate::OutputOptions;
             use crate::ReportFormat;
             use crate::corpus_diff_command;
             let before = TempDir::new().expect("Failed to create before temp dir");
@@ -1075,6 +1081,7 @@ constraints:
                 &after.path().to_path_buf(),
                 None,
                 &ReportFormat::Json,
+                &OutputOptions::new(None, false, false),
             );
             assert!(result.is_ok());
         }
@@ -1140,13 +1147,18 @@ constraints:
 
         #[test]
         fn test_corpus_fingerprint_command_execution() {
+            use crate::OutputOptions;
             use crate::ReportFormat;
             use crate::corpus_fingerprint_command;
             let dir = TempDir::new().expect("Failed to create temp dir");
             create_temp_hl7_file(&dir, "test.hl7");
 
-            let result =
-                corpus_fingerprint_command(&dir.path().to_path_buf(), None, &ReportFormat::Json);
+            let result = corpus_fingerprint_command(
+                &dir.path().to_path_buf(),
+                None,
+                &ReportFormat::Json,
+                &OutputOptions::new(None, false, false),
+            );
             assert!(result.is_ok());
         }
 
@@ -1197,6 +1209,7 @@ constraints:
                     false,
                     &crate::ReportFormat::Text,
                     false,
+                    &crate::OutputOptions::new(None, false, false),
                 )
                 .is_ok()
             );

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -3127,6 +3127,288 @@ action = "hash"
         assert!(output_text(&output.stdout).contains("hash:sha256:"));
         assert!(output_text(&output.stderr).contains("Redaction receipt"));
     }
+
+    fn json_from_file(path: &std::path::Path) -> serde_json::Value {
+        serde_json::from_slice(&std::fs::read(path).expect("output file should be readable"))
+            .expect("output file should contain JSON")
+    }
+
+    #[test]
+    fn test_report_commands_write_output_file_and_keep_stdout_quiet() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "message.hl7", MISSING_PID3_MESSAGE);
+        let profile = create_temp_profile(&dir, "profile.yaml", PROFILE_REQUIRING_PID3);
+        let corpus = dir.path().join("corpus");
+        let before = dir.path().join("before");
+        let after = dir.path().join("after");
+        std::fs::create_dir_all(&corpus).unwrap();
+        std::fs::create_dir_all(&before).unwrap();
+        std::fs::create_dir_all(&after).unwrap();
+        create_temp_file(&dir, "corpus/adt.hl7", VALID_ADT_MESSAGE.as_bytes());
+        create_temp_file(&dir, "before/adt.hl7", VALID_ADT_MESSAGE.as_bytes());
+        create_temp_file(&dir, "after/adt.hl7", VALID_ADT_MESSAGE.as_bytes());
+
+        let val_report = dir.path().join("validation-report.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "val",
+                message.to_str().unwrap(),
+                "--profile",
+                profile.to_str().unwrap(),
+                "--report",
+                "json",
+                "--output",
+                val_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("validation command should run");
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&val_report)["valid"], false);
+
+        let val_text_report = dir.path().join("validation-report.txt");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "val",
+                message.to_str().unwrap(),
+                "--profile",
+                profile.to_str().unwrap(),
+                "--report",
+                "text",
+                "--summary",
+                "--output",
+                val_text_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("text validation command should run");
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+        assert!(output_text(&output.stderr).contains("validation failed"));
+        let val_text_output = std::fs::read_to_string(&val_text_report).unwrap();
+        assert!(val_text_output.contains("Validation failed"));
+        assert!(!val_text_output.contains("Validation Summary"));
+
+        let lint_report = dir.path().join("profile-lint.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "lint",
+                profile.to_str().unwrap(),
+                "--report",
+                "json",
+                "--output",
+                lint_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("profile lint should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&lint_report)["valid"], true);
+
+        let explain_report = dir.path().join("profile-explain.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "explain",
+                profile.to_str().unwrap(),
+                "--format",
+                "json",
+                "--output",
+                explain_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("profile explain should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            json_from_file(&explain_report)["message_structure"],
+            "ADT_A01"
+        );
+
+        let fixtures = dir.path().join("fixtures");
+        std::fs::create_dir_all(fixtures.join("valid")).unwrap();
+        std::fs::create_dir_all(fixtures.join("invalid")).unwrap();
+        create_temp_file(
+            &dir,
+            "fixtures/valid/valid.hl7",
+            VALID_ADT_MESSAGE.as_bytes(),
+        );
+        create_temp_file(
+            &dir,
+            "fixtures/invalid/missing_pid3.hl7",
+            MISSING_PID3_MESSAGE.as_bytes(),
+        );
+        let test_report = dir.path().join("profile-test.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "test",
+                profile.to_str().unwrap(),
+                fixtures.to_str().unwrap(),
+                "--report",
+                "json",
+                "--output",
+                test_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("profile test should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&test_report)["valid"], true);
+
+        let summary_report = dir.path().join("corpus-summary.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "summarize",
+                corpus.to_str().unwrap(),
+                "--format",
+                "json",
+                "--output",
+                summary_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("corpus summarize should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&summary_report)["message_count"], 1);
+
+        let fingerprint_report = dir.path().join("corpus-fingerprint.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "fingerprint",
+                corpus.to_str().unwrap(),
+                "--format",
+                "json",
+                "--output",
+                fingerprint_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("corpus fingerprint should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&fingerprint_report)["message_count"], 1);
+
+        let diff_report = dir.path().join("corpus-diff.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "corpus",
+                "diff",
+                before.to_str().unwrap(),
+                after.to_str().unwrap(),
+                "--format",
+                "json",
+                "--output",
+                diff_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("corpus diff should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&diff_report)["diff_version"], "1");
+    }
+
+    #[test]
+    fn test_redact_bundle_and_replay_write_output_files_and_keep_stdout_quiet() {
+        let dir = create_temp_dir();
+        let message = create_temp_hl7_with_content(&dir, "message.hl7", VALID_ADT_MESSAGE);
+        let profile = create_temp_profile(&dir, "profile.yaml", PROFILE_REQUIRING_PID3);
+        let policy = create_temp_profile(&dir, "policy.toml", SAFE_ANALYSIS_POLICY);
+
+        let redacted = dir.path().join("message.redacted.hl7");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message.to_str().unwrap(),
+                "--policy",
+                policy.to_str().unwrap(),
+                "--format",
+                "hl7",
+                "--output",
+                redacted.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("redact should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.is_empty());
+        assert!(
+            std::fs::read_to_string(&redacted)
+                .unwrap()
+                .contains("hash:sha256:")
+        );
+
+        let bundle_dir = dir.path().join("bundle");
+        let bundle_summary = dir.path().join("bundle-summary.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "bundle",
+                message.to_str().unwrap(),
+                "--profile",
+                profile.to_str().unwrap(),
+                "--redact-policy",
+                policy.to_str().unwrap(),
+                "--out",
+                bundle_dir.to_str().unwrap(),
+                "--output",
+                bundle_summary.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("bundle should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&bundle_summary)["bundle_version"], "1");
+
+        let replay_report = dir.path().join("replay-report.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "replay",
+                bundle_dir.to_str().unwrap(),
+                "--format",
+                "json",
+                "--output",
+                replay_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("replay should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&replay_report)["reproduced"], true);
+    }
 }
 
 // =========================================================================

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -63,6 +63,11 @@ The CLI output contract is stable enough for CI and automation:
 
 - JSON/YAML output goes to stdout as the primary machine-readable artifact.
 - Human text output also goes to stdout.
+- Evidence report commands support `--output <path>` to write the same artifact
+  to a file while keeping stdout quiet.
+- `--quiet` suppresses non-error diagnostics; top-level errors still use stderr.
+- `--no-color` is accepted by evidence commands so automation can opt out of
+  colored diagnostics as formatting evolves.
 - Diagnostics and top-level errors are written to stderr by the global error
   path.
 - `hl7v2 redact --format hl7` writes the redacted message to stdout and a short

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -72,6 +72,8 @@ Current behavior is script-grade:
 
 - Machine-readable JSON/YAML goes to stdout as the primary artifact.
 - Human text output also goes to stdout.
+- Evidence report commands support `--output <path>` for file capture with
+  stdout quiet, plus `--quiet` and `--no-color` for automation contexts.
 - Top-level diagnostics use stderr through the global error handler.
 - `redact --format hl7` sends the redacted HL7 body to stdout and a short
   receipt to stderr.


### PR DESCRIPTION
## Summary
- add `--output`, `--quiet`, and `--no-color` to evidence-producing CLI commands
- route validation, profile, corpus, redaction, bundle, and replay artifacts through a shared output helper
- keep stdout quiet when `--output` is used, while preserving top-level error diagnostics on stderr
- document the output-file behavior in the CLI README and evidence architecture/audit docs

## Tests
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests output_contract -- --nocapture`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`