### PR TITLE
cli: add sample validation commands

### DIFF
--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -13,6 +13,14 @@ hl7v2 doctor --server-url http://127.0.0.1:8080/health --format json
 hl7v2 doctor --format json --schema-version 2 --output doctor-report.json --quiet --no-color
 ```
 
+Generate and validate built-in synthetic samples:
+
+```bash
+hl7v2 sample --type ADT_A01
+hl7v2 sample --type ORU_R01 --output oru_r01.hl7
+hl7v2 validate-sample --type ADT_A01 --profile profiles/adt_a01.yaml --report json --schema-version 2
+```
+
 Lint a profile before using it as an interface contract:
 
 ```bash

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -256,6 +256,56 @@ enum Commands {
         no_color: bool,
     },
 
+    /// Print a built-in synthetic HL7 sample message
+    Sample {
+        /// Built-in sample message type
+        #[arg(long = "type", value_enum)]
+        sample_type: SampleType,
+
+        /// Write the sample HL7 message to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
+    },
+
+    /// Validate a built-in synthetic sample against a profile
+    ValidateSample {
+        /// Built-in sample message type
+        #[arg(long = "type", value_enum)]
+        sample_type: SampleType,
+
+        /// Profile YAML file
+        #[arg(long)]
+        profile: PathBuf,
+
+        /// Output validation report format (json, yaml, text)
+        #[arg(long, value_enum, default_value = "text")]
+        report: ReportFormat,
+
+        /// Evidence schema version for machine-readable validation reports
+        #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u8).range(1..=2))]
+        schema_version: u8,
+
+        /// Write the validation report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Suppress non-error diagnostics
+        #[arg(long)]
+        quiet: bool,
+
+        /// Disable colored diagnostics
+        #[arg(long)]
+        no_color: bool,
+    },
+
     /// Inspect and lint validation profiles
     Profile {
         #[command(subcommand)]
@@ -649,6 +699,23 @@ enum RedactFormat {
     Hl7,
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum SampleType {
+    #[value(name = "ADT_A01", alias = "adt_a01", alias = "adt-a01")]
+    AdtA01,
+    #[value(name = "ORU_R01", alias = "oru_r01", alias = "oru-r01")]
+    OruR01,
+}
+
+impl SampleType {
+    const fn message(self) -> &'static str {
+        match self {
+            Self::AdtA01 => SAMPLE_ADT_A01,
+            Self::OruR01 => SAMPLE_ORU_R01,
+        }
+    }
+}
+
 struct OutputOptions<'a> {
     output: Option<&'a PathBuf>,
     quiet: bool,
@@ -700,7 +767,9 @@ struct ValCommandOptions<'a> {
     summary: bool,
 }
 
-const DOCTOR_BUILTIN_SAMPLE: &[u8] = b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
+const SAMPLE_ADT_A01: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01^ADT_A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
+const SAMPLE_ORU_R01: &str = "MSH|^~\\&|LAB|LAB|EHR|HOSP|202605030101||ORU^R01^ORU_R01|CTRL456|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\rOBR|1|ORD1|FILL1|CBC^Complete Blood Count\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+const DOCTOR_BUILTIN_SAMPLE: &[u8] = SAMPLE_ADT_A01.as_bytes();
 
 #[derive(serde::Serialize)]
 struct DoctorReport {
@@ -1336,6 +1405,30 @@ async fn main() {
             *schema_version,
             &OutputOptions::new(output.as_ref(), *quiet, *no_color),
         ),
+        Commands::Sample {
+            sample_type,
+            output,
+            quiet,
+            no_color,
+        } => sample_command(
+            *sample_type,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+        ),
+        Commands::ValidateSample {
+            sample_type,
+            profile,
+            report,
+            schema_version,
+            output,
+            quiet,
+            no_color,
+        } => validate_sample_command(
+            *sample_type,
+            profile,
+            report,
+            *schema_version,
+            &OutputOptions::new(output.as_ref(), *quiet, *no_color),
+        ),
         Commands::Profile { command } => match command {
             ProfileCommands::Lint {
                 profile,
@@ -1576,6 +1669,78 @@ fn doctor_command(
 
     if report.has_errors() {
         return Err(CliFailure::check_failed("doctor reported failed checks"));
+    }
+
+    Ok(())
+}
+
+fn sample_command(
+    sample_type: SampleType,
+    output_options: &OutputOptions<'_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    output_options.emit(sample_type.message())
+}
+
+fn validate_sample_command(
+    sample_type: SampleType,
+    profile: &PathBuf,
+    report: &ReportFormat,
+    schema_version: u8,
+    output_options: &OutputOptions<'_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if schema_version == 2 && *report == ReportFormat::Text {
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "validation report schema v2 is available only with --report json or --report yaml",
+        )));
+    }
+
+    let message = parse(sample_type.message().as_bytes())?;
+    let profile_yaml = fs::read_to_string(profile)?;
+    let loaded_profile = load_profile(&profile_yaml)?;
+    let issues = validate(&message, &loaded_profile);
+    let validation_report = ValidationReport::from_issues(
+        &message,
+        Some(profile.to_string_lossy().to_string()),
+        issues,
+    );
+
+    let output = match report {
+        ReportFormat::Json if schema_version == 2 => {
+            let report_v2 = validation_report_v2_for_cli(
+                &validation_report,
+                profile,
+                &profile_yaml,
+                &loaded_profile,
+            );
+            serde_json::to_string_pretty(&report_v2)?
+        }
+        ReportFormat::Yaml if schema_version == 2 => {
+            let report_v2 = validation_report_v2_for_cli(
+                &validation_report,
+                profile,
+                &profile_yaml,
+                &loaded_profile,
+            );
+            serde_yaml::to_string(&report_v2)?
+        }
+        ReportFormat::Json => serde_json::to_string_pretty(&validation_report)?,
+        ReportFormat::Yaml => serde_yaml::to_string(&validation_report)?,
+        ReportFormat::Text => {
+            if validation_report.valid {
+                "Validation passed: No issues found".to_string()
+            } else {
+                format!(
+                    "Validation failed: {} issues found",
+                    validation_report.issue_count
+                )
+            }
+        }
+    };
+    output_options.emit(&output)?;
+
+    if !validation_report.valid {
+        return Err(CliFailure::check_failed("sample validation failed"));
     }
 
     Ok(())

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -108,6 +108,43 @@ mod cli_unit_tests {
         }
 
         #[test]
