### PR TITLE
release: prepare v1.3.0 dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.3.0] - 2026-05-09
+
 ### Added
 
 - Prepared the v1.3.0 Evidence Loop release candidate around deterministic

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "async-lock",
  "bytes",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-bench"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "criterion",
  "futures",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-cli"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-e2e-tests"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-examples"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "hl7v2",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-python"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "hl7v2",
  "pyo3",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-server"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-test-utils"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "hl7v2",
  "insta",
@@ -5556,7 +5556,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.93"
 
@@ -193,7 +193,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-hl7v2 = { version = "1.2.1", path = "crates/hl7v2", features = [
+hl7v2 = { version = "1.3.0", path = "crates/hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` contains the v1.3.0 Evidence Loop release candidate, which is not yet published. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.3.0 Evidence Loop release line, which is not yet published. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.2.1
+  version: 1.3.0
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-bench/Cargo.toml
+++ b/crates/hl7v2-bench/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "parsing"]
 
 [dependencies]
 # Library surface under benchmark
-hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
+hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml.workspace = true
 sha2.workspace = true
-hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
+hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
@@ -27,7 +27,7 @@ hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
     "network",
     "synthetic",
 ] }
-hl7v2-server = { version = "1.2.1", path = "../hl7v2-server" }
+hl7v2-server = { version = "1.3.0", path = "../hl7v2-server" }
 sysinfo = "0.38.2"
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -967,7 +967,7 @@ constraints:
         fn test_format_corpus_diff_report_text() {
             let report = hl7v2::synthetic::corpus::CorpusDiffReport {
                 diff_version: "1".to_string(),
-                tool_version: "1.2.1".to_string(),
+                tool_version: "1.3.0".to_string(),
                 before_root: "before".to_string(),
                 after_root: "after".to_string(),
                 profile: None,
@@ -1090,7 +1090,7 @@ constraints:
         fn test_format_corpus_fingerprint_report_text() {
             let report = hl7v2::synthetic::corpus::CorpusFingerprint {
                 fingerprint_version: "1".to_string(),
-                tool_version: "1.2.1".to_string(),
+                tool_version: "1.3.0".to_string(),
                 root: "corpus".to_string(),
                 profile: Some(hl7v2::synthetic::corpus::CorpusFingerprintProfile {
                     path: "profile.yaml".to_string(),

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2849,7 +2849,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut fingerprint, "/tool_version", "1.2.1");
+        set(&mut fingerprint, "/tool_version", "1.3.0");
         set(&mut fingerprint, "/root", "site-a");
         assert_fixture("corpus-fingerprint", fingerprint);
 
@@ -2864,7 +2864,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut diff, "/tool_version", "1.2.1");
+        set(&mut diff, "/tool_version", "1.3.0");
         set(&mut diff, "/before_root", "before");
         set(&mut diff, "/after_root", "after");
         assert_fixture("corpus-diff", diff);
@@ -2918,7 +2918,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
                 .expect("bundle manifest should be readable"),
         )
         .expect("bundle manifest should be JSON");
-        set(&mut manifest, "/tool_version", "1.2.1");
+        set(&mut manifest, "/tool_version", "1.3.0");
         for artifact in manifest
             .get_mut("artifacts")
             .and_then(Value::as_array_mut)
@@ -2938,7 +2938,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut replay, "/tool_version", "1.2.1");
+        set(&mut replay, "/tool_version", "1.3.0");
         assert_fixture("evidence-replay", replay);
     }
 }

--- a/crates/hl7v2-e2e-tests/Cargo.toml
+++ b/crates/hl7v2-e2e-tests/Cargo.toml
@@ -12,15 +12,15 @@ repository.workspace = true
 
 [dependencies]
 # Local crates - full system integration
-hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
+hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
     "stream",
     "network",
 ] }
