### PR TITLE
contracts: add corpus v2 provenance schemas

### DIFF
--- a/docs/architecture/evidence-provenance-versioning.md
+++ b/docs/architecture/evidence-provenance-versioning.md
@@ -111,9 +111,9 @@ Do the migration in narrow PRs:
 
 1. Add v2 schemas and v2 golden fixtures for the highest-value shared reports:
    `ValidationReport`, `CorpusFingerprint`, `CorpusDiffReport`, and
-   `RedactionReceipt`. `ValidationReport` now has the first target v2 schema
-   and fixture; producers still emit the current v1 shape until migrated
-   explicitly.
+   `RedactionReceipt`. `ValidationReport`, `CorpusFingerprint`, and
+   `CorpusDiffReport` now have target v2 schemas and fixtures; producers still
+   emit the current v1 shapes until migrated explicitly.
 2. Add additive Rust fields behind explicit v2 serializers or conversion
    helpers. Do not break callers that still expect the v1 shapes.
 3. Update CLI JSON/YAML output to choose the v2 shape only when the command or

--- a/fixtures/evidence/corpus-diff-v2.json
+++ b/fixtures/evidence/corpus-diff-v2.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "2",
+  "diff_version": "1",
+  "tool_name": "hl7v2-cli",
+  "tool_version": "1.4.0",
+  "before_root": "before",
+  "after_root": "after",
+  "profile": null,
+  "file_count": {
+    "before": 1,
+    "after": 1,
+    "delta": 0
+  },
+  "message_count": {
+    "before": 1,
+    "after": 1,
+    "delta": 0
+  },
+  "parse_error_count": {
+    "before": 0,
+    "after": 0,
+    "delta": 0
+  },
+  "new_message_types": ["ORU^R01"],
+  "removed_message_types": ["ADT^A01"],
+  "new_segments": [],
+  "removed_segments": [],
+  "message_type_counts": [
+    {"value": "ADT^A01", "before": 1, "after": 0, "delta": -1},
+    {"value": "ORU^R01", "before": 0, "after": 1, "delta": 1}
+  ],
+  "segment_counts": [],
+  "field_presence": [],
+  "field_cardinality": [],
+  "value_shape_stats": [],
+  "validation_issue_code_counts": []
+}

