### PR TITLE
server: add print-config and readiness checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
 name = "hl7v2-server"
 version = "1.2.1"
 dependencies = [
+ "assert_cmd",
  "axum 0.8.9",
  "cucumber",
  "governor 0.8.1",
@@ -1624,6 +1625,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml",
  "tonic 0.12.3",
  "tonic-build",
  "tower 0.5.3",

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -33,8 +33,7 @@ cargo run --bin hl7v2-server
 ### Environment Variables
 
 ```bash
-export HL7V2_HOST="0.0.0.0"              # Bind address (default: 127.0.0.1)
-export HL7V2_PORT="8080"                  # Port (default: 8080)
+export BIND_ADDRESS="0.0.0.0:8080"        # Bind address (default: 127.0.0.1:8080)
 export HL7V2_MAX_CONCURRENT="100"         # Max concurrent requests (default: 100)
 export HL7V2_MAX_BODY_SIZE="1048576"      # Max body size in bytes (default: 1MB)
 export HL7V2_API_KEY="your-secret-key"    # API key for authentication (optional)
@@ -51,8 +50,7 @@ docker build -t hl7v2-server:latest .
 
 # Run container
 docker run -p 8080:8080 \
-  -e HL7V2_HOST=0.0.0.0 \
-  -e HL7V2_PORT=8080 \
+  -e BIND_ADDRESS=0.0.0.0:8080 \
   -e RUST_LOG=info \
   hl7v2-server:latest
 ```
@@ -81,8 +79,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      HL7V2_HOST: "0.0.0.0"
-      HL7V2_PORT: "8080"
+      BIND_ADDRESS: "0.0.0.0:8080"
       HL7V2_MAX_CONCURRENT: "200"
       RUST_LOG: "info"
     healthcheck:
@@ -275,8 +272,7 @@ For NixOS deployments, see [NIX_USAGE.md](NIX_USAGE.md) for complete guide.
 
 **Bind Address and Port:**
 ```bash
-HL7V2_HOST="0.0.0.0"  # Listen on all interfaces
-HL7V2_PORT="8080"      # HTTP port
+BIND_ADDRESS="0.0.0.0:8080"  # Listen on all interfaces
 ```
 
 **Concurrency Limiting:**
@@ -315,23 +311,27 @@ export RUST_LOG_FORMAT="json"
 
 ### Configuration File
 
-Create `config.yaml`:
+Set `HL7V2_CONFIG` to a TOML or YAML file. The server consumes the `[server]`
+section from the same checked config shape as `config.example.toml`.
 
-```yaml
-server:
-  bind_address: "0.0.0.0:8080"
-  max_body_size: 1048576
-  max_concurrent: 100
+Create `config.toml`:
 
-logging:
-  level: "info"
-  format: "json"
+```toml
+[server]
+host = "0.0.0.0"
+port = 8080
+# api_key = "your-secret-api-key-here"
 
-security:
-  api_key_required: true
-  cors_allowed_origins:
-    - "https://app.example.com"
-    - "https://dashboard.example.com"
+[logging]
+level = "info"
+log_to_file = false
+```
+
+Then run:
+
+```bash
+HL7V2_CONFIG=/etc/hl7v2/config.toml hl7v2-server --print-config
+HL7V2_CONFIG=/etc/hl7v2/config.toml hl7v2-server
 ```
 
 ## Monitoring

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ The fastest way to get started is with the HTTP API server:
 cargo run --bin hl7v2-server
 
 # Or with custom configuration
-HL7V2_HOST=0.0.0.0 HL7V2_PORT=8080 cargo run --bin hl7v2-server
+BIND_ADDRESS=0.0.0.0:8080 cargo run --bin hl7v2-server
+
+# Inspect sanitized effective configuration and exit
+cargo run --bin hl7v2-server -- --print-config
 ```
 
 **Parse a message via HTTP:**

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -67,7 +67,7 @@ paths:
   /ready:
     get:
       summary: Readiness check
-      description: Returns JSON ready status
+      description: Returns startup readiness checks and typed evidence self-check status
       tags: [health]
       operationId: readinessCheck
       responses:
@@ -76,10 +76,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ready:
-                    type: boolean
+                $ref: '#/components/schemas/ReadyResponse'
+        '503':
+          description: Service is not ready
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadyResponse'
 
   /metrics:
     get:
@@ -245,6 +248,34 @@ components:
           type: string
         uptime_seconds:
           type: integer
+
+    ReadyResponse:
+      type: object
+      required: [ready, status, version, checks]
+      properties:
+        ready:
+          type: boolean
+        status:
+          type: string
+          enum: [ready, not_ready]
+        version:
+          type: string
+        checks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReadinessCheck'
+
+    ReadinessCheck:
+      type: object
+      required: [name, status, message]
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum: [pass, fail]
+        message:
+          type: string
 
     ParseRequest:
       type: object

--- a/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
@@ -6,7 +6,7 @@
 //! - Request size limits
 
 use axum::http::{Request, StatusCode, header};
-use hl7v2_server::{AppState, build_router};
+use hl7v2_server::{AppState, ServerConfig, build_router};
 use std::sync::Arc;
 use std::time::Instant;
 use tower::ServiceExt;
@@ -19,6 +19,7 @@ async fn test_auth_missing_api_key_fails() {
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
     let app = build_router(state);
 
@@ -49,6 +50,7 @@ async fn test_auth_valid_api_key_succeeds() {
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
     let app = build_router(state);
 
@@ -85,6 +87,7 @@ async fn test_auth_invalid_api_key_fails() {
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
     let app = build_router(state);
 
@@ -116,6 +119,7 @@ async fn test_health_metrics_public() {
         metrics_handle: Arc::new(metrics_handle),
         api_key: Some("secret-key".to_string()),
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
     let app = build_router(state);
 

--- a/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
@@ -35,6 +35,7 @@ fn create_test_router() -> axum::Router {
         metrics_handle: Arc::new(metrics_handle),
         api_key: None,
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
     build_router(state)
 }
@@ -890,6 +891,8 @@ mod server_integration {
             max_body_size: 10 * 1024 * 1024,
             api_key: None,
             cors_allowed_origins: Default::default(),
+            profile_paths: Vec::new(),
+            config_source: None,
         };
 
         // Build server

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -26,6 +26,7 @@ hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+toml = "1.1.2"
 axum = { workspace = true }
 tower = { workspace = true, features = ["limit"] }
 tower-http = { workspace = true, features = ["trace", "cors", "compression-gzip"] }
@@ -55,6 +56,7 @@ http-body-util = "0.1"
 cucumber = "0.22.1"
 serde_json = { workspace = true }
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
+assert_cmd = "2.0"
 
 [[test]]
 name = "bdd_tests"

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -67,7 +67,7 @@ paths:
   /ready:
     get:
       summary: Readiness check
-      description: Returns JSON ready status
+      description: Returns startup readiness checks and typed evidence self-check status
       tags: [health]
       operationId: readinessCheck
       responses:
@@ -76,10 +76,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  ready:
-                    type: boolean
+                $ref: '#/components/schemas/ReadyResponse'
+        '503':
+          description: Service is not ready
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadyResponse'
 
   /metrics:
     get:
@@ -245,6 +248,34 @@ components:
           type: string
         uptime_seconds:
           type: integer
+
+    ReadyResponse:
+      type: object
+      required: [ready, status, version, checks]
+      properties:
+        ready:
+          type: boolean
+        status:
+          type: string
+          enum: [ready, not_ready]
+        version:
+          type: string
+        checks:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReadinessCheck'
+
+    ReadinessCheck:
+      type: object
+      required: [name, status, message]
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum: [pass, fail]
+        message:
+          type: string
 
     ParseRequest:
       type: object

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -23,6 +23,18 @@ pub async fn health_handler(State(state): State<Arc<AppState>>) -> impl IntoResp
     (StatusCode::OK, Json(response))
 }
 
+/// Handler for GET /ready
+pub async fn ready_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let response = state.ready_response();
+    let status = if response.ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (status, Json(response))
+}
+
 /// Handler for POST /hl7/parse
 pub async fn parse_handler(
     State(_state): State<Arc<AppState>>,

--- a/crates/hl7v2-server/src/main.rs
+++ b/crates/hl7v2-server/src/main.rs
@@ -1,10 +1,26 @@
 //! HL7v2 HTTP/REST API server binary.
 
-use hl7v2_server::{CorsAllowedOrigins, Server};
+use hl7v2_server::{Server, ServerConfig};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let command = parse_args(std::env::args().skip(1))
+        .map_err(|message| std::io::Error::new(std::io::ErrorKind::InvalidInput, message))?;
+    if command == ServerCommand::Help {
+        println!("{}", usage());
+        return Ok(());
+    }
+
+    let config = ServerConfig::from_env()?;
+    if command == ServerCommand::PrintConfig {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&config.to_public_config())?
+        );
+        return Ok(());
+    }
+
     // Initialize tracing/logging
     tracing_subscriber::registry()
         .with(
@@ -14,33 +30,87 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    // Get bind address from environment or use default
-    let bind_address = std::env::var("BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0:8080".to_string());
-
     tracing::info!("Starting HL7v2 HTTP server");
-    tracing::info!("Bind address: {}", bind_address);
-
-    // Get API key from environment if set
-    let api_key = std::env::var("HL7V2_API_KEY").ok();
-    if api_key.is_some() {
+    tracing::info!("Bind address: {}", config.bind_address);
+    if config.api_key.is_some() {
         tracing::info!("API key authentication enabled");
     } else {
         tracing::warn!("API key authentication disabled (public access enabled)");
     }
-
-    let cors_allowed_origins = std::env::var("HL7V2_CORS_ALLOWED_ORIGINS")
-        .map(|value| CorsAllowedOrigins::from_csv(&value))
-        .unwrap_or_default();
-    tracing::info!("CORS allowed origins: {:?}", cors_allowed_origins);
+    tracing::info!("CORS allowed origins: {:?}", config.cors_allowed_origins);
 
     // Create and run server
-    let server = Server::builder()
-        .bind(bind_address)
-        .api_key(api_key)
-        .cors_allowed_origins(cors_allowed_origins)
-        .build();
+    let server = Server::new(config);
 
     server.serve().await?;
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServerCommand {
+    Serve,
+    PrintConfig,
+    Help,
+}
+
+fn parse_args<I, S>(args: I) -> Result<ServerCommand, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut command = ServerCommand::Serve;
+
+    for arg in args {
+        match arg.as_ref() {
+            "--print-config" => command = ServerCommand::PrintConfig,
+            "-h" | "--help" => command = ServerCommand::Help,
+            unknown => {
+                return Err(format!(
+                    "unknown argument '{unknown}'. Run hl7v2-server --help for usage."
+                ));
+            }
+        }
+    }
+
+    Ok(command)
+}
+
+fn usage() -> &'static str {
+    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server] host, port, api_key\n  BIND_ADDRESS                Override bind address, for example 0.0.0.0:8080\n  HL7V2_API_KEY               API key for protected /hl7/* routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_defaults_to_serve() {
+        assert_eq!(
+            parse_args(std::iter::empty::<&str>()),
+            Ok(ServerCommand::Serve)
+        );
+    }
+
+    #[test]
+    fn parse_args_accepts_print_config() {
+        assert_eq!(
+            parse_args(["--print-config"]),
+            Ok(ServerCommand::PrintConfig)
+        );
+    }
+
+    #[test]
+    fn parse_args_accepts_help() {
+        assert_eq!(parse_args(["--help"]), Ok(ServerCommand::Help));
+        assert_eq!(parse_args(["-h"]), Ok(ServerCommand::Help));
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_arguments() {
+        assert!(matches!(
+            parse_args(["--unknown"]),
+            Err(error) if error.contains("unknown argument")
+        ));
+    }
 }

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -18,6 +18,90 @@ pub struct HealthResponse {
     pub uptime_seconds: u64,
 }
 
+/// Readiness check response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadyResponse {
+    /// Whether the service is ready to receive traffic.
+    pub ready: bool,
+    /// Overall readiness status.
+    pub status: ReadinessStatus,
+    /// Server package version.
+    pub version: String,
+    /// Individual readiness checks.
+    pub checks: Vec<ReadinessCheck>,
+}
+
+impl ReadyResponse {
+    /// Build a readiness response from individual checks.
+    pub fn from_checks(checks: Vec<ReadinessCheck>) -> Self {
+        let ready = checks
+            .iter()
+            .all(|check| check.status == ReadinessCheckStatus::Pass);
+
+        Self {
+            ready,
+            status: if ready {
+                ReadinessStatus::Ready
+            } else {
+                ReadinessStatus::NotReady
+            },
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            checks,
+        }
+    }
+}
+
+/// Overall readiness status.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadinessStatus {
+    /// All required checks passed.
+    Ready,
+    /// At least one required check failed.
+    NotReady,
+}
+
+/// Individual readiness check.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReadinessCheck {
+    /// Stable check name.
+    pub name: String,
+    /// Check status.
+    pub status: ReadinessCheckStatus,
+    /// Human-readable diagnostic message.
+    pub message: String,
+}
+
+impl ReadinessCheck {
+    /// Build a passing readiness check.
+    pub fn pass(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: ReadinessCheckStatus::Pass,
+            message: message.into(),
+        }
+    }
+
+    /// Build a failing readiness check.
+    pub fn fail(name: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: ReadinessCheckStatus::Fail,
+            message: message.into(),
+        }
+    }
+}
+
+/// Individual readiness check status.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReadinessCheckStatus {
+    /// Check passed.
+    Pass,
+    /// Check failed.
+    Fail,
+}
+
 /// Health status enum
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -16,7 +16,7 @@ use tower_http::{
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::handlers::{
-    ack_handler, health_handler, normalize_handler, parse_handler, validate_handler,
+    ack_handler, health_handler, normalize_handler, parse_handler, ready_handler, validate_handler,
 };
 use crate::metrics::{metrics_handler, middleware::metrics_middleware};
 use crate::middleware::{auth_middleware, create_concurrency_limit_layer};
@@ -82,13 +82,6 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .layer(create_concurrency_limit_layer()) // Concurrency limiting applied first (last in stack)
 }
 
-/// Handler for GET /ready
-async fn ready_handler() -> &'static str {
-    // Simple readiness check - if we can respond, we're ready
-    // In production, you might want to check database connections, etc.
-    "{\"ready\":true}"
-}
-
 /// Build CORS layer
 fn build_cors_layer(origins: &CorsAllowedOrigins) -> CorsLayer {
     let layer = CorsLayer::new().allow_methods(Any).allow_headers(Any);
@@ -129,6 +122,7 @@ mod tests {
             metrics_handle: Arc::new(metrics_handle),
             api_key: Some(api_key.clone()),
             cors_allowed_origins: CorsAllowedOrigins::default(),
+            readiness_checks: crate::server::ServerConfig::default().readiness_checks(),
         });
         (build_router(state), api_key)
     }
@@ -178,6 +172,7 @@ mod tests {
             metrics_handle: Arc::new(metrics_handle),
             api_key: None,
             cors_allowed_origins: CorsAllowedOrigins::default(),
+            readiness_checks: crate::server::ServerConfig::default().readiness_checks(),
         });
 
         let app = build_router(state);
@@ -211,6 +206,7 @@ mod tests {
             metrics_handle: Arc::new(metrics_handle),
             api_key: None,
             cors_allowed_origins: CorsAllowedOrigins::default(),
+            readiness_checks: crate::server::ServerConfig::default().readiness_checks(),
         });
 
         let app = build_router(state);

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -1,7 +1,12 @@
 //! HTTP server implementation.
 
+use crate::models::{ReadinessCheck, ReadyResponse};
 use metrics_exporter_prometheus::PrometheusHandle;
+use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
+use std::fs;
 use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::net::TcpListener;
@@ -21,6 +26,15 @@ pub struct AppState {
     pub api_key: Option<String>,
     /// CORS origin policy for browser clients
     pub cors_allowed_origins: CorsAllowedOrigins,
+    /// Startup readiness checks.
+    pub readiness_checks: Vec<ReadinessCheck>,
+}
+
+impl AppState {
+    /// Build the current readiness response.
+    pub fn ready_response(&self) -> ReadyResponse {
+        ReadyResponse::from_checks(self.readiness_checks.clone())
+    }
 }
 
 /// CORS origin policy.
@@ -76,6 +90,10 @@ pub struct ServerConfig {
     pub api_key: Option<String>,
     /// CORS origin policy
     pub cors_allowed_origins: CorsAllowedOrigins,
+    /// Configured profile files that must load before the server is ready.
+    pub profile_paths: Vec<String>,
+    /// Optional config file source used to build this configuration.
+    pub config_source: Option<String>,
 }
 
 impl Default for ServerConfig {
@@ -85,7 +103,249 @@ impl Default for ServerConfig {
             max_body_size: 10 * 1024 * 1024, // 10MB
             api_key: None,
             cors_allowed_origins: CorsAllowedOrigins::default(),
+            profile_paths: Vec::new(),
+            config_source: None,
         }
+    }
+}
+
+/// Sanitized server configuration suitable for printing and diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublicServerConfig {
+    /// Address the server will bind.
+    pub bind_address: String,
+    /// Maximum request body size in bytes.
+    pub max_body_size: usize,
+    /// Whether an API key is configured without exposing the secret.
+    pub api_key_configured: bool,
+    /// CORS origin policy.
+    pub cors_allowed_origins: PublicCorsAllowedOrigins,
+    /// Profile paths checked by readiness.
+    pub profile_paths: Vec<String>,
+    /// Optional config file source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_source: Option<String>,
+}
+
+/// Sanitized CORS origin policy for printed config.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublicCorsAllowedOrigins {
+    /// Policy mode: `any` or `list`.
+    pub mode: String,
+    /// Configured origins when mode is `list`.
+    pub origins: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FileConfig {
+    #[serde(default)]
+    server: FileServerConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FileServerConfig {
+    host: Option<String>,
+    port: Option<u16>,
+    api_key: Option<String>,
+}
+
+impl ServerConfig {
+    /// Build server configuration from supported environment variables.
+    pub fn from_env() -> Result<Self> {
+        let config_path = std::env::var_os("HL7V2_CONFIG").map(PathBuf::from);
+        Self::from_sources(
+            config_path.as_deref(),
+            std::env::var("BIND_ADDRESS").ok(),
+            std::env::var("HL7V2_API_KEY").ok(),
+            std::env::var("HL7V2_CORS_ALLOWED_ORIGINS").ok(),
+            std::env::var_os("HL7V2_PROFILE_PATHS"),
+        )
+    }
+
+    /// Build server configuration from explicit sources.
+    pub fn from_sources(
+        config_path: Option<&Path>,
+        bind_address: Option<String>,
+        api_key: Option<String>,
+        cors_allowed_origins: Option<String>,
+        profile_paths: Option<OsString>,
+    ) -> Result<Self> {
+        let mut config = if let Some(path) = config_path {
+            let mut config = Self::from_config_file(path)?;
+            config.config_source = Some(path.display().to_string());
+            config
+        } else {
+            Self::default()
+        };
+
+        if let Some(bind_address) = bind_address {
+            config.bind_address = bind_address;
+        }
+
+        if let Some(api_key) = api_key {
+            config.api_key = Some(api_key);
+        }
+
+        if let Some(cors_allowed_origins) = cors_allowed_origins {
+            config.cors_allowed_origins = CorsAllowedOrigins::from_csv(&cors_allowed_origins);
+        }
+
+        if let Some(profile_paths) = profile_paths {
+            config.profile_paths = split_profile_paths(profile_paths);
+        }
+
+        Ok(config)
+    }
+
+    fn from_config_file(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path).map_err(|error| {
+            crate::Error::Config(format!("Failed to read config file: {error}"))
+        })?;
+        let file_config: FileConfig = match path.extension().and_then(|value| value.to_str()) {
+            Some("yaml" | "yml") => serde_yaml::from_str(&content).map_err(|error| {
+                crate::Error::Config(format!("Failed to parse YAML config file: {error}"))
+            })?,
+            _ => toml::from_str(&content).map_err(|error| {
+                crate::Error::Config(format!("Failed to parse TOML config file: {error}"))
+            })?,
+        };
+
+        let mut config = Self::default();
+        if let Some(host) = file_config.server.host {
+            let port = file_config.server.port.unwrap_or(8080);
+            config.bind_address = format!("{host}:{port}");
+        } else if let Some(port) = file_config.server.port {
+            config.bind_address = format!("0.0.0.0:{port}");
+        }
+        if let Some(api_key) = file_config.server.api_key {
+            config.api_key = Some(api_key);
+        }
+
+        Ok(config)
+    }
+
+    /// Return a sanitized public view of this configuration.
+    pub fn to_public_config(&self) -> PublicServerConfig {
+        PublicServerConfig {
+            bind_address: self.bind_address.clone(),
+            max_body_size: self.max_body_size,
+            api_key_configured: self.api_key.is_some(),
+            cors_allowed_origins: public_cors_allowed_origins(&self.cors_allowed_origins),
+            profile_paths: self.profile_paths.clone(),
+            config_source: self.config_source.clone(),
+        }
+    }
+
+    /// Build startup readiness checks for this configuration.
+    pub fn readiness_checks(&self) -> Vec<ReadinessCheck> {
+        let mut checks = Vec::new();
+
+        checks.push(ReadinessCheck::pass(
+            "config",
+            "server configuration parsed",
+        ));
+
+        match self.bind_address.parse::<SocketAddr>() {
+            Ok(_) => checks.push(ReadinessCheck::pass("bind_address", "bind address parsed")),
+            Err(error) => checks.push(ReadinessCheck::fail(
+                "bind_address",
+                format!("bind address did not parse: {error}"),
+            )),
+        }
+
+        checks.push(profile_readiness_check(&self.profile_paths));
+        checks.push(validation_report_readiness_check());
+
+        checks
+    }
+}
+
+fn split_profile_paths(paths: OsString) -> Vec<String> {
+    std::env::split_paths(&paths)
+        .map(|path| path.to_string_lossy().trim().to_string())
+        .filter(|path| !path.is_empty())
+        .collect()
+}
+
+fn public_cors_allowed_origins(origins: &CorsAllowedOrigins) -> PublicCorsAllowedOrigins {
+    match origins {
+        CorsAllowedOrigins::Any => PublicCorsAllowedOrigins {
+            mode: "any".to_string(),
+            origins: Vec::new(),
+        },
+        CorsAllowedOrigins::List(origins) => PublicCorsAllowedOrigins {
+            mode: "list".to_string(),
+            origins: origins.clone(),
+        },
+    }
+}
+
+fn profile_readiness_check(profile_paths: &[String]) -> ReadinessCheck {
+    if profile_paths.is_empty() {
+        return ReadinessCheck::pass("configured_profiles", "no configured profiles");
+    }
+
+    for path in profile_paths {
+        match fs::read_to_string(path) {
+            Ok(content) => {
+                if let Err(error) = hl7v2::load_profile_checked(&content) {
+                    return ReadinessCheck::fail(
+                        "configured_profiles",
+                        format!("profile {path} did not load: {error}"),
+                    );
+                }
+            }
+            Err(error) => {
+                return ReadinessCheck::fail(
+                    "configured_profiles",
+                    format!("profile {path} could not be read: {error}"),
+                );
+            }
+        }
+    }
+
+    ReadinessCheck::pass(
+        "configured_profiles",
+        format!("loaded {} configured profile(s)", profile_paths.len()),
+    )
+}
+
+fn validation_report_readiness_check() -> ReadinessCheck {
+    const SAMPLE_MESSAGE: &str =
+        "MSH|^~\\&|HL7V2|READY|OPS|OPS|202605030101||ADT^A01|READY1|P|2.5\r";
+    const SAMPLE_PROFILE: &str = r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+    required: true
+    max_uses: 1
+"#;
+
+    let result = (|| -> std::result::Result<bool, String> {
+        let message = hl7v2::parse(SAMPLE_MESSAGE.as_bytes()).map_err(|error| error.to_string())?;
+        let profile =
+            hl7v2::load_profile_checked(SAMPLE_PROFILE).map_err(|error| error.to_string())?;
+        let issues = hl7v2::validate(&message, &profile);
+        let report =
+            hl7v2::ValidationReport::from_issues(&message, Some(profile.message_structure), issues);
+
+        Ok(!report.message_type.is_empty() && report.profile.is_some())
+    })();
+
+    match result {
+        Ok(true) => ReadinessCheck::pass(
+            "validation_report",
+            "validation report self-check produced typed evidence",
+        ),
+        Ok(false) => ReadinessCheck::fail(
+            "validation_report",
+            "validation report self-check returned incomplete evidence",
+        ),
+        Err(error) => ReadinessCheck::fail(
+            "validation_report",
+            format!("validation report self-check failed: {error}"),
+        ),
     }
 }
 
@@ -106,6 +366,7 @@ impl Server {
             metrics_handle: Arc::new(metrics_handle),
             api_key: config.api_key.clone(),
             cors_allowed_origins: config.cors_allowed_origins.clone(),
+            readiness_checks: config.readiness_checks(),
         });
 
         Self { config, state }
@@ -180,6 +441,16 @@ impl ServerBuilder {
         self
     }
 
+    /// Set profile files that must load before readiness passes.
+    pub fn profile_paths<I, S>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config.profile_paths = paths.into_iter().map(Into::into).collect();
+        self
+    }
+
     /// Build the server
     pub fn build(self) -> Server {
         Server::new(self.config)
@@ -213,6 +484,7 @@ mod tests {
         assert_eq!(config.bind_address, "0.0.0.0:8080");
         assert_eq!(config.max_body_size, 10 * 1024 * 1024);
         assert_eq!(config.cors_allowed_origins, CorsAllowedOrigins::Any);
+        assert!(config.profile_paths.is_empty());
     }
 
     #[test]
@@ -226,5 +498,117 @@ mod tests {
                 "https://ops.example".to_string()
             ])
         );
+    }
+
+    #[test]
+    fn server_config_loads_config_file_and_env_style_overrides() {
+        let path = temp_file_path("server-config.toml");
+        fs::write(
+            &path,
+            r#"
+[server]
+host = "127.0.0.1"
+port = 18080
+api_key = "file-secret"
+"#,
+        )
+        .expect("config fixture should be written");
+
+        let config = ServerConfig::from_sources(
+            Some(&path),
+            Some("0.0.0.0:19090".to_string()),
+            Some("env-secret".to_string()),
+            Some("https://app.example,https://ops.example".to_string()),
+            None,
+        )
+        .expect("config should load");
+
+        assert_eq!(config.bind_address, "0.0.0.0:19090");
+        assert_eq!(config.api_key.as_deref(), Some("env-secret"));
+        assert_eq!(
+            config.cors_allowed_origins,
+            CorsAllowedOrigins::List(vec![
+                "https://app.example".to_string(),
+                "https://ops.example".to_string()
+            ])
+        );
+        assert_eq!(config.config_source, Some(path.display().to_string()));
+
+        fs::remove_file(path).expect("config fixture should be removed");
+    }
+
+    #[test]
+    fn public_config_redacts_api_key_value() {
+        let config = ServerConfig {
+            api_key: Some("super-secret".to_string()),
+            ..ServerConfig::default()
+        };
+
+        let printed = serde_json::to_string(&config.to_public_config())
+            .expect("public config should serialize");
+
+        assert!(printed.contains("\"api_key_configured\":true"));
+        assert!(!printed.contains("super-secret"));
+    }
+
+    #[test]
+    fn readiness_checks_load_configured_profiles() {
+        let path = temp_file_path("ready-profile.yaml");
+        fs::write(
+            &path,
+            r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+"#,
+        )
+        .expect("profile fixture should be written");
+
+        let config = ServerConfig::from_sources(
+            None,
+            None,
+            None,
+            None,
+            Some(OsString::from(path.as_os_str())),
+        )
+        .expect("config should build");
+        let check = config
+            .readiness_checks()
+            .into_iter()
+            .find(|check| check.name == "configured_profiles")
+            .expect("configured profile check should exist");
+
+        assert_eq!(check.status, crate::models::ReadinessCheckStatus::Pass);
+        assert!(check.message.contains("loaded 1 configured profile"));
+
+        fs::remove_file(path).expect("profile fixture should be removed");
+    }
+
+    #[test]
+    fn readiness_checks_fail_missing_configured_profile() {
+        let config = ServerConfig {
+            profile_paths: vec!["missing-profile.yaml".to_string()],
+            ..ServerConfig::default()
+        };
+        let check = config
+            .readiness_checks()
+            .into_iter()
+            .find(|check| check.name == "configured_profiles")
+            .expect("configured profile check should exist");
+
+        assert_eq!(check.status, crate::models::ReadinessCheckStatus::Fail);
+        assert!(check.message.contains("missing-profile.yaml"));
+    }
+
+    fn temp_file_path(name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "hl7v2-server-{}-{nonce}-{name}",
+            std::process::id()
+        ))
     }
 }

--- a/crates/hl7v2-server/tests/bdd_tests.rs
+++ b/crates/hl7v2-server/tests/bdd_tests.rs
@@ -61,6 +61,7 @@ impl ServerWorld {
             metrics_handle: Arc::new(metrics_handle),
             api_key: self.api_key.clone(),
             cors_allowed_origins: Default::default(),
+            readiness_checks: hl7v2_server::ServerConfig::default().readiness_checks(),
         });
         hl7v2_server::routes::build_router(state)
     }

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -17,6 +17,8 @@ pub fn create_test_server() -> Server {
         max_body_size: 1024 * 1024,              // 1MB
         api_key: None,
         cors_allowed_origins: Default::default(),
+        profile_paths: Vec::new(),
+        config_source: None,
     };
     Server::new(config)
 }
@@ -29,6 +31,7 @@ pub fn create_test_router() -> Router {
         metrics_handle: Arc::new(metrics_handle),
         api_key: None,
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
     hl7v2_server::routes::build_router(state)
 }

--- a/crates/hl7v2-server/tests/config_print_test.rs
+++ b/crates/hl7v2-server/tests/config_print_test.rs
@@ -1,0 +1,64 @@
+//! Tests for the standalone server configuration print mode.
+
+#[test]
+fn print_config_outputs_sanitized_effective_config_and_exits()
+-> Result<(), Box<dyn std::error::Error>> {
+    let output = assert_cmd::Command::cargo_bin("hl7v2-server")?
+        .arg("--print-config")
+        .env("BIND_ADDRESS", "127.0.0.1:19090")
+        .env("HL7V2_API_KEY", "super-secret")
+        .env("HL7V2_CORS_ALLOWED_ORIGINS", "https://app.example")
+        .env_remove("HL7V2_CONFIG")
+        .env_remove("HL7V2_PROFILE_PATHS")
+        .output()?;
+
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "print-config exited with status {}",
+            output.status
+        ))
+        .into());
+    }
+    if !output.stderr.is_empty() {
+        return Err(std::io::Error::other("print-config should not write stderr").into());
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+    if stdout.contains("super-secret") {
+        return Err(std::io::Error::other("print-config leaked the API key value").into());
+    }
+
+    let config: serde_json::Value = serde_json::from_str(&stdout)?;
+    if config
+        .get("bind_address")
+        .and_then(serde_json::Value::as_str)
+        != Some("127.0.0.1:19090")
+    {
+        return Err(std::io::Error::other("print-config did not include bind address").into());
+    }
+    if config
+        .get("api_key_configured")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return Err(std::io::Error::other("print-config did not mark API key configured").into());
+    }
+    let cors = config.get("cors_allowed_origins");
+    if cors
+        .and_then(|value| value.get("mode"))
+        .and_then(serde_json::Value::as_str)
+        != Some("list")
+    {
+        return Err(std::io::Error::other("print-config did not include CORS list mode").into());
+    }
+    if cors
+        .and_then(|value| value.get("origins"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|origins| origins.first())
+        .and_then(serde_json::Value::as_str)
+        != Some("https://app.example")
+    {
+        return Err(std::io::Error::other("print-config did not include CORS origin").into());
+    }
+
+    Ok(())
+}

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -17,7 +17,7 @@ mod tests {
         ParseStreamRequest, ParseStreamResponse, ValidateRequest, generate_ack_request,
         health_check_response, validation_issue,
     };
-    use hl7v2_server::server::AppState;
+    use hl7v2_server::server::{AppState, ServerConfig};
     use http_body_util::Empty;
     use metrics_exporter_prometheus::PrometheusBuilder;
     use std::sync::Arc;
@@ -35,6 +35,7 @@ mod tests {
             metrics_handle: Arc::new(handle),
             api_key: None,
             cors_allowed_origins: Default::default(),
+            readiness_checks: ServerConfig::default().readiness_checks(),
         })
     }
 

--- a/crates/hl7v2-server/tests/health_endpoints_test.rs
+++ b/crates/hl7v2-server/tests/health_endpoints_test.rs
@@ -10,7 +10,9 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use hl7v2_server::models::{ReadinessCheck, ReadinessCheckStatus, ReadinessStatus, ReadyResponse};
 use http_body_util::BodyExt;
+use std::{sync::Arc, time::Instant};
 use tower::ServiceExt;
 
 mod common;
@@ -159,12 +161,68 @@ async fn test_ready_endpoint_returns_ready_status() {
         .await
         .unwrap();
 
-    let body = response.into_body().collect().await.unwrap().to_bytes();
-    let body_str = String::from_utf8(body.to_vec()).unwrap();
-
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok());
     assert!(
-        body_str.contains("\"ready\":true"),
-        "Ready endpoint should return ready: true"
+        content_type.is_some_and(|value| value.contains("application/json")),
+        "Readiness response should be JSON"
+    );
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let ready: ReadyResponse = serde_json::from_slice(&body).unwrap();
+
+    assert!(ready.ready, "Ready endpoint should return ready: true");
+    assert_eq!(ready.status, ReadinessStatus::Ready);
+    assert!(
+        ready
+            .checks
+            .iter()
+            .any(|check| check.name == "validation_report"
+                && check.status == ReadinessCheckStatus::Pass),
+        "Ready response should include validation report self-check"
+    );
+}
+
+#[tokio::test]
+async fn test_ready_endpoint_returns_503_when_startup_check_failed() {
+    let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
+    let state = Arc::new(hl7v2_server::AppState {
+        start_time: Instant::now(),
+        metrics_handle: Arc::new(metrics_handle),
+        api_key: None,
+        cors_allowed_origins: Default::default(),
+        readiness_checks: vec![ReadinessCheck::fail(
+            "configured_profiles",
+            "profile missing-profile.yaml could not be read",
+        )],
+    });
+    let app = hl7v2_server::build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let ready: ReadyResponse = serde_json::from_slice(&body).unwrap();
+    assert!(!ready.ready);
+    assert_eq!(ready.status, ReadinessStatus::NotReady);
+    assert_eq!(
+        ready.checks.first().map(|check| &check.status),
+        Some(&ReadinessCheckStatus::Fail)
     );
 }
 

--- a/crates/hl7v2-server/tests/http_runtime_contract_test.rs
+++ b/crates/hl7v2-server/tests/http_runtime_contract_test.rs
@@ -27,6 +27,7 @@ fn test_router(api_key: Option<&str>, cors_allowed_origins: CorsAllowedOrigins) 
         metrics_handle: Arc::new(metrics_handle),
         api_key: api_key.map(str::to_string),
         cors_allowed_origins,
+        readiness_checks: hl7v2_server::ServerConfig::default().readiness_checks(),
     });
     build_router(state)
 }
@@ -209,6 +210,26 @@ async fn test_metrics_stays_public_when_api_key_is_configured() {
                     8080,
                 ))))
                 .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_ready_stays_public_when_api_key_is_configured() {
+    let app = test_router(Some("secret-key"), CorsAllowedOrigins::default());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/ready")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/hl7v2-server/tests/middleware_test.rs
+++ b/crates/hl7v2-server/tests/middleware_test.rs
@@ -13,7 +13,7 @@ use axum::{
 use hl7v2_server::{
     handlers::{parse_handler, validate_handler},
     metrics::{init_metrics_recorder, metrics_handler},
-    server::AppState,
+    server::{AppState, ServerConfig},
 };
 use std::sync::Arc;
 use std::time::Instant;
@@ -39,6 +39,7 @@ fn build_test_router(
         metrics_handle: Arc::new(metrics_handle),
         api_key: None,
         cors_allowed_origins: Default::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
     });
 
     // Rate limit configuration

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -153,6 +153,12 @@ curl http://localhost:8080/health
 # Returns: {"status":"healthy","uptime_seconds":3600}
 ```
 
+**Readiness Check:**
+```bash
+curl http://localhost:8080/ready
+# Returns startup checks such as config, configured_profiles, and validation_report
+```
+
 **Prometheus Metrics:**
 ```bash
 curl http://localhost:8080/metrics

--- a/schemas/config/hl7v2-config-v1.schema.json
+++ b/schemas/config/hl7v2-config-v1.schema.json
@@ -2,13 +2,13 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://schemas.hl7v2-rs.org/config/v1",
   "title": "HL7v2-rs Configuration Schema",
-  "description": "Configuration file for the currently implemented CLI configuration loader",
+  "description": "Configuration file for implemented CLI helpers and the standalone HTTP server",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "server": {
       "type": "object",
-      "description": "HTTP server defaults used by CLI configuration helpers",
+      "description": "HTTP server defaults used by the standalone server and CLI configuration helpers",
       "additionalProperties": false,
       "properties": {
         "host": {


### PR DESCRIPTION
## Summary
- add `hl7v2-server --print-config` with sanitized effective config output and env/config file loading
- replace `/ready` string response with typed readiness checks, including profile loading and validation-report self-checks
- update OpenAPI, docs, server/e2e tests, and config schema wording for the implemented server config path

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 check -p hl7v2-server --all-targets`
- `cargo +1.93.0 test -p hl7v2-server --test health_endpoints_test --test http_runtime_contract_test --test proto_packaging_test --test config_print_test`
- `cargo +1.93.0 test -p hl7v2-server`
- `cargo +1.93.0 clippy -p hl7v2-server --all-targets -- -D warnings`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d target/contracts/config/config.example.json --spec=draft7`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check --workspace --all-targets --all-features`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 test -p hl7v2-e2e-tests --all-features`
- `cargo +1.93.0 run -p xtask -- publish-plan`