### PR TITLE
server: add inline corpus evidence endpoints

### DIFF
--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -287,6 +287,105 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /hl7/corpus/summarize:
+    post:
+      summary: Summarize inline HL7 corpus
+      description: |
+        Summarize caller-supplied HL7 messages without reading filesystem paths from the request. Message ids are safe labels used only for parse-error attribution.
+      tags: [hl7]
+      operationId: summarizeInlineCorpus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusSummaryRequest'
+      responses:
+        '200':
+          description: Corpus summary generated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CorpusSummary'
+                  - $ref: '#/components/schemas/CorpusSummaryV2'
+        '400':
+          description: Invalid corpus request or schema version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
+  /hl7/corpus/fingerprint:
+    post:
+      summary: Fingerprint inline HL7 corpus
+      description: |
+        Generate a deterministic compact signature for caller-supplied HL7 messages. Optional inline profile content adds profile identity metadata and validation issue-code counts.
+      tags: [hl7]
+      operationId: fingerprintInlineCorpus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusFingerprintRequest'
+      responses:
+        '200':
+          description: Corpus fingerprint generated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CorpusFingerprint'
+                  - $ref: '#/components/schemas/CorpusFingerprintV2'
+        '400':
+          description: Invalid corpus request, profile, or schema version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
+  /hl7/corpus/diff:
+    post:
+      summary: Diff inline HL7 corpora
+      description: |
+        Compare before and after sets of caller-supplied HL7 messages. Optional inline profile content adds profile identity metadata and validation issue-code deltas.
+      tags: [hl7]
+      operationId: diffInlineCorpus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusDiffRequest'
+      responses:
+        '200':
+          description: Corpus diff generated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CorpusDiffReport'
+                  - $ref: '#/components/schemas/CorpusDiffReportV2'
+        '400':
+          description: Invalid corpus request, profile, or schema version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
   /hl7/ack:
     post:
       summary: Generate HL7 ACK
@@ -790,6 +889,525 @@ components:
           allOf:
             - $ref: '#/components/schemas/ValidationReport'
           nullable: true
+
+    CorpusMessageInput:
+      type: object
+      required: [message]
+      properties:
+        id:
+          type: string
+          pattern: '^(?!\.{1,2}$)[A-Za-z0-9_.-]{1,128}$'
+          description: Safe label used for parse-error attribution; not interpreted as a filesystem path
+        message:
+          type: string
+          description: Raw HL7 message content; MLLP framing is detected automatically
+
+    CorpusSummaryRequest:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        summary_schema_version:
+          type: integer
+          enum: [1, 2]
+          default: 1
+          description: Opt into the v2 corpus summary response shape
+
+    CorpusFingerprintRequest:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        profile:
+          type: string
+          description: Optional inline profile YAML used for validation issue-code counts
+        fingerprint_schema_version:
+          type: integer
+          enum: [1, 2]
+          default: 1
+          description: Opt into the v2 corpus fingerprint response shape
+
+    CorpusDiffRequest:
+      type: object
+      required: [before, after]
+      properties:
+        before:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        after:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        profile:
+          type: string
+          description: Optional inline profile YAML used for validation issue-code deltas
+        diff_schema_version:
+          type: integer
+          enum: [1, 2]
+          default: 1
+          description: Opt into the v2 corpus diff response shape
+
+    CorpusCount:
+      type: object
+      required: [value, count]
+      properties:
+        value:
+          type: string
+        count:
+          type: integer
+          minimum: 0
+
+    CorpusFieldPresence:
+      type: object
+      required: [path, message_count, occurrence_count]
+      properties:
+        path:
+          type: string
+          description: HL7 field path such as PID.3
+        message_count:
+          type: integer
+          minimum: 0
+        occurrence_count:
+          type: integer
+          minimum: 0
+
+    CorpusParseFailure:
+      type: object
+      required: [path, error]
+      properties:
+        path:
+          type: string
+          description: Safe message id supplied by the caller or generated by the server
+        error:
+          type: string
+          description: Parser error string; raw message content is not echoed
+
+    CorpusSummary:
+      type: object
+      required:
+        - root
+        - file_count
+        - message_count
+        - parse_error_count
+        - total_bytes
+        - message_types
+        - segments
+        - field_presence
+        - parse_errors
+      properties:
+        root:
+          type: string
+          enum: ['<inline-corpus>']
+        file_count:
+          type: integer
+          minimum: 0
+        message_count:
+          type: integer
+          minimum: 0
+        parse_error_count:
+          type: integer
+          minimum: 0
+        total_bytes:
+          type: integer
+          minimum: 0
+        message_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        field_presence:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldPresence'
+        parse_errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusParseFailure'
+
+    CorpusSummaryV2:
+      allOf:
+        - $ref: '#/components/schemas/CorpusSummary'
+        - type: object
+          required: [schema_version, tool_name, tool_version]
+          properties:
+            schema_version:
+              type: string
+              enum: ['2']
+            tool_name:
+              type: string
+              enum: [hl7v2-server]
+            tool_version:
+              type: string
+
+    CorpusFingerprintProfile:
+      type: object
+      required: [path, sha256, version, message_structure]
+      properties:
+        path:
+          type: string
+          enum: ['<inline-profile>']
+        sha256:
+          type: string
+          pattern: '^[a-f0-9]{64}$'
+        version:
+          type: string
+        message_structure:
+          type: string
+
+    CorpusFieldCardinality:
+      type: object
+      required: [path, min_per_message, max_per_message, total_occurrences, message_count]
+      properties:
+        path:
+          type: string
+        min_per_message:
+          type: integer
+          minimum: 0
+        max_per_message:
+          type: integer
+          minimum: 0
+        total_occurrences:
+          type: integer
+          minimum: 0
+        message_count:
+          type: integer
+          minimum: 0
+
+    CorpusValueShapeStats:
+      type: object
+      required: [path, coded_count, timestamp_count, numeric_count, null_count, text_count]
+      properties:
+        path:
+          type: string
+        coded_count:
+          type: integer
+          minimum: 0
+        timestamp_count:
+          type: integer
+          minimum: 0
+        numeric_count:
+          type: integer
+          minimum: 0
+        null_count:
+          type: integer
+          minimum: 0
+        text_count:
+          type: integer
+          minimum: 0
+
+    CorpusFingerprint:
+      type: object
+      required:
+        - fingerprint_version
+        - tool_version
+        - root
+        - profile
+        - file_count
+        - message_count
+        - parse_error_count
+        - message_type_counts
+        - segment_counts
+        - field_presence
+        - field_cardinality
+        - value_shape_stats
+        - validation_issue_code_counts
+      properties:
+        fingerprint_version:
+          type: string
+          enum: ['1']
+        tool_version:
+          type: string
+        root:
+          type: string
+          enum: ['<inline-corpus>', '<inline-before>', '<inline-after>']
+        profile:
+          allOf:
+            - $ref: '#/components/schemas/CorpusFingerprintProfile'
+          nullable: true
+        file_count:
+          type: integer
+          minimum: 0
+        message_count:
+          type: integer
+          minimum: 0
+        parse_error_count:
+          type: integer
+          minimum: 0
+        message_type_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        segment_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        field_presence:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldPresence'
+        field_cardinality:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldCardinality'
+        value_shape_stats:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusValueShapeStats'
+        validation_issue_code_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+
+    CorpusFingerprintV2:
+      allOf:
+        - $ref: '#/components/schemas/CorpusFingerprint'
+        - type: object
+          required: [schema_version, tool_name]
+          properties:
+            schema_version:
+              type: string
+              enum: ['2']
+            tool_name:
+              type: string
+              enum: [hl7v2-server]
+
+    CorpusTotalDiff:
+      type: object
+      required: [before, after, delta]
+      properties:
+        before:
+          type: integer
+          minimum: 0
+        after:
+          type: integer
+          minimum: 0
+        delta:
+          type: integer
+
+    CorpusCountDiff:
+      type: object
+      required: [value, before, after, delta]
+      properties:
+        value:
+          type: string
+        before:
+          type: integer
+          minimum: 0
+        after:
+          type: integer
+          minimum: 0
+        delta:
+          type: integer
+
+    CorpusFieldPresenceDiff:
+      type: object
+      required:
+        - path
+        - before_message_count
+        - after_message_count
+        - message_count_delta
+        - before_occurrence_count
+        - after_occurrence_count
+        - occurrence_count_delta
+      properties:
+        path:
+          type: string
+        before_message_count:
+          type: integer
+          minimum: 0
+        after_message_count:
+          type: integer
+          minimum: 0
+        message_count_delta:
+          type: integer
+        before_occurrence_count:
+          type: integer
+          minimum: 0
+        after_occurrence_count:
+          type: integer
+          minimum: 0
+        occurrence_count_delta:
+          type: integer
+
+    CorpusFieldCardinalityDiff:
+      type: object
+      required:
+        - path
+        - before_min_per_message
+        - after_min_per_message
+        - min_per_message_delta
+        - before_max_per_message
+        - after_max_per_message
+        - max_per_message_delta
+        - before_total_occurrences
+        - after_total_occurrences
+        - total_occurrences_delta
+        - before_message_count
+        - after_message_count
+        - message_count_delta
+      properties:
+        path:
+          type: string
+        before_min_per_message:
+          type: integer
+          minimum: 0
+        after_min_per_message:
+          type: integer
+          minimum: 0
+        min_per_message_delta:
+          type: integer
+        before_max_per_message:
+          type: integer
+          minimum: 0
+        after_max_per_message:
+          type: integer
+          minimum: 0
+        max_per_message_delta:
+          type: integer
+        before_total_occurrences:
+          type: integer
+          minimum: 0
+        after_total_occurrences:
+          type: integer
+          minimum: 0
+        total_occurrences_delta:
+          type: integer
+        before_message_count:
+          type: integer
+          minimum: 0
+        after_message_count:
+          type: integer
+          minimum: 0
+        message_count_delta:
+          type: integer
+
+    CorpusValueShapeStatsDiff:
+      type: object
+      required: [path, coded_count, timestamp_count, numeric_count, null_count, text_count]
+      properties:
+        path:
+          type: string
+        coded_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        timestamp_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        numeric_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        null_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        text_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+
+    CorpusDiffReport:
+      type: object
+      required:
+        - diff_version
+        - tool_version
+        - before_root
+        - after_root
+        - profile
+        - file_count
+        - message_count
+        - parse_error_count
+        - new_message_types
+        - removed_message_types
+        - new_segments
+        - removed_segments
+        - message_type_counts
+        - segment_counts
+        - field_presence
+        - field_cardinality
+        - value_shape_stats
+        - validation_issue_code_counts
+      properties:
+        diff_version:
+          type: string
+          enum: ['1']
+        tool_version:
+          type: string
+        before_root:
+          type: string
+          enum: ['<inline-before>']
+        after_root:
+          type: string
+          enum: ['<inline-after>']
+        profile:
+          allOf:
+            - $ref: '#/components/schemas/CorpusFingerprintProfile'
+          nullable: true
+        file_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        message_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        parse_error_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        new_message_types:
+          type: array
+          items:
+            type: string
+        removed_message_types:
+          type: array
+          items:
+            type: string
+        new_segments:
+          type: array
+          items:
+            type: string
+        removed_segments:
+          type: array
+          items:
+            type: string
+        message_type_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCountDiff'
+        segment_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCountDiff'
+        field_presence:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldPresenceDiff'
+        field_cardinality:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldCardinalityDiff'
+        value_shape_stats:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusValueShapeStatsDiff'
+        validation_issue_code_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCountDiff'
+
+    CorpusDiffReportV2:
+      allOf:
+        - $ref: '#/components/schemas/CorpusDiffReport'
+        - type: object
+          required: [schema_version, tool_name]
+          properties:
+            schema_version:
+              type: string
+              enum: ['2']
+            tool_name:
+              type: string
+              enum: [hl7v2-server]
 
     EvidenceReplayCheck:
       type: object

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -19,6 +19,7 @@ hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "ack",
     "normalize",
     "redact",
