### PR TITLE
contracts: add validation report v2 provenance schema

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -145,10 +145,14 @@ jobs:
 
       - name: Validate Evidence Fixtures
         run: |
-          for schema in schemas/evidence/*-v1.schema.json; do
+          for schema in schemas/evidence/*-v*.schema.json; do
             name="$(basename "$schema")"
-            name="${name%-v1.schema.json}"
+            name="${name%.schema.json}"
             data="fixtures/evidence/${name}.json"
+            if [ ! -f "$data" ]; then
+              legacy_name="${name%-v1}"
+              data="fixtures/evidence/${legacy_name}.json"
+            fi
             echo "Validating $data against $schema"
             ajv validate -c ajv-formats \
               -s "$schema" \

--- a/docs/architecture/evidence-provenance-versioning.md
+++ b/docs/architecture/evidence-provenance-versioning.md
@@ -111,7 +111,9 @@ Do the migration in narrow PRs:
 
 1. Add v2 schemas and v2 golden fixtures for the highest-value shared reports:
    `ValidationReport`, `CorpusFingerprint`, `CorpusDiffReport`, and
-   `RedactionReceipt`.
+   `RedactionReceipt`. `ValidationReport` now has the first target v2 schema
+   and fixture; producers still emit the current v1 shape until migrated
+   explicitly.
 2. Add additive Rust fields behind explicit v2 serializers or conversion
    helpers. Do not break callers that still expect the v1 shapes.
 3. Update CLI JSON/YAML output to choose the v2 shape only when the command or

--- a/fixtures/evidence/validation-report-v2.json
+++ b/fixtures/evidence/validation-report-v2.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "2",
+  "tool_name": "hl7v2-cli",
+  "tool_version": "1.4.0",
+  "valid": false,
+  "message_type": "ADT^A01",
+  "profile": "profile.yaml",
+  "profile_identity": {
+    "label": "profile.yaml",
+    "message_structure": "ADT_A01",
+    "version": "2.5.1",
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "segment_count": 2,
+  "issue_count": 1,
+  "issues": [
+    {
+      "code": "missing_required_field",
+      "severity": "error",
+      "path": "PID.3",
+      "rule_id": "missing_required_field",
+      "message": "Required field PID.3 is missing",
+      "segment_index": 1,
+      "field_index": 3
+    }
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -45,12 +45,17 @@ CLI and server configuration (hl7v2.toml):
 - CLI defaults
 - Logging defaults
 
-### Evidence (`evidence/*-v1.schema.json`)
+### Evidence (`evidence/*-v*.schema.json`)
 Machine-readable evidence artifacts emitted by the CLI, library, server, and
 Python lanes:
 - Validation reports and profile lint/test/explain reports
 - Corpus summary, fingerprint, and diff reports
 - Redaction receipts and evidence bundle/replay summaries
+
+`validation-report-v2.schema.json` is the first target evidence schema with
+embedded `schema_version`, `tool_name`, and `tool_version` fields. It is a
+contract artifact for the planned v2 migration; current v1 producers remain
+valid until implementation PRs explicitly move their output shape.
 
 #### Evidence Null And Empty Semantics
 
@@ -172,10 +177,15 @@ evidence fixtures, then compiles every schema:
     Path("target/contracts/config/config.example.json").write_text(json.dumps(data), encoding="utf-8")
     PY
     ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d 'target/contracts/config/*.json' --spec=draft7
-    for schema in schemas/evidence/*-v1.schema.json; do
+    for schema in schemas/evidence/*-v*.schema.json; do
       name="$(basename "$schema")"
-      name="${name%-v1.schema.json}"
-      ajv validate -c ajv-formats -s "$schema" -d "fixtures/evidence/${name}.json" --spec=draft7
+      name="${name%.schema.json}"
+      data="fixtures/evidence/${name}.json"
+      if [ ! -f "$data" ]; then
+        legacy_name="${name%-v1}"
+        data="fixtures/evidence/${legacy_name}.json"
+      fi
+      ajv validate -c ajv-formats -s "$schema" -d "$data" --spec=draft7
     done
 ```
 

--- a/schemas/evidence/validation-report-v2.schema.json
+++ b/schemas/evidence/validation-report-v2.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/validation-report/v2",
+  "title": "HL7v2 Validation Report v2",
+  "description": "Machine-readable validation report with embedded evidence provenance. This is the v2 target contract; v1 producers remain valid until migrated explicitly.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "tool_name",
+    "tool_version",
+    "valid",
+    "message_type",
+    "segment_count",
+    "issue_count",
+    "issues"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "2",
+      "description": "Evidence artifact schema version."
+    },
+    "tool_name": {
+      "type": "string",
+      "enum": ["hl7v2", "hl7v2-cli", "hl7v2-server", "hl7v2-python"],
+      "description": "Producer surface that generated this report."
+    },
+    "tool_version": {
+      "type": "string",
+      "description": "Semantic version of the producing crate or binding package."
+    },
+    "valid": {
+      "type": "boolean",
+      "description": "Whether the message passed validation without error-level issues."
+    },
+    "message_type": {
+      "type": "string",
+      "description": "HL7 trigger event from MSH.9, such as ADT^A01."
+    },
+    "profile": {
+      "type": "string",
+      "description": "Surface-local profile display label. Use profile_identity for reproducible identity."
+    },
+    "profile_identity": {
+      "$ref": "#/definitions/profile_identity"
+    },
+    "segment_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of parsed message segments."
+    },
+    "issue_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of validation issues in this report."
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/validation_issue"
+      }
+    }
+  },
+  "definitions": {
+    "profile_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Display label for the profile source. This is not a canonical identity by itself."
+        },
+        "message_structure": {
+          "type": "string",
+          "description": "Loaded profile message structure when known."
+        },
+        "version": {
+          "type": "string",
+          "description": "Loaded profile HL7 version when known."
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "SHA-256 digest of the profile bytes when available."
+        }
+      }
+    },
+    "validation_issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Stable snake_case issue code."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning"]
+        },
+        "path": {
+          "type": "string",
+          "description": "HL7 path associated with the issue, such as PID.3."
+        },
+        "rule_id": {
+          "type": "string",
+          "description": "Stable validation rule identifier."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable issue message."
+        },
+        "segment_index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based segment index when known."
+        },
+        "field_index": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "One-based HL7 field index when known."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `validation-report-v2.schema.json` with embedded `schema_version`, `tool_name`, `tool_version`, and optional `profile_identity`
- add a v2 validation-report golden fixture
- widen the API Contracts evidence-fixture loop so versioned evidence schemas validate matching versioned fixtures, while preserving the existing v1 fixture naming convention
- update schema docs and the provenance plan to call this out as the first target v2 evidence contract

## Contract compatibility
- Producers are unchanged: CLI, server, Rust, and Python continue emitting the current v1 validation report shape.
- Consumers of v1 output are unaffected; the existing `validation-report-v1.schema.json` and fixture remain in place.
- This PR only introduces a target v2 schema/fixture and ensures API Contracts validate it.

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/evidence/validation-report-v2.schema.json -d fixtures/evidence/validation-report-v2.json --spec=draft7`
- PowerShell equivalent of the API Contracts evidence fixture loop over `schemas/evidence/*-v*.schema.json`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Note
A Bash reproduction of the evidence fixture loop timed out locally because it invoked `npx` once per schema under WSL on Windows. I cleaned up the stale WSL process and validated the same schema/fixture mapping through PowerShell instead.
