### PR TITLE
docs: define evidence null and empty semantics

### DIFF
--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -83,6 +83,9 @@ The CLI output contract is stable enough for CI and automation:
 3 = IO/runtime/environment error
 ```
 
+Evidence JSON null, omitted-field, and empty-array semantics are documented in
+[`schemas/README.md`](../../schemas/README.md#evidence-null-and-empty-semantics).
+
 ## Remaining Contract Hardening Gaps
 
 The v1.3.0 evidence loop has schema-backed JSON artifacts, golden fixtures,
@@ -93,7 +96,6 @@ few places where provenance or identity is still implicit:
 - `schema_version` or artifact-specific version naming for every machine
   artifact.
 - `tool_version` where users need provenance outside an environment file.
-- Explicit null and empty-list behavior for optional fields.
 - Explicit profile identity semantics for validation reports, since CLI reports
   the supplied profile path while server and Python reports use the loaded
   profile message structure.

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -51,8 +51,8 @@ summary/fingerprint/diff dict outputs, and safe-analysis redaction output.
 | `ProfileTestReport` | CLI report with fixture cases, pass/fail status, embedded validation reports, and optional expected-report comparison. | JSON Schema and golden fixture exist; CLI-local type with no embedded version fields. |
 | `ProfileExplainReport` | CLI report with profile SHA-256, structure, version, segments, constraints, tables, rules, and lint summary. | JSON Schema and golden fixture exist; no embedded artifact version or tool version. |
 | `CorpusSummary` | Shared Rust corpus summary type. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; no embedded version fields. |
-| `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; null/empty behavior still needs clearer docs. |
-| `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; null/empty behavior still needs clearer docs. |
+| `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; `profile: null` and empty-array semantics are documented in the schema README. |
+| `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; `profile: null` and empty-array semantics are documented in the schema README. |
 | `RedactionReceipt` | CLI, server, and Python receipts record PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | JSON Schema, golden fixture, and synthetic PHI leak-sentinel tests exist; no embedded version fields. |
 | `EvidenceBundleSummary` | CLI stdout JSON summary, Python `bundle()` output, and server `/hl7/bundle` JSON response include `bundle_version`, output directory/id, message type, validation status, redaction status, and artifact list. | JSON Schema and golden fixture exist; no `tool_version` in the summary itself. |
 | Bundle artifacts | CLI, Python, and server bundles write `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, `replay.ps1`, `README.md`, and `manifest.json`. | Bundle README is generated and manifest-hashed; profile text is user-authored and included as supplied. |
@@ -99,13 +99,13 @@ Current behavior is script-grade:
 
 The evidence loop is contract-grade enough for the v1.3.0 release: schemas,
 goldens, CLI output semantics, manifest verification, server edge-guard routes,
-Python parity, and user guides are in place. Remaining hardening work:
+Python parity, user guides, and documented evidence null/empty semantics are in
+place. Remaining hardening work:
 
 1. Add artifact version and tool version fields consistently.
-2. Document null/empty-list behavior for optional fields.
-3. Add broader synthetic PHI leak sentinels for future server/Python evidence
+2. Add broader synthetic PHI leak sentinels for future server/Python evidence
    wrappers and additional fixture families.
-4. Promote shared report types out of CLI-local structs when server or Python
+3. Promote shared report types out of CLI-local structs when server or Python
    parity needs them.
 
 ## Verification Performed For This Audit

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -52,6 +52,34 @@ Python lanes:
 - Corpus summary, fingerprint, and diff reports
 - Redaction receipts and evidence bundle/replay summaries
 
+#### Evidence Null And Empty Semantics
+
+Evidence schemas use a small set of conventions so CI jobs and data pipelines
+can distinguish "not applicable" from "not evaluated":
+
+- Required fields are always present, even when their value is empty.
+- Empty arrays mean the category was evaluated and no entries were found. For
+  example, `issues: []`, `parse_errors: []`, `new_segments: []`, and
+  `validation_issue_code_counts: []` are successful empty results, not missing
+  scans.
+- Explicit `null` means the field is known but not applicable or not available
+  for this artifact. For example, corpus `profile: null` means no profile was
+  supplied, replay `message_type: null` means replay could not recover a message
+  type, and replay `validation_valid: null` means validation was not regenerated.
+- Optional fields that are absent are additive context fields, not failed
+  checks. For example, `validation_report` is absent from replay reports when
+  replay fails before a report can be regenerated.
+- Numeric counters use `0` when the category was evaluated and empty. Consumers
+  should prefer the explicit status fields, such as `valid`, `reproduced`, and
+  replay check statuses, when deciding whether work succeeded.
+- Profile explain fields such as `message_type`, `parent`, component bounds,
+  datatype bounds, patterns, and expression guardrail limits use `null` for
+  unspecified profile configuration.
+
+These conventions are part of the evidence contract for the `*-v1` schemas.
+Changing a field from absent to required, from empty array to omitted, or from
+`null` to a sentinel string is a contract change.
+
 ## Usage
 
 ### Validate YAML Against Schema


### PR DESCRIPTION
## Summary
- document evidence JSON conventions for required fields, empty arrays, explicit nulls, absent optional fields, and zero counters
- link the convention from the evidence artifact architecture reference
- remove null/empty behavior from the remaining hardening gap list now that it is documented

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`