### PR TITLE
fix: align evidence bundle message type replay

### DIFF
--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -2104,7 +2104,7 @@ fn bundle_command(
         Some("profile.yaml".to_string()),
         validate(&redacted_message, &loaded_profile),
     );
-    let message_type = message_field_text(&message, "MSH", 9).unwrap_or_else(|| "unknown".into());
+    let message_type = validation_report.message_type.clone();
     let environment = EvidenceBundleEnvironment {
         bundle_version: "1",
         tool_name: "hl7v2-cli",

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -1947,7 +1947,7 @@ action = "drop"
 mod bundle_command {
     use super::*;
 
-    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01^ADT_A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
     const PID5_CONSTRAINT_PROFILE: &str = r#"
 message_structure: ADT_A01
 version: "2.5.1"
@@ -2288,7 +2288,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
 mod replay_command {
     use super::*;
 
-    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+    const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01^ADT_A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
     const SAFE_ANALYSIS_POLICY: &str = r#"
 [[rules]]
 path = "PID.3"

--- a/crates/hl7v2/src/evidence.rs
+++ b/crates/hl7v2/src/evidence.rs
@@ -251,7 +251,7 @@ pub fn write_safe_analysis_bundle(
         bundle_version: BUNDLE_VERSION.to_string(),
         tool_name: tool_name.to_string(),
         tool_version: env!("CARGO_PKG_VERSION").to_string(),
-        message_type: redaction_output.message_type.clone(),
+        message_type: validation_report.message_type.clone(),
         input_sha256: redaction_output.input_sha256,
         profile_sha256: compute_sha256(profile_yaml),
         redaction_policy_sha256: redaction_output.policy_sha256,
@@ -302,7 +302,7 @@ pub fn write_safe_analysis_bundle(
     Ok(EvidenceBundleSummary {
         bundle_version: BUNDLE_VERSION.to_string(),
         output_dir: ".".to_string(),
-        message_type: redaction_output.message_type,
+        message_type: validation_report.message_type.clone(),
         validation_valid: validation_report.valid,
         validation_issue_count: validation_report.issue_count,
         redaction_phi_removed: redaction_output.receipt.phi_removed,
@@ -936,7 +936,7 @@ mod tests {
     use super::{EvidenceReplayCheckStatus, replay_evidence_bundle, write_safe_analysis_bundle};
 
     fn raw_message() -> &'static str {
-        "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605080101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M"
+        "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605080101||ADT^A01^ADT_A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M"
     }
 
     fn profile_yaml() -> &'static str {


### PR DESCRIPTION
## Summary
- align evidence bundle `message_type` metadata with the regenerated `ValidationReport` message type
- cover three-component `MSH.9` values in bundle/replay regression fixtures
- keep replay integrity checks from failing on `ADT^A01^ADT_A01` inputs that validate as `ADT^A01`

## Validation
- cargo +1.93.0 fmt --all -- --check
- cargo +1.93.0 test -p hl7v2 --features profile,redact evidence
- cargo +1.93.0 test -p hl7v2-cli --test integration_tests replay
- cargo +1.93.0 test -p hl7v2-cli --test integration_tests bundle
- cargo +1.93.0 clippy -p hl7v2 --features profile,redact --all-targets -- -D warnings
- cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings
- $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed

Manual reproduction fixed:
- bundle + replay with `test_data/valid_message.hl7` and `profiles/generic.yaml` now exits 0 with `environment-match` passing.