+    "synthetic",
     "stream",
     "network",
 ] }

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -287,6 +287,105 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /hl7/corpus/summarize:
+    post:
+      summary: Summarize inline HL7 corpus
+      description: |
+        Summarize caller-supplied HL7 messages without reading filesystem paths from the request. Message ids are safe labels used only for parse-error attribution.
+      tags: [hl7]
+      operationId: summarizeInlineCorpus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusSummaryRequest'
+      responses:
+        '200':
+          description: Corpus summary generated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CorpusSummary'
+                  - $ref: '#/components/schemas/CorpusSummaryV2'
+        '400':
+          description: Invalid corpus request or schema version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
+  /hl7/corpus/fingerprint:
+    post:
+      summary: Fingerprint inline HL7 corpus
+      description: |
+        Generate a deterministic compact signature for caller-supplied HL7 messages. Optional inline profile content adds profile identity metadata and validation issue-code counts.
+      tags: [hl7]
+      operationId: fingerprintInlineCorpus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusFingerprintRequest'
+      responses:
+        '200':
+          description: Corpus fingerprint generated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CorpusFingerprint'
+                  - $ref: '#/components/schemas/CorpusFingerprintV2'
+        '400':
+          description: Invalid corpus request, profile, or schema version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
+  /hl7/corpus/diff:
+    post:
+      summary: Diff inline HL7 corpora
+      description: |
+        Compare before and after sets of caller-supplied HL7 messages. Optional inline profile content adds profile identity metadata and validation issue-code deltas.
+      tags: [hl7]
+      operationId: diffInlineCorpus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusDiffRequest'
+      responses:
+        '200':
+          description: Corpus diff generated
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CorpusDiffReport'
+                  - $ref: '#/components/schemas/CorpusDiffReportV2'
+        '400':
+          description: Invalid corpus request, profile, or schema version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+
   /hl7/ack:
     post:
       summary: Generate HL7 ACK
@@ -790,6 +889,525 @@ components:
           allOf:
             - $ref: '#/components/schemas/ValidationReport'
           nullable: true
