### PR TITLE
test: broaden server evidence PHI sentinels

### DIFF
--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tower::ServiceExt;
 
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
 
 const PROFILE: &str = r#"
 message_structure: ADT_A01
@@ -52,6 +52,26 @@ reason = "date of birth"
 path = "PID.11"
 action = "drop"
 reason = "patient address"
+
+[[rules]]
+path = "PID.13"
+action = "drop"
+reason = "patient phone"
+
+[[rules]]
+path = "NK1.2"
+action = "drop"
+reason = "next-of-kin name"
+
+[[rules]]
+path = "NK1.4"
+action = "drop"
+reason = "next-of-kin address"
+
+[[rules]]
+path = "NK1.5"
+action = "drop"
+reason = "next-of-kin phone"
 
 [[rules]]
 path = "MSH.9"
@@ -284,7 +304,16 @@ async fn test_bundle_endpoint_rejects_existing_bundle_id() {
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in ["Doe^John", "123456^^^HOSP^MR", "19700101", "123 Main St"] {
+    for sentinel in [
+        "Doe^John",
+        "123456^^^HOSP^MR",
+        "19700101",
+        "123 Main St",
+        "5558675309",
+        "Watcher^Nora",
+        "900 Support Way",
+        "5550001234",
+    ] {
         assert!(!content.contains(sentinel), "content leaked {sentinel}");
     }
 }

--- a/crates/hl7v2-server/tests/quarantine_output_hooks_test.rs
+++ b/crates/hl7v2-server/tests/quarantine_output_hooks_test.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tower::ServiceExt;
 
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
 
 const VALID_PROFILE: &str = r#"
 message_structure: "ADT_A01"
@@ -71,6 +71,26 @@ reason = "date of birth"
 path = "PID.11"
 action = "drop"
 reason = "patient address"
+
+[[rules]]
+path = "PID.13"
+action = "drop"
+reason = "patient phone"
+
+[[rules]]
+path = "NK1.2"
+action = "drop"
+reason = "next-of-kin name"
+
+[[rules]]
+path = "NK1.4"
+action = "drop"
+reason = "next-of-kin address"
+
+[[rules]]
+path = "NK1.5"
+action = "drop"
+reason = "next-of-kin phone"
 
 [[rules]]
 path = "MSH.9"
@@ -277,7 +297,16 @@ async fn test_quarantine_hook_fails_closed_without_configured_path() {
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in ["Doe^John", "123456^^^HOSP^MR", "19700101", "123 Main St"] {
+    for sentinel in [
+        "Doe^John",
+        "123456^^^HOSP^MR",
+        "19700101",
+        "123 Main St",
+        "5558675309",
+        "Watcher^Nora",
+        "900 Support Way",
+        "5550001234",
+    ] {
         assert!(!content.contains(sentinel), "content leaked {sentinel}");
     }
 }

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -16,7 +16,7 @@ use tower::ServiceExt;
 
 mod common;
 
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
 
 const REDACTION_POLICY: &str = r#"
 [[rules]]
@@ -38,6 +38,26 @@ reason = "drop date of birth"
 path = "PID.11"
 action = "drop"
 reason = "drop patient address"
+
+[[rules]]
+path = "PID.13"
+action = "drop"
+reason = "drop patient phone"
+
+[[rules]]
+path = "NK1.2"
+action = "drop"
+reason = "drop next-of-kin name"
+
+[[rules]]
+path = "NK1.4"
+action = "drop"
+reason = "drop next-of-kin address"
+
+[[rules]]
+path = "NK1.5"
+action = "drop"
+reason = "drop next-of-kin phone"
 "#;
 
 const VALIDATION_PROFILE: &str = r#"
@@ -113,10 +133,7 @@ async fn test_validate_redacted_returns_report_receipt_and_redacted_hl7_without_
             .unwrap()
             .contains("hash:sha256:")
     );
-    assert!(!body_text.contains("Doe^John"));
-    assert!(!body_text.contains("123456^^^HOSP^MR"));
-    assert!(!body_text.contains("19700101"));
-    assert!(!body_text.contains("123 Main St"));
+    assert_no_phi(&body_text);
 }
 
 #[tokio::test]
@@ -162,7 +179,7 @@ async fn test_validate_redacted_report_is_generated_from_redacted_message() {
 
     assert_eq!(body_json["validation_report"]["valid"], false);
     assert_eq!(body_json["validation_report"]["issues"][0]["path"], "PID.5");
-    assert!(!body_text.contains("Doe^John"));
+    assert_no_phi(&body_text);
 }
 
 #[tokio::test]
@@ -193,8 +210,20 @@ reason = "hash patient identifier"
 
     assert_eq!(body_json["code"], "REDACTION_ERROR");
     assert!(body_json["message"].as_str().unwrap().contains("PID.5"));
-    assert!(!body_text.contains("Doe^John"));
-    assert!(!body_text.contains("123456^^^HOSP^MR"));
-    assert!(!body_text.contains("19700101"));
-    assert!(!body_text.contains("123 Main St"));
+    assert_no_phi(&body_text);
+}
+
+fn assert_no_phi(content: &str) {
+    for sentinel in [
+        "Doe^John",
+        "123456^^^HOSP^MR",
+        "19700101",
+        "123 Main St",
+        "5558675309",
+        "Watcher^Nora",
+        "900 Support Way",
+        "5550001234",
+    ] {
+        assert!(!content.contains(sentinel), "content leaked {sentinel}");
+    }
 }

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -104,8 +104,8 @@ Python parity, user guides, and documented evidence null/empty semantics are in
 place. Remaining hardening work:
 
 1. Add artifact version and tool version fields consistently.
-2. Add broader synthetic PHI leak sentinels for future server/Python evidence
-   wrappers and additional fixture families.
+2. Expand PHI leak sentinels beyond the current synthetic patient/contact
+   fixture family as new evidence surfaces or policy modes are added.
 3. Promote shared report types out of CLI-local structs when server or Python
    parity needs them.
 


### PR DESCRIPTION
## Summary
- broaden server safe-evidence fixtures with phone and next-of-kin sentinel values
- require `/hl7/validate-redacted`, `/hl7/bundle`, and quarantine output artifacts to keep those sentinels out of responses and generated evidence files
- update the current-state audit so the remaining PHI-sentinel gap is scoped to future fixture families and new surfaces

## Security surface
This touches PHI/safe-sharing regression coverage only. Runtime redaction behavior and server endpoints are unchanged.

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 test -p hl7v2-server --test validate_redacted_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test bundle_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test quarantine_output_hooks_test`
- `cargo +1.93.0 clippy -p hl7v2-server --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`