### PR TITLE
server: add policy-driven ACK endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ curl -X POST http://localhost:8080/hl7/validate-redacted \
   }'
 ```
 
+**Generate a policy-driven ACK/NAK:**
+```bash
+curl -X POST http://localhost:8080/hl7/ack-policy \
+  -H "X-API-Key: your-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "MSH|^~\\&|...",
+    "profile": "..."
+  }'
+```
+
 **Create a redacted evidence bundle:**
 ```bash
 # Requires HL7V2_BUNDLE_OUTPUT_ROOT to point at an existing writable directory.

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -240,7 +240,7 @@ paths:
     post:
       summary: Generate HL7 ACK
       description: |
-        Generate an HL7 v2 ACK message for a parsed inbound message.
+        Generate an HL7 v2 ACK message with an explicit caller-supplied ACK code.
       tags: [hl7]
       operationId: generateAck
       security:
@@ -260,6 +260,39 @@ paths:
                 $ref: '#/components/schemas/AckResponse'
         '400':
           description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
+  /hl7/ack-policy:
+    post:
+      summary: Generate policy-driven HL7 ACK
+      description: |
+        Parse and validate an inbound HL7 v2 message, then choose an ACK or NAK code using the server's configured ACK policy.
+      tags: [hl7]
+      operationId: generatePolicyAck
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AckPolicyRequest'
+      responses:
+        '200':
+          description: Policy-driven ACK generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AckPolicyResponse'
+        '400':
+          description: Invalid message or profile
           content:
             application/json:
               schema:
@@ -646,6 +679,68 @@ components:
           enum: [AA, AE, AR, CA, CE, CR]
         metadata:
           $ref: '#/components/schemas/MessageMetadata'
+
+    AckPolicyRequest:
+      type: object
+      required: [message, profile]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        profile:
+          type: string
+          description: Profile content (YAML) used to validate before choosing ACK or NAK
+        mllp_framed:
+          type: boolean
+          default: false
+          description: Whether the input message is MLLP framed
+        mllp_frame:
+          type: boolean
+          default: false
+          description: Whether to MLLP frame the ACK response
+
+    AckPolicyResponse:
+      type: object
+      required: [ack_message, ack_code, decision, metadata]
+      properties:
+        ack_message:
+          type: string
+          description: Generated ACK or NAK message
+        ack_code:
+          type: string
+          enum: [AA, AR, CA, CR]
+        decision:
+          $ref: '#/components/schemas/AckPolicyDecision'
+        validation_report:
+          allOf:
+            - $ref: '#/components/schemas/ValidationReport'
+          nullable: true
+          description: Validation report used for the decision, absent when the message could not be parsed
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    AckPolicyDecision:
+      type: object
+      required: [mode, outcome, reason, ack_code, include_error_text]
+      properties:
+        mode:
+          type: string
+          enum: [original, enhanced]
+        outcome:
+          type: string
+          enum: [accepted, rejected]
+        reason:
+          type: string
+          enum: [valid, parse_error, validation_error]
+        ack_code:
+          type: string
+          enum: [AA, AR, CA, CR]
+        include_error_text:
+          type: boolean
+        error_text:
+          type: string
+          nullable: true
+          description: Non-PHI error text included in ERR when configured
 
     NormalizeRequest:
       type: object

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,12 @@ port = 8080
 # api_key = "secret-key"
 # bundle_output_root = "bundles"
 
+[ack]
+mode = "original" # original|enhanced
+accept_on = "valid"
+reject_on = ["parse_error", "validation_error"]
+include_error_text = true
+
 [cli]
 default_version = "2.5.1"
 output_format = "text"

