### PR TITLE
contracts: add redaction receipt v2 provenance schema

### DIFF
--- a/docs/architecture/evidence-provenance-versioning.md
+++ b/docs/architecture/evidence-provenance-versioning.md
@@ -111,9 +111,9 @@ Do the migration in narrow PRs:
 
 1. Add v2 schemas and v2 golden fixtures for the highest-value shared reports:
    `ValidationReport`, `CorpusFingerprint`, `CorpusDiffReport`, and
-   `RedactionReceipt`. `ValidationReport`, `CorpusFingerprint`, and
-   `CorpusDiffReport` now have target v2 schemas and fixtures; producers still
-   emit the current v1 shapes until migrated explicitly.
+   `RedactionReceipt`. These artifacts now have target v2 schemas and
+   fixtures; producers still emit the current v1 shapes until migrated
+   explicitly.
 2. Add additive Rust fields behind explicit v2 serializers or conversion
    helpers. Do not break callers that still expect the v1 shapes.
 3. Update CLI JSON/YAML output to choose the v2 shape only when the command or

--- a/fixtures/evidence/redaction-receipt-v2.json
+++ b/fixtures/evidence/redaction-receipt-v2.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "2",
+  "tool_name": "hl7v2-cli",
+  "tool_version": "1.4.0",
+  "phi_removed": true,
+  "hash_algorithm": "sha256",
+  "actions": [
+    {
+      "path": "PID.3",
+      "action": "hash",
+      "reason": "patient identifier",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "PID.5",
+      "action": "drop",
+      "reason": "patient name",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "PID.7",
+      "action": "drop",
+      "reason": "date of birth",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "PID.11",
+      "action": "drop",
+      "reason": "patient address",
+      "matched_count": 1,
+      "optional": false,
+      "status": "applied"
+    },
+    {
+      "path": "MSH.9",
+      "action": "retain",
+      "reason": "message type is needed for analysis",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    },
+    {
+      "path": "MSH.10",
+      "action": "retain",
+      "reason": "control id is needed for replay correlation",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    },
+    {
+      "path": "OBX.3",
+      "action": "retain",
+      "reason": "observation identifier is needed for analysis",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    },
+    {
+      "path": "OBX.5",
+      "action": "retain",
+      "reason": "non-PHI synthetic observation value shape is needed for analysis",
+      "matched_count": 1,
+      "optional": false,
+      "status": "retained"
+    }
+  ]
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -53,10 +53,10 @@ Python lanes:
 - Redaction receipts and evidence bundle/replay summaries
 
 The first target v2 evidence schemas are `validation-report-v2.schema.json`,
-`corpus-fingerprint-v2.schema.json`, and `corpus-diff-v2.schema.json`. They
-add embedded `schema_version`, `tool_name`, and `tool_version` fields while
-keeping their v1 counterparts valid until implementation PRs explicitly move
-producer output shapes.
+`corpus-fingerprint-v2.schema.json`, `corpus-diff-v2.schema.json`, and
+`redaction-receipt-v2.schema.json`. They add embedded `schema_version`,
+`tool_name`, and `tool_version` fields while keeping their v1 counterparts
+valid until implementation PRs explicitly move producer output shapes.
 
 #### Evidence Null And Empty Semantics
 

--- a/schemas/evidence/redaction-receipt-v2.schema.json
+++ b/schemas/evidence/redaction-receipt-v2.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.hl7v2-rs.org/evidence/redaction-receipt/v2",
+  "title": "HL7v2 Redaction Receipt v2",
+  "description": "Machine-readable receipt describing safe-analysis redaction actions with embedded evidence provenance. This is the v2 target contract; v1 producers remain valid until migrated explicitly.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "tool_name",
+    "tool_version",
+    "phi_removed",
+    "hash_algorithm",
+    "actions"
+  ],
+  "properties": {
+    "schema_version": {"const": "2"},
+    "tool_name": {
+      "type": "string",
+      "enum": ["hl7v2", "hl7v2-cli", "hl7v2-server", "hl7v2-python"]
+    },
+    "tool_version": {"type": "string"},
+    "phi_removed": {
+      "type": "boolean",
+      "description": "Whether any configured PHI-bearing path was removed or hashed."
+    },
+    "hash_algorithm": {
+      "type": "string",
+      "enum": ["sha256"],
+      "description": "Hash algorithm used by hash redaction actions."
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/redaction_action"
+      }
+    }
+  },
+  "definitions": {
+    "redaction_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "action", "reason", "matched_count", "optional", "status"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "HL7 path covered by this policy action."
+        },
+        "action": {
+          "type": "string",
+          "enum": ["hash", "drop", "retain"]
+        },
+        "reason": {
+          "type": "string",
+          "description": "Policy reason for the action."
+        },
+        "matched_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of matching values affected by the action."
+        },
+        "optional": {
+          "type": "boolean",
+          "description": "Whether missing matches are acceptable for this policy rule."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["applied", "retained", "not_found"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the target `redaction-receipt-v2` evidence JSON schema with embedded `schema_version`, `tool_name`, and `tool_version`
- add a matching v2 fixture for API Contracts evidence validation
- update evidence provenance docs and schema docs to include RedactionReceipt in the initial target-v2 batch

## Contract compatibility
- This does not change producer output yet.
- Existing v1 redaction receipt schema and fixtures remain valid.
- v2 is an explicit target contract for the later producer migration.

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/evidence/redaction-receipt-v2.schema.json -d fixtures/evidence/redaction-receipt-v2.json --spec=draft7`
- PowerShell equivalent of API Contracts evidence fixture loop for all `schemas/evidence/*-v*.schema.json`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`