### PR TITLE
server: add redacted structured evidence logs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -309,6 +309,12 @@ export RUST_LOG="hl7v2_server=debug,hl7v2_prof=info"
 export RUST_LOG_FORMAT="json"
 ```
 
+`RUST_LOG_FORMAT=json` emits tracing fields as JSON records. The server's HL7
+evidence workflow logs include message type, validation status, issue counts,
+redaction status, hashed control/correlation identifiers, and hashed caller
+bundle IDs. Raw HL7 payloads, raw `MSH.10` control IDs, profile YAML, redaction
+policies, bundle output roots, and quarantine roots are not logged by default.
+
 ### Configuration File
 
 Set `HL7V2_CONFIG` to a TOML or YAML file. The server consumes the `[server]`

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -24,6 +24,15 @@ Useful release-candidate workflows include:
 The server reuses the same evidence contracts as the CLI and `hl7v2` library
 instead of defining a server-only report language.
 
+Structured logs are emitted for parse, validation, redacted validation, bundle,
+replay, ACK, and ACK-policy workflows. They include message type, validation
+status, issue counts, redaction status, and hashed correlation identifiers. Raw
+HL7 payloads, raw message control IDs, profile YAML, redaction policies, and
+local filesystem roots are not logged by default.
+
+Set `RUST_LOG_FORMAT=json` to emit these fields as JSON records. The default is
+human-readable text logs.
+
 ## Usage
 
 Inspect effective configuration without leaking secrets:

--- a/crates/hl7v2-server/src/audit.rs
+++ b/crates/hl7v2-server/src/audit.rs
@@ -1,0 +1,171 @@
+//! Redacted structured audit log helpers for server evidence workflows.
+
+use sha2::{Digest, Sha256};
+
+use crate::models::{AckPolicyOutcome, AckPolicyReason};
+
+/// Structured event emitted when `/hl7/parse` completes.
+pub(crate) const EVENT_PARSE: &str = "hl7v2.parse.completed";
+/// Structured event emitted when `/hl7/validate` completes.
+pub(crate) const EVENT_VALIDATE: &str = "hl7v2.validate.completed";
+/// Structured event emitted when `/hl7/validate-redacted` completes.
+pub(crate) const EVENT_VALIDATE_REDACTED: &str = "hl7v2.validate_redacted.completed";
+/// Structured event emitted when `/hl7/bundle` writes an evidence bundle.
+pub(crate) const EVENT_BUNDLE: &str = "hl7v2.bundle.completed";
+/// Structured event emitted when `/hl7/replay` verifies a bundle.
+pub(crate) const EVENT_REPLAY: &str = "hl7v2.replay.completed";
+/// Structured event emitted when `/hl7/ack` generates an ACK.
+pub(crate) const EVENT_ACK: &str = "hl7v2.ack.completed";
+/// Structured event emitted when `/hl7/ack-policy` makes an ACK policy decision.
+pub(crate) const EVENT_ACK_POLICY: &str = "hl7v2.ack_policy.completed";
+/// Structured event emitted when `/hl7/normalize` completes.
+pub(crate) const EVENT_NORMALIZE: &str = "hl7v2.normalize.completed";
+/// Structured event emitted when a request returns an application error.
+pub(crate) const EVENT_ERROR: &str = "hl7v2.request.failed";
+
+/// Message context safe to put in structured logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MessageLogContext {
+    /// Message type from `MSH.9`, or `UNKNOWN` when unavailable.
+    pub message_type: String,
+    /// SHA-256 hash of `MSH.10`, or `missing` when no control ID is present.
+    pub message_control_id_hash: String,
+    /// Correlation identifier derived from the control ID hash.
+    pub correlation_id: String,
+}
+
+impl MessageLogContext {
+    /// Build log context without retaining raw message identifiers.
+    pub(crate) fn from_message(message: &hl7v2::Message) -> Self {
+        let message_type =
+            joined_components(message, "MSH.9").unwrap_or_else(|| "UNKNOWN".to_string());
+        let message_control_id = hl7v2::get(message, "MSH.10").unwrap_or("");
+        let message_control_id_hash = hash_or_missing(message_control_id);
+
+        Self {
+            message_type,
+            correlation_id: message_control_id_hash.clone(),
+            message_control_id_hash,
+        }
+    }
+}
+
+/// Hash a caller-supplied identifier before logging it.
+pub(crate) fn hash_identifier(identifier: &str) -> String {
+    hash_or_missing(identifier)
+}
+
+/// Stable validation status string for structured logs.
+pub(crate) fn validation_status(valid: bool) -> &'static str {
+    if valid { "valid" } else { "invalid" }
+}
+
+/// Stable redaction status string for structured logs.
+pub(crate) fn redaction_status(phi_removed: bool) -> &'static str {
+    if phi_removed {
+        "phi_removed"
+    } else {
+        "no_phi_removed"
+    }
+}
+
+/// Stable ACK policy outcome label for structured logs.
+pub(crate) fn ack_outcome_label(outcome: AckPolicyOutcome) -> &'static str {
+    match outcome {
+        AckPolicyOutcome::Accepted => "accepted",
+        AckPolicyOutcome::Rejected => "rejected",
+    }
+}
+
+/// Stable ACK policy reason label for structured logs.
+pub(crate) fn ack_reason_label(reason: AckPolicyReason) -> &'static str {
+    match reason {
+        AckPolicyReason::Valid => "valid",
+        AckPolicyReason::ParseError => "parse_error",
+        AckPolicyReason::ValidationError => "validation_error",
+    }
+}
+
+fn hash_or_missing(value: &str) -> String {
+    if value.is_empty() {
+        "missing".to_string()
+    } else {
+        let mut hasher = Sha256::new();
+        hasher.update(value.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+}
+
+fn joined_components(message: &hl7v2::Message, path: &str) -> Option<String> {
+    let mut components = Vec::new();
+
+    for index in 1.. {
+        let component_path = format!("{path}.{index}");
+        match hl7v2::get(message, &component_path) {
+            Some(value) if !value.is_empty() => components.push(value.to_string()),
+            Some(_) => {}
+            None => break,
+        }
+    }
+
+    if components.is_empty() {
+        hl7v2::get(message, path).map(str::to_string)
+    } else {
+        Some(components.join("^"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_MESSAGE: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John\r";
+    const MISSING_CONTROL_ID: &str =
+        "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ORU^R01||P|2.5\r";
+
+    #[test]
+    fn message_log_context_hashes_control_id_without_echoing_it() {
+        let message = hl7v2::parse(SAMPLE_MESSAGE.as_bytes()).expect("message should parse");
+        let context = MessageLogContext::from_message(&message);
+
+        assert_eq!(context.message_type, "ADT^A01");
+        assert_eq!(context.message_control_id_hash.len(), 64);
+        assert_eq!(context.correlation_id, context.message_control_id_hash);
+        assert!(!context.message_control_id_hash.contains("CTRL123"));
+    }
+
+    #[test]
+    fn message_log_context_reports_missing_control_id_without_hashing_phi() {
+        let message = hl7v2::parse(MISSING_CONTROL_ID.as_bytes()).expect("message should parse");
+        let context = MessageLogContext::from_message(&message);
+
+        assert_eq!(context.message_type, "ORU^R01");
+        assert_eq!(context.message_control_id_hash, "missing");
+        assert_eq!(context.correlation_id, "missing");
+    }
+
+    #[test]
+    fn hash_identifier_never_echoes_caller_supplied_identifier() {
+        let hash = hash_identifier("case-Doe-123456");
+
+        assert_eq!(hash.len(), 64);
+        assert!(!hash.contains("Doe"));
+        assert!(!hash.contains("123456"));
+    }
+
+    #[test]
+    fn stable_status_labels_are_machine_friendly() {
+        assert_eq!(validation_status(true), "valid");
+        assert_eq!(validation_status(false), "invalid");
+        assert_eq!(redaction_status(true), "phi_removed");
+        assert_eq!(redaction_status(false), "no_phi_removed");
+        assert_eq!(ack_outcome_label(AckPolicyOutcome::Accepted), "accepted");
+        assert_eq!(ack_outcome_label(AckPolicyOutcome::Rejected), "rejected");
+        assert_eq!(ack_reason_label(AckPolicyReason::Valid), "valid");
+        assert_eq!(ack_reason_label(AckPolicyReason::ParseError), "parse_error");
+        assert_eq!(
+            ack_reason_label(AckPolicyReason::ValidationError),
+            "validation_error"
+        );
+    }
+}

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use crate::audit::{self, MessageLogContext};
 use crate::models::*;
 use crate::redaction::redact_message;
 use crate::server::AppState;
@@ -47,6 +48,7 @@ pub async fn parse_handler(
 
     // Extract metadata
     let metadata = extract_metadata(&message)?;
+    let log_context = MessageLogContext::from_message(&message);
 
     // Optionally convert to JSON
     let message_json = if request.options.include_json {
@@ -54,6 +56,17 @@ pub async fn parse_handler(
     } else {
         None
     };
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_PARSE,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        segment_count = metadata.segment_count,
+        include_json = request.options.include_json,
+        "parsed HL7 message"
+    );
 
     let response = ParseResponse {
         message: message_json,
@@ -74,6 +87,7 @@ pub async fn validate_handler(
 
     // Extract metadata
     let metadata = extract_metadata(&message)?;
+    let log_context = MessageLogContext::from_message(&message);
 
     // Load the profile before validation. Profile load failures are client
     // errors, not successful validation results.
@@ -89,6 +103,20 @@ pub async fn validate_handler(
     );
     let validation_report_v2 = (report_schema_version == 2)
         .then(|| validation_report_v2_for_server(&report, &request.profile, &profile));
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_VALIDATE,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        profile = %profile.message_structure,
+        validation_status = audit::validation_status(report.valid),
+        valid = report.valid,
+        issue_count = report.issue_count,
+        report_schema_version,
+        "validated HL7 message"
+    );
 
     // Preserve legacy error/warning arrays while exposing the shared report issues.
     let mut errors = Vec::new();
@@ -147,6 +175,7 @@ pub async fn validate_redacted_handler(
         requested_quarantine_schema_version(request.quarantine_schema_version)?;
     let raw_input = request.message.into_bytes();
     let mut message = parse_request_message(&raw_input, request.mllp_framed)?;
+    let log_context = MessageLogContext::from_message(&message);
     let receipt =
         redact_message(&mut message, &request.redaction_policy).map_err(AppError::Redaction)?;
     let redacted_hl7 = String::from_utf8(hl7v2::write(&message))
@@ -180,6 +209,29 @@ pub async fn validate_redacted_handler(
     } else {
         None
     };
+    let quarantine_output_id = quarantine
+        .as_ref()
+        .map_or("none", |summary| summary.output_dir.as_str());
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_VALIDATE_REDACTED,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        profile = %profile.message_structure,
+        validation_status = audit::validation_status(validation_report.valid),
+        valid = validation_report.valid,
+        issue_count = validation_report.issue_count,
+        redaction_status = audit::redaction_status(receipt.phi_removed),
+        redaction_phi_removed = receipt.phi_removed,
+        quarantine_output_id,
+        include_redacted_hl7 = request.include_redacted_hl7,
+        report_schema_version,
+        redaction_receipt_schema_version,
+        quarantine_schema_version,
+        "validated redacted HL7 message"
+    );
 
     let response = ValidateRedactedResponse {
         validation_report,
@@ -208,6 +260,7 @@ pub async fn bundle_handler(
 
     let raw_input = request.message.into_bytes();
     let mut message = parse_request_message(&raw_input, request.mllp_framed)?;
+    let log_context = MessageLogContext::from_message(&message);
     let receipt =
         redact_message(&mut message, &request.redaction_policy).map_err(AppError::Redaction)?;
     let redacted_hl7 = String::from_utf8(hl7v2::write(&message))
@@ -234,6 +287,24 @@ pub async fn bundle_handler(
         })
         .map_err(AppError::from)?;
 
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_BUNDLE,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        profile = %profile.message_structure,
+        validation_status = audit::validation_status(summary.validation_valid),
+        valid = summary.validation_valid,
+        issue_count = summary.validation_issue_count,
+        redaction_status = audit::redaction_status(summary.redaction_phi_removed),
+        redaction_phi_removed = summary.redaction_phi_removed,
+        bundle_id_hash = %audit::hash_identifier(&summary.output_dir),
+        artifact_count = summary.artifacts.len(),
+        artifact_schema_version,
+        "wrote redacted evidence bundle"
+    );
+
     Ok((StatusCode::CREATED, Json(summary)))
 }
 
@@ -259,6 +330,25 @@ pub async fn replay_handler(
     }
 
     let report = hl7v2::evidence::replay_evidence_bundle(&bundle_dir, "hl7v2-server");
+    let message_type = report.message_type.as_deref().unwrap_or("unknown");
+    let validation_status = report
+        .validation_valid
+        .map_or("not_available", audit::validation_status);
+    let validation_issue_count = report.validation_issue_count.unwrap_or(0);
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_REPLAY,
+        message_type,
+        bundle_id_hash = %audit::hash_identifier(&request.bundle_id),
+        reproduced = report.reproduced,
+        validation_status,
+        issue_count = validation_issue_count,
+        check_count = report.checks.len(),
+        replay_report_schema_version = report_schema_version,
+        "replayed evidence bundle"
+    );
+
     let response = if report_schema_version == 2 {
         serde_json::to_value(report.to_v2())
     } else {
@@ -357,6 +447,7 @@ pub async fn ack_handler(
     Json(request): Json<AckRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
+    let log_context = MessageLogContext::from_message(&message);
     let ack_code = map_ack_code(request.code);
 
     let ack_message = if let Some(error_message) = request.error_message.as_deref() {
@@ -380,6 +471,17 @@ pub async fn ack_handler(
         ack_code: request.code.as_str().to_string(),
         metadata,
     };
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_ACK,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        ack_code = request.code.as_str(),
+        mllp_frame = request.mllp_frame,
+        "generated ACK"
+    );
 
     Ok((StatusCode::OK, Json(response)))
 }
@@ -414,6 +516,7 @@ pub async fn ack_policy_handler(
             }
             Err(error) => return Err(error),
         };
+    let log_context = MessageLogContext::from_message(&message);
 
     let ack_code = ack_code_from_policy_decision(&decision)?;
     let ack_message = if let Some(error_text) = decision.error_text.as_deref() {
@@ -430,6 +533,29 @@ pub async fn ack_policy_handler(
     } else {
         ack_bytes
     };
+
+    let validation_status = validation_report.as_ref().map_or("parse_error", |report| {
+        audit::validation_status(report.valid)
+    });
+    let issue_count = validation_report
+        .as_ref()
+        .map_or(0, |report| report.issue_count);
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_ACK_POLICY,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        validation_status,
+        issue_count,
+        ack_outcome = audit::ack_outcome_label(decision.outcome),
+        ack_reason = audit::ack_reason_label(decision.reason),
+        ack_code = %decision.ack_code,
+        include_error_text = decision.include_error_text,
+        mllp_frame = request.mllp_frame,
+        "generated policy ACK decision"
+    );
 
     let response = AckPolicyResponse {
         ack_message: String::from_utf8(ack_bytes)
@@ -461,6 +587,7 @@ pub async fn normalize_handler(
     let normalized_message = hl7v2::parse(&normalized_bytes)
         .map_err(|e| AppError::Parse(format!("Normalized message parse error: {}", e)))?;
     let metadata = extract_metadata(&normalized_message)?;
+    let log_context = MessageLogContext::from_message(&normalized_message);
 
     let response_bytes = if request.options.mllp_frame {
         hl7v2::wrap_mllp(&normalized_bytes)
@@ -473,6 +600,17 @@ pub async fn normalize_handler(
             .map_err(|e| AppError::Internal(format!("Normalized message was not UTF-8: {}", e)))?,
         metadata,
     };
+
+    tracing::info!(
+        target: "hl7v2_server::evidence",
+        event = audit::EVENT_NORMALIZE,
+        message_type = %log_context.message_type,
+        message_control_id_hash = %log_context.message_control_id_hash,
+        correlation_id = %log_context.correlation_id,
+        canonical_delimiters = request.options.canonical_delimiters,
+        mllp_frame = request.options.mllp_frame,
+        "normalized HL7 message"
+    );
 
     Ok((StatusCode::OK, Json(response)))
 }
@@ -1054,6 +1192,14 @@ impl IntoResponse for AppError {
             AppError::QuarantineConflict(msg) => (StatusCode::CONFLICT, "QUARANTINE_EXISTS", msg),
             AppError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", msg),
         };
+
+        tracing::warn!(
+            target: "hl7v2_server::evidence",
+            event = audit::EVENT_ERROR,
+            status = status.as_u16(),
+            error_code = code,
+            "request failed"
+        );
 
         let error = ErrorResponse::new(code, message);
         (status, Json(error)).into_response()

--- a/crates/hl7v2-server/src/lib.rs
+++ b/crates/hl7v2-server/src/lib.rs
@@ -47,6 +47,8 @@
     reason = "pre-existing server runtime lint debt is tracked in policy/clippy-debt.toml"
 )]
 
+mod audit;
+
 pub mod evidence;
 pub mod grpc;
 pub mod handlers;

--- a/crates/hl7v2-server/src/main.rs
+++ b/crates/hl7v2-server/src/main.rs
@@ -21,14 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    // Initialize tracing/logging
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "hl7v2_server=info,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    init_tracing();
 
     tracing::info!("Starting HL7v2 HTTP server");
     tracing::info!("Bind address: {}", config.bind_address);
@@ -77,7 +70,41 @@ where
 }
 
 fn usage() -> &'static str {
-    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server], [ack], and [quarantine] settings\n  BIND_ADDRESS                Override bind address, for example 0.0.0.0:8080\n  HL7V2_API_KEY               API key for protected /hl7/* routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes\n  HL7V2_BUNDLE_OUTPUT_ROOT    Existing writable directory for server-generated evidence bundles"
+    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server], [ack], and [quarantine] settings\n  BIND_ADDRESS                Override bind address, for example 0.0.0.0:8080\n  HL7V2_API_KEY               API key for protected /hl7/* routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes\n  HL7V2_BUNDLE_OUTPUT_ROOT    Existing writable directory for server-generated evidence bundles\n  RUST_LOG                    tracing filter, for example hl7v2_server=info,tower_http=debug\n  RUST_LOG_FORMAT             set to json for JSON logs; any other value uses text logs"
+}
+
+fn init_tracing() {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "hl7v2_server=info,tower_http=debug".into());
+    let subscriber = tracing_subscriber::registry().with(env_filter);
+
+    match log_format_from_env() {
+        LogFormat::Json => subscriber
+            .with(tracing_subscriber::fmt::layer().json())
+            .init(),
+        LogFormat::Text => subscriber.with(tracing_subscriber::fmt::layer()).init(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    Text,
+    Json,
+}
+
+fn log_format_from_env() -> LogFormat {
+    std::env::var("RUST_LOG_FORMAT")
+        .ok()
+        .and_then(|value| parse_log_format(&value))
+        .unwrap_or(LogFormat::Text)
+}
+
+fn parse_log_format(value: &str) -> Option<LogFormat> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "text" | "pretty" => Some(LogFormat::Text),
+        "json" => Some(LogFormat::Json),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -112,5 +139,15 @@ mod tests {
             parse_args(["--unknown"]),
             Err(error) if error.contains("unknown argument")
         ));
+    }
+
+    #[test]
+    fn parse_log_format_accepts_json_and_text_values() {
+        assert_eq!(parse_log_format("json"), Some(LogFormat::Json));
+        assert_eq!(parse_log_format(" JSON "), Some(LogFormat::Json));
+        assert_eq!(parse_log_format("text"), Some(LogFormat::Text));
+        assert_eq!(parse_log_format("pretty"), Some(LogFormat::Text));
+        assert_eq!(parse_log_format(""), Some(LogFormat::Text));
+        assert_eq!(parse_log_format("xml"), None);
     }
 }

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -430,6 +430,29 @@ curl http://127.0.0.1:18080/metrics
 Use `/health` for process liveness. Use `/ready` for deployment readiness. Use
 the evidence endpoints for interface decisions.
 
+The server also emits structured evidence workflow logs for parse, validate,
+validate-redacted, bundle, replay, ACK, and ACK-policy requests. The useful
+fields are intentionally operational rather than payload-bearing:
+
+```text
+event
+message_type
+message_control_id_hash
+correlation_id
+validation_status
+issue_count
+redaction_status
+bundle_id_hash
+quarantine_output_id
+ack_code
+ack_outcome
+ack_reason
+```
+
+The raw HL7 message, raw `MSH.10` control ID, profile YAML, redaction policy,
+bundle output root, and quarantine root are not logged by default. Use the
+bundle, quarantine, and replay artifacts when you need deeper evidence.
+
 ## Deployment Notes
 
 - Keep `HL7V2_API_KEY` configured for `/hl7/*` routes.


### PR DESCRIPTION
## Summary
- add redacted structured evidence log events for server parse, validate, validate-redacted, bundle, replay, ACK, ACK-policy, normalize, and application error paths
- hash message control IDs and caller bundle IDs before logging, and keep raw HL7 payloads, profile YAML, redaction policies, and local output roots out of server logs
- make documented `RUST_LOG_FORMAT=json` behavior real and document the safe log field contract

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-server audit`
- `cargo +1.93.0 test -p hl7v2-server --bin hl7v2-server`
- `cargo +1.93.0 test -p hl7v2-server --test validate_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test validate_redacted_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test bundle_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test replay_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test ack_policy_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test parse_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test http_runtime_contract_test`
- `cargo +1.93.0 clippy -p hl7v2-server --all-targets -- -D warnings`
- `cargo +1.93.0 test -p hl7v2-server`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`