### PR TITLE
cli: add doctor output options

### DIFF
--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -10,6 +10,7 @@ Run first-use diagnostics:
 hl7v2 doctor
 hl7v2 doctor --sample message.hl7 --profile profiles/adt_a01.yaml
 hl7v2 doctor --server-url http://127.0.0.1:8080/health --format json
+hl7v2 doctor --format json --schema-version 2 --output doctor-report.json --quiet --no-color
 ```
 
 Lint a profile before using it as an interface contract:

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -242,6 +242,18 @@ enum Commands {
         /// Evidence schema version for machine-readable doctor reports
         #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u8).range(1..=2))]
         schema_version: u8,
+
+        /// Write the doctor report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
     },
 
     /// Inspect and lint validation profiles
@@ -1313,12 +1325,16 @@ async fn main() {
             server_url,
             format,
             schema_version,
+            output,
+            quiet,
+            no_color,
         } => doctor_command(
             sample.as_ref(),
             profile.as_ref(),
             server_url.as_deref(),
             format,
             *schema_version,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
         ),
         Commands::Profile { command } => match command {
             ProfileCommands::Lint {
@@ -1537,6 +1553,7 @@ fn doctor_command(
     server_url: Option<&str>,
     format: &ReportFormat,
     schema_version: u8,
+    output_options: &OutputOptions<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut report = DoctorReport {
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -1555,7 +1572,7 @@ fn doctor_command(
     add_python_check(&mut report);
 
     let output = format_doctor_report(&report, format, schema_version)?;
-    println!("{}", output);
+    output_options.emit(&output)?;
 
     if report.has_errors() {
         return Err(CliFailure::check_failed("doctor reported failed checks"));

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -102,6 +102,9 @@ mod cli_unit_tests {
                 .get_arguments()
                 .find(|arg| arg.get_id() == "schema_version");
             assert!(schema_version_arg.is_some());
+            assert!(doctor.get_arguments().any(|arg| arg.get_id() == "output"));
+            assert!(doctor.get_arguments().any(|arg| arg.get_id() == "quiet"));
+            assert!(doctor.get_arguments().any(|arg| arg.get_id() == "no_color"));
         }
 
         #[test]

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -4407,6 +4407,26 @@ action = "hash"
         create_temp_file(&dir, "before/adt.hl7", VALID_ADT_MESSAGE.as_bytes());
         create_temp_file(&dir, "after/adt.hl7", VALID_ADT_MESSAGE.as_bytes());
 
+        let doctor_report = dir.path().join("doctor-report.json");
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "doctor",
+                "--format",
+                "json",
+                "--schema-version",
+                "2",
+                "--output",
+                doctor_report.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("doctor should run");
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        assert_eq!(json_from_file(&doctor_report)["schema_version"], "2");
+
         let val_report = dir.path().join("validation-report.json");
         let mut cmd = cli_command();
         let output = cmd


### PR DESCRIPTION
## Summary
- add `--output`, `--quiet`, and `--no-color` to `hl7v2 doctor`
- route doctor output through the shared CLI `OutputOptions` path so report capture matches the other evidence commands
- extend output-contract coverage and CLI README examples for doctor report file output

## Validation
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests output_contract`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests doctor`
- `cargo +1.93.0 test -p hl7v2-cli --bins doctor`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`