### PR TITLE
docs: prepare v1.3.0 evidence loop readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Prepared the v1.3.0 Evidence Loop release candidate around deterministic
+  HL7 interface evidence: first-run diagnostics, typed validation reports,
+  profile lint/test/explain, corpus summarize/fingerprint/diff,
+  safe-analysis redaction, evidence bundle/replay, and Python binding parity.
+- Added schema-backed evidence artifacts and golden fixtures for
+  validation reports, profile reports, corpus reports, redaction receipts,
+  bundle summaries, and replay reports.
+- Added CLI automation semantics for evidence commands: stable exit codes,
+  machine-readable stdout, diagnostic stderr, `--output`, `--quiet`, and
+  `--no-color` support.
+- Added server-side edge-guard workflows: sanitized `--print-config`,
+  readiness checks, redacted validation, evidence bundle creation,
+  policy-driven ACK/NAK decisions, and quarantine output hooks.
+- Added Python binding APIs for parse, JSON export, normalize, validation
+  reports, corpus summary/fingerprint/diff, safe-analysis redaction,
+  evidence bundle creation, and replay verification.
+- Added workflow guides for first-use evidence, vendor upgrade diffs,
+  safe support bundles, and validation sidecar deployment.
+
+### Changed
+
+- Evidence bundles now include manifest and README artifacts, and replay
+  verifies manifest hashes before comparing regenerated evidence.
+- Current release documentation positions v1.3.0 as the Evidence Loop
+  release candidate while keeping v1.2.1 as the latest published Rust release.
+
+### Fixed
+
+- Aligned evidence bundle replay message-type handling with the bundle
+  contract so replay reports reproduce the stored validation report.
+
 ---
 
 ## [1.2.1] - 2026-05-08
@@ -34,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.0] - 2026-05-03
+## Historical pre-v1.2.1 recovery notes - 2026-05-03
 
 ### Added
 
@@ -192,29 +225,19 @@ See [docs/STATUS.md](docs/STATUS.md) for complete status.
 
 ## Future Releases
 
-### v1.2.0 (Planned - 8 weeks)
-- Server mode with HTTP/gRPC
-- Remote profile loading
-- Streaming backpressure
-- CLI enhancements
-- Corpus manifest
-- Expression engine improvements
+### v1.3.0 Evidence Loop Release
 
-**See**: [ROADMAP.md](ROADMAP.md) and [docs/STATUS.md](docs/STATUS.md)
+- Promote the current evidence-loop candidate once final release validation
+  passes: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` publish dry-runs,
+  full gate checks, API contract checks, and Python wheel smoke proof.
+- Keep `hl7v2-python` on the Python/maturin lane instead of the Rust
+  crates.io publish graph.
 
-### v1.3.0 (Planned - 12 weeks after v1.2)
-- Language bindings (C, Python, JavaScript, Java)
-- Database integration (PostgreSQL, Snowflake)
-- Message queue integration (Kafka, RabbitMQ)
-- Cloud storage integration (S3, GCS, Azure Blob)
-- Advanced analytics
+### Later releases
 
-### v2.0.0 (Planned - 24 weeks after v1.3)
-- Security & compliance (HIPAA, TLS, encryption)
-- Audit logging with integrity
-- High availability & clustering
-- Advanced analytics & dashboards
-- GUI interface
+- Continue server sidecar hardening, Python distribution proof, profile
+  conformance quality, and compatibility-shim policy cleanup as separate
+  release trains.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` contains the v1.3.0 Evidence Loop release candidate, which is not yet published. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -25,6 +25,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
 | **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published to crates.io; Python remains a separate binding lane |
+| **Evidence Loop** | Candidate | Current `main` includes typed reports, profile test/explain, corpus fingerprint/diff, redaction, bundle/replay, schemas, goldens, and server/Python parity for a v1.3.0 release candidate |
 
 ## Features
 

--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -66,6 +66,8 @@ fields must be protected when present and cannot be retained.
 
 `hl7v2 bundle` writes a redacted evidence packet containing:
 