+        fn test_sample_commands_exist() {
+            use crate::Cli;
+            let schema = Cli::command();
+
+            let sample = schema
+                .get_subcommands()
+                .find(|command| command.get_name() == "sample")
+                .expect("sample command should exist");
+            assert!(
+                sample
+                    .get_arguments()
+                    .any(|arg| arg.get_id() == "sample_type")
+            );
+            assert!(sample.get_arguments().any(|arg| arg.get_id() == "output"));
+
+            let validate_sample = schema
+                .get_subcommands()
+                .find(|command| command.get_name() == "validate-sample")
+                .expect("validate-sample command should exist");
+            assert!(
+                validate_sample
+                    .get_arguments()
+                    .any(|arg| arg.get_id() == "sample_type")
+            );
+            assert!(
+                validate_sample
+                    .get_arguments()
+                    .any(|arg| arg.get_id() == "schema_version")
+            );
+            assert!(
+                validate_sample
+                    .get_arguments()
+                    .any(|arg| arg.get_id() == "output")
+            );
+        }
+
+        #[test]
         fn test_profile_command_has_test_subcommand() {
             use crate::Cli;
             let schema = Cli::command();

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -443,6 +443,118 @@ mod doctor_command {
     }
 }
 
+mod sample_command {
+    use super::*;
+
+    const ADT_PROFILE: &str = r#"
+message_structure: ADT_A01
+version: "2.5"
+segments:
+  - id: MSH
+  - id: PID
+constraints:
+  - path: PID.3
+    required: true
+"#;
+
+    #[test]
+    fn test_sample_outputs_builtin_adt_message() {
+        let mut cmd = cli_command();
+        cmd.args(["sample", "--type", "ADT_A01"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("ADT^A01^ADT_A01"))
+            .stdout(predicate::str::contains("PID|1||123456^^^HOSP^MR"));
+    }
+
+    #[test]
+    fn test_sample_writes_output_file() {
+        let dir = create_temp_dir();
+        let output_file = dir.path().join("sample.hl7");
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "sample",
+                "--type",
+                "ORU_R01",
+                "--output",
+                output_file.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("sample should run");
+
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        let sample = read_file(&output_file);
+        assert!(String::from_utf8_lossy(&sample).contains("ORU^R01^ORU_R01"));
+        assert!(String::from_utf8_lossy(&sample).contains("OBX|1|NM|718-7"));
+    }
+
+    #[test]
+    fn test_validate_sample_json_schema_version_two() {
+        let dir = create_temp_dir();
+        let profile = create_temp_profile(&dir, "profile.yaml", ADT_PROFILE);
+        let report_file = dir.path().join("sample-validation.json");
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "validate-sample",
+                "--type",
+                "ADT_A01",
+                "--profile",
+                profile.to_str().unwrap(),
+                "--report",
+                "json",
+                "--schema-version",
+                "2",
+                "--output",
+                report_file.to_str().unwrap(),
+                "--quiet",
+                "--no-color",
+            ])
+            .output()
+            .expect("validate-sample should run");
+
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stdout.is_empty());
+        let report: serde_json::Value =
+            serde_json::from_slice(&read_file(&report_file)).expect("report should be JSON");
+        assert_eq!(report["schema_version"], "2");
+        assert_eq!(report["valid"], true);
+        assert_eq!(report["message_type"], "ADT^A01");
+    }
+
+    #[test]
+    fn test_validate_sample_text_rejects_schema_version_two() {
+        let dir = create_temp_dir();
+        let profile = create_temp_profile(&dir, "profile.yaml", ADT_PROFILE);
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "validate-sample",
+                "--type",
+                "ADT_A01",
+                "--profile",
+                profile.to_str().unwrap(),
+                "--schema-version",
+                "2",
+            ])
+            .output()
+            .expect("validate-sample should run");
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        assert!(String::from_utf8_lossy(&output.stderr).contains(
+            "validation report schema v2 is available only with --report json or --report yaml"
+        ));
+    }
+}
+
 // =========================================================================
 // Parse Command Tests
 // =========================================================================