+
+    CorpusMessageInput:
+      type: object
+      required: [message]
+      properties:
+        id:
+          type: string
+          pattern: '^(?!\.{1,2}$)[A-Za-z0-9_.-]{1,128}$'
+          description: Safe label used for parse-error attribution; not interpreted as a filesystem path
+        message:
+          type: string
+          description: Raw HL7 message content; MLLP framing is detected automatically
+
+    CorpusSummaryRequest:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        summary_schema_version:
+          type: integer
+          enum: [1, 2]
+          default: 1
+          description: Opt into the v2 corpus summary response shape
+
+    CorpusFingerprintRequest:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        profile:
+          type: string
+          description: Optional inline profile YAML used for validation issue-code counts
+        fingerprint_schema_version:
+          type: integer
+          enum: [1, 2]
+          default: 1
+          description: Opt into the v2 corpus fingerprint response shape
+
+    CorpusDiffRequest:
+      type: object
+      required: [before, after]
+      properties:
+        before:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        after:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CorpusMessageInput'
+        profile:
+          type: string
+          description: Optional inline profile YAML used for validation issue-code deltas
+        diff_schema_version:
+          type: integer
+          enum: [1, 2]
+          default: 1
+          description: Opt into the v2 corpus diff response shape
+
+    CorpusCount:
+      type: object
+      required: [value, count]
+      properties:
+        value:
+          type: string
+        count:
+          type: integer
+          minimum: 0
+
+    CorpusFieldPresence:
+      type: object
+      required: [path, message_count, occurrence_count]
+      properties:
+        path:
+          type: string
+          description: HL7 field path such as PID.3
+        message_count:
+          type: integer
+          minimum: 0
+        occurrence_count:
+          type: integer
+          minimum: 0
+
+    CorpusParseFailure:
+      type: object
+      required: [path, error]
+      properties:
+        path:
+          type: string
+          description: Safe message id supplied by the caller or generated by the server
+        error:
+          type: string
+          description: Parser error string; raw message content is not echoed
+
+    CorpusSummary:
+      type: object
+      required:
+        - root
+        - file_count
+        - message_count
+        - parse_error_count
+        - total_bytes
+        - message_types
+        - segments
+        - field_presence
+        - parse_errors
+      properties:
+        root:
+          type: string
+          enum: ['<inline-corpus>']
+        file_count:
+          type: integer
+          minimum: 0
+        message_count:
+          type: integer
+          minimum: 0
+        parse_error_count:
+          type: integer
+          minimum: 0
+        total_bytes:
+          type: integer
+          minimum: 0
+        message_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        field_presence:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldPresence'
+        parse_errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusParseFailure'
+
+    CorpusSummaryV2:
+      allOf:
+        - $ref: '#/components/schemas/CorpusSummary'
+        - type: object
+          required: [schema_version, tool_name, tool_version]
+          properties:
+            schema_version:
+              type: string
+              enum: ['2']
+            tool_name:
+              type: string
+              enum: [hl7v2-server]
+            tool_version:
+              type: string
+
+    CorpusFingerprintProfile:
+      type: object
+      required: [path, sha256, version, message_structure]
+      properties:
+        path:
+          type: string
+          enum: ['<inline-profile>']
+        sha256:
+          type: string
+          pattern: '^[a-f0-9]{64}$'
+        version:
+          type: string
+        message_structure:
+          type: string
+
+    CorpusFieldCardinality:
+      type: object
+      required: [path, min_per_message, max_per_message, total_occurrences, message_count]
+      properties:
+        path:
+          type: string
+        min_per_message:
+          type: integer
+          minimum: 0
+        max_per_message:
+          type: integer
+          minimum: 0
+        total_occurrences:
+          type: integer
+          minimum: 0
+        message_count:
+          type: integer
+          minimum: 0
+
+    CorpusValueShapeStats:
+      type: object
+      required: [path, coded_count, timestamp_count, numeric_count, null_count, text_count]
+      properties:
+        path:
+          type: string
+        coded_count:
+          type: integer
+          minimum: 0
+        timestamp_count:
+          type: integer
+          minimum: 0
+        numeric_count:
+          type: integer
+          minimum: 0
+        null_count:
+          type: integer
+          minimum: 0
+        text_count:
+          type: integer
+          minimum: 0
+
+    CorpusFingerprint:
+      type: object
+      required:
+        - fingerprint_version
+        - tool_version
+        - root
+        - profile
+        - file_count
+        - message_count
+        - parse_error_count
+        - message_type_counts
+        - segment_counts
+        - field_presence
+        - field_cardinality
+        - value_shape_stats
+        - validation_issue_code_counts
+      properties:
+        fingerprint_version:
+          type: string
+          enum: ['1']
+        tool_version:
+          type: string
+        root:
+          type: string
+          enum: ['<inline-corpus>', '<inline-before>', '<inline-after>']
+        profile:
+          allOf:
+            - $ref: '#/components/schemas/CorpusFingerprintProfile'
+          nullable: true
+        file_count:
+          type: integer
+          minimum: 0
+        message_count:
+          type: integer
+          minimum: 0
+        parse_error_count:
+          type: integer
+          minimum: 0
+        message_type_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        segment_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+        field_presence:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldPresence'
+        field_cardinality:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldCardinality'
+        value_shape_stats:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusValueShapeStats'
+        validation_issue_code_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCount'
+
+    CorpusFingerprintV2:
+      allOf:
+        - $ref: '#/components/schemas/CorpusFingerprint'
+        - type: object
+          required: [schema_version, tool_name]
+          properties:
+            schema_version:
+              type: string
+              enum: ['2']
+            tool_name:
+              type: string
+              enum: [hl7v2-server]
+
+    CorpusTotalDiff:
+      type: object
+      required: [before, after, delta]
+      properties:
+        before:
+          type: integer
+          minimum: 0
+        after:
+          type: integer
+          minimum: 0
+        delta:
+          type: integer
+
+    CorpusCountDiff:
+      type: object
+      required: [value, before, after, delta]
+      properties:
+        value:
+          type: string
+        before:
+          type: integer
+          minimum: 0
+        after:
+          type: integer
+          minimum: 0
+        delta:
+          type: integer
+
+    CorpusFieldPresenceDiff:
+      type: object
+      required:
+        - path
+        - before_message_count
+        - after_message_count
+        - message_count_delta
+        - before_occurrence_count
+        - after_occurrence_count
+        - occurrence_count_delta
+      properties:
+        path:
+          type: string
+        before_message_count:
+          type: integer
+          minimum: 0
+        after_message_count:
+          type: integer
+          minimum: 0
+        message_count_delta:
+          type: integer
+        before_occurrence_count:
+          type: integer
+          minimum: 0
+        after_occurrence_count:
+          type: integer
+          minimum: 0
+        occurrence_count_delta:
+          type: integer
+
+    CorpusFieldCardinalityDiff:
+      type: object
+      required:
+        - path
+        - before_min_per_message
+        - after_min_per_message
+        - min_per_message_delta
+        - before_max_per_message
+        - after_max_per_message
+        - max_per_message_delta
+        - before_total_occurrences
+        - after_total_occurrences
+        - total_occurrences_delta
+        - before_message_count
+        - after_message_count
+        - message_count_delta
+      properties:
+        path:
+          type: string
+        before_min_per_message:
+          type: integer
+          minimum: 0
+        after_min_per_message:
+          type: integer
+          minimum: 0
+        min_per_message_delta:
+          type: integer
+        before_max_per_message:
+          type: integer
+          minimum: 0
+        after_max_per_message:
+          type: integer
+          minimum: 0
+        max_per_message_delta:
+          type: integer
+        before_total_occurrences:
+          type: integer
+          minimum: 0
+        after_total_occurrences:
+          type: integer
+          minimum: 0
+        total_occurrences_delta:
+          type: integer
+        before_message_count:
+          type: integer
+          minimum: 0
+        after_message_count:
+          type: integer
+          minimum: 0
+        message_count_delta:
+          type: integer
+
+    CorpusValueShapeStatsDiff:
+      type: object
+      required: [path, coded_count, timestamp_count, numeric_count, null_count, text_count]
+      properties:
+        path:
+          type: string
+        coded_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        timestamp_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        numeric_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        null_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        text_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+
+    CorpusDiffReport:
+      type: object
+      required:
+        - diff_version
+        - tool_version
+        - before_root
+        - after_root
+        - profile
+        - file_count
+        - message_count
+        - parse_error_count
+        - new_message_types
+        - removed_message_types
+        - new_segments
+        - removed_segments
+        - message_type_counts
+        - segment_counts
+        - field_presence
+        - field_cardinality
+        - value_shape_stats
+        - validation_issue_code_counts
+      properties:
+        diff_version:
+          type: string
+          enum: ['1']
+        tool_version:
+          type: string
+        before_root:
+          type: string
+          enum: ['<inline-before>']
+        after_root:
+          type: string
+          enum: ['<inline-after>']
+        profile:
+          allOf:
+            - $ref: '#/components/schemas/CorpusFingerprintProfile'
+          nullable: true
+        file_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        message_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        parse_error_count:
+          $ref: '#/components/schemas/CorpusTotalDiff'
+        new_message_types:
+          type: array
+          items:
+            type: string
+        removed_message_types:
+          type: array
+          items:
+            type: string
+        new_segments:
+          type: array
+          items:
+            type: string
+        removed_segments:
+          type: array
+          items:
+            type: string
+        message_type_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCountDiff'
+        segment_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCountDiff'
+        field_presence:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldPresenceDiff'
+        field_cardinality:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusFieldCardinalityDiff'
+        value_shape_stats:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusValueShapeStatsDiff'
+        validation_issue_code_counts:
+          type: array
+          items:
+            $ref: '#/components/schemas/CorpusCountDiff'
+
+    CorpusDiffReportV2:
+      allOf:
+        - $ref: '#/components/schemas/CorpusDiffReport'
+        - type: object
+          required: [schema_version, tool_name]
+          properties:
+            schema_version:
+              type: string
+              enum: ['2']
+            tool_name:
+              type: string
+              enum: [hl7v2-server]
 
     EvidenceReplayCheck:
       type: object

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -6,6 +6,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::models::*;
@@ -268,6 +269,88 @@ pub async fn replay_handler(
     Ok((StatusCode::OK, Json(response)))
 }
 