--- a/fixtures/evidence/corpus-fingerprint-v2.json
+++ b/fixtures/evidence/corpus-fingerprint-v2.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "2",
+  "fingerprint_version": "1",
+  "tool_name": "hl7v2-cli",
+  "tool_version": "1.4.0",
+  "root": "site-a",
+  "profile": null,
+  "file_count": 1,
+  "message_count": 1,
+  "parse_error_count": 0,
+  "message_type_counts": [
+    {"value": "ADT^A01", "count": 1}
+  ],
+  "segment_counts": [
+    {"value": "MSH", "count": 1}
+  ],
+  "field_presence": [
+    {"path": "MSH.2", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.9", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.10", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.11", "message_count": 1, "occurrence_count": 1},
+    {"path": "MSH.12", "message_count": 1, "occurrence_count": 1}
+  ],
+  "field_cardinality": [
+    {
+      "path": "MSH.2",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.9",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.10",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.11",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    },
+    {
+      "path": "MSH.12",
+      "min_per_message": 1,
+      "max_per_message": 1,
+      "total_occurrences": 1,
+      "message_count": 1
+    }
+  ],
+  "value_shape_stats": [
+    {
+      "path": "MSH.2",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 1
+    },
+    {
+      "path": "MSH.9",
+      "coded_count": 1,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 0
+    },
+    {
+      "path": "MSH.10",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 1
+    },
+    {
+      "path": "MSH.11",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 0,
+      "null_count": 0,
+      "text_count": 1
+    },
+    {
+      "path": "MSH.12",
+      "coded_count": 0,
+      "timestamp_count": 0,
+      "numeric_count": 1,
+      "null_count": 0,
+      "text_count": 0
+    }
+  ],
+  "validation_issue_code_counts": []
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -52,10 +52,11 @@ Python lanes:
 - Corpus summary, fingerprint, and diff reports
 - Redaction receipts and evidence bundle/replay summaries
 
-`validation-report-v2.schema.json` is the first target evidence schema with
-embedded `schema_version`, `tool_name`, and `tool_version` fields. It is a
-contract artifact for the planned v2 migration; current v1 producers remain
-valid until implementation PRs explicitly move their output shape.
+The first target v2 evidence schemas are `validation-report-v2.schema.json`,
+`corpus-fingerprint-v2.schema.json`, and `corpus-diff-v2.schema.json`. They
+add embedded `schema_version`, `tool_name`, and `tool_version` fields while
+keeping their v1 counterparts valid until implementation PRs explicitly move
+producer output shapes.
 
 #### Evidence Null And Empty Semantics
 

--- a/schemas/evidence/corpus-diff-v2.schema.json
+++ b/schemas/evidence/corpus-diff-v2.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/corpus-diff/v2",
+  "title": "HL7v2 Corpus Diff Report v2",
+  "description": "Difference report for two HL7 v2 corpora with embedded evidence provenance. This is the v2 target contract; v1 producers remain valid until migrated explicitly.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "diff_version",
+    "tool_name",
+    "tool_version",
+    "before_root",
+    "after_root",
+    "profile",
+    "file_count",
+    "message_count",
+    "parse_error_count",
+    "new_message_types",
+    "removed_message_types",
+    "new_segments",
+    "removed_segments",
+    "message_type_counts",
+    "segment_counts",
+    "field_presence",
+    "field_cardinality",
+    "value_shape_stats",
+    "validation_issue_code_counts"
+  ],
+  "properties": {
+    "schema_version": {"const": "2"},
+    "diff_version": {"type": "string"},
+    "tool_name": {
+      "type": "string",
+      "enum": ["hl7v2", "hl7v2-cli", "hl7v2-server", "hl7v2-python"]
+    },
+    "tool_version": {"type": "string"},
+    "before_root": {"type": "string"},
+    "after_root": {"type": "string"},
+    "profile": {"anyOf": [{"$ref": "#/definitions/profile"}, {"type": "null"}]},
+    "file_count": {"$ref": "#/definitions/total_diff"},
+    "message_count": {"$ref": "#/definitions/total_diff"},
+    "parse_error_count": {"$ref": "#/definitions/total_diff"},
+    "new_message_types": {"type": "array", "items": {"type": "string"}},
+    "removed_message_types": {"type": "array", "items": {"type": "string"}},
+    "new_segments": {"type": "array", "items": {"type": "string"}},
+    "removed_segments": {"type": "array", "items": {"type": "string"}},
+    "message_type_counts": {"type": "array", "items": {"$ref": "#/definitions/count_diff"}},
+    "segment_counts": {"type": "array", "items": {"$ref": "#/definitions/count_diff"}},
+    "field_presence": {"type": "array", "items": {"$ref": "#/definitions/field_presence_diff"}},
+    "field_cardinality": {"type": "array", "items": {"$ref": "#/definitions/field_cardinality_diff"}},
+    "value_shape_stats": {"type": "array", "items": {"$ref": "#/definitions/value_shape_stats_diff"}},
+    "validation_issue_code_counts": {"type": "array", "items": {"$ref": "#/definitions/count_diff"}}
+  },
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "version", "message_structure"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "version": {"type": "string"},
+        "message_structure": {"type": "string"}
+      }
+    },
+    "total_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["before", "after", "delta"],
+      "properties": {
+        "before": {"type": "integer", "minimum": 0},
+        "after": {"type": "integer", "minimum": 0},
+        "delta": {"type": "integer"}
+      }
+    },
+    "count_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "before", "after", "delta"],
+      "properties": {
+        "value": {"type": "string"},
+        "before": {"type": "integer", "minimum": 0},
+        "after": {"type": "integer", "minimum": 0},
+        "delta": {"type": "integer"}
+      }
+    },
+    "field_presence_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "before_message_count",
+        "after_message_count",
+        "message_count_delta",
+        "before_occurrence_count",
+        "after_occurrence_count",
+        "occurrence_count_delta"
+      ],
+      "properties": {
+        "path": {"type": "string"},
+        "before_message_count": {"type": "integer", "minimum": 0},
+        "after_message_count": {"type": "integer", "minimum": 0},
+        "message_count_delta": {"type": "integer"},
+        "before_occurrence_count": {"type": "integer", "minimum": 0},
+        "after_occurrence_count": {"type": "integer", "minimum": 0},
+        "occurrence_count_delta": {"type": "integer"}
+      }
+    },
+    "field_cardinality_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "before_min_per_message",
+        "after_min_per_message",
+        "min_per_message_delta",
+        "before_max_per_message",
+        "after_max_per_message",
+        "max_per_message_delta",
+        "before_total_occurrences",
+        "after_total_occurrences",
+        "total_occurrences_delta",
+        "before_message_count",
+        "after_message_count",
+        "message_count_delta"
+      ],
+      "properties": {
+        "path": {"type": "string"},
+        "before_min_per_message": {"type": "integer", "minimum": 0},
+        "after_min_per_message": {"type": "integer", "minimum": 0},
+        "min_per_message_delta": {"type": "integer"},
+        "before_max_per_message": {"type": "integer", "minimum": 0},
+        "after_max_per_message": {"type": "integer", "minimum": 0},
+        "max_per_message_delta": {"type": "integer"},
+        "before_total_occurrences": {"type": "integer", "minimum": 0},
+        "after_total_occurrences": {"type": "integer", "minimum": 0},
+        "total_occurrences_delta": {"type": "integer"},
+        "before_message_count": {"type": "integer", "minimum": 0},
+        "after_message_count": {"type": "integer", "minimum": 0},
+        "message_count_delta": {"type": "integer"}
+      }
+    },
+    "value_shape_stats_diff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "coded_count", "timestamp_count", "numeric_count", "null_count", "text_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "coded_count": {"$ref": "#/definitions/total_diff"},
+        "timestamp_count": {"$ref": "#/definitions/total_diff"},
+        "numeric_count": {"$ref": "#/definitions/total_diff"},
+        "null_count": {"$ref": "#/definitions/total_diff"},
+        "text_count": {"$ref": "#/definitions/total_diff"}
+      }
+    }
+  }
+}