-hl7v2-test-utils = { version = "1.2.1", path = "../hl7v2-test-utils" }
-hl7v2-server = { version = "1.2.1", path = "../hl7v2-server" }
+hl7v2-test-utils = { version = "1.3.0", path = "../hl7v2-test-utils" }
+hl7v2-server = { version = "1.3.0", path = "../hl7v2-server" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
+hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 
 [dependencies]
 # Local crates
-hl7v2 = { version = "1.2.1", path = "../hl7v2", features = [
+hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.2.1
+  version: 1.3.0
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-test-utils/Cargo.toml
+++ b/crates/hl7v2-test-utils/Cargo.toml
@@ -11,7 +11,7 @@ publish = false  # Dev-only crate
 repository.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.2.1", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.3.0", path = "../hl7v2", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-09
-> **Project Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` contains the post-v1.2.1 v1.3.0 Evidence Loop release candidate, which is not yet published.
+> **Project Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.3.0 Evidence Loop release line, which is not yet published.
 
 ## Core Components
 
@@ -47,10 +47,9 @@ This document provides a transparent view of which features are fully implemente
 
 ## Evidence Loop Candidate (current main)
 
-Current `main` adds a v1.3.0 release candidate around deterministic HL7
-interface evidence. This work is available from source but has not gone through
-the final v1.3.0 publish dry-runs, tag, release notes publication, or crates.io
-upload.
+Current `main` prepares the v1.3.0 release line around deterministic HL7
+interface evidence. This work is available from source but has not been tagged,
+released on GitHub, or uploaded to crates.io.
 
 | Area | Status | Notes |
 |------|--------|-------|
@@ -70,7 +69,7 @@ Release-note draft: [`docs/releases/v1.3.0-evidence-loop-draft.md`](releases/v1.
 
 - ⏳ **Publish plan**: confirm `cargo run -p xtask -- publish-plan` still resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ⏳ **Full gate**: run the current full release gate on the v1.3.0 release head.
-- ⏳ **Direct dry-runs**: run `cargo publish --dry-run` for `hl7v2`, then dependent dry-runs for `hl7v2-server` and `hl7v2-cli`.
+- ⏳ **Dry-runs**: run workspace-patched publish verification for the full graph, then direct `cargo publish --dry-run` for `hl7v2`. Dependent direct dry-runs may need to wait until `hl7v2` v1.3.0 is visible in the crates.io index.
 - ⏳ **Python proof**: run the maturin wheel build/install/import smoke lane without publishing `hl7v2-python` to crates.io.
 - ⏳ **Release notes and tag**: publish final release notes and tag only after the checks above pass on the release head.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -66,11 +66,12 @@ released on GitHub, or uploaded to crates.io.
 ## v1.3.0 Readiness Checklist
 
 Release-note draft: [`docs/releases/v1.3.0-evidence-loop-draft.md`](releases/v1.3.0-evidence-loop-draft.md).
+Dry-run receipt: [`docs/audits/publish-dry-run-2026-05-09.md`](audits/publish-dry-run-2026-05-09.md).
 
-- ⏳ **Publish plan**: confirm `cargo run -p xtask -- publish-plan` still resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-- ⏳ **Full gate**: run the current full release gate on the v1.3.0 release head.
-- ⏳ **Dry-runs**: run workspace-patched publish verification for the full graph, then direct `cargo publish --dry-run` for `hl7v2`. Dependent direct dry-runs may need to wait until `hl7v2` v1.3.0 is visible in the crates.io index.
-- ⏳ **Python proof**: run the maturin wheel build/install/import smoke lane without publishing `hl7v2-python` to crates.io.
+- ✅ **Publish plan**: `cargo run -p xtask -- publish-plan` resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- ✅ **Full gate**: `cargo run -p xtask -- gate --check` passes on the v1.3.0 package line.
+- ✅ **Dry-runs**: workspace-patched publish verification passes for the full graph and direct `cargo publish --dry-run` passes for `hl7v2`. Dependent direct dry-runs correctly wait for `hl7v2` v1.3.0 to exist in the crates.io index.
+- ✅ **Python proof**: the maturin wheel build/install/import smoke lane passes without publishing `hl7v2-python` to crates.io.
 - ⏳ **Release notes and tag**: publish final release notes and tag only after the checks above pass on the release head.
 
 ## Historical Plans

--- a/docs/audits/publish-dry-run-2026-05-09.md
+++ b/docs/audits/publish-dry-run-2026-05-09.md
@@ -1,0 +1,142 @@
+# v1.3.0 Publish Dry-Run Receipt
+
+Date: 2026-05-09
+
+This receipt records release-head package verification for the v1.3.0 Evidence
+Loop release candidate. No crates were published by these commands.
+
+## Version Line
+
+The workspace package line and active workspace packages were prepared as
+`1.3.0`.
+
+Verified with:
+
+```powershell
+cargo +1.93.0 metadata --format-version 1 --no-deps
+```
+
+Observed public package versions:
+
+| Package | Version |
+| ------- | ------- |
+| `hl7v2` | `1.3.0` |
+| `hl7v2-server` | `1.3.0` |
+| `hl7v2-cli` | `1.3.0` |
+
+`hl7v2-python` is also versioned as `1.3.0` for the Python/maturin lane, but
+it remains `publish = false` for crates.io.
+
+## Publish Plan
+
+```powershell
+cargo +1.93.0 run -p xtask -- publish-plan
+```
+
+Result:
+
+```text
+crates.io publish order
+ 1. hl7v2
+ 2. hl7v2-server
+ 3. hl7v2-cli
+```
+
+## Rust Dry-Runs
+
+Direct `hl7v2` dry-run:
+
+```powershell
+cargo +1.93.0 publish -p hl7v2 --dry-run
+```
+
+Result: pass.
+
+```text
+Packaging hl7v2 v1.3.0
+Packaged 62 files, 881.9KiB (168.8KiB compressed)
+Verifying hl7v2 v1.3.0
+Uploading hl7v2 v1.3.0
+warning: aborting upload due to dry run
+```
+
+Workspace-patched graph dry-run:
+
+```powershell
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches
+```
+
+Result: pass.
+
+```text
+Dry-running hl7v2...
+Dry-running hl7v2-server...
+Dry-running hl7v2-cli...
+Publish dry-run checks passed!
+```
+
+Packaged artifacts:
+
+| Package | Version | Package size | Compressed |
+| ------- | ------- | ------------ | ---------- |
+| `hl7v2` | `1.3.0` | 881.9 KiB | 168.8 KiB |
+| `hl7v2-server` | `1.3.0` | 428.8 KiB | 91.1 KiB |
+| `hl7v2-cli` | `1.3.0` | 511.5 KiB | 92.2 KiB |
+
+Direct dependent dry-runs before publishing `hl7v2` are expected to stop at the
+crates.io index boundary:
+
+```powershell
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
+```
+
+Both reported that `hl7v2 = "^1.3.0"` could not be resolved because crates.io
+currently exposes `hl7v2` `1.2.1` and does not yet contain `1.3.0`.
+
+## Gate
+
+```powershell
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+cargo +1.93.0 run -p xtask -- gate --check
+```
+
+Result: pass.
+
+The gate checked lint policy, no-panic-family policy, non-Rust file policy,
+formatting, dependency graph warmup, clippy, and test compilation.
+
+## Python Lane Proof
+
+The Python binding remains outside the Rust crates.io publish graph. The wheel
+proof was run with the build backend version required by `pyproject.toml`:
+
+```powershell
+python -m maturin --version
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+python -m maturin build --release --out dist
+python -m pip install --force-reinstall dist\hl7v2_python-1.3.0-cp314-cp314-win_amd64.whl
+python tests/python_smoke/smoke.py
+```
+
+Result: pass.
+
+```text
+maturin 1.13.1
+Built wheel for CPython 3.14 to dist\hl7v2_python-1.3.0-cp314-cp314-win_amd64.whl
+Successfully installed hl7v2-python-1.3.0
+hl7v2-python smoke ok version=1.3.0 segments=2
+```
+
+## Publish Boundary
+
+These checks do not publish anything. Actual publish order remains:
+
+1. `cargo +1.93.0 publish -p hl7v2`
+2. wait for `hl7v2` `1.3.0` to appear in the crates.io index
+3. `cargo +1.93.0 publish -p hl7v2-server`
+4. `cargo +1.93.0 publish -p hl7v2-cli`
+
+`hl7v2-python` should stay on the Python packaging lane unless a separate
+TestPyPI/PyPI release decision is made.

--- a/docs/guides/first-10-minutes.md
+++ b/docs/guides/first-10-minutes.md
@@ -49,7 +49,7 @@ Expected output includes local diagnostics:
 
 ```json
 {
-  "version": "1.2.1",
+  "version": "1.3.0",
   "checks": [
     {
       "name": "sample-parse",

--- a/docs/releases/v1.3.0-evidence-loop-draft.md
+++ b/docs/releases/v1.3.0-evidence-loop-draft.md
@@ -1,6 +1,7 @@
 # v1.3.0 Evidence Loop Release Draft
 
-Status: draft only. v1.3.0 has not been tagged or published.
+Status: draft only. v1.3.0 has passed local release dry-runs but has not been
+tagged or published.
 
 This release is intended to make HL7v2 the evidence layer for HL7 v2
 interfaces: raw messages and corpora become validation reports, profile
@@ -73,7 +74,10 @@ Historical implementation microcrate names are not part of this release train.
 
 ## Required Release Checks
 
-Run these on the final release head before tagging or publishing:
+Release dry-run receipt:
+[`docs/audits/publish-dry-run-2026-05-09.md`](../audits/publish-dry-run-2026-05-09.md).
+
+Run these again on the final release head before tagging or publishing:
 
 ```powershell
 cargo +1.93.0 run -p xtask -- publish-plan

--- a/fixtures/evidence/corpus-diff.json
+++ b/fixtures/evidence/corpus-diff.json
@@ -1,6 +1,6 @@
 {
   "diff_version": "1",
-  "tool_version": "1.2.1",
+  "tool_version": "1.3.0",
   "before_root": "before",
   "after_root": "after",
   "profile": null,

--- a/fixtures/evidence/corpus-fingerprint.json
+++ b/fixtures/evidence/corpus-fingerprint.json
@@ -1,6 +1,6 @@
 {
   "fingerprint_version": "1",
-  "tool_version": "1.2.1",
+  "tool_version": "1.3.0",
   "root": "site-a",
   "profile": null,
   "file_count": 1,

--- a/fixtures/evidence/evidence-bundle-manifest.json
+++ b/fixtures/evidence/evidence-bundle-manifest.json
@@ -1,7 +1,7 @@
 {
   "bundle_version": "1",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.2.1",
+  "tool_version": "1.3.0",
   "artifacts": [
     {
       "path": "message.redacted.hl7",

--- a/fixtures/evidence/evidence-replay.json
+++ b/fixtures/evidence/evidence-replay.json
@@ -2,7 +2,7 @@
   "replay_version": "1",
   "bundle_version": "1",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.2.1",
+  "tool_version": "1.3.0",
   "message_type": "ADT^A01",
   "reproduced": true,
   "validation_valid": true,


### PR DESCRIPTION
## Summary
- bump the workspace package line and internal path dependency versions to `1.3.0`
- promote the evidence-loop changelog entries into the v1.3.0 release section
- record the v1.3.0 publish dry-run receipt and Python wheel smoke proof

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 publish -p hl7v2 --dry-run`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `cargo +1.93.0 publish -p hl7v2-server --dry-run` stops at crates.io index because `hl7v2 1.3.0` is not published yet
- `cargo +1.93.0 publish -p hl7v2-cli --dry-run` stops at crates.io index because `hl7v2 1.3.0` is not published yet
- `python -m maturin --version` => `maturin 1.13.1`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; python -m maturin build --release --out dist`
- `python -m pip install --force-reinstall dist\hl7v2_python-1.3.0-cp314-cp314-win_amd64.whl`
- `python tests/python_smoke/smoke.py`

Publish plan remains:
1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`

## Notes
- No crates were published by this PR.
- `hl7v2-python` remains outside the Rust crates.io graph; the wheel smoke is packaging proof only.
- Dependent direct dry-runs should be rerun after `hl7v2 1.3.0` is visible in the crates.io index during the actual publish sequence.