### PR TITLE
evidence: add bundle manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "sysinfo",
  "tempfile",
  "tokio",

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml.workspace = true
+sha2.workspace = true
 hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "profile",
     "ack",

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -34,6 +34,7 @@ use hl7v2::{
     load_profile, load_profile_checked, normalize, parse, parse_mllp, to_json, validate, wrap_mllp,
     write, write_mllp,
 };
+use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -911,6 +912,21 @@ struct EvidenceBundleSummary {
     validation_issue_count: usize,
     redaction_phi_removed: bool,
     artifacts: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct EvidenceBundleManifest {
+    bundle_version: &'static str,
+    tool_name: &'static str,
+    tool_version: &'static str,
+    artifacts: Vec<EvidenceBundleManifestArtifact>,
+}
+
+#[derive(serde::Serialize)]
+struct EvidenceBundleManifestArtifact {
+    path: String,
+    role: &'static str,
+    sha256: String,
 }
 
 #[derive(serde::Serialize)]
@@ -2112,19 +2128,33 @@ fn bundle_command(
     fs::write(out.join("replay.sh"), replay_shell_script())?;
     fs::write(out.join("replay.ps1"), replay_powershell_script())?;
 
-    let artifacts = [
-        "message.redacted.hl7",
-        "validation-report.json",
-        "field-paths.json",
-        "profile.yaml",
-        "redaction-receipt.json",
-        "environment.json",
-        "replay.sh",
-        "replay.ps1",
-    ]
-    .into_iter()
-    .map(String::from)
-    .collect();
+    let artifact_specs = [
+        ("message.redacted.hl7", "redacted_message"),
+        ("validation-report.json", "validation_report"),
+        ("field-paths.json", "field_path_trace"),
+        ("profile.yaml", "profile"),
+        ("redaction-receipt.json", "redaction_receipt"),
+        ("environment.json", "environment"),
+        ("replay.sh", "replay_shell_script"),
+        ("replay.ps1", "replay_powershell_script"),
+    ];
+    let manifest = EvidenceBundleManifest {
+        bundle_version: "1",
+        tool_name: "hl7v2-cli",
+        tool_version: env!("CARGO_PKG_VERSION"),
+        artifacts: artifact_specs
+            .iter()
+            .map(|(path, role)| bundle_manifest_artifact(out, path, role))
+            .collect::<Result<_, _>>()?,
+    };
+    write_json_file(&out.join("manifest.json"), &manifest)?;
+
+    let mut artifacts = artifact_specs
+        .iter()
+        .map(|(path, _)| (*path).to_string())
+        .collect::<Vec<_>>();
+    artifacts.push("manifest.json".to_string());
+
     let summary = EvidenceBundleSummary {
         bundle_version: "1",
         output_dir: ".".to_string(),
@@ -2487,6 +2517,22 @@ fn write_json_file<T: serde::Serialize>(
 ) -> Result<(), Box<dyn std::error::Error>> {
     fs::write(path, serde_json::to_vec_pretty(value)?)?;
     Ok(())
+}
+
+fn bundle_manifest_artifact(
+    bundle_dir: &Path,
+    path: &'static str,
+    role: &'static str,
+) -> Result<EvidenceBundleManifestArtifact, Box<dyn std::error::Error>> {
+    let bytes = fs::read(bundle_dir.join(path))?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let sha256 = format!("{:x}", hasher.finalize());
+    Ok(EvidenceBundleManifestArtifact {
+        path: path.to_string(),
+        role,
+        sha256,
+    })
 }
 
 fn replay_shell_script() -> &'static str {

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -22,6 +22,13 @@ use common::{
     truncated_hl7_message,
 };
 
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 // =========================================================================
 // Help and Version Tests
 // =========================================================================
@@ -1883,6 +1890,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             "environment.json",
             "replay.sh",
             "replay.ps1",
+            "manifest.json",
         ] {
             assert!(
                 bundle_dir.join(artifact).exists(),
@@ -1905,6 +1913,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             "environment.json",
             "replay.sh",
             "replay.ps1",
+            "manifest.json",
         ] {
             let content = std::fs::read_to_string(bundle_dir.join(artifact)).unwrap();
             assert!(
@@ -1953,6 +1962,25 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             environment["replay_command"],
             "hl7v2 val message.redacted.hl7 --profile profile.yaml --report json"
         );
+
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("manifest.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(manifest["bundle_version"], "1");
+        assert_eq!(manifest["tool_name"], "hl7v2-cli");
+        let artifacts = manifest["artifacts"].as_array().unwrap();
+        assert_eq!(artifacts.len(), 8);
+        assert!(artifacts.iter().any(|artifact| {
+            artifact["path"] == "message.redacted.hl7"
+                && artifact["role"] == "redacted_message"
+                && artifact["sha256"].as_str().is_some_and(is_sha256_hex)
+        }));
+        assert!(artifacts.iter().any(|artifact| {
+            artifact["path"] == "validation-report.json"
+                && artifact["role"] == "validation_report"
+                && artifact["sha256"].as_str().is_some_and(is_sha256_hex)
+        }));
     }
 
     #[test]
@@ -2508,6 +2536,22 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
         )
         .expect("bundle redaction receipt should be JSON");
         assert_fixture("redaction-receipt", receipt);
+
+        let mut manifest: Value = serde_json::from_slice(
+            &std::fs::read(bundle.join("manifest.json"))
+                .expect("bundle manifest should be readable"),
+        )
+        .expect("bundle manifest should be JSON");
+        set(&mut manifest, "/tool_version", "1.2.1");
+        for artifact in manifest
+            .get_mut("artifacts")
+            .and_then(Value::as_array_mut)
+            .expect("manifest artifacts should be an array")
+        {
+            artifact["sha256"] =
+                "0000000000000000000000000000000000000000000000000000000000000000".into();
+        }
+        assert_fixture("evidence-bundle-manifest", manifest);
 
         let mut replay = command_json(
             &[

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -39,7 +39,8 @@ failed, what changed, what was redacted, and how to replay the result.
 | Redaction output | `hl7v2 redact --format json` | CLI-local `RedactionOutput` | Has input and policy SHA-256 values plus receipt; no `schema_version`; no `tool_version`; only the nested receipt has a JSON Schema today. |
 | Redaction receipt | `hl7v2 redact --format json`, bundle `redaction-receipt.json` | CLI-local `RedactionReceipt` | Captures actions and PHI removal status; JSON Schema exists at `schemas/evidence/redaction-receipt-v1.schema.json`; no `schema_version`; no `tool_version`. |
 | Field path trace | Bundle `field-paths.json` | CLI-local `FieldPathTraceReport` | Captures redacted message field paths and value shapes; no `schema_version`; no JSON Schema. |
-| Evidence bundle summary | `hl7v2 bundle ...` stdout | CLI-local `EvidenceBundleSummary` | Has `bundle_version`; JSON Schema exists at `schemas/evidence/evidence-bundle-v1.schema.json`; no `tool_version`; no manifest or artifact hashes yet. |
+| Evidence bundle summary | `hl7v2 bundle ...` stdout | CLI-local `EvidenceBundleSummary` | Has `bundle_version`; JSON Schema exists at `schemas/evidence/evidence-bundle-v1.schema.json`; no `tool_version`; includes `manifest.json` in the artifact list. |
+| Evidence bundle manifest | Bundle `manifest.json` | CLI-local `EvidenceBundleManifest` | Records `bundle_version`, `tool_version`, bundle-relative artifact paths, roles, and SHA-256 hashes; JSON Schema exists at `schemas/evidence/evidence-bundle-manifest-v1.schema.json`; replay hash verification is a follow-up. |
 | Evidence bundle environment | Bundle `environment.json` | CLI-local `EvidenceBundleEnvironment` | Has `bundle_version`, `tool_name`, `tool_version`, input/profile/policy hashes, and replay command. |
 | Evidence replay report | `hl7v2 replay --format json|yaml|text` | CLI-local `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, optional regenerated validation report, and JSON Schema at `schemas/evidence/evidence-replay-v1.schema.json`; no manifest hash verification yet. |
 
@@ -88,7 +89,7 @@ The next contract-hardening work should lock:
   artifact.
 - `tool_version` where users need provenance outside an environment file.
 - Explicit null and empty-list behavior for optional fields.
-- Bundle manifest and artifact SHA-256 verification during replay.
+- Manifest artifact SHA-256 verification during replay.
 - Redaction leak sentinel tests for synthetic PHI fixtures.
 - Server and Python parity for any artifact promoted beyond CLI-only use.
 

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -47,8 +47,9 @@ parity.
 | `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. | Needs JSON Schema and golden fixtures. |
 | `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. | Needs JSON Schema and golden fixtures. |
 | `RedactionReceipt` | CLI receipt records PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | CLI-local type; missing version fields, JSON Schema, and dedicated leak-sentinel fixture family. |
-| `EvidenceBundleSummary` | CLI stdout JSON summary includes `bundle_version`, output directory, message type, validation status, redaction status, and artifact list. | No manifest; no artifact hashes in summary. |
-| Bundle artifacts | `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, and `replay.ps1`. | No `manifest.json`; replay does not verify artifact hashes. |
+| `EvidenceBundleSummary` | CLI stdout JSON summary includes `bundle_version`, output directory, message type, validation status, redaction status, and artifact list. | Includes `manifest.json`; no `tool_version` in the summary itself. |
+| Bundle artifacts | `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, `replay.ps1`, and `manifest.json`. | Replay does not yet verify manifest hashes. |
+| `EvidenceBundleManifest` | Bundle `manifest.json` records bundle-relative artifact paths, roles, and SHA-256 hashes. | Hash verification is produced but not enforced until the replay-manifest verification PR. |
 | `EvidenceReplayReport` | CLI report with `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, reproduction status, and optional regenerated validation report. | No manifest verification yet; report schema not locked. |
 | Python validation report | `report.valid`, `message_type`, `profile`, `segment_count`, `issue_count`, `to_dict()`, and `to_json()` mirror `ValidationReport`. | Python does not yet expose corpus, redaction, bundle, or replay artifact APIs. |
 
@@ -90,18 +91,14 @@ Current behavior is script-grade:
 The evidence loop exists, but it is not yet fully contract-grade. Remaining
 hardening work:
 
-1. Add JSON Schemas for machine-readable evidence artifacts.
-2. Add representative golden fixtures and normalized snapshot comparisons.
-3. Add artifact version and tool version fields consistently.
-4. Document null/empty-list behavior for optional fields.
-5. Add bundle `manifest.json` with artifact SHA-256 values.
-6. Make replay verify artifact integrity, not only validation reproduction.
-7. Add synthetic PHI leak sentinels for redaction, bundle, replay, and later
+1. Add artifact version and tool version fields consistently.
+2. Document null/empty-list behavior for optional fields.
+3. Make replay verify manifest artifact integrity, not only validation
+   reproduction.
+4. Add synthetic PHI leak sentinels for redaction, bundle, replay, and later
    Python wrappers.
-8. Promote shared report types out of CLI-local structs when server or Python
+5. Promote shared report types out of CLI-local structs when server or Python
    parity needs them.
-9. Add consistent `--output`, `--quiet`, and `--no-color` behavior for evidence
-   commands.
 
 ## Verification Performed For This Audit
 

--- a/fixtures/evidence/evidence-bundle-manifest.json
+++ b/fixtures/evidence/evidence-bundle-manifest.json
@@ -1,0 +1,47 @@
+{
+  "bundle_version": "1",
+  "tool_name": "hl7v2-cli",
+  "tool_version": "1.2.1",
+  "artifacts": [
+    {
+      "path": "message.redacted.hl7",
+      "role": "redacted_message",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "validation-report.json",
+      "role": "validation_report",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "field-paths.json",
+      "role": "field_path_trace",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "profile.yaml",
+      "role": "profile",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "redaction-receipt.json",
+      "role": "redaction_receipt",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "environment.json",
+      "role": "environment",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "replay.sh",
+      "role": "replay_shell_script",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "replay.ps1",
+      "role": "replay_powershell_script",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ]
+}

--- a/fixtures/evidence/evidence-bundle.json
+++ b/fixtures/evidence/evidence-bundle.json
@@ -13,6 +13,7 @@
     "redaction-receipt.json",
     "environment.json",
     "replay.sh",
-    "replay.ps1"
+    "replay.ps1",
+    "manifest.json"
   ]
 }

--- a/schemas/evidence/evidence-bundle-manifest-v1.schema.json
+++ b/schemas/evidence/evidence-bundle-manifest-v1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/evidence-bundle-manifest/v1",
+  "title": "HL7v2 Evidence Bundle Manifest",
+  "description": "Machine-readable manifest written inside an evidence bundle. Paths are bundle-relative and hashes are SHA-256 digests of artifact contents.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bundle_version",
+    "tool_name",
+    "tool_version",
+    "artifacts"
+  ],
+  "properties": {
+    "bundle_version": {
+      "type": "string"
+    },
+    "tool_name": {
+      "type": "string",
+      "enum": ["hl7v2-cli"]
+    },
+    "tool_version": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/artifact"
+      }
+    }
+  },
+  "definitions": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "role", "sha256"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^(?![A-Za-z]:)(?!/)(?!.*\\\\).+$",
+          "description": "Bundle-relative artifact path. Absolute paths and Windows separators are not allowed."
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "redacted_message",
+            "validation_report",
+            "field_path_trace",
+            "profile",
+            "redaction_receipt",
+            "environment",
+            "replay_shell_script",
+            "replay_powershell_script"
+          ]
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- write `manifest.json` into evidence bundles with bundle-relative artifact paths, roles, and SHA-256 hashes
- add a JSON Schema and golden fixture for the bundle manifest artifact
- include `manifest.json` in bundle summaries and PHI leak regression checks
- update evidence artifact docs to show manifest production, with replay hash verification left to the next PR

## Security / contract notes
- manifest paths are bundle-relative and schema-constrained against absolute/Windows paths
- manifest hashes are computed over artifact bytes with a direct workspace `sha2` dependency
- replay still does not enforce manifest hash verification in this PR

## Tests
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- evidence schema loop with `npx -y -p ajv-cli -p ajv-formats ajv validate ...`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`