--- a/schemas/evidence/corpus-fingerprint-v2.schema.json
+++ b/schemas/evidence/corpus-fingerprint-v2.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/corpus-fingerprint/v2",
+  "title": "HL7v2 Corpus Fingerprint v2",
+  "description": "Deterministic compact signature for a file or directory corpus with embedded evidence provenance. This is the v2 target contract; v1 producers remain valid until migrated explicitly.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "fingerprint_version",
+    "tool_name",
+    "tool_version",
+    "root",
+    "profile",
+    "file_count",
+    "message_count",
+    "parse_error_count",
+    "message_type_counts",
+    "segment_counts",
+    "field_presence",
+    "field_cardinality",
+    "value_shape_stats",
+    "validation_issue_code_counts"
+  ],
+  "properties": {
+    "schema_version": {"const": "2"},
+    "fingerprint_version": {"type": "string"},
+    "tool_name": {
+      "type": "string",
+      "enum": ["hl7v2", "hl7v2-cli", "hl7v2-server", "hl7v2-python"]
+    },
+    "tool_version": {"type": "string"},
+    "root": {"type": "string"},
+    "profile": {"anyOf": [{"$ref": "#/definitions/profile"}, {"type": "null"}]},
+    "file_count": {"type": "integer", "minimum": 0},
+    "message_count": {"type": "integer", "minimum": 0},
+    "parse_error_count": {"type": "integer", "minimum": 0},
+    "message_type_counts": {"type": "array", "items": {"$ref": "#/definitions/count"}},
+    "segment_counts": {"type": "array", "items": {"$ref": "#/definitions/count"}},
+    "field_presence": {"type": "array", "items": {"$ref": "#/definitions/field_presence"}},
+    "field_cardinality": {"type": "array", "items": {"$ref": "#/definitions/field_cardinality"}},
+    "value_shape_stats": {"type": "array", "items": {"$ref": "#/definitions/value_shape_stats"}},
+    "validation_issue_code_counts": {"type": "array", "items": {"$ref": "#/definitions/count"}}
+  },
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "version", "message_structure"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "version": {"type": "string"},
+        "message_structure": {"type": "string"}
+      }
+    },
+    "count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "count"],
+      "properties": {
+        "value": {"type": "string"},
+        "count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "field_presence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "message_count", "occurrence_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "message_count": {"type": "integer", "minimum": 0},
+        "occurrence_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "field_cardinality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "min_per_message", "max_per_message", "total_occurrences", "message_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "min_per_message": {"type": "integer", "minimum": 0},
+        "max_per_message": {"type": "integer", "minimum": 0},
+        "total_occurrences": {"type": "integer", "minimum": 0},
+        "message_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "value_shape_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "coded_count", "timestamp_count", "numeric_count", "null_count", "text_count"],
+      "properties": {
+        "path": {"type": "string"},
+        "coded_count": {"type": "integer", "minimum": 0},
+        "timestamp_count": {"type": "integer", "minimum": 0},
+        "numeric_count": {"type": "integer", "minimum": 0},
+        "null_count": {"type": "integer", "minimum": 0},
+        "text_count": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add target v2 schemas and fixtures for corpus fingerprint and corpus diff evidence artifacts
- embed `schema_version` and `tool_name` while preserving existing domain version fields (`fingerprint_version`, `diff_version`) and `tool_version`
- update provenance docs/schema README to reflect the validation-report plus corpus v2 target schema set

## Contract compatibility
- Producers are unchanged: CLI, Rust, and Python still emit the current v1 corpus fingerprint/diff shapes.
- v1 schemas and fixtures remain valid and validated.
- These are target v2 contracts for a later explicit producer migration.

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/evidence/corpus-fingerprint-v2.schema.json -d fixtures/evidence/corpus-fingerprint-v2.json --spec=draft7`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/evidence/corpus-diff-v2.schema.json -d fixtures/evidence/corpus-diff-v2.json --spec=draft7`
- PowerShell equivalent of the API Contracts evidence fixture loop over `schemas/evidence/*-v*.schema.json`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
