### PR TITLE
docs: define evidence profile label semantics

### DIFF
--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -55,10 +55,11 @@ failed, what changed, what was redacted, and how to replay the result.
 | Server | `/hl7/validate` exposes the shared validation issue fields and preserves legacy `errors` / `warnings`; `/hl7/validate-redacted` applies safe-analysis redaction, returns a validation report plus redaction receipt, and can write configured quarantine output for failed validation; `/hl7/bundle` writes redacted evidence bundles under a configured server root; `/hl7/ack-policy` returns policy-driven ACK/NAK decisions backed by validation reports. Replay endpoints and corpus artifacts remain follow-up work. |
 | Python | Exposes parse, JSON conversion, normalize, validation report dict/JSON parity, corpus summary/fingerprint/diff dict parity, safe-analysis redaction dict output, evidence bundle creation, and replay verification. |
 
-One current validation-report parity wrinkle is the profile label. The CLI uses
-the profile file path, while the server and Python binding use the loaded
-profile `message_structure`. The report fields are otherwise shared through
-`hl7v2::ValidationReport`.
+`ValidationReport.profile` is a surface-local display label, not a canonical
+profile identity. The CLI uses the supplied profile path, while the server and
+Python binding use the loaded profile `message_structure`. Consumers that need
+reproducible profile identity should use artifacts with profile SHA-256
+metadata. The report fields are otherwise shared through `hl7v2::ValidationReport`.
 
 ## Output Semantics
 
@@ -96,9 +97,6 @@ few places where provenance or identity is still implicit:
 - `schema_version` or artifact-specific version naming for every machine
   artifact.
 - `tool_version` where users need provenance outside an environment file.
-- Explicit profile identity semantics for validation reports, since CLI reports
-  the supplied profile path while server and Python reports use the loaded
-  profile message structure.
 - Shared library types for any CLI-local report promoted beyond CLI-only use.
 
 ## Non-Goals

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -70,11 +70,12 @@ summary/fingerprint/diff dict outputs, and safe-analysis redaction output.
 | Server | Validation report parity for `/hl7/validate`; redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; replay endpoint and corpus artifacts remain follow-up work. |
 | Python | Minimum API parity for parse, `to_json`, normalize, validation reports, corpus summary/fingerprint/diff dict outputs, safe-analysis redaction output, bundle creation, and replay verification. |
 
-One known validation parity detail remains: the CLI report `profile` value is
-the profile path supplied by the user, while the server and Python surfaces use
-the loaded profile message structure. The shape is schema-backed and shared; the
-profile identity semantics still need to be made explicit before profile labels
-are treated as cross-surface equivalent.
+One validation parity detail is intentionally documented as a label convention:
+the CLI report `profile` value is the profile path supplied by the user, while
+the server and Python surfaces use the loaded profile message structure. The
+shape is schema-backed and shared, but `ValidationReport.profile` is not a
+canonical profile identity. Consumers that need reproducible profile identity
+should use artifacts with profile SHA-256 metadata.
 
 ## CLI Automation Semantics
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -80,6 +80,21 @@ These conventions are part of the evidence contract for the `*-v1` schemas.
 Changing a field from absent to required, from empty array to omitted, or from
 `null` to a sentinel string is a contract change.
 
+#### Evidence Profile Labels
+
+`ValidationReport.profile` is a display label for the profile used by that
+surface, not a canonical cross-surface profile identity:
+
+- CLI validation reports use the profile path supplied by the user.
+- Server validation reports use the loaded profile `message_structure`.
+- Python validation reports use the loaded profile `message_structure`.
+
+Consumers that need reproducible profile identity should use artifacts that
+carry `profile_sha256` or profile metadata, such as profile explain reports,
+corpus fingerprints/diffs with a profile, or evidence bundle environment and
+manifest files. Do not compare `ValidationReport.profile` across CLI, server,
+and Python as if it were a stable hash or normalized profile id.
+
 ## Usage
 
 ### Validate YAML Against Schema


### PR DESCRIPTION
## Summary
- document `ValidationReport.profile` as a surface-local display label, not a canonical profile identity
- point consumers that need reproducible profile identity to SHA-bearing profile artifacts
- remove profile identity semantics from the remaining evidence hardening gap list

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`