### PR TITLE
docs: record v1.3.0 publish receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Prepared the v1.3.0 Evidence Loop release candidate around deterministic
+- Released the v1.3.0 Evidence Loop around deterministic
   HL7 interface evidence: first-run diagnostics, typed validation reports,
   profile lint/test/explain, corpus summarize/fingerprint/diff,
   safe-analysis redaction, evidence bundle/replay, and Python binding parity.
@@ -38,8 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Evidence bundles now include manifest and README artifacts, and replay
   verifies manifest hashes before comparing regenerated evidence.
-- Current release documentation positions v1.3.0 as the Evidence Loop
-  release candidate while keeping v1.2.1 as the latest published Rust release.
+- Current release documentation positions v1.3.0 as the published Evidence
+  Loop release for the final Rust package graph.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.3.0 Evidence Loop release line, which is not yet published. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -24,8 +24,8 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
-| **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published to crates.io; Python remains a separate binding lane |
-| **Evidence Loop** | Candidate | Current `main` includes typed reports, profile test/explain, corpus fingerprint/diff, redaction, bundle/replay, schemas, goldens, and server/Python parity for a v1.3.0 release candidate |
+| **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published to crates.io; Python remains a separate binding lane |
+| **Evidence Loop** | Stable | v1.3.0 includes typed reports, profile test/explain, corpus fingerprint/diff, redaction, bundle/replay, schemas, goldens, and server/Python parity |
 
 ## Features
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-09
-> **Project Status**: v1.2.1 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.3.0 Evidence Loop release line, which is not yet published.
+> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 
 ## Core Components
 
@@ -15,7 +15,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2-python` | 🟡 Experimental | Smoke | PyO3 binding package held out of the crates.io Rust publish graph; validated through the Python/maturin wheel smoke lane before any PyPI release. |
 | retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
-## Published Feature Set (v1.2.1)
+## Published Feature Set (v1.3.0)
 
 ### 🚀 Connectivity
 - ✅ **MLLP Over TCP**: Fully implemented async client and server.
@@ -37,48 +37,49 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: CI, Coverage, Security, Extended, Benchmarks, and API Contracts are green on the 2026-05-08 `v1.2.1` release head after manual API Contracts and Coverage dispatches.
+- ✅ **Main workflows**: required CI success, Coverage, Security, Python Wheels, and API Contracts are green on the v1.3.0 release head. Extended tests passed in the main CI run; benchmark artifacts remain a non-publish performance lane.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.2.1 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-08.md`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-08.md`.
+- ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-09.md`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-09.md`.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The binding is verified through a maturin wheel build/install/import smoke lane before any PyPI or TestPyPI release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
-- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. The fresh `v1.2.1` tag points at the current release head.
+- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1` and `v1.3.0` tags point at their release heads.
 
 ## Evidence Loop Candidate (current main)
 
-Current `main` prepares the v1.3.0 release line around deterministic HL7
-interface evidence. This work is available from source but has not been tagged,
-released on GitHub, or uploaded to crates.io.
+v1.3.0 is the Evidence Loop release line around deterministic HL7 interface
+evidence. It is tagged, released on GitHub, and uploaded to crates.io for the
+final Rust package graph.
 
 | Area | Status | Notes |
 |------|--------|-------|
-| First-run diagnostics | ✅ Candidate | `hl7v2 doctor` verifies CLI version, sample parse, profile loading, JSON output, optional server reachability, and optional Python binding presence. |
-| Typed validation evidence | ✅ Candidate | `ValidationReport` is shared by library, CLI, server validation, and Python bindings. |
-| Profiles as code | ✅ Candidate | `profile lint`, `profile test`, and `profile explain` produce machine-readable profile evidence. |
-| Corpus observability | ✅ Candidate | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. |
-| Safe support packets | ✅ Candidate | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
-| Evidence contracts | ✅ Candidate | JSON schemas and golden fixtures guard the machine-readable evidence artifacts. |
-| CLI automation contract | ✅ Candidate | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
-| Server edge guard | ✅ Candidate | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/ack-policy`, and quarantine hooks. |
-| Python evidence lane | 🟡 Candidate | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph. |
+| First-run diagnostics | ✅ Stable | `hl7v2 doctor` verifies CLI version, sample parse, profile loading, JSON output, optional server reachability, and optional Python binding presence. |
+| Typed validation evidence | ✅ Stable | `ValidationReport` is shared by library, CLI, server validation, and Python bindings. |
+| Profiles as code | ✅ Stable | `profile lint`, `profile test`, and `profile explain` produce machine-readable profile evidence. |
+| Corpus observability | ✅ Stable | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. |
+| Safe support packets | ✅ Stable | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
+| Evidence contracts | ✅ Stable | JSON schemas and golden fixtures guard the machine-readable evidence artifacts. |
+| CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
+| Server edge guard | ✅ Stable | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/ack-policy`, and quarantine hooks. |
+| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph. |
 
 ## v1.3.0 Readiness Checklist
 
-Release-note draft: [`docs/releases/v1.3.0-evidence-loop-draft.md`](releases/v1.3.0-evidence-loop-draft.md).
+Release notes: [`docs/releases/v1.3.0-evidence-loop.md`](releases/v1.3.0-evidence-loop.md).
 Dry-run receipt: [`docs/audits/publish-dry-run-2026-05-09.md`](audits/publish-dry-run-2026-05-09.md).
+Publish receipt: [`docs/audits/publish-2026-05-09.md`](audits/publish-2026-05-09.md).
 
 - ✅ **Publish plan**: `cargo run -p xtask -- publish-plan` resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Full gate**: `cargo run -p xtask -- gate --check` passes on the v1.3.0 package line.
-- ✅ **Dry-runs**: workspace-patched publish verification passes for the full graph and direct `cargo publish --dry-run` passes for `hl7v2`. Dependent direct dry-runs correctly wait for `hl7v2` v1.3.0 to exist in the crates.io index.
+- ✅ **Dry-runs**: workspace-patched publish verification passes for the full graph and direct `cargo publish --dry-run` passes in dependency order after each dependency is visible in the crates.io index.
 - ✅ **Python proof**: the maturin wheel build/install/import smoke lane passes without publishing `hl7v2-python` to crates.io.
-- ⏳ **Release notes and tag**: publish final release notes and tag only after the checks above pass on the release head.
+- ✅ **Release notes and tag**: `v1.3.0` is tagged and the GitHub release is published.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current published release**: v1.2.1 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
+**Current published release**: v1.3.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
-**Current main**: contains the v1.3.0 Evidence Loop release candidate, which still needs final release-head validation before publication.
+**Current main**: tracks the published v1.3.0 Evidence Loop release line.

--- a/docs/audits/publish-2026-05-09.md
+++ b/docs/audits/publish-2026-05-09.md
@@ -1,0 +1,82 @@
+# Publish Receipt - 2026-05-09
+
+## Context
+
+This receipt records the actual crates.io publication for `hl7v2-rs` v1.3.0,
+the Evidence Loop release.
+
+The published Rust package graph is:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+`hl7v2-python` remains `publish = false` for crates.io and stays on the
+separate Python/maturin binding lane.
+
+## Release Head
+
+```text
+5aa8b56 release: prepare v1.3.0 dry-run (#492)
+```
+
+The `v1.3.0` tag points at this release head and was pushed to GitHub. The
+GitHub release is:
+
+```text
+https://github.com/EffortlessMetrics/hl7v2-rs/releases/tag/v1.3.0
+```
+
+## Pre-Publish Verification
+
+Release-head verification was recorded in:
+
+```text
+docs/audits/publish-dry-run-2026-05-09.md
+```
+
+Final direct dry-runs were run in dependency order:
+
+```powershell
+cargo +1.93.0 publish -p hl7v2 --dry-run
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
+```
+
+The dependent direct dry-runs were rerun after each dependency became visible
+in the crates.io index.
+
+## Publish Commands
+
+```powershell
+cargo +1.93.0 publish -p hl7v2
+cargo +1.93.0 publish -p hl7v2-server
+cargo +1.93.0 publish -p hl7v2-cli
+```
+
+## Results
+
+Cargo reported successful upload and index availability for:
+
+| Crate | Version | Result |
+| --- | --- | --- |
+| `hl7v2` | `1.3.0` | Published |
+| `hl7v2-server` | `1.3.0` | Published |
+| `hl7v2-cli` | `1.3.0` | Published |
+
+Registry verification:
+
+```text
+hl7v2 = "1.3.0"
+hl7v2-server = "1.3.0"
+hl7v2-cli = "1.3.0"
+```
+
+`cargo +1.93.0 info --registry crates-io` resolved each package at version
+`1.3.0`.
+
+## Status
+
+The v1.3.0 final Rust package graph is published to crates.io. Historical old
+implementation package names remain compatibility artifacts and are not the
+product surface for new code.

--- a/docs/audits/publish-dry-run-2026-05-09.md
+++ b/docs/audits/publish-dry-run-2026-05-09.md
@@ -3,7 +3,10 @@
 Date: 2026-05-09
 
 This receipt records release-head package verification for the v1.3.0 Evidence
-Loop release candidate. No crates were published by these commands.
+Loop release line. No crates were published by these commands.
+
+This dry-run receipt was followed by the actual `v1.3.0` crates.io publish.
+See [`docs/audits/publish-2026-05-09.md`](publish-2026-05-09.md).
 
 ## Version Line
 

--- a/docs/releases/v1.3.0-evidence-loop.md
+++ b/docs/releases/v1.3.0-evidence-loop.md
@@ -1,7 +1,7 @@
-# v1.3.0 Evidence Loop Release Draft
+# v1.3.0 Evidence Loop Release
 
-Status: draft only. v1.3.0 has passed local release dry-runs but has not been
-tagged or published.
+Status: published. `v1.3.0` is tagged, released on GitHub, and published to
+crates.io for the final Rust package graph.
 
 This release is intended to make HL7v2 the evidence layer for HL7 v2
 interfaces: raw messages and corpora become validation reports, profile
@@ -77,7 +77,10 @@ Historical implementation microcrate names are not part of this release train.
 Release dry-run receipt:
 [`docs/audits/publish-dry-run-2026-05-09.md`](../audits/publish-dry-run-2026-05-09.md).
 
-Run these again on the final release head before tagging or publishing:
+Publish receipt:
+[`docs/audits/publish-2026-05-09.md`](../audits/publish-2026-05-09.md).
+
+These checks were run on the final release head before tagging and publishing:
 
 ```powershell
 cargo +1.93.0 run -p xtask -- publish-plan
@@ -95,9 +98,8 @@ maturin build --release --out dist
 python tests/python_smoke/smoke.py
 ```
 
-If dependent crate dry-runs are performed before `hl7v2` is published for the
-new version, document any crates.io index dependency failures honestly and rerun
-the dependent dry-runs after `hl7v2` is visible.
+Dependent direct dry-runs were rerun after each dependency became visible in
+the crates.io index.
 
 ## Release Notes Positioning
 


### PR DESCRIPTION
## Summary
- Record the actual v1.3.0 crates.io publish receipt for `hl7v2`, `hl7v2-server`, and `hl7v2-cli`
- Update README, status, changelog, and release notes from release-candidate wording to published v1.3.0 wording
- Keep `hl7v2-python` documented as a separate maturin/Python lane outside crates.io

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- stale release wording scan with `rg`

## Publish evidence
- `cargo +1.93.0 publish -p hl7v2` succeeded for v1.3.0
- `cargo +1.93.0 publish -p hl7v2-server` succeeded for v1.3.0
- `cargo +1.93.0 publish -p hl7v2-cli` succeeded for v1.3.0
- `cargo +1.93.0 info --registry crates-io` resolves all three crates at v1.3.0
- GitHub release: https://github.com/EffortlessMetrics/hl7v2-rs/releases/tag/v1.3.0