--- a/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
@@ -21,6 +21,7 @@ async fn test_auth_missing_api_key_fails() {
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     let app = build_router(state);
 
@@ -53,6 +54,7 @@ async fn test_auth_valid_api_key_succeeds() {
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     let app = build_router(state);
 
@@ -91,6 +93,7 @@ async fn test_auth_invalid_api_key_fails() {
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     let app = build_router(state);
 
@@ -124,6 +127,7 @@ async fn test_health_metrics_public() {
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     let app = build_router(state);
 

--- a/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/server_api_tests.rs
@@ -37,6 +37,7 @@ fn create_test_router() -> axum::Router {
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     build_router(state)
 }
@@ -895,6 +896,7 @@ mod server_integration {
             profile_paths: Vec::new(),
             config_source: None,
             bundle_output_root: None,
+            ack_policy: Default::default(),
         };
 
         // Build server

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -240,7 +240,7 @@ paths:
     post:
       summary: Generate HL7 ACK
       description: |
-        Generate an HL7 v2 ACK message for a parsed inbound message.
+        Generate an HL7 v2 ACK message with an explicit caller-supplied ACK code.
       tags: [hl7]
       operationId: generateAck
       security:
@@ -260,6 +260,39 @@ paths:
                 $ref: '#/components/schemas/AckResponse'
         '400':
           description: Invalid message format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limit exceeded
+
+  /hl7/ack-policy:
+    post:
+      summary: Generate policy-driven HL7 ACK
+      description: |
+        Parse and validate an inbound HL7 v2 message, then choose an ACK or NAK code using the server's configured ACK policy.
+      tags: [hl7]
+      operationId: generatePolicyAck
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AckPolicyRequest'
+      responses:
+        '200':
+          description: Policy-driven ACK generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AckPolicyResponse'
+        '400':
+          description: Invalid message or profile
           content:
             application/json:
               schema:
@@ -646,6 +679,68 @@ components:
           enum: [AA, AE, AR, CA, CE, CR]
         metadata:
           $ref: '#/components/schemas/MessageMetadata'
+
+    AckPolicyRequest:
+      type: object
+      required: [message, profile]
+      properties:
+        message:
+          type: string
+          description: Raw HL7 message content
+        profile:
+          type: string
+          description: Profile content (YAML) used to validate before choosing ACK or NAK
+        mllp_framed:
+          type: boolean
+          default: false
+          description: Whether the input message is MLLP framed
+        mllp_frame:
+          type: boolean
+          default: false
+          description: Whether to MLLP frame the ACK response
+
+    AckPolicyResponse:
+      type: object
+      required: [ack_message, ack_code, decision, metadata]
+      properties:
+        ack_message:
+          type: string
+          description: Generated ACK or NAK message
+        ack_code:
+          type: string
+          enum: [AA, AR, CA, CR]
+        decision:
+          $ref: '#/components/schemas/AckPolicyDecision'
+        validation_report:
+          allOf:
+            - $ref: '#/components/schemas/ValidationReport'
+          nullable: true
+          description: Validation report used for the decision, absent when the message could not be parsed
+        metadata:
+          $ref: '#/components/schemas/MessageMetadata'
+
+    AckPolicyDecision:
+      type: object
+      required: [mode, outcome, reason, ack_code, include_error_text]
+      properties:
+        mode:
+          type: string
+          enum: [original, enhanced]
+        outcome:
+          type: string
+          enum: [accepted, rejected]
+        reason:
+          type: string
+          enum: [valid, parse_error, validation_error]
+        ack_code:
+          type: string
+          enum: [AA, AR, CA, CR]
+        include_error_text:
+          type: boolean
+        error_text:
+          type: string
+          nullable: true
+          description: Non-PHI error text included in ERR when configured
 
     NormalizeRequest:
       type: object

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -231,6 +231,65 @@ pub async fn ack_handler(
     Ok((StatusCode::OK, Json(response)))
 }
 
+/// Handler for POST /hl7/ack-policy
+pub async fn ack_policy_handler(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<AckPolicyRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let raw_input = request.message.into_bytes();
+    let policy = &state.ack_policy;
+
+    let (message, validation_report, decision) =
+        match parse_request_message(&raw_input, request.mllp_framed) {
+            Ok(message) => {
+                let profile = hl7v2::load_profile_checked(&request.profile)
+                    .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
+                let issues = hl7v2::validate(&message, &profile);
+                let report = hl7v2::ValidationReport::from_issues(
+                    &message,
+                    Some(profile.message_structure.clone()),
+                    issues,
+                );
+                let decision = ack_policy_decision_for_validation(policy, &report)?;
+                (message, Some(report), decision)
+            }
+            Err(error) if policy.rejects(AckPolicyRejectCondition::ParseError) => {
+                let message = parse_msh_for_ack_policy(&raw_input, request.mllp_framed)
+                    .map_err(|_fallback_error| error)?;
+                let decision = ack_policy_reject_decision(policy, AckPolicyReason::ParseError, 0);
+                (message, None, decision)
+            }
+            Err(error) => return Err(error),
+        };
+
+    let ack_code = ack_code_from_policy_decision(&decision)?;
+    let ack_message = if let Some(error_text) = decision.error_text.as_deref() {
+        hl7v2::ack_with_error(&message, ack_code, Some(error_text))
+    } else {
+        hl7v2::ack(&message, ack_code)
+    }
+    .map_err(|e| AppError::Internal(format!("Failed to generate policy ACK: {}", e)))?;
+
+    let metadata = extract_metadata(&ack_message)?;
+    let ack_bytes = hl7v2::write(&ack_message);
+    let ack_bytes = if request.mllp_frame {
+        hl7v2::wrap_mllp(&ack_bytes)
+    } else {
+        ack_bytes
+    };
+
+    let response = AckPolicyResponse {
+        ack_message: String::from_utf8(ack_bytes)
+            .map_err(|e| AppError::Internal(format!("ACK was not UTF-8: {}", e)))?,
+        ack_code: decision.ack_code.clone(),
+        decision,
+        validation_report,
+        metadata,
+    };
+
+    Ok((StatusCode::OK, Json(response)))
+}
+
 /// Handler for POST /hl7/normalize
 pub async fn normalize_handler(
     State(_state): State<Arc<AppState>>,
@@ -277,6 +336,34 @@ fn parse_request_message(
     }
 }
 
+fn parse_msh_for_ack_policy(
+    message_bytes: &[u8],
+    mllp_framed: bool,
+) -> Result<hl7v2::Message, AppError> {
+    let input = if mllp_framed {
+        hl7v2::unwrap_mllp(message_bytes)
+            .map_err(|e| AppError::Parse(format!("MLLP parse error: {}", e)))?
+    } else {
+        message_bytes
+    };
+
+    let first_segment_end = input
+        .iter()
+        .position(|byte| matches!(byte, b'\r' | b'\n'))
+        .unwrap_or(input.len());
+    let msh = &input[..first_segment_end];
+    if !msh.starts_with(b"MSH") {
+        return Err(AppError::Parse(
+            "Parse error: message did not contain a usable MSH segment".to_string(),
+        ));
+    }
+
+    let mut buffer = msh.to_vec();
+    buffer.push(b'\r');
+    hl7v2::parse(&buffer)
+        .map_err(|e| AppError::Parse(format!("MSH parse error for ACK policy: {}", e)))
+}
+
 fn map_ack_code(code: AckRequestCode) -> hl7v2::AckCode {
     match code {
         AckRequestCode::Aa => hl7v2::AckCode::AA,
@@ -285,6 +372,83 @@ fn map_ack_code(code: AckRequestCode) -> hl7v2::AckCode {
         AckRequestCode::Ca => hl7v2::AckCode::CA,
         AckRequestCode::Ce => hl7v2::AckCode::CE,
         AckRequestCode::Cr => hl7v2::AckCode::CR,
+    }
+}
+
+fn ack_policy_decision_for_validation(
+    policy: &AckPolicyConfig,
+    report: &hl7v2::ValidationReport,
+) -> Result<AckPolicyDecision, AppError> {
+    if report.valid && policy.accept_on == AckPolicyAcceptOn::Valid {
+        let ack_code = match policy.mode {
+            AckPolicyMode::Original => AckRequestCode::Aa,
+            AckPolicyMode::Enhanced => AckRequestCode::Ca,
+        };
+        return Ok(AckPolicyDecision {
+            mode: policy.mode,
+            outcome: AckPolicyOutcome::Accepted,
+            reason: AckPolicyReason::Valid,
+            ack_code: ack_code.as_str().to_string(),
+            include_error_text: false,
+            error_text: None,
+        });
+    }
+
+    if policy.rejects(AckPolicyRejectCondition::ValidationError) {
+        return Ok(ack_policy_reject_decision(
+            policy,
+            AckPolicyReason::ValidationError,
+            report.issue_count,
+        ));
+    }
+
+    Err(AppError::Validation(
+        "ACK policy did not define a decision for validation failure".to_string(),
+    ))
+}
+
+fn ack_policy_reject_decision(
+    policy: &AckPolicyConfig,
+    reason: AckPolicyReason,
+    issue_count: usize,
+) -> AckPolicyDecision {
+    let ack_code = match policy.mode {
+        AckPolicyMode::Original => AckRequestCode::Ar,
+        AckPolicyMode::Enhanced => AckRequestCode::Cr,
+    };
+    let error_text = policy
+        .include_error_text
+        .then(|| ack_policy_error_text(reason, issue_count));
+
+    AckPolicyDecision {
+        mode: policy.mode,
+        outcome: AckPolicyOutcome::Rejected,
+        reason,
+        ack_code: ack_code.as_str().to_string(),
+        include_error_text: policy.include_error_text,
+        error_text,
+    }
+}
+
+fn ack_policy_error_text(reason: AckPolicyReason, issue_count: usize) -> String {
+    match reason {
+        AckPolicyReason::Valid => "message accepted".to_string(),
+        AckPolicyReason::ParseError => "message parsing failed".to_string(),
+        AckPolicyReason::ValidationError => {
+            format!("message validation failed with {issue_count} issue(s)")
+        }
+    }
+}
+
+fn ack_code_from_policy_decision(decision: &AckPolicyDecision) -> Result<hl7v2::AckCode, AppError> {
+    match decision.ack_code.as_str() {
+        "AA" => Ok(hl7v2::AckCode::AA),
+        "AR" => Ok(hl7v2::AckCode::AR),
+        "CA" => Ok(hl7v2::AckCode::CA),
+        "CR" => Ok(hl7v2::AckCode::CR),
+        code => Err(AppError::Internal(format!(
+            "ACK policy produced unsupported ACK code: {code}"
+        ))),
     }
 }
 

--- a/crates/hl7v2-server/src/lib.rs
+++ b/crates/hl7v2-server/src/lib.rs
@@ -57,6 +57,7 @@ pub mod redaction;
 pub mod routes;
 pub mod server;
 
+pub use models::{AckPolicyAcceptOn, AckPolicyConfig, AckPolicyMode, AckPolicyRejectCondition};
 pub use routes::build_router;
 pub use server::{AppState, CorsAllowedOrigins, Server, ServerBuilder, ServerConfig};
 

--- a/crates/hl7v2-server/src/main.rs
+++ b/crates/hl7v2-server/src/main.rs
@@ -77,7 +77,7 @@ where
 }
 
 fn usage() -> &'static str {
-    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server] host, port, api_key, bundle_output_root\n  BIND_ADDRESS                Override bind address, for example 0.0.0.0:8080\n  HL7V2_API_KEY               API key for protected /hl7/* routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes\n  HL7V2_BUNDLE_OUTPUT_ROOT    Existing writable directory for server-generated evidence bundles"
+    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server] and [ack] settings\n  BIND_ADDRESS                Override bind address, for example 0.0.0.0:8080\n  HL7V2_API_KEY               API key for protected /hl7/* routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes\n  HL7V2_BUNDLE_OUTPUT_ROOT    Existing writable directory for server-generated evidence bundles"
 }
 
 #[cfg(test)]

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -486,6 +486,153 @@ pub struct AckResponse {
     pub metadata: MessageMetadata,
 }
 
+/// Configurable server ACK policy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AckPolicyConfig {
+    /// ACK mode to use when choosing generated ACK/NAK codes.
+    #[serde(default)]
+    pub mode: AckPolicyMode,
+    /// Condition that causes an accept ACK.
+    #[serde(default)]
+    pub accept_on: AckPolicyAcceptOn,
+    /// Conditions that cause reject ACKs.
+    #[serde(default = "default_ack_reject_on")]
+    pub reject_on: Vec<AckPolicyRejectCondition>,
+    /// Whether generated NAKs should include non-PHI error text in `ERR`.
+    #[serde(default = "default_include_error_text")]
+    pub include_error_text: bool,
+}
+
+impl Default for AckPolicyConfig {
+    fn default() -> Self {
+        Self {
+            mode: AckPolicyMode::Original,
+            accept_on: AckPolicyAcceptOn::Valid,
+            reject_on: default_ack_reject_on(),
+            include_error_text: true,
+        }
+    }
+}
+
+impl AckPolicyConfig {
+    /// Return whether the policy rejects the supplied condition.
+    pub fn rejects(&self, condition: AckPolicyRejectCondition) -> bool {
+        self.reject_on.contains(&condition)
+    }
+}
+
+fn default_ack_reject_on() -> Vec<AckPolicyRejectCondition> {
+    vec![
+        AckPolicyRejectCondition::ParseError,
+        AckPolicyRejectCondition::ValidationError,
+    ]
+}
+
+fn default_include_error_text() -> bool {
+    true
+}
+
+/// ACK policy mode.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AckPolicyMode {
+    /// Use original mode application ACK codes: `AA` and `AR`.
+    #[default]
+    Original,
+    /// Use enhanced mode commit ACK codes: `CA` and `CR`.
+    Enhanced,
+}
+
+/// ACK policy accept condition.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AckPolicyAcceptOn {
+    /// Accept only after the message validates against the supplied profile.
+    #[default]
+    Valid,
+}
+
+/// ACK policy reject condition.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AckPolicyRejectCondition {
+    /// Reject when the inbound message cannot be parsed enough to validate.
+    ParseError,
+    /// Reject when validation against the supplied profile fails.
+    ValidationError,
+}
+
+/// Policy-driven ACK request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AckPolicyRequest {
+    /// Raw HL7 message content.
+    pub message: String,
+    /// Inline profile YAML content used for validation before deciding ACK/NAK.
+    pub profile: String,
+    /// Whether the input message is MLLP framed.
+    #[serde(default)]
+    pub mllp_framed: bool,
+    /// Whether to MLLP frame the ACK response.
+    #[serde(default)]
+    pub mllp_frame: bool,
+}
+
+/// Policy-driven ACK response body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AckPolicyResponse {
+    /// Generated ACK or NAK message, optionally MLLP framed.
+    pub ack_message: String,
+    /// Generated ACK code.
+    pub ack_code: String,
+    /// Decision details used to choose the ACK code.
+    pub decision: AckPolicyDecision,
+    /// Validation report used for the decision, when the message parsed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validation_report: Option<hl7v2::ValidationReport>,
+    /// Metadata extracted from the generated ACK message.
+    pub metadata: MessageMetadata,
+}
+
+/// ACK policy decision details.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AckPolicyDecision {
+    /// Configured ACK mode.
+    pub mode: AckPolicyMode,
+    /// Decision outcome.
+    pub outcome: AckPolicyOutcome,
+    /// Reason for the decision.
+    pub reason: AckPolicyReason,
+    /// Generated ACK code.
+    pub ack_code: String,
+    /// Whether non-PHI error text was included in the ACK.
+    pub include_error_text: bool,
+    /// Error text included in the ACK, when configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_text: Option<String>,
+}
+
+/// ACK policy decision outcome.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AckPolicyOutcome {
+    /// Message was accepted.
+    Accepted,
+    /// Message was rejected.
+    Rejected,
+}
+
+/// ACK policy decision reason.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AckPolicyReason {
+    /// Message parsed and validated successfully.
+    Valid,
+    /// Message could not be parsed.
+    ParseError,
+    /// Message parsed but failed profile validation.
+    ValidationError,
+}
+
 /// Normalize request body
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NormalizeRequest {

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -16,8 +16,8 @@ use tower_http::{
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::handlers::{
-    ack_handler, bundle_handler, health_handler, normalize_handler, parse_handler, ready_handler,
-    validate_handler, validate_redacted_handler,
+    ack_handler, ack_policy_handler, bundle_handler, health_handler, normalize_handler,
+    parse_handler, ready_handler, validate_handler, validate_redacted_handler,
 };
 use crate::metrics::{metrics_handler, middleware::metrics_middleware};
 use crate::middleware::{auth_middleware, create_concurrency_limit_layer};
@@ -44,6 +44,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/validate-redacted", post(validate_redacted_handler))
         .route("/bundle", post(bundle_handler))
         .route("/ack", post(ack_handler))
+        .route("/ack-policy", post(ack_policy_handler))
         .route("/normalize", post(normalize_handler));
 
     // Apply authentication if API key is configured in state
@@ -127,6 +128,7 @@ mod tests {
             cors_allowed_origins: CorsAllowedOrigins::default(),
             readiness_checks: crate::server::ServerConfig::default().readiness_checks(),
             bundle_output_root: None,
+            ack_policy: Default::default(),
         });
         (build_router(state), api_key)
     }
@@ -178,6 +180,7 @@ mod tests {
             cors_allowed_origins: CorsAllowedOrigins::default(),
             readiness_checks: crate::server::ServerConfig::default().readiness_checks(),
             bundle_output_root: None,
+            ack_policy: Default::default(),
         });
 
         let app = build_router(state);
@@ -213,6 +216,7 @@ mod tests {
             cors_allowed_origins: CorsAllowedOrigins::default(),
             readiness_checks: crate::server::ServerConfig::default().readiness_checks(),
             bundle_output_root: None,
+            ack_policy: Default::default(),
         });
 
         let app = build_router(state);

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -1,6 +1,6 @@
 //! HTTP server implementation.
 
-use crate::models::{ReadinessCheck, ReadyResponse};
+use crate::models::{AckPolicyConfig, ReadinessCheck, ReadyResponse};
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
@@ -30,6 +30,8 @@ pub struct AppState {
     pub readiness_checks: Vec<ReadinessCheck>,
     /// Configured root for server-generated evidence bundles.
     pub bundle_output_root: Option<PathBuf>,
+    /// Policy used by the policy-driven ACK endpoint.
+    pub ack_policy: AckPolicyConfig,
 }
 
 impl AppState {
@@ -98,6 +100,8 @@ pub struct ServerConfig {
     pub config_source: Option<String>,
     /// Optional filesystem root for server-generated evidence bundles.
     pub bundle_output_root: Option<PathBuf>,
+    /// Policy used by the policy-driven ACK endpoint.
+    pub ack_policy: AckPolicyConfig,
 }
 
 impl Default for ServerConfig {
@@ -110,6 +114,7 @@ impl Default for ServerConfig {
             profile_paths: Vec::new(),
             config_source: None,
             bundle_output_root: None,
+            ack_policy: AckPolicyConfig::default(),
         }
     }
 }
@@ -132,6 +137,8 @@ pub struct PublicServerConfig {
     pub config_source: Option<String>,
     /// Whether server-side evidence bundle output is configured.
     pub bundle_output_root_configured: bool,
+    /// Policy used by the policy-driven ACK endpoint.
+    pub ack_policy: AckPolicyConfig,
 }
 
 /// Sanitized CORS origin policy for printed config.
@@ -147,6 +154,8 @@ pub struct PublicCorsAllowedOrigins {
 struct FileConfig {
     #[serde(default)]
     server: FileServerConfig,
+    #[serde(default)]
+    ack: AckPolicyConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -237,6 +246,7 @@ impl ServerConfig {
         if let Some(bundle_output_root) = file_config.server.bundle_output_root {
             config.bundle_output_root = Some(bundle_output_root);
         }
+        config.ack_policy = file_config.ack;
 
         Ok(config)
     }
@@ -251,6 +261,7 @@ impl ServerConfig {
             profile_paths: self.profile_paths.clone(),
             config_source: self.config_source.clone(),
             bundle_output_root_configured: self.bundle_output_root.is_some(),
+            ack_policy: self.ack_policy.clone(),
         }
     }
 
@@ -433,6 +444,7 @@ impl Server {
             cors_allowed_origins: config.cors_allowed_origins.clone(),
             readiness_checks: config.readiness_checks(),
             bundle_output_root: config.bundle_output_root.clone(),
+            ack_policy: config.ack_policy.clone(),
         });
 
         Self { config, state }
@@ -523,6 +535,12 @@ impl ServerBuilder {
         self
     }
 
+    /// Set the policy used by the policy-driven ACK endpoint.
+    pub fn ack_policy(mut self, policy: AckPolicyConfig) -> Self {
+        self.config.ack_policy = policy;
+        self
+    }
+
     /// Build the server
     pub fn build(self) -> Server {
         Server::new(self.config)
@@ -582,6 +600,12 @@ mod tests {
 host = "127.0.0.1"
 port = 18080
 api_key = "file-secret"
+
+[ack]
+mode = "enhanced"
+accept_on = "valid"
+reject_on = ["validation_error"]
+include_error_text = false
 "#,
         )
         .expect("config fixture should be written");
@@ -599,6 +623,15 @@ api_key = "file-secret"
         assert_eq!(config.bind_address, "0.0.0.0:19090");
         assert_eq!(config.api_key.as_deref(), Some("env-secret"));
         assert_eq!(config.bundle_output_root, Some(PathBuf::from("bundles")));
+        assert_eq!(
+            config.ack_policy.mode,
+            crate::models::AckPolicyMode::Enhanced
+        );
+        assert_eq!(
+            config.ack_policy.reject_on,
+            vec![crate::models::AckPolicyRejectCondition::ValidationError]
+        );
+        assert!(!config.ack_policy.include_error_text);
         assert_eq!(
             config.cors_allowed_origins,
             CorsAllowedOrigins::List(vec![
@@ -623,6 +656,16 @@ api_key = "file-secret"
 
         assert!(printed.contains("\"api_key_configured\":true"));
         assert!(!printed.contains("super-secret"));
+    }
+
+    #[test]
+    fn public_config_includes_ack_policy_without_secret_material() {
+        let printed = serde_json::to_string(&ServerConfig::default().to_public_config())
+            .expect("public config should serialize");
+
+        assert!(printed.contains("\"ack_policy\""));
+        assert!(printed.contains("\"mode\":\"original\""));
+        assert!(printed.contains("\"reject_on\":[\"parse_error\",\"validation_error\"]"));
     }
 
     #[test]

--- a/crates/hl7v2-server/tests/ack_policy_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/ack_policy_endpoint_test.rs
@@ -1,0 +1,205 @@
+//! Integration tests for the /hl7/ack-policy endpoint.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "endpoint integration tests use static JSON fixtures for contract coverage"
+)]
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use hl7v2_server::{
+    AckPolicyConfig, AckPolicyMode, AppState, CorsAllowedOrigins, ServerConfig, build_router,
+};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Instant;
+use tower::ServiceExt;
+
+const SAMPLE_MSG: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
+const VALID_PROFILE: &str = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+constraints:
+  - path: "PID.3"
+    required: true
+"#;
+const INVALID_PROFILE: &str = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+constraints:
+  - path: "PID.99"
+    required: true
+"#;
+const PARTIAL_PARSE_MESSAGE: &str =
+    "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPI";
+
+fn test_router(policy: AckPolicyConfig, api_key: Option<&str>) -> axum::Router {
+    let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
+    let state = Arc::new(AppState {
+        start_time: Instant::now(),
+        metrics_handle: Arc::new(metrics_handle),
+        api_key: api_key.map(str::to_string),
+        cors_allowed_origins: CorsAllowedOrigins::default(),
+        readiness_checks: ServerConfig::default().readiness_checks(),
+        bundle_output_root: None,
+        ack_policy: policy,
+    });
+    build_router(state)
+}
+
+fn ack_policy_request(message: &str, profile: &str) -> Request<Body> {
+    let body = json!({
+        "message": message,
+        "profile": profile,
+        "mllp_framed": false,
+        "mllp_frame": false
+    });
+
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            8080,
+        ))))
+        .uri("/hl7/ack-policy")
+        .method("POST")
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap()
+}
+
+async fn post_ack_policy(
+    app: axum::Router,
+    message: &str,
+    profile: &str,
+) -> (StatusCode, Value, String) {
+    let response = app
+        .oneshot(ack_policy_request(message, profile))
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let value = serde_json::from_str(&body_text).unwrap_or_else(|_| json!({}));
+    (status, value, body_text)
+}
+
+#[tokio::test]
+async fn test_ack_policy_accepts_valid_message_with_original_mode() {
+    let (status, body, body_text) = post_ack_policy(
+        test_router(AckPolicyConfig::default(), None),
+        SAMPLE_MSG,
+        VALID_PROFILE,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ack_code"], "AA");
+    assert_eq!(body["decision"]["mode"], "original");
+    assert_eq!(body["decision"]["outcome"], "accepted");
+    assert_eq!(body["decision"]["reason"], "valid");
+    assert_eq!(body["validation_report"]["valid"], true);
+    assert!(
+        body["ack_message"]
+            .as_str()
+            .unwrap()
+            .contains("MSA|AA|CTRL123")
+    );
+    assert_no_phi(&body_text);
+}
+
+#[tokio::test]
+async fn test_ack_policy_rejects_validation_failure_without_phi() {
+    let (status, body, body_text) = post_ack_policy(
+        test_router(AckPolicyConfig::default(), None),
+        SAMPLE_MSG,
+        INVALID_PROFILE,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ack_code"], "AR");
+    assert_eq!(body["decision"]["outcome"], "rejected");
+    assert_eq!(body["decision"]["reason"], "validation_error");
+    assert_eq!(
+        body["decision"]["error_text"],
+        "message validation failed with 1 issue(s)"
+    );
+    assert_eq!(body["validation_report"]["valid"], false);
+    assert!(
+        body["ack_message"]
+            .as_str()
+            .unwrap()
+            .contains("MSA|AR|CTRL123")
+    );
+    assert_no_phi(&body_text);
+}
+
+#[tokio::test]
+async fn test_ack_policy_uses_enhanced_mode_codes() {
+    let policy = AckPolicyConfig {
+        mode: AckPolicyMode::Enhanced,
+        ..AckPolicyConfig::default()
+    };
+
+    let (status, body, body_text) =
+        post_ack_policy(test_router(policy, None), SAMPLE_MSG, VALID_PROFILE).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ack_code"], "CA");
+    assert_eq!(body["decision"]["mode"], "enhanced");
+    assert!(
+        body["ack_message"]
+            .as_str()
+            .unwrap()
+            .contains("MSA|CA|CTRL123")
+    );
+    assert_no_phi(&body_text);
+}
+
+#[tokio::test]
+async fn test_ack_policy_rejects_parse_error_when_msh_is_usable() {
+    let (status, body, body_text) = post_ack_policy(
+        test_router(AckPolicyConfig::default(), None),
+        PARTIAL_PARSE_MESSAGE,
+        VALID_PROFILE,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ack_code"], "AR");
+    assert_eq!(body["decision"]["reason"], "parse_error");
+    assert!(body["validation_report"].is_null());
+    assert!(
+        body["ack_message"]
+            .as_str()
+            .unwrap()
+            .contains("MSA|AR|CTRL123")
+    );
+    assert_no_phi(&body_text);
+}
+
+#[tokio::test]
+async fn test_ack_policy_still_requires_auth_when_configured() {
+    let response = test_router(AckPolicyConfig::default(), Some("secret"))
+        .oneshot(ack_policy_request(SAMPLE_MSG, VALID_PROFILE))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+fn assert_no_phi(content: &str) {
+    for sentinel in ["Doe^John", "123456^^^HOSP^MR", "19700101"] {
+        assert!(!content.contains(sentinel), "content leaked {sentinel}");
+    }
+}

--- a/crates/hl7v2-server/tests/bdd_tests.rs
+++ b/crates/hl7v2-server/tests/bdd_tests.rs
@@ -63,6 +63,7 @@ impl ServerWorld {
             cors_allowed_origins: Default::default(),
             readiness_checks: hl7v2_server::ServerConfig::default().readiness_checks(),
             bundle_output_root: None,
+            ack_policy: Default::default(),
         });
         hl7v2_server::routes::build_router(state)
     }

--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -114,6 +114,7 @@ fn test_router(bundle_output_root: Option<PathBuf>) -> axum::Router {
         cors_allowed_origins: CorsAllowedOrigins::default(),
         readiness_checks: hl7v2_server::ServerConfig::default().readiness_checks(),
         bundle_output_root,
+        ack_policy: Default::default(),
     });
     build_router(state)
 }

--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -20,6 +20,7 @@ pub fn create_test_server() -> Server {
         profile_paths: Vec::new(),
         config_source: None,
         bundle_output_root: None,
+        ack_policy: Default::default(),
     };
     Server::new(config)
 }
@@ -34,6 +35,7 @@ pub fn create_test_router() -> Router {
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     hl7v2_server::routes::build_router(state)
 }

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -37,6 +37,7 @@ mod tests {
             cors_allowed_origins: Default::default(),
             readiness_checks: ServerConfig::default().readiness_checks(),
             bundle_output_root: None,
+            ack_policy: Default::default(),
         })
     }
 

--- a/crates/hl7v2-server/tests/health_endpoints_test.rs
+++ b/crates/hl7v2-server/tests/health_endpoints_test.rs
@@ -198,6 +198,7 @@ async fn test_ready_endpoint_returns_503_when_startup_check_failed() {
             "profile missing-profile.yaml could not be read",
         )],
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     let app = hl7v2_server::build_router(state);
 

--- a/crates/hl7v2-server/tests/http_runtime_contract_test.rs
+++ b/crates/hl7v2-server/tests/http_runtime_contract_test.rs
@@ -36,6 +36,7 @@ fn test_router(api_key: Option<&str>, cors_allowed_origins: CorsAllowedOrigins) 
         cors_allowed_origins,
         readiness_checks: hl7v2_server::ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
     build_router(state)
 }
@@ -177,6 +178,30 @@ async fn test_new_hl7_routes_require_api_key_when_configured() {
                     serde_json::to_string(&json!({
                         "message": SAMPLE_MSG,
                         "code": "AA"
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/hl7/ack-policy")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&json!({
+                        "message": SAMPLE_MSG,
+                        "profile": MINIMAL_PROFILE
                     }))
                     .unwrap(),
                 ))

--- a/crates/hl7v2-server/tests/middleware_test.rs
+++ b/crates/hl7v2-server/tests/middleware_test.rs
@@ -41,6 +41,7 @@ fn build_test_router(
         cors_allowed_origins: Default::default(),
         readiness_checks: ServerConfig::default().readiness_checks(),
         bundle_output_root: None,
+        ack_policy: Default::default(),
     });
 
     // Rate limit configuration

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -194,7 +194,8 @@ curl -X POST http://localhost:8080/hl7/bundle \
 ### 5. Generate ACK
 **POST** `/hl7/ack`
 
-Generates an HL7 ACK response from an inbound message.
+Generates an HL7 ACK response from an inbound message with an explicit
+caller-supplied ACK code.
 
 **Request Body:**
 ```json
@@ -208,7 +209,69 @@ Generates an HL7 ACK response from an inbound message.
 
 ---
 
-### 6. Normalize HL7 Message
+### 6. Generate Policy-Driven ACK
+**POST** `/hl7/ack-policy`
+
+Parses and validates an inbound message, then chooses an ACK or NAK code from
+the server ACK policy. Configure the policy in `HL7V2_CONFIG`:
+
+```toml
+[ack]
+mode = "original" # original|enhanced
+accept_on = "valid"
+reject_on = ["parse_error", "validation_error"]
+include_error_text = true
+```
+
+Default behavior preserves original-mode application ACK codes: `AA` for valid
+messages and `AR` for parse or validation failures. Enhanced mode uses `CA` and
+`CR`. Error text is intentionally generic and does not include raw field values.
+
+**Request Body:**
+```json
+{
+  "message": "MSH|^~\\&|...",
+  "profile": "message_structure: ADT_A01\nversion: \"2.5\"\nsegments:\n  - id: MSH\n",
+  "mllp_framed": false,
+  "mllp_frame": false
+}
+```
+
+**Response Body:**
+```json
+{
+  "ack_message": "MSH|^~\\&|...",
+  "ack_code": "AA",
+  "decision": {
+    "mode": "original",
+    "outcome": "accepted",
+    "reason": "valid",
+    "ack_code": "AA",
+    "include_error_text": false
+  },
+  "validation_report": {
+    "valid": true,
+    "message_type": "ADT^A01",
+    "profile": "ADT_A01",
+    "segment_count": 2,
+    "issue_count": 0,
+    "issues": []
+  },
+  "metadata": {
+    "message_type": "ACK^ADT",
+    "version": "2.5",
+    "sending_application": "RECEIVER",
+    "sending_facility": "FACILITY",
+    "message_control_id": "MSG123",
+    "segment_count": 2,
+    "charsets": []
+  }
+}
+```
+
+---
+
+### 7. Normalize HL7 Message
 **POST** `/hl7/normalize`
 
 Rewrites an HL7 message with stable delimiters and optional MLLP output framing.
@@ -227,7 +290,7 @@ Rewrites an HL7 message with stable delimiters and optional MLLP output framing.
 
 ---
 
-### 7. Health & Metrics
+### 8. Health & Metrics
 
 **Health Check:**
 ```bash

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -50,7 +50,7 @@ failed, what changed, what was redacted, and how to replay the result.
 | --- | --- |
 | Rust library | Owns the shared `ValidationReport`, `ProfileLintReport`, and corpus summary/fingerprint/diff types. Bundle, replay, profile test, and profile explain report types are currently CLI-local. |
 | CLI | Produces the complete evidence loop today. Most commands support JSON/YAML/text. `redact` supports JSON or HL7 output. `bundle` currently emits JSON summary only. |
-| Server | `/hl7/validate` exposes the shared validation issue fields and preserves legacy `errors` / `warnings`; `/hl7/validate-redacted` applies safe-analysis redaction and returns a validation report plus redaction receipt; `/hl7/bundle` writes redacted evidence bundles under a configured server root. Replay endpoints, corpus artifacts, ACK policy, and quarantine hooks remain follow-up work. |
+| Server | `/hl7/validate` exposes the shared validation issue fields and preserves legacy `errors` / `warnings`; `/hl7/validate-redacted` applies safe-analysis redaction and returns a validation report plus redaction receipt; `/hl7/bundle` writes redacted evidence bundles under a configured server root; `/hl7/ack-policy` returns policy-driven ACK/NAK decisions backed by validation reports. Replay endpoints, corpus artifacts, and quarantine hooks remain follow-up work. |
 | Python | Exposes parse, JSON conversion, normalize, and validation report dict/JSON parity. It does not yet expose corpus, redaction, bundle, or replay artifacts. |
 
 One current validation-report parity wrinkle is the profile label. The CLI uses

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -32,10 +32,10 @@ hl7v2 replay <bundle/> --format json
 ```
 
 The server exposes validation report parity through `/hl7/validate`, safe
-redacted validation through `/hl7/validate-redacted`, and server-side evidence
-bundle creation through `/hl7/bundle` when a bundle output root is configured.
-Python exposes parse, JSON conversion, normalization, and validation report
-dict/JSON parity.
+redacted validation through `/hl7/validate-redacted`, server-side evidence
+bundle creation through `/hl7/bundle` when a bundle output root is configured,
+and policy-driven ACK/NAK decisions through `/hl7/ack-policy`. Python exposes
+parse, JSON conversion, normalization, and validation report dict/JSON parity.
 
 ## Artifact Status
 
@@ -61,7 +61,7 @@ dict/JSON parity.
 | --- | --- |
 | Rust | Shared validation, profile lint, corpus summary/fingerprint/diff, parse, normalize, write, ACK, and redaction module APIs. Several evidence packet reports remain CLI-local. |
 | CLI | Complete current loop: doctor, profile lint/test/explain, validation, corpus summarize/fingerprint/diff, redact, bundle, and replay. |
-| Server | Validation report parity for `/hl7/validate`; redacted validation parity for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle`; replay endpoint, corpus artifacts, ACK policy, and quarantine hooks remain follow-up work. |
+| Server | Validation report parity for `/hl7/validate`; redacted validation parity for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; replay endpoint, corpus artifacts, and quarantine hooks remain follow-up work. |
 | Python | Minimum API parity for parse, `to_json`, normalize, and validation reports. Corpus, redaction, bundle, and replay APIs remain follow-up work. |
 
 One known validation parity detail remains: the CLI report `profile` value is

--- a/schemas/config/hl7v2-config-v1.schema.json
+++ b/schemas/config/hl7v2-config-v1.schema.json
@@ -36,6 +36,39 @@
         }
       }
     },
+    "ack": {
+      "type": "object",
+      "description": "Policy used by the standalone HTTP server policy-driven ACK endpoint",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["original", "enhanced"],
+          "default": "original",
+          "description": "ACK mode used when choosing generated ACK/NAK codes"
+        },
+        "accept_on": {
+          "type": "string",
+          "enum": ["valid"],
+          "default": "valid",
+          "description": "Condition that causes an accept ACK"
+        },
+        "reject_on": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["parse_error", "validation_error"]
+          },
+          "default": ["parse_error", "validation_error"],
+          "description": "Conditions that cause reject ACKs"
+        },
+        "include_error_text": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether generated NAKs include non-PHI error text in ERR"
+        }
+      }
+    },
     "cli": {
       "type": "object",
       "description": "Command-line defaults",
@@ -85,6 +118,12 @@
         "host": "0.0.0.0",
         "port": 8080,
         "bundle_output_root": "bundles"
+      },
+      "ack": {
+        "mode": "original",
+        "accept_on": "valid",
+        "reject_on": ["parse_error", "validation_error"],
+        "include_error_text": true
       },
       "cli": {
         "default_version": "2.5.1",


### PR DESCRIPTION
## Summary

Adds a policy-driven HTTP ACK endpoint for the server without changing the existing explicit `/hl7/ack` generator.

- adds `POST /hl7/ack-policy` for parse -> validate -> ACK/NAK decisions
- adds top-level `[ack]` config with original/enhanced mode, accept/reject conditions, and generic error-text control
- keeps API-key auth on the new route through the existing `/hl7/*` middleware
- documents the route in OpenAPI, config schema, README, API guide, and evidence docs

## Behavior and safety

- `/hl7/ack` remains caller-controlled and unchanged.
- `/hl7/ack-policy` returns `AA`/`AR` in original mode and `CA`/`CR` in enhanced mode.
- Parse-error rejection only emits an ACK when the request contains a usable MSH segment; otherwise the original parse error is returned.
- Policy error text is intentionally generic (`message parsing failed`, `message validation failed with N issue(s)`) so raw message PHI is not copied into ACK decisions or response metadata.
- The ACK policy config contains no secrets and is safe to expose through `--print-config`.

## Validation

- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 check -p hl7v2-server --all-targets`
- `cargo +1.93.0 test -p hl7v2-server --test ack_policy_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test ack_policy_endpoint_test --test http_runtime_contract_test --test config_print_test --test proto_packaging_test`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 clippy -p hl7v2-server --all-targets -- -D warnings`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`