### PR TITLE
evidence: verify bundle manifest on replay

### DIFF
--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -41,7 +41,7 @@ use std::fmt;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process;
 use std::time::Duration;
 mod config;
@@ -914,18 +914,18 @@ struct EvidenceBundleSummary {
     artifacts: Vec<String>,
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Deserialize, serde::Serialize)]
 struct EvidenceBundleManifest {
-    bundle_version: &'static str,
-    tool_name: &'static str,
-    tool_version: &'static str,
+    bundle_version: String,
+    tool_name: String,
+    tool_version: String,
     artifacts: Vec<EvidenceBundleManifestArtifact>,
 }
 
-#[derive(serde::Serialize)]
+#[derive(serde::Deserialize, serde::Serialize)]
 struct EvidenceBundleManifestArtifact {
     path: String,
-    role: &'static str,
+    role: String,
     sha256: String,
 }
 
@@ -2128,20 +2128,11 @@ fn bundle_command(
     fs::write(out.join("replay.sh"), replay_shell_script())?;
     fs::write(out.join("replay.ps1"), replay_powershell_script())?;
 
-    let artifact_specs = [
-        ("message.redacted.hl7", "redacted_message"),
-        ("validation-report.json", "validation_report"),
-        ("field-paths.json", "field_path_trace"),
-        ("profile.yaml", "profile"),
-        ("redaction-receipt.json", "redaction_receipt"),
-        ("environment.json", "environment"),
-        ("replay.sh", "replay_shell_script"),
-        ("replay.ps1", "replay_powershell_script"),
-    ];
+    let artifact_specs = bundle_artifact_specs();
     let manifest = EvidenceBundleManifest {
-        bundle_version: "1",
-        tool_name: "hl7v2-cli",
-        tool_version: env!("CARGO_PKG_VERSION"),
+        bundle_version: "1".to_string(),
+        tool_name: "hl7v2-cli".to_string(),
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
         artifacts: artifact_specs
             .iter()
             .map(|(path, role)| bundle_manifest_artifact(out, path, role))
@@ -2189,6 +2180,7 @@ fn replay_command(
 fn build_replay_report(bundle: &Path) -> EvidenceReplayReport {
     let mut checks = Vec::new();
     let required_artifacts = [
+        "manifest.json",
         "message.redacted.hl7",
         "validation-report.json",
         "field-paths.json",
@@ -2219,6 +2211,50 @@ fn build_replay_report(bundle: &Path) -> EvidenceReplayReport {
                 missing_artifacts.join(", ")
             ),
         ));
+    }
+
+    let manifest = match read_bundle_manifest(bundle) {
+        Ok(manifest) => {
+            checks.push(replay_check(
+                "manifest",
+                EvidenceReplayCheckStatus::Pass,
+                "manifest.json parsed",
+            ));
+            Some(manifest)
+        }
+        Err(error) => {
+            checks.push(replay_check(
+                "manifest",
+                EvidenceReplayCheckStatus::Fail,
+                error,
+            ));
+            None
+        }
+    };
+    let manifest_bundle_version = manifest
+        .as_ref()
+        .map(|manifest| manifest.bundle_version.clone());
+    let manifest_catalog_ok = manifest
+        .as_ref()
+        .is_some_and(|manifest| verify_bundle_manifest_catalog(manifest, &mut checks));
+    let manifest_hashes_ok = manifest_catalog_ok
+        && manifest
+            .as_ref()
+            .is_some_and(|manifest| verify_bundle_manifest_hashes(bundle, manifest, &mut checks));
+
+    if !manifest_hashes_ok {
+        return EvidenceReplayReport {
+            replay_version: "1",
+            bundle_version: manifest_bundle_version,
+            tool_name: "hl7v2-cli",
+            tool_version: env!("CARGO_PKG_VERSION"),
+            message_type: None,
+            reproduced: false,
+            validation_valid: None,
+            validation_issue_count: None,
+            checks,
+            validation_report: None,
+        };
     }
 
     let environment = match read_bundle_json_value(bundle, "environment.json") {
@@ -2398,7 +2434,8 @@ fn build_replay_report(bundle: &Path) -> EvidenceReplayReport {
         .all(|check| check.status == EvidenceReplayCheckStatus::Pass);
     let bundle_version = environment
         .as_ref()
-        .and_then(|value| json_string(value, "bundle_version"));
+        .and_then(|value| json_string(value, "bundle_version"))
+        .or(manifest_bundle_version);
     let message_type = actual_report
         .as_ref()
         .map(|report| report.message_type.clone())
@@ -2439,6 +2476,154 @@ fn replay_check(
         status,
         message: message.into(),
     }
+}
+
+fn bundle_artifact_specs() -> [(&'static str, &'static str); 8] {
+    [
+        ("message.redacted.hl7", "redacted_message"),
+        ("validation-report.json", "validation_report"),
+        ("field-paths.json", "field_path_trace"),
+        ("profile.yaml", "profile"),
+        ("redaction-receipt.json", "redaction_receipt"),
+        ("environment.json", "environment"),
+        ("replay.sh", "replay_shell_script"),
+        ("replay.ps1", "replay_powershell_script"),
+    ]
+}
+
+fn read_bundle_manifest(bundle: &Path) -> Result<EvidenceBundleManifest, String> {
+    let contents = read_bundle_string(bundle, "manifest.json")?;
+    serde_json::from_str(&contents)
+        .map_err(|error| format!("manifest.json is invalid JSON: {error}"))
+}
+
+fn verify_bundle_manifest_catalog(
+    manifest: &EvidenceBundleManifest,
+    checks: &mut Vec<EvidenceReplayCheck>,
+) -> bool {
+    let expected = bundle_artifact_specs();
+    let mut errors = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+
+    for artifact in &manifest.artifacts {
+        if !seen_paths.insert(artifact.path.clone()) {
+            errors.push("duplicate artifact path".to_string());
+        }
+        if safe_bundle_relative_path(&artifact.path).is_err() {
+            errors.push("unsafe artifact path".to_string());
+            continue;
+        }
+        if !is_lower_sha256_hex(&artifact.sha256) {
+            errors.push(format!("{} has invalid sha256", artifact.path));
+        }
+        if !expected
+            .iter()
+            .any(|(path, role)| *path == artifact.path.as_str() && *role == artifact.role.as_str())
+        {
+            errors.push(format!(
+                "{} has unexpected role {}",
+                artifact.path, artifact.role
+            ));
+        }
+    }
+
+    for (expected_path, expected_role) in expected {
+        if !manifest
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == expected_path && artifact.role == expected_role)
+        {
+            errors.push(format!("missing manifest entry for {expected_path}"));
+        }
+    }
+
+    if errors.is_empty() {
+        checks.push(replay_check(
+            "manifest-artifacts",
+            EvidenceReplayCheckStatus::Pass,
+            "manifest lists expected bundle artifacts",
+        ));
+        true
+    } else {
+        checks.push(replay_check(
+            "manifest-artifacts",
+            EvidenceReplayCheckStatus::Fail,
+            format!("manifest artifact catalog invalid: {}", errors.join(", ")),
+        ));
+        false
+    }
+}
+
+fn verify_bundle_manifest_hashes(
+    bundle: &Path,
+    manifest: &EvidenceBundleManifest,
+    checks: &mut Vec<EvidenceReplayCheck>,
+) -> bool {
+    let mut errors = Vec::new();
+
+    for artifact in &manifest.artifacts {
+        let relative_path = match safe_bundle_relative_path(&artifact.path) {
+            Ok(relative_path) => relative_path,
+            Err(error) => {
+                errors.push(error);
+                continue;
+            }
+        };
+        match fs::read(bundle.join(relative_path)) {
+            Ok(bytes) => {
+                let actual = compute_sha256_bytes(&bytes);
+                if actual != artifact.sha256 {
+                    errors.push(format!("{} hash mismatch", artifact.path));
+                }
+            }
+            Err(error) => {
+                errors.push(format!("could not read {}: {error}", artifact.path));
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        checks.push(replay_check(
+            "manifest-hashes",
+            EvidenceReplayCheckStatus::Pass,
+            "manifest artifact hashes match bundle contents",
+        ));
+        true
+    } else {
+        checks.push(replay_check(
+            "manifest-hashes",
+            EvidenceReplayCheckStatus::Fail,
+            format!("manifest hash verification failed: {}", errors.join(", ")),
+        ));
+        false
+    }
+}
+
+fn safe_bundle_relative_path(path: &str) -> Result<PathBuf, String> {
+    if path.is_empty() || path.contains('\\') {
+        return Err("manifest artifact path must be bundle-relative".to_string());
+    }
+
+    let relative_path = Path::new(path);
+    if relative_path.is_absolute()
+        || relative_path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::Prefix(_) | Component::RootDir
+            )
+        })
+    {
+        return Err("manifest artifact path must be bundle-relative".to_string());
+    }
+
+    Ok(relative_path.to_path_buf())
+}
+
+fn is_lower_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
 }
 
 fn read_bundle_artifact(bundle: &Path, artifact: &str) -> Result<Vec<u8>, String> {
@@ -2525,14 +2710,17 @@ fn bundle_manifest_artifact(
     role: &'static str,
 ) -> Result<EvidenceBundleManifestArtifact, Box<dyn std::error::Error>> {
     let bytes = fs::read(bundle_dir.join(path))?;
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let sha256 = format!("{:x}", hasher.finalize());
     Ok(EvidenceBundleManifestArtifact {
         path: path.to_string(),
-        role,
-        sha256,
+        role: role.to_string(),
+        sha256: compute_sha256_bytes(&bytes),
     })
+}
+
+fn compute_sha256_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
 }
 
 fn replay_shell_script() -> &'static str {

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2160,7 +2160,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
     }
 
     #[test]
-    fn test_replay_fails_when_stored_validation_report_drifts() {
+    fn test_replay_fails_when_stored_validation_report_is_tampered() {
         let dir = create_temp_dir();
         let bundle_dir = create_replayable_bundle(&dir);
         let report_path = bundle_dir.join("validation-report.json");
@@ -2184,12 +2184,106 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
         let report: serde_json::Value =
             serde_json::from_str(&stdout).expect("replay failure output should be JSON");
         assert_eq!(report["reproduced"], false);
+        assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+            check["name"] == "manifest-hashes"
+                && check["status"] == "fail"
+                && check["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("validation-report.json")
+        }));
+    }
+
+    #[test]
+    fn test_replay_fails_when_redacted_message_is_tampered() {
+        let dir = create_temp_dir();
+        let bundle_dir = create_replayable_bundle(&dir);
+        let message_path = bundle_dir.join("message.redacted.hl7");
+        let mut message = std::fs::read_to_string(&message_path).unwrap();
+        message.push_str("OBX|2|ST|LEAK^SENTINEL^L||not-phi\r");
+        std::fs::write(&message_path, message).unwrap();
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", bundle_dir.to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("Failed to execute replay");
+
+        assert!(!output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("replay failure output should be JSON");
+        assert_eq!(report["reproduced"], false);
+        assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+            check["name"] == "manifest-hashes"
+                && check["status"] == "fail"
+                && check["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("message.redacted.hl7")
+        }));
+    }
+
+    #[test]
+    fn test_replay_fails_when_manifest_is_malformed() {
+        let dir = create_temp_dir();
+        let bundle_dir = create_replayable_bundle(&dir);
+        std::fs::write(bundle_dir.join("manifest.json"), b"{not-json").unwrap();
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", bundle_dir.to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("Failed to execute replay");
+
+        assert!(!output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("replay failure output should be JSON");
+        assert_eq!(report["reproduced"], false);
         assert!(
             report["checks"]
                 .as_array()
                 .unwrap()
                 .iter()
-                .any(|check| check["name"] == "report-match" && check["status"] == "fail")
+                .any(|check| check["name"] == "manifest" && check["status"] == "fail")
+        );
+    }
+
+    #[test]
+    fn test_replay_fails_when_manifest_hash_is_wrong() {
+        let dir = create_temp_dir();
+        let bundle_dir = create_replayable_bundle(&dir);
+        let manifest_path = bundle_dir.join("manifest.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        manifest["artifacts"][0]["sha256"] =
+            serde_json::json!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["replay", bundle_dir.to_str().unwrap(), "--format", "json"])
+            .output()
+            .expect("Failed to execute replay");
+
+        assert!(!output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("replay failure output should be JSON");
+        assert_eq!(report["reproduced"], false);
+        assert!(
+            report["checks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|check| check["name"] == "manifest-hashes"
+                    && check["status"] == "fail"
+                    && check["message"].as_str().unwrap().contains("hash mismatch"))
         );
     }
 

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -40,9 +40,9 @@ failed, what changed, what was redacted, and how to replay the result.
 | Redaction receipt | `hl7v2 redact --format json`, bundle `redaction-receipt.json` | CLI-local `RedactionReceipt` | Captures actions and PHI removal status; JSON Schema exists at `schemas/evidence/redaction-receipt-v1.schema.json`; no `schema_version`; no `tool_version`. |
 | Field path trace | Bundle `field-paths.json` | CLI-local `FieldPathTraceReport` | Captures redacted message field paths and value shapes; no `schema_version`; no JSON Schema. |
 | Evidence bundle summary | `hl7v2 bundle ...` stdout | CLI-local `EvidenceBundleSummary` | Has `bundle_version`; JSON Schema exists at `schemas/evidence/evidence-bundle-v1.schema.json`; no `tool_version`; includes `manifest.json` in the artifact list. |
-| Evidence bundle manifest | Bundle `manifest.json` | CLI-local `EvidenceBundleManifest` | Records `bundle_version`, `tool_version`, bundle-relative artifact paths, roles, and SHA-256 hashes; JSON Schema exists at `schemas/evidence/evidence-bundle-manifest-v1.schema.json`; replay hash verification is a follow-up. |
+| Evidence bundle manifest | Bundle `manifest.json` | CLI-local `EvidenceBundleManifest` | Records `bundle_version`, `tool_version`, bundle-relative artifact paths, roles, and SHA-256 hashes; JSON Schema exists at `schemas/evidence/evidence-bundle-manifest-v1.schema.json`; replay verifies manifest catalog and hashes before using artifacts. |
 | Evidence bundle environment | Bundle `environment.json` | CLI-local `EvidenceBundleEnvironment` | Has `bundle_version`, `tool_name`, `tool_version`, input/profile/policy hashes, and replay command. |
-| Evidence replay report | `hl7v2 replay --format json|yaml|text` | CLI-local `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, optional regenerated validation report, and JSON Schema at `schemas/evidence/evidence-replay-v1.schema.json`; no manifest hash verification yet. |
+| Evidence replay report | `hl7v2 replay --format json|yaml|text` | CLI-local `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, optional regenerated validation report, and JSON Schema at `schemas/evidence/evidence-replay-v1.schema.json`; fails closed on malformed manifests, missing artifacts, and hash mismatches. |
 
 ## Current Parity
 
@@ -89,7 +89,7 @@ The next contract-hardening work should lock:
   artifact.
 - `tool_version` where users need provenance outside an environment file.
 - Explicit null and empty-list behavior for optional fields.
-- Manifest artifact SHA-256 verification during replay.
+- Bundle README and clearer human replay instructions.
 - Redaction leak sentinel tests for synthetic PHI fixtures.
 - Server and Python parity for any artifact promoted beyond CLI-only use.
 

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -48,9 +48,9 @@ parity.
 | `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. | Needs JSON Schema and golden fixtures. |
 | `RedactionReceipt` | CLI receipt records PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | CLI-local type; missing version fields, JSON Schema, and dedicated leak-sentinel fixture family. |
 | `EvidenceBundleSummary` | CLI stdout JSON summary includes `bundle_version`, output directory, message type, validation status, redaction status, and artifact list. | Includes `manifest.json`; no `tool_version` in the summary itself. |
-| Bundle artifacts | `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, `replay.ps1`, and `manifest.json`. | Replay does not yet verify manifest hashes. |
-| `EvidenceBundleManifest` | Bundle `manifest.json` records bundle-relative artifact paths, roles, and SHA-256 hashes. | Hash verification is produced but not enforced until the replay-manifest verification PR. |
-| `EvidenceReplayReport` | CLI report with `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, reproduction status, and optional regenerated validation report. | No manifest verification yet; report schema not locked. |
+| Bundle artifacts | `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, `replay.ps1`, and `manifest.json`. | No generated bundle README yet. |
+| `EvidenceBundleManifest` | Bundle `manifest.json` records bundle-relative artifact paths, roles, and SHA-256 hashes. | Replay verifies manifest catalog and hashes before using artifacts. |
+| `EvidenceReplayReport` | CLI report with `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, reproduction status, and optional regenerated validation report. | Fails closed on malformed manifests, missing artifacts, and hash mismatches; report schema exists. |
 | Python validation report | `report.valid`, `message_type`, `profile`, `segment_count`, `issue_count`, `to_dict()`, and `to_json()` mirror `ValidationReport`. | Python does not yet expose corpus, redaction, bundle, or replay artifact APIs. |
 
 ## Surface Parity
@@ -93,8 +93,7 @@ hardening work:
 
 1. Add artifact version and tool version fields consistently.
 2. Document null/empty-list behavior for optional fields.
-3. Make replay verify manifest artifact integrity, not only validation
-   reproduction.
+3. Add generated bundle README content and clearer human replay instructions.
 4. Add synthetic PHI leak sentinels for redaction, bundle, replay, and later
    Python wrappers.
 5. Promote shared report types out of CLI-local structs when server or Python

--- a/fixtures/evidence/evidence-replay.json
+++ b/fixtures/evidence/evidence-replay.json
@@ -14,6 +14,21 @@
       "message": "all expected bundle artifacts are present"
     },
     {
+      "name": "manifest",
+      "status": "pass",
+      "message": "manifest.json parsed"
+    },
+    {
+      "name": "manifest-artifacts",
+      "status": "pass",
+      "message": "manifest lists expected bundle artifacts"
+    },
+    {
+      "name": "manifest-hashes",
+      "status": "pass",
+      "message": "manifest artifact hashes match bundle contents"
+    },
+    {
       "name": "environment",
       "status": "pass",
       "message": "environment.json parsed"


### PR DESCRIPTION
## Summary
- make `hl7v2 replay` parse and validate `manifest.json` before using bundle artifacts
- verify manifest catalog entries, safe bundle-relative paths, expected roles, and SHA-256 hashes
- fail closed on malformed manifests, missing artifacts, wrong hashes, and tampered bundle files
- update replay golden fixtures and evidence docs to reflect manifest verification

## Security / contract notes
- manifest artifact paths are treated as untrusted input and rejected unless they are bundle-relative
- replay stops before parsing/validating artifacts when manifest verification fails
- failure reports name bundle artifact paths only; no raw message content is emitted

## Tests
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- evidence schema loop with `npx -y -p ajv-cli -p ajv-formats ajv validate ...`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`