--- a/docs/guides/first-10-minutes.md
+++ b/docs/guides/first-10-minutes.md
@@ -66,7 +66,28 @@ Expected output includes local diagnostics:
 If this fails, fix the local install before testing real feeds. If Python is not
 installed, the Python binding check can warn without blocking the Rust CLI.
 
-## 2. Lint and Explain the Profile
+## 2. Generate and Validate a Built-In Sample
+
+```bash
+hl7v2 sample --type ADT_A01 --output target/hl7v2-first-10-minutes/sample.hl7
+hl7v2 validate-sample --type ADT_A01 --profile profiles/generic.yaml --report json --schema-version 2
+```
+
+Expected validation output includes:
+
+```json
+{
+  "schema_version": "2",
+  "tool_name": "hl7v2-cli",
+  "valid": true,
+  "message_type": "ADT^A01"
+}
+```
+
+If this fails, the local profile is not aligned with the built-in ADT_A01
+sample. Fix that before moving to site-specific messages.
+
+## 3. Lint and Explain the Profile
 
 ```bash
 hl7v2 profile lint profiles/generic.yaml --report json
@@ -109,7 +130,7 @@ Expected fields include:
 If lint fails, treat that as a profile input error. Fix the profile before
 trusting validation, corpus fingerprints, or evidence bundles built from it.
 
-## 3. Validate One Message
+## 4. Validate One Message
 
 ```bash
 hl7v2 val test_data/valid_message.hl7 --profile profiles/generic.yaml --report json
@@ -142,7 +163,7 @@ Expected behavior:
 This is the automation contract: pipelines can keep the evidence report while
 still failing the job.
 
-## 4. Test the Profile Fixtures
+## 5. Test the Profile Fixtures
 
 ```bash
 hl7v2 profile test profiles/generic.yaml target/hl7v2-first-10-minutes/fixtures --report json
@@ -163,7 +184,7 @@ The `valid/` fixture must validate. The `invalid/` fixture must fail validation.
 If either expectation is wrong, the profile test command exits `1` and reports
 the case-level failure.
 
-## 5. Summarize and Fingerprint the Corpus
+## 6. Summarize and Fingerprint the Corpus
 
 ```bash
 hl7v2 corpus summarize target/hl7v2-first-10-minutes/fixtures --format json
@@ -213,7 +234,7 @@ If `parse_error_count` is not zero for files you expected to parse, inspect
 line endings first. HL7 segment separators are carriage returns (`\r`);
 LF-only samples can be rejected.
 
-## 6. Diff Before and After
+## 7. Diff Before and After
 
 Use the valid fixture as `before` and the invalid fixture as `after`:
 
@@ -251,7 +272,7 @@ Expected fields:
 This is the vendor-upgrade and migration workflow in miniature: same message
 type, same parser status, but field presence and validation evidence changed.
 
-## 7. Redact, Bundle, and Replay
+## 8. Redact, Bundle, and Replay
 
 Create a safe-analysis policy:
 


### PR DESCRIPTION
## Summary
- add `hl7v2 sample --type ADT_A01|ORU_R01` with file-output support
- add `hl7v2 validate-sample` so built-in samples can be checked against a supplied profile using the existing validation report v1/v2 shapes
- document the first-run sample path in the CLI README and first-10-minutes guide

## Validation
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests sample_command`
- `cargo +1.93.0 test -p hl7v2-cli --bins sample_commands_exist`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 clippy -p hl7v2-cli --all-targets -- -D warnings`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 run -p hl7v2-cli -- validate-sample --type ADT_A01 --profile profiles/generic.yaml --report json --schema-version 2 | Set-Content -Path target/validate-sample-v2-live.json`
- `npx -y -p ajv-cli -p ajv-formats ajv validate -c ajv-formats -s schemas/evidence/validation-report-v2.schema.json -d target/validate-sample-v2-live.json --spec=draft7`