+- `manifest.json`
+- `README.md`
 - `message.redacted.hl7`
 - `validation-report.json`
 - `field-paths.json`

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -1,7 +1,57 @@
 # hl7v2-server
 
-HL7 v2 server implementation supporting MLLP and HTTP.
+HTTP/gRPC runtime service for HL7 v2 validation and evidence workflows.
+
+`hl7v2-server` is the deployable sidecar/edge-guard crate in the
+[`hl7v2-rs`](https://github.com/EffortlessMetrics/hl7v2-rs) workspace. It is
+separate from the `hl7v2` library crate because it carries runtime concerns:
+HTTP/gRPC serving, metrics, authentication, rate limits, config loading, and
+filesystem output roots.
+
+## Sidecar workflows
+
+Useful release-candidate workflows include:
+
+- `hl7v2-server --print-config` for sanitized effective configuration output.
+- `GET /ready` for startup readiness checks.
+- `POST /hl7/validate` for typed validation reports.
+- `POST /hl7/validate-redacted` for validate-and-redact workflows.
+- `POST /hl7/bundle` for server-created redacted evidence bundles under a
+  configured bundle output root.
+- `POST /hl7/ack-policy` for policy-driven ACK/NAK decisions.
+- `/metrics` for Prometheus metrics.
+
+The server reuses the same evidence contracts as the CLI and `hl7v2` library
+instead of defining a server-only report language.
 
 ## Usage
 
-For usage examples, see the [examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples) directory in the root of the repository.
+Inspect effective configuration without leaking secrets:
+
+```bash
+hl7v2-server --print-config
+```
+
+Run readiness after startup:
+
+```bash
+curl http://127.0.0.1:8080/ready
+```
+
+Create a redacted validation report:
+
+```bash
+curl -X POST http://127.0.0.1:8080/hl7/validate-redacted \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "MSH|^~\\&|App||Fac||20250128||ADT^A01|123|P|2.5.1\rPID|1||MRN123||Doe^John\r",
+    "profile": "name: ADT_A01\nmessage_type: ADT^A01\nsegments: []\n",
+    "redaction_policy": "[[rules]]\npath = \"PID.3\"\naction = \"hash\"\nreason = \"patient identifier\"\n[[rules]]\npath = \"PID.5\"\naction = \"drop\"\nreason = \"patient name\"\n"
+  }'
+```
+
+For a full operator walkthrough, see the
+[Deploy Validation Sidecar guide](https://github.com/EffortlessMetrics/hl7v2-rs/blob/main/docs/guides/deploy-validation-sidecar.md).
+For source examples, see the
+[examples/](https://github.com/EffortlessMetrics/hl7v2-rs/tree/main/examples)
+directory in the root of the repository.

--- a/crates/hl7v2/README.md
+++ b/crates/hl7v2/README.md
@@ -43,6 +43,20 @@ Implementer APIs are grouped under modules such as `hl7v2::model`,
 `hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`, `hl7v2::transport`,
 `hl7v2::conformance`, and `hl7v2::synthetic`.
 
+## Evidence APIs
+
+The crate also exposes the evidence-loop building blocks used by the CLI,
+server, and Python binding:
+
+- typed validation reports through `hl7v2::ValidationReport`
+- profile lint/test/explain report types under `hl7v2::conformance`
+- corpus summary, fingerprint, and diff helpers under `hl7v2::synthetic::corpus`
+- safe-analysis redaction helpers under `hl7v2::redact`
+- evidence bundle and replay helpers under `hl7v2::evidence`
+
+These APIs are the source of truth for the machine-readable artifacts documented
+in the workspace evidence schemas and guides.
+
 ## License
 
 AGPL-3.0-or-later

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,8 +2,8 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-08
-> **Project Status**: v1.2.1 published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+> **Last Updated**: 2026-05-09
+> **Project Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` contains the post-v1.2.1 v1.3.0 Evidence Loop release candidate, which is not yet published.
 
 ## Core Components
 
@@ -15,7 +15,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2-python` | 🟡 Experimental | Smoke | PyO3 binding package held out of the crates.io Rust publish graph; validated through the Python/maturin wheel smoke lane before any PyPI release. |
 | retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
-## Feature Set (v1.2.1)
+## Published Feature Set (v1.2.1)
 
 ### 🚀 Connectivity
 - ✅ **MLLP Over TCP**: Fully implemented async client and server.
@@ -45,9 +45,40 @@ This document provides a transparent view of which features are fully implemente
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. The fresh `v1.2.1` tag points at the current release head.
 
+## Evidence Loop Candidate (current main)
+
+Current `main` adds a v1.3.0 release candidate around deterministic HL7
+interface evidence. This work is available from source but has not gone through
+the final v1.3.0 publish dry-runs, tag, release notes publication, or crates.io
+upload.
+
+| Area | Status | Notes |
+|------|--------|-------|
+| First-run diagnostics | ✅ Candidate | `hl7v2 doctor` verifies CLI version, sample parse, profile loading, JSON output, optional server reachability, and optional Python binding presence. |
+| Typed validation evidence | ✅ Candidate | `ValidationReport` is shared by library, CLI, server validation, and Python bindings. |
+| Profiles as code | ✅ Candidate | `profile lint`, `profile test`, and `profile explain` produce machine-readable profile evidence. |
+| Corpus observability | ✅ Candidate | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. |
+| Safe support packets | ✅ Candidate | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
+| Evidence contracts | ✅ Candidate | JSON schemas and golden fixtures guard the machine-readable evidence artifacts. |
+| CLI automation contract | ✅ Candidate | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
+| Server edge guard | ✅ Candidate | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/ack-policy`, and quarantine hooks. |
+| Python evidence lane | 🟡 Candidate | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph. |
+
+## v1.3.0 Readiness Checklist
+
+Release-note draft: [`docs/releases/v1.3.0-evidence-loop-draft.md`](releases/v1.3.0-evidence-loop-draft.md).
+
+- ⏳ **Publish plan**: confirm `cargo run -p xtask -- publish-plan` still resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- ⏳ **Full gate**: run the current full release gate on the v1.3.0 release head.
+- ⏳ **Direct dry-runs**: run `cargo publish --dry-run` for `hl7v2`, then dependent dry-runs for `hl7v2-server` and `hl7v2-cli`.
+- ⏳ **Python proof**: run the maturin wheel build/install/import smoke lane without publishing `hl7v2-python` to crates.io.
+- ⏳ **Release notes and tag**: publish final release notes and tag only after the checks above pass on the release head.
+
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current code is tested, package-verified, tagged as `v1.2.1`, and published to crates.io for the final Rust package graph.**
+**Current published release**: v1.2.1 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
+
+**Current main**: contains the v1.3.0 Evidence Loop release candidate, which still needs final release-head validation before publication.

--- a/docs/releases/v1.3.0-evidence-loop-draft.md
+++ b/docs/releases/v1.3.0-evidence-loop-draft.md
@@ -1,0 +1,124 @@
+# v1.3.0 Evidence Loop Release Draft
+
+Status: draft only. v1.3.0 has not been tagged or published.
+
+This release is intended to make HL7v2 the evidence layer for HL7 v2
+interfaces: raw messages and corpora become validation reports, profile
+receipts, corpus fingerprints, drift reports, redacted support bundles, and
+replayable proofs.
+
+## Publish Surface
+
+The Rust crates.io publish graph remains:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+`hl7v2-python` stays on the Python/maturin lane. It should be proven with a
+wheel build, install, import, and smoke tests, but it should not be published to
+crates.io.
+
+Historical implementation microcrate names are not part of this release train.
+
+## Highlights
+
+### Evidence CLI
+
+- `hl7v2 doctor` for first-run diagnostics.
+- Typed `ValidationReport` output for validation workflows.
+- `profile lint`, `profile test`, and `profile explain` for profiles as code.
+- `corpus summarize`, `corpus fingerprint`, and `corpus diff` for feed
+  observability and before/after drift analysis.
+- `redact`, `bundle`, and `replay` for safe support packets and reproducible
+  failure evidence.
+- Stable CLI automation semantics: machine-readable stdout, diagnostic stderr,
+  stable exit codes, `--output`, `--quiet`, and `--no-color`.
+
+### Evidence Contracts
+
+- JSON schemas for the machine-readable evidence artifacts.
+- Golden fixtures for representative validation, profile, corpus, redaction,
+  bundle, and replay outputs.
+- Evidence bundles include manifests and generated README files.
+- Replay verifies manifest hashes before regenerating and comparing validation
+  evidence.
+
+### Server Edge Guard
+
+- Sanitized `hl7v2-server --print-config`.
+- `/ready` readiness checks for config, profiles, bundle roots, quarantine
+  output, and validation-report generation.
+- `/hl7/validate-redacted` for validate-and-redact workflows.
+- `/hl7/bundle` for server-side evidence packet creation under a configured
+  output root.
+- `/hl7/ack-policy` for policy-driven ACK/NAK decisions.
+- Quarantine hooks for failed redacted validation requests.
+
+### Python Binding Lane
+
+- Wheel proof with maturin remains the packaging gate.
+- Python APIs cover parse, JSON export, normalize, validation reports, corpus
+  summary/fingerprint/diff, safe-analysis redaction, evidence bundle creation,
+  and replay verification.
+- Python remains a separate distribution lane until TestPyPI/PyPI proof is
+  intentionally executed.
+
+### Guides
+
+- First 10 Minutes guide.
+- Vendor Upgrade Diff guide.
+- Safe Support Bundle guide.
+- Deploy Validation Sidecar guide.
+
+## Required Release Checks
+
+Run these on the final release head before tagging or publishing:
+
+```powershell
+cargo +1.93.0 run -p xtask -- publish-plan
+cargo +1.93.0 run -p xtask -- gate --check
+cargo +1.93.0 publish -p hl7v2 --dry-run
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
+```
+
+For the Python lane:
+
+```powershell
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+maturin build --release --out dist
+python tests/python_smoke/smoke.py
+```
+
+If dependent crate dry-runs are performed before `hl7v2` is published for the
+new version, document any crates.io index dependency failures honestly and rerun
+the dependent dry-runs after `hl7v2` is visible.
+
+## Release Notes Positioning
+
+Suggested title:
+
+```text
+v1.3.0 Evidence Loop Release
+```
+
+Suggested summary:
+
+```text
+HL7v2 v1.3.0 turns the parser and validator into an evidence workflow:
+diagnose a local install, lint and test profiles, validate messages, summarize
+and diff corpora, redact sensitive fields, bundle failures safely, replay the
+proof, and use the same artifacts from the CLI, Rust APIs, server, and Python
+bindings.
+```
+
+## Known Boundaries
+
+- `hl7v2-python` is not part of the Rust crates.io publish graph.
+- Old microcrate package names are not republished.
+- Redaction receipts and bundle metadata are designed to avoid raw message PHI,
+  but profile files are user-authored inputs and are not automatically
+  sanitized unless explicitly passed through a redaction workflow.
+- The server remains an edge guard and validation sidecar, not a full interface
+  engine.


### PR DESCRIPTION
## Summary
- document v1.3.0 as the Evidence Loop release candidate while keeping v1.2.1 as the latest published Rust release
- add a draft v1.3.0 release-notes handoff with publish surface, highlights, required checks, and known boundaries
- update root and crate READMEs for the current evidence-loop, server sidecar, bundle manifest, and Python-lane story

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

Publish plan remains:
1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`

## Notes
- Docs-only readiness PR; no version bump, tag, or publish claim.
- `hl7v2-python` remains a separate Python/maturin lane and is not part of the Rust crates.io graph.