+/// Handler for POST /hl7/corpus/summarize
+pub async fn corpus_summarize_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(request): Json<CorpusSummaryRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let schema_version = requested_corpus_summary_schema_version(request.summary_schema_version)?;
+    let ids = validated_corpus_message_ids(&request.messages, "messages", "message")?;
+    let messages = corpus_message_refs(&request.messages, &ids);
+    let summary = hl7v2::synthetic::corpus::summarize_corpus_messages("<inline-corpus>", &messages);
+    let response = if schema_version == 2 {
+        serde_json::to_value(summary.to_v2("hl7v2-server", env!("CARGO_PKG_VERSION")))
+    } else {
+        serde_json::to_value(summary)
+    }
+    .map_err(|error| AppError::Internal(format!("could not serialize corpus summary: {error}")))?;
+
+    Ok((StatusCode::OK, Json(response)))
+}
+
+/// Handler for POST /hl7/corpus/fingerprint
+pub async fn corpus_fingerprint_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(request): Json<CorpusFingerprintRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let schema_version =
+        requested_corpus_fingerprint_schema_version(request.fingerprint_schema_version)?;
+    let ids = validated_corpus_message_ids(&request.messages, "messages", "message")?;
+    let messages = corpus_message_refs(&request.messages, &ids);
+    let mut fingerprint =
+        hl7v2::synthetic::corpus::fingerprint_corpus_messages("<inline-corpus>", &messages);
+
+    if let Some(profile_yaml) = request.profile.as_deref() {
+        attach_profile_to_fingerprint(&mut fingerprint, profile_yaml, &request.messages)?;
+    }
+
+    let response = if schema_version == 2 {
+        serde_json::to_value(fingerprint.to_v2("hl7v2-server"))
+    } else {
+        serde_json::to_value(fingerprint)
+    }
+    .map_err(|error| {
+        AppError::Internal(format!("could not serialize corpus fingerprint: {error}"))
+    })?;
+
+    Ok((StatusCode::OK, Json(response)))
+}
+
+/// Handler for POST /hl7/corpus/diff
+pub async fn corpus_diff_handler(
+    State(_state): State<Arc<AppState>>,
+    Json(request): Json<CorpusDiffRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let schema_version = requested_corpus_diff_schema_version(request.diff_schema_version)?;
+    let before_ids = validated_corpus_message_ids(&request.before, "before", "before")?;
+    let after_ids = validated_corpus_message_ids(&request.after, "after", "after")?;
+    let before_messages = corpus_message_refs(&request.before, &before_ids);
+    let after_messages = corpus_message_refs(&request.after, &after_ids);
+    let mut before_fingerprint =
+        hl7v2::synthetic::corpus::fingerprint_corpus_messages("<inline-before>", &before_messages);
+    let mut after_fingerprint =
+        hl7v2::synthetic::corpus::fingerprint_corpus_messages("<inline-after>", &after_messages);
+
+    if let Some(profile_yaml) = request.profile.as_deref() {
+        let profile_metadata =
+            attach_profile_to_fingerprint(&mut before_fingerprint, profile_yaml, &request.before)?;
+        after_fingerprint.profile = Some(profile_metadata);
+        after_fingerprint.validation_issue_code_counts =
+            validation_issue_counts_for_messages(&request.after, profile_yaml)?;
+    }
+
+    let diff =
+        hl7v2::synthetic::corpus::diff_corpus_fingerprints(&before_fingerprint, &after_fingerprint);
+    let response = if schema_version == 2 {
+        serde_json::to_value(diff.to_v2("hl7v2-server"))
+    } else {
+        serde_json::to_value(diff)
+    }
+    .map_err(|error| AppError::Internal(format!("could not serialize corpus diff: {error}")))?;
+
+    Ok((StatusCode::OK, Json(response)))
+}
+
 /// Handler for POST /hl7/ack
 pub async fn ack_handler(
     State(_state): State<Arc<AppState>>,
@@ -454,6 +537,157 @@ fn requested_replay_report_schema_version(version: Option<u8>) -> Result<u8, App
             "unsupported replay report schema version {other}; expected 1 or 2"
         ))),
     }
+}
+
+fn requested_corpus_summary_schema_version(version: Option<u8>) -> Result<u8, AppError> {
+    match version.unwrap_or(1) {
+        1 => Ok(1),
+        2 => Ok(2),
+        other => Err(AppError::Validation(format!(
+            "unsupported corpus summary schema version {other}; expected 1 or 2"
+        ))),
+    }
+}
+
+fn requested_corpus_fingerprint_schema_version(version: Option<u8>) -> Result<u8, AppError> {
+    match version.unwrap_or(1) {
+        1 => Ok(1),
+        2 => Ok(2),
+        other => Err(AppError::Validation(format!(
+            "unsupported corpus fingerprint schema version {other}; expected 1 or 2"
+        ))),
+    }
+}
+
+fn requested_corpus_diff_schema_version(version: Option<u8>) -> Result<u8, AppError> {
+    match version.unwrap_or(1) {
+        1 => Ok(1),
+        2 => Ok(2),
+        other => Err(AppError::Validation(format!(
+            "unsupported corpus diff schema version {other}; expected 1 or 2"
+        ))),
+    }
+}
+
+fn validated_corpus_message_ids(
+    messages: &[CorpusMessageInput],
+    field_name: &str,
+    default_prefix: &str,
+) -> Result<Vec<String>, AppError> {
+    if messages.is_empty() {
+        return Err(AppError::Validation(format!(
+            "{field_name} must contain at least one message"
+        )));
+    }
+
+    messages
+        .iter()
+        .enumerate()
+        .map(|(index, message)| {
+            let label = message
+                .id
+                .clone()
+                .unwrap_or_else(|| format!("{default_prefix}-{}", index.saturating_add(1)));
+            validate_corpus_message_id(&label)?;
+            Ok(label)
+        })
+        .collect()
+}
+
+fn validate_corpus_message_id(label: &str) -> Result<(), AppError> {
+    if label.is_empty() || label == "." || label == ".." || label.len() > 128 {
+        return Err(AppError::Validation(
+            "corpus message id must be 1-128 characters and cannot be '.' or '..'".to_string(),
+        ));
+    }
+
+    if !label
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-'))
+    {
+        return Err(AppError::Validation(
+            "corpus message id must use only ASCII letters, numbers, '.', '_' or '-'".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn corpus_message_refs<'a>(
+    messages: &'a [CorpusMessageInput],
+    ids: &'a [String],
+) -> Vec<hl7v2::synthetic::corpus::CorpusMessageRef<'a>> {
+    messages
+        .iter()
+        .zip(ids.iter())
+        .map(|(message, id)| {
+            hl7v2::synthetic::corpus::CorpusMessageRef::new(id.as_str(), message.message.as_bytes())
+        })
+        .collect()
+}
+
+fn attach_profile_to_fingerprint(
+    fingerprint: &mut hl7v2::synthetic::corpus::CorpusFingerprint,
+    profile_yaml: &str,
+    messages: &[CorpusMessageInput],
+) -> Result<hl7v2::synthetic::corpus::CorpusFingerprintProfile, AppError> {
+    let profile = hl7v2::load_profile_checked(profile_yaml)
+        .map_err(|error| AppError::ProfileLoad(error.to_string()))?;
+    let metadata = hl7v2::synthetic::corpus::CorpusFingerprintProfile {
+        path: "<inline-profile>".to_string(),
+        sha256: compute_sha256(profile_yaml),
+        version: profile.version.clone(),
+        message_structure: profile.message_structure.clone(),
+    };
+    fingerprint.profile = Some(metadata.clone());
+    fingerprint.validation_issue_code_counts =
+        validation_issue_counts_for_loaded_profile(messages, &profile);
+    Ok(metadata)
+}
+
+fn validation_issue_counts_for_messages(
+    messages: &[CorpusMessageInput],
+    profile_yaml: &str,
+) -> Result<Vec<hl7v2::synthetic::corpus::CorpusCount>, AppError> {
+    let profile = hl7v2::load_profile_checked(profile_yaml)
+        .map_err(|error| AppError::ProfileLoad(error.to_string()))?;
+    Ok(validation_issue_counts_for_loaded_profile(
+        messages, &profile,
+    ))
+}
+
+fn validation_issue_counts_for_loaded_profile(
+    messages: &[CorpusMessageInput],
+    profile: &hl7v2::Profile,
+) -> Vec<hl7v2::synthetic::corpus::CorpusCount> {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+
+    for message in messages {
+        let parsed = if hl7v2::is_mllp_framed(message.message.as_bytes()) {
+            hl7v2::parse_mllp(message.message.as_bytes())
+        } else {
+            hl7v2::parse(message.message.as_bytes())
+        };
+        let Ok(parsed) = parsed else {
+            continue;
+        };
+
+        let issues = hl7v2::validate(&parsed, profile);
+        let report = hl7v2::ValidationReport::from_issues(
+            &parsed,
+            Some(profile.message_structure.clone()),
+            issues,
+        );
+        for issue in report.issues {
+            let count = counts.entry(issue.code).or_insert(0);
+            *count = count.saturating_add(1);
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|(value, count)| hl7v2::synthetic::corpus::CorpusCount { value, count })
+        .collect()
 }
 
 fn validation_report_v2_for_server(

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -319,6 +319,66 @@ pub struct ReplayRequest {
     pub replay_report_schema_version: Option<u8>,
 }
 
+/// Inline corpus message supplied to corpus evidence endpoints.
+///
+/// `id` is a label used in parse-error reports. It is not interpreted as a
+/// filesystem path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorpusMessageInput {
+    /// Optional caller-facing message label.
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Raw HL7 message content. MLLP framing is detected automatically.
+    pub message: String,
+}
+
+/// Server inline corpus summary request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorpusSummaryRequest {
+    /// Inline HL7 messages to summarize.
+    pub messages: Vec<CorpusMessageInput>,
+    /// Optional corpus summary schema version.
+    ///
+    /// Omitted or `1` preserves the default summary shape. `2` returns the v2
+    /// summary shape with embedded evidence provenance.
+    #[serde(default)]
+    pub summary_schema_version: Option<u8>,
+}
+
+/// Server inline corpus fingerprint request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorpusFingerprintRequest {
+    /// Inline HL7 messages to fingerprint.
+    pub messages: Vec<CorpusMessageInput>,
+    /// Optional inline profile YAML content for validation issue-code counts.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Optional corpus fingerprint schema version.
+    ///
+    /// Omitted or `1` preserves the default fingerprint shape. `2` returns the
+    /// v2 fingerprint shape with embedded evidence provenance.
+    #[serde(default)]
+    pub fingerprint_schema_version: Option<u8>,
+}
+
+/// Server inline corpus diff request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CorpusDiffRequest {
+    /// Inline before-corpus messages.
+    pub before: Vec<CorpusMessageInput>,
+    /// Inline after-corpus messages.
+    pub after: Vec<CorpusMessageInput>,
+    /// Optional inline profile YAML content for validation issue-code deltas.
+    #[serde(default)]
+    pub profile: Option<String>,
+    /// Optional corpus diff schema version.
+    ///
+    /// Omitted or `1` preserves the default diff report shape. `2` returns the
+    /// v2 diff report shape with embedded evidence provenance.
+    #[serde(default)]
+    pub diff_schema_version: Option<u8>,
+}
+
 /// Evidence bundle summary response body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvidenceBundleSummary {

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -16,7 +16,8 @@ use tower_http::{
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::handlers::{
-    ack_handler, ack_policy_handler, bundle_handler, health_handler, normalize_handler,
+    ack_handler, ack_policy_handler, bundle_handler, corpus_diff_handler,
+    corpus_fingerprint_handler, corpus_summarize_handler, health_handler, normalize_handler,
     parse_handler, ready_handler, replay_handler, validate_handler, validate_redacted_handler,
 };
 use crate::metrics::{metrics_handler, middleware::metrics_middleware};
@@ -44,6 +45,9 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/validate-redacted", post(validate_redacted_handler))
         .route("/bundle", post(bundle_handler))
         .route("/replay", post(replay_handler))
+        .route("/corpus/summarize", post(corpus_summarize_handler))
+        .route("/corpus/fingerprint", post(corpus_fingerprint_handler))
+        .route("/corpus/diff", post(corpus_diff_handler))
         .route("/ack", post(ack_handler))
         .route("/ack-policy", post(ack_policy_handler))
         .route("/normalize", post(normalize_handler));

--- a/crates/hl7v2-server/tests/corpus_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/corpus_endpoint_test.rs
@@ -1,0 +1,200 @@
+//! Integration tests for inline corpus evidence endpoints.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "endpoint integration tests use static JSON fixtures for contract coverage"
+)]
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+mod common;
+
+fn post_json(path: &str, request_body: Value) -> Request<Body> {
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            8080,
+        ))))
+        .uri(path)
+        .method("POST")
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+        .unwrap()
+}
+
+async fn post_corpus(path: &str, request_body: Value) -> (StatusCode, Value, String) {
+    let app = common::create_test_router();
+    let response = app.oneshot(post_json(path, request_body)).await.unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let value = serde_json::from_str(&body_text).unwrap_or_else(|_| json!({}));
+    (status, value, body_text)
+}
+
+#[tokio::test]
+async fn test_corpus_summarize_accepts_inline_messages_without_echoing_payloads() {
+    let request_body = json!({
+        "messages": [
+            { "id": "adt-1", "message": common::fixtures::ADT_A01_VALID },
+            { "id": "bad-1", "message": common::fixtures::INVALID_MALFORMED }
+        ]
+    });
+
+    let (status, body, body_text) = post_corpus("/hl7/corpus/summarize", request_body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["root"], "<inline-corpus>");
+    assert_eq!(body["file_count"], 2);
+    assert_eq!(body["message_count"], 1);
+    assert_eq!(body["parse_error_count"], 1);
+    assert_eq!(body["parse_errors"][0]["path"], "bad-1");
+    assert!(
+        body["message_types"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|count| count["value"] == "ADT^A01" && count["count"] == 1)
+    );
+    assert!(!body_text.contains("Doe"));
+    assert!(!body_text.contains("MRN123"));
+    assert!(!body_text.contains(common::fixtures::INVALID_MALFORMED));
+}
+
+#[tokio::test]
+async fn test_corpus_fingerprint_schema_v2_includes_profile_issue_counts() {
+    let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+constraints:
+  - path: "PID.3"
+    required: true
+"#;
+    let request_body = json!({
+        "messages": [
+            { "id": "minimal-1", "message": common::fixtures::MINIMAL_VALID }
+        ],
+        "profile": profile,
+        "fingerprint_schema_version": 2
+    });
+
+    let (status, body, body_text) = post_corpus("/hl7/corpus/fingerprint", request_body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["schema_version"], "2");
+    assert_eq!(body["tool_name"], "hl7v2-server");
+    assert_eq!(body["root"], "<inline-corpus>");
+    assert_eq!(body["profile"]["path"], "<inline-profile>");
+    assert_eq!(body["profile"]["message_structure"], "ADT_A01");
+    assert!(
+        body["validation_issue_code_counts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|count| count["value"] == "missing_required_field" && count["count"] == 1)
+    );
+    assert!(!body_text.contains("minimal-1"));
+}
+
+#[tokio::test]
+async fn test_corpus_diff_reports_inline_before_after_deltas() {
+    let request_body = json!({
+        "before": [
+            { "id": "before-adt", "message": common::fixtures::ADT_A01_VALID }
+        ],
+        "after": [
+            { "id": "after-adt", "message": common::fixtures::ADT_A01_VALID },
+            { "id": "after-oru", "message": common::fixtures::ORU_R01_VALID }
+        ],
+        "diff_schema_version": 2
+    });
+
+    let (status, body, body_text) = post_corpus("/hl7/corpus/diff", request_body).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["schema_version"], "2");
+    assert_eq!(body["tool_name"], "hl7v2-server");
+    assert_eq!(body["before_root"], "<inline-before>");
+    assert_eq!(body["after_root"], "<inline-after>");
+    assert_eq!(body["message_count"]["delta"], 1);
+    assert_eq!(body["new_message_types"], json!(["ORU^R01"]));
+    assert!(
+        body["field_presence"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|field| field["path"] == "OBX.5" && field["message_count_delta"] == 1)
+    );
+    assert!(!body_text.contains("Patient^Test"));
+    assert!(!body_text.contains("MRN789"));
+}
+
+#[tokio::test]
+async fn test_corpus_endpoints_reject_empty_message_sets() {
+    let request_body = json!({
+        "messages": []
+    });
+
+    let (status, body, _) = post_corpus("/hl7/corpus/summarize", request_body).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "VALIDATION_ERROR");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("must contain at least one message")
+    );
+}
+
+#[tokio::test]
+async fn test_corpus_endpoints_reject_path_like_message_ids() {
+    let request_body = json!({
+        "messages": [
+            { "id": "../secret", "message": common::fixtures::ADT_A01_VALID }
+        ]
+    });
+
+    let (status, body, body_text) = post_corpus("/hl7/corpus/summarize", request_body).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "VALIDATION_ERROR");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("corpus message id")
+    );
+    assert!(!body_text.contains("Doe"));
+    assert!(!body_text.contains("MRN123"));
+}
+
+#[tokio::test]
+async fn test_corpus_endpoints_reject_unknown_schema_versions() {
+    let request_body = json!({
+        "messages": [
+            { "id": "adt-1", "message": common::fixtures::ADT_A01_VALID }
+        ],
+        "summary_schema_version": 9
+    });
+
+    let (status, body, _) = post_corpus("/hl7/corpus/summarize", request_body).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "VALIDATION_ERROR");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("unsupported corpus summary schema version")
+    );
+}

--- a/crates/hl7v2/src/synthetic/corpus.rs
+++ b/crates/hl7v2/src/synthetic/corpus.rs
@@ -32,7 +32,7 @@
 //! assert_eq!(parsed.seed, 42);
 //! ```
 
-use crate::model::{Atom, Field, Message};
+use crate::model::{Atom, Error, Field, Message};
 use crate::parser::{parse, parse_mllp};
 use crate::transport::mllp::is_mllp_framed;
 use crate::writer::write;
@@ -133,6 +133,26 @@ pub struct CorpusParseFailure {
     pub path: String,
     /// Parser error string for this file.
     pub error: String,
+}
+
+/// In-memory corpus message supplied by a caller.
+///
+/// `id` is an artifact label used in parse-error reports. It is not treated as
+/// a filesystem path by the corpus helpers.
+#[derive(Debug, Clone, Copy)]
+pub struct CorpusMessageRef<'a> {
+    /// Caller-facing message label.
+    pub id: &'a str,
+    /// Raw HL7 message bytes. Messages may be plain or MLLP-framed.
+    pub bytes: &'a [u8],
+}
+
+impl<'a> CorpusMessageRef<'a> {
+    /// Build an in-memory corpus message reference.
+    #[must_use]
+    pub const fn new(id: &'a str, bytes: &'a [u8]) -> Self {
+        Self { id, bytes }
+    }
 }
 
 /// Summary of a directory or file corpus of HL7 v2 messages.
@@ -757,6 +777,68 @@ pub fn summarize_corpus_path(path: impl AsRef<Path>) -> Result<CorpusSummary, Co
     })
 }
 
+/// Summarize an in-memory corpus of HL7 v2 messages.
+///
+/// Each message is parsed as plain HL7 unless it is MLLP framed. Messages that
+/// fail to parse are recorded in the returned summary rather than failing the
+/// whole operation.
+#[must_use]
+pub fn summarize_corpus_messages(
+    root: impl Into<String>,
+    messages: &[CorpusMessageRef<'_>],
+) -> CorpusSummary {
+    let mut message_type_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut segment_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut field_message_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut field_occurrence_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut parse_errors = Vec::new();
+    let mut total_bytes = 0usize;
+    let mut message_count = 0usize;
+
+    for message_ref in messages {
+        total_bytes = total_bytes.saturating_add(message_ref.bytes.len());
+
+        match parse_corpus_message_bytes(message_ref.bytes) {
+            Ok(message) => {
+                message_count = message_count.saturating_add(1);
+                increment_count(&mut message_type_counts, extract_message_type(&message));
+                record_message_shape(
+                    &message,
+                    &mut segment_counts,
+                    &mut field_message_counts,
+                    &mut field_occurrence_counts,
+                );
+            }
+            Err(error) => parse_errors.push(CorpusParseFailure {
+                path: message_ref.id.to_string(),
+                error: error.to_string(),
+            }),
+        }
+    }
+
+    let mut field_presence: Vec<CorpusFieldPresence> = field_occurrence_counts
+        .into_iter()
+        .map(|(path, occurrence_count)| CorpusFieldPresence {
+            message_count: field_message_counts.get(&path).copied().unwrap_or_default(),
+            path,
+            occurrence_count,
+        })
+        .collect();
+    field_presence.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+
+    CorpusSummary {
+        root: root.into(),
+        file_count: messages.len(),
+        message_count,
+        parse_error_count: parse_errors.len(),
+        total_bytes,
+        message_types: counts_to_vec(message_type_counts),
+        segments: counts_to_vec(segment_counts),
+        field_presence,
+        parse_errors,
+    }
+}
+
 /// Diff two file or directory corpora of HL7 v2 messages.
 ///
 /// This fingerprints both inputs using [`fingerprint_corpus_path`] and returns
@@ -852,6 +934,37 @@ pub fn fingerprint_corpus_path(path: impl AsRef<Path>) -> Result<CorpusFingerpri
     })
 }
 
+/// Fingerprint an in-memory corpus of HL7 v2 messages.
+///
+/// The fingerprint is a compact deterministic feed signature derived from the
+/// parsed messages in the corpus. Parse failures are counted but skipped for
+/// shape-level dimensions.
+#[must_use]
+pub fn fingerprint_corpus_messages(
+    root: impl Into<String>,
+    messages: &[CorpusMessageRef<'_>],
+) -> CorpusFingerprint {
+    let summary = summarize_corpus_messages(root, messages);
+    let (field_cardinality, value_shape_stats) =
+        collect_fingerprint_details_from_messages(messages, summary.message_count);
+
+    CorpusFingerprint {
+        fingerprint_version: "1".to_string(),
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        root: summary.root,
+        profile: None,
+        file_count: summary.file_count,
+        message_count: summary.message_count,
+        parse_error_count: summary.parse_error_count,
+        message_type_counts: summary.message_types,
+        segment_counts: summary.segments,
+        field_presence: summary.field_presence,
+        field_cardinality,
+        value_shape_stats,
+        validation_issue_code_counts: Vec::new(),
+    }
+}
+
 fn collect_fingerprint_details(
     root: &Path,
     message_count: usize,
@@ -916,6 +1029,58 @@ fn collect_fingerprint_details(
     Ok((cardinality, value_shape_stats))
 }
 
+fn collect_fingerprint_details_from_messages(
+    messages: &[CorpusMessageRef<'_>],
+    message_count: usize,
+) -> (Vec<CorpusFieldCardinality>, Vec<CorpusValueShapeStats>) {
+    let mut cardinality: BTreeMap<String, FieldCardinalityAccumulator> = BTreeMap::new();
+    let mut value_shapes: BTreeMap<String, CorpusValueShapeStats> = BTreeMap::new();
+
+    for message_ref in messages {
+        let Ok(message) = parse_corpus_message_bytes(message_ref.bytes) else {
+            continue;
+        };
+
+        let mut message_occurrences: BTreeMap<String, usize> = BTreeMap::new();
+        record_fingerprint_message_shape(&message, &mut message_occurrences, &mut value_shapes);
+
+        for (path, occurrences) in message_occurrences {
+            let entry = cardinality.entry(path).or_default();
+            entry.present_message_count = entry.present_message_count.saturating_add(1);
+            entry.total_occurrences = entry.total_occurrences.saturating_add(occurrences);
+            entry.max_per_message = entry.max_per_message.max(occurrences);
+            entry.min_present_per_message = match entry.min_present_per_message {
+                Some(current) => Some(current.min(occurrences)),
+                None => Some(occurrences),
+            };
+        }
+    }
+
+    let mut cardinality: Vec<CorpusFieldCardinality> = cardinality
+        .into_iter()
+        .map(|(path, stats)| {
+            let min_per_message = if stats.present_message_count < message_count {
+                0
+            } else {
+                stats.min_present_per_message.unwrap_or_default()
+            };
+            CorpusFieldCardinality {
+                path,
+                min_per_message,
+                max_per_message: stats.max_per_message,
+                total_occurrences: stats.total_occurrences,
+                message_count: stats.present_message_count,
+            }
+        })
+        .collect();
+    cardinality.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+
+    let mut value_shape_stats: Vec<CorpusValueShapeStats> = value_shapes.into_values().collect();
+    value_shape_stats.sort_by(|left, right| compare_field_paths(&left.path, &right.path));
+
+    (cardinality, value_shape_stats)
+}
+
 fn collect_corpus_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), CorpusError> {
     if path.is_file() {
         files.push(path.to_path_buf());
@@ -940,6 +1105,14 @@ fn collect_corpus_files(path: &Path, files: &mut Vec<PathBuf>) -> Result<(), Cor
     }
 
     Ok(())
+}
+
+fn parse_corpus_message_bytes(message_bytes: &[u8]) -> Result<Message, Error> {
+    if is_mllp_framed(message_bytes) {
+        parse_mllp(message_bytes)
+    } else {
+        parse(message_bytes)
+    }
 }
 
 fn relative_corpus_path(root: &Path, file: &Path) -> String {
@@ -1499,6 +1672,59 @@ mod summary_tests {
                 .first()
                 .map(|failure| failure.path.as_str()),
             Some("invalid.hl7")
+        );
+    }
+
+    #[test]
+    fn summarize_corpus_messages_uses_message_ids_for_parse_failures() {
+        let messages = [
+            CorpusMessageRef::new("adt-1", ADT_A01.as_bytes()),
+            CorpusMessageRef::new("bad-1", b"not an hl7 message"),
+        ];
+
+        let summary = summarize_corpus_messages("<inline-corpus>", &messages);
+
+        assert_eq!(summary.root, "<inline-corpus>");
+        assert_eq!(summary.file_count, 2);
+        assert_eq!(summary.message_count, 1);
+        assert_eq!(summary.parse_error_count, 1);
+        assert_eq!(
+            summary
+                .parse_errors
+                .first()
+                .map(|failure| failure.path.as_str()),
+            Some("bad-1")
+        );
+        let Some(parse_failure) = summary.parse_errors.first() else {
+            panic!("parse failure should be recorded");
+        };
+        assert!(!parse_failure.error.contains("not an hl7 message"));
+    }
+
+    #[test]
+    fn fingerprint_corpus_messages_reports_shape_and_diffable_output() {
+        let before_messages = [CorpusMessageRef::new("adt-1", ADT_A01.as_bytes())];
+        let after_messages = [
+            CorpusMessageRef::new("adt-1", ADT_A01.as_bytes()),
+            CorpusMessageRef::new("oru-1", ORU_R01.as_bytes()),
+        ];
+
+        let before = fingerprint_corpus_messages("<inline-before>", &before_messages);
+        let after = fingerprint_corpus_messages("<inline-after>", &after_messages);
+        let diff = diff_corpus_fingerprints(&before, &after);
+
+        assert_eq!(before.root, "<inline-before>");
+        assert_eq!(after.root, "<inline-after>");
+        assert_eq!(before.message_count, 1);
+        assert_eq!(after.message_count, 2);
+        assert_eq!(diff.new_message_types, vec!["ORU^R01".to_string()]);
+        assert!(
+            after
+                .field_cardinality
+                .iter()
+                .any(|field| field.path == "OBX.5"
+                    && field.min_per_message == 0
+                    && field.max_per_message == 1)
         );
     }
 

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -279,7 +279,89 @@ curl -X POST http://localhost:8080/hl7/replay \
 
 ---
 
-### 6. Generate ACK
+### 6. Inline Corpus Evidence
+
+The server can summarize, fingerprint, and diff caller-supplied message sets
+without reading filesystem paths from the request. Each message may include an
+optional safe `id` label; the label is used only for parse-error attribution
+and must be a single ASCII label, not a path.
+
+These endpoints do not echo raw message payloads in success or validation-error
+responses. Parse failures report the safe message id and parser error.
+
+**POST** `/hl7/corpus/summarize`
+
+```json
+{
+  "messages": [
+    {
+      "id": "before-adt-1",
+      "message": "MSH|^~\\&|..."
+    }
+  ],
+  "summary_schema_version": 2
+}
+```
+
+**POST** `/hl7/corpus/fingerprint`
+
+```json
+{
+  "messages": [
+    {
+      "id": "site-a-1",
+      "message": "MSH|^~\\&|..."
+    }
+  ],
+  "profile": "message_structure: ADT_A01\nversion: \"2.5\"\nsegments:\n  - id: MSH\n",
+  "fingerprint_schema_version": 2
+}
+```
+
+**POST** `/hl7/corpus/diff`
+
+```json
+{
+  "before": [
+    {
+      "id": "before-1",
+      "message": "MSH|^~\\&|..."
+    }
+  ],
+  "after": [
+    {
+      "id": "after-1",
+      "message": "MSH|^~\\&|..."
+    }
+  ],
+  "profile": "message_structure: ADT_A01\nversion: \"2.5\"\nsegments:\n  - id: MSH\n",
+  "diff_schema_version": 2
+}
+```
+
+The response shapes match the CLI corpus artifacts. V2 responses add
+`schema_version` and `tool_name` provenance while preserving the v1 fields:
+
+```json
+{
+  "schema_version": "2",
+  "tool_name": "hl7v2-server",
+  "diff_version": "1",
+  "before_root": "<inline-before>",
+  "after_root": "<inline-after>",
+  "message_count": {
+    "before": 1,
+    "after": 2,
+    "delta": 1
+  },
+  "new_message_types": ["ORU^R01"],
+  "validation_issue_code_counts": []
+}
+```
+
+---
+
+### 7. Generate ACK
 **POST** `/hl7/ack`
 
 Generates an HL7 ACK response from an inbound message with an explicit
@@ -297,7 +379,7 @@ caller-supplied ACK code.
 
 ---
 
-### 7. Generate Policy-Driven ACK
+### 8. Generate Policy-Driven ACK
 **POST** `/hl7/ack-policy`
 
 Parses and validates an inbound message, then chooses an ACK or NAK code from
@@ -359,7 +441,7 @@ messages and `AR` for parse or validation failures. Enhanced mode uses `CA` and
 
 ---
 
-### 8. Normalize HL7 Message
+### 9. Normalize HL7 Message
 **POST** `/hl7/normalize`
 
 Rewrites an HL7 message with stable delimiters and optional MLLP output framing.
@@ -378,7 +460,7 @@ Rewrites an HL7 message with stable delimiters and optional MLLP output framing.
 
 ---
 
-### 9. Health & Metrics
+### 10. Health & Metrics
 
 **Health Check:**
 ```bash

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -39,9 +39,12 @@ redacted validation through `/hl7/validate-redacted`, server-side evidence
 bundle creation through `/hl7/bundle` when a bundle output root is configured,
 server-side replay verification through `/hl7/replay`, policy-driven ACK/NAK
 decisions through `/hl7/ack-policy`, and configured quarantine output for
-failed redacted validation. Python exposes parse, JSON
-conversion, normalization, validation report dict/JSON parity, corpus
-summary/fingerprint/diff dict outputs, and safe-analysis redaction output.
+failed redacted validation. It also exposes inline corpus summary,
+fingerprint, and diff endpoints under `/hl7/corpus/*`; these accept message
+content directly and do not read filesystem paths from request bodies. Python
+exposes parse, JSON conversion, normalization, validation report dict/JSON
+parity, corpus summary/fingerprint/diff dict outputs, and safe-analysis
+redaction output.
 
 ## Artifact Status
 
@@ -70,7 +73,7 @@ summary/fingerprint/diff dict outputs, and safe-analysis redaction output.
 | --- | --- |
 | Rust | Shared validation, profile lint, corpus summary/fingerprint/diff, parse, normalize, write, ACK, redaction module APIs, and Python-facing bundle/replay evidence APIs. Profile test and profile explain reports remain CLI-local. |
 | CLI | Complete current loop: doctor, profile lint/test/explain, validation, corpus summarize/fingerprint/diff, redact, bundle, and replay. |
-| Server | Validation report parity for `/hl7/validate`; redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle` with opt-in v2 bundle-internal artifacts; configured-root replay verification for `/hl7/replay`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; corpus artifacts remain follow-up work. |
+| Server | Validation report parity for `/hl7/validate`; redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle` with opt-in v2 bundle-internal artifacts; configured-root replay verification for `/hl7/replay`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; inline corpus summary/fingerprint/diff endpoints under `/hl7/corpus/*`. |
 | Python | Minimum API parity for parse, `to_json`, normalize, validation reports, corpus summary/fingerprint/diff dict outputs, safe-analysis redaction output, bundle creation, and replay verification. |
 
 One validation parity detail is intentionally documented as a label convention:

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -19,6 +19,7 @@ cargo run -q -p hl7v2-server -- --print-config
 | `--print-config` | Print sanitized effective configuration without leaking secrets. |
 | `GET /ready` | Prove config, profile loading, output roots, and validation-report self-checks are ready. |
 | `POST /hl7/validate-redacted` | Validate after safe-analysis redaction and optionally quarantine failures. |
+| `POST /hl7/corpus/*` | Summarize, fingerprint, and diff inline message sets without request path reads. |
 | `POST /hl7/bundle` | Create server-side redacted evidence bundles under a configured root. |
 | `POST /hl7/ack-policy` | Generate ACK/NAK responses from parse and validation results. |
 | `GET /metrics` | Expose Prometheus metrics for sidecar observation. |
@@ -274,7 +275,58 @@ Because quarantine is enabled, failed validation writes redacted artifacts under
 the configured quarantine root. The response reports a root-relative output id,
 not the server filesystem path.
 
-## 6. Create a Server-Side Evidence Bundle
+## 6. Inspect Inline Corpus Drift
+
+The corpus endpoints accept inline message bodies. They do not accept server
+filesystem paths, so callers can use them from CI or a migration script without
+granting read access to arbitrary server locations.
+
+```powershell
+$before = Get-Content test_data/invalid_message.hl7 -Raw
+$after = Get-Content test_data/valid_message.hl7 -Raw
+
+$body = @{
+    before = @(
+        @{ id = "before-1"; message = $before }
+    )
+    after = @(
+        @{ id = "after-1"; message = $after }
+    )
+    profile = $profile
+    diff_schema_version = 2
+} | ConvertTo-Json -Depth 8
+
+Invoke-RestMethod `
+    -Method Post `
+    -Uri http://127.0.0.1:18080/hl7/corpus/diff `
+    -Headers @{ "X-API-Key" = "dev-secret" } `
+    -ContentType "application/json" `
+    -Body $body |
+    ConvertTo-Json -Depth 20 |
+    Set-Content target/hl7v2-sidecar/reports/corpus-diff.json
+```
+
+Expected fields:
+
+```json
+{
+  "schema_version": "2",
+  "tool_name": "hl7v2-server",
+  "before_root": "<inline-before>",
+  "after_root": "<inline-after>",
+  "message_count": {
+    "before": 1,
+    "after": 1,
+    "delta": 0
+  },
+  "validation_issue_code_counts": []
+}
+```
+
+Use `/hl7/corpus/summarize` for aggregate counts and
+`/hl7/corpus/fingerprint` for a deterministic feed signature.
+
+## 7. Create a Server-Side Evidence Bundle
 
 The bundle endpoint writes under `bundle_output_root`. The request supplies a
 safe `bundle_id`, not an arbitrary filesystem path:
@@ -324,7 +376,7 @@ If the endpoint returns `503 BUNDLE_OUTPUT_NOT_CONFIGURED`, set
 `[server].bundle_output_root` or `HL7V2_BUNDLE_OUTPUT_ROOT` to an existing
 writable directory and restart the server.
 
-## 7. Generate ACK/NAK from Policy
+## 8. Generate ACK/NAK from Policy
 
 Use `/hl7/ack-policy` when the sidecar needs to decide an ACK from the same
 validation evidence:
@@ -366,7 +418,7 @@ For the invalid sample, expected fields include:
 
 Enhanced mode uses `CA` and `CR` instead of `AA` and `AR`.
 
-## 8. Observe the Sidecar
+## 9. Observe the Sidecar
 
 Check liveness and metrics:
 


### PR DESCRIPTION
## Summary
- add shared in-memory corpus helpers for summary and fingerprint generation
- expose inline server corpus endpoints for summarize, fingerprint, and diff under `/hl7/corpus/*`
- document the request/response contracts in OpenAPI, API guide, sidecar guide, and evidence-loop audit
- add endpoint coverage for v1/v2 outputs, profile issue counts, deltas, empty inputs, unsafe IDs, and unsupported schema versions

## Security / Data Boundary
- corpus endpoints accept inline message content only; they do not accept filesystem paths
- caller-supplied message IDs are validated as safe labels and are used only for parse-error attribution
- success/error responses emit aggregate evidence and labels, not raw HL7 payloads
- tests assert PHI fixture values and malformed raw payloads are not echoed

## Validation
- `cargo +1.93.0 test -p hl7v2 --all-features corpus`
- `cargo +1.93.0 test -p hl7v2-server --test corpus_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --all-features openapi`
- `cargo +1.93.0 check -p hl7v2-server --all-features`
- `cargo +1.93.0 clippy -p hl7v2 --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 clippy -p hl7v2-server --all-targets --all-features -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `npx @stoplight/spectral-cli lint crates/hl7v2-server/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
