### PR TITLE
docs: refresh evidence loop status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Parser / Core** | Stable | Main CI, workspace tests, and contract checks green after the `hl7v2` facade and foundation-module collapse |
 | **Writer / Normalize** | Stable | Writer tests plus HTTP/gRPC normalization contract coverage |
 | **MLLP / Network** | Stable | MLLP parse/framing tests and CI matrix coverage |
-| **REST Server** | Stable | Runtime and OpenAPI agree for parse, validate, ACK, and normalize routes |
+| **REST Server** | Stable | Runtime and OpenAPI agree for parse, validate, redacted validation, bundle/replay, ACK, normalize, inline corpus evidence, readiness, and redacted structured logs |
 | **gRPC Service** | Beta | Contract tests cover Parse, Validate, GenerateAck, Normalize, and HealthCheck; ParseStream is explicitly unsupported |
 | **Lifecycle** | Beta | Domain tests exist, but lifecycle is not part of the current HTTP/gRPC contract gate |
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
 | **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published to crates.io; Python remains a separate binding lane |
-| **Evidence Loop** | Stable | v1.3.0 includes typed reports, profile test/explain, corpus fingerprint/diff, redaction, bundle/replay, schemas, goldens, and server/Python parity |
+| **Evidence Loop** | Stable | v1.3.0 includes typed reports, profile test/explain, corpus fingerprint/diff, redaction, bundle/replay, schemas, goldens, and server/Python parity; current main adds redacted structured server evidence logs |
 
 ## Features
 
@@ -170,6 +170,10 @@ curl http://localhost:8080/metrics  # Prometheus metrics
 ```
 
 See the [OpenAPI specification](api/openapi/hl7v2-api-v1.yaml) for complete API documentation.
+Server evidence workflow logs are structured and PHI-conscious. Set
+`RUST_LOG_FORMAT=json` for JSON records; logged identifiers such as message
+control IDs and bundle IDs are hashed, and raw HL7, profile YAML, redaction
+policy TOML, and configured filesystem roots are not logged by default.
 
 ### CLI Tools
 
@@ -310,9 +314,10 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 
 ### HTTP/REST API Server (`hl7v2-server`)
 
-- **RESTful API**: Parse, validate, acknowledge, and normalize HL7 messages over HTTP
+- **RESTful API**: Parse, validate, redact, bundle, replay, acknowledge, normalize, and inspect inline corpus evidence over HTTP
 - **Health & Readiness**: Production-ready health checks
 - **Prometheus metrics**: Request counts, latencies, error rates
+- **Redacted structured logs**: Evidence workflow logs hash message control IDs and bundle IDs while avoiding raw HL7, profile YAML, redaction policy TOML, and configured filesystem roots by default
 - **Concurrency limiting**: Built-in backpressure (100 concurrent requests default)
 - **CORS support**: Configurable allowed origins, with permissive local default
 - **Compression**: Gzip compression for responses
@@ -361,7 +366,9 @@ python tests/python_smoke/smoke.py
 The current binding proof covers wheel build, install, import, version
 metadata, parse, segment count, JSON conversion, validation report parity,
 corpus summary/fingerprint/diff dict outputs, safe-analysis redaction, evidence
-bundle creation, and replay verification.
+bundle creation, and replay verification. Validation, corpus, redaction,
+bundle, and replay APIs also support the same opt-in v2 evidence shapes used by
+the CLI/server contracts where those surfaces expose v2 output.
 
 ## Performance Characteristics
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,14 +3,14 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-09
-> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is the post-v1.3.0 evidence-hardening line.
 
 ## Core Components
 
 | Crate | Status | Coverage | Notes |
 |-------|--------|----------|-------|
 | `hl7v2` | ✅ 100% | 92% | Canonical Rust library crate for parsing, writing, validation, transport framing, ACK, normalization, and generation. Foundation model, escape, and MLLP implementations now live here. |
-| `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, and normalization routes. |
+| `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, normalization, redacted validation, configured-root bundle/replay, inline corpus evidence, readiness, quarantine, and redacted structured logs. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
 | `hl7v2-python` | 🟡 Experimental | Smoke | PyO3 binding package held out of the crates.io Rust publish graph; validated through the Python/maturin wheel smoke lane before any PyPI release. |
 | retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
@@ -27,7 +27,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **API Authentication**: Constant-time API Key validation.
 - ✅ **Rate Limiting**: Per-IP throttling to prevent DoS.
 - ✅ **Prometheus Metrics**: Throughput, latency, and error tracking.
-- ✅ **Audit Ready**: Structured JSON logging.
+- ✅ **Audit Ready**: Redacted structured evidence logs with hashed message-control and bundle identifiers; JSON output is available with `RUST_LOG_FORMAT=json`.
 
 ### 🧪 Quality Assurance
 - ✅ **BDD Tests**: Real validation scenarios verified with Cucumber.
@@ -45,7 +45,7 @@ This document provides a transparent view of which features are fully implemente
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1` and `v1.3.0` tags point at their release heads.
 
-## Evidence Loop Release (current main)
+## Evidence Loop Release And Current Main
 
 v1.3.0 is the Evidence Loop release line around deterministic HL7 interface
 evidence. It is tagged, released on GitHub, and uploaded to crates.io for the
@@ -60,7 +60,7 @@ final Rust package graph.
 | Safe support packets | ✅ Stable | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
 | Evidence contracts | ✅ Stable | JSON schemas and golden fixtures guard the machine-readable evidence artifacts. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
-| Server edge guard | ✅ Stable | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/ack-policy`, and quarantine hooks. |
+| Server edge guard | ✅ Stable | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/replay`, `/hl7/ack-policy`, inline corpus endpoints, quarantine hooks, and redacted structured evidence logs. |
 | Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph. |
 
 ## v1.3.0 Readiness Checklist
@@ -82,4 +82,5 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 
 **Current published release**: v1.3.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
-**Current main**: tracks the published v1.3.0 Evidence Loop release line.
+**Current main**: tracks the post-v1.3.0 Evidence Loop hardening line. The
+published Rust crates remain v1.3.0 until the next release train.

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -2,8 +2,8 @@
 
 This document maps the current evidence-loop artifacts and their contract
 status. It is a current-state reference for the schema, golden-fixture, CLI
-output-contract, server parity, and Python parity surfaces in the v1.3.0
-evidence loop.
+output-contract, server parity, redacted server logging, and Python parity
+surfaces in the v1.3.0 evidence loop and current post-release hardening line.
 
 ## Product Loop
 
@@ -11,6 +11,7 @@ The evidence loop is:
 
 ```text
 raw feed / message
+  -> doctor / environment proof
   -> profile lint
   -> profile test / explain
   -> validation report
@@ -20,6 +21,8 @@ raw feed / message
   -> safe-analysis redact
   -> redacted evidence bundle
   -> replay verification
+  -> server sidecar evidence
+  -> Python data workflow
 ```
 
 The target is deterministic, machine-readable proof of what arrived, what
@@ -52,8 +55,8 @@ failed, what changed, what was redacted, and how to replay the result.
 | --- | --- |
 | Rust library | Owns the shared `ValidationReport`, `ProfileLintReport`, corpus summary/fingerprint/diff types, redaction output/receipt types, and Python-facing evidence bundle/replay types. Profile test and profile explain report types are currently CLI-local. |
 | CLI | Produces the complete evidence loop today. Most commands support JSON/YAML/text. `redact` supports JSON or HL7 output. `bundle` currently emits JSON summary only. |
-| Server | `/hl7/validate` exposes the shared validation issue fields, preserves legacy `errors` / `warnings`, and can include `validation_report_v2` when `report_schema_version` is `2`; `/hl7/validate-redacted` applies safe-analysis redaction, returns a validation report plus redaction receipt, can include the same v2 validation artifact, and can write configured quarantine output for failed validation; `/hl7/corpus/summarize`, `/hl7/corpus/fingerprint`, and `/hl7/corpus/diff` produce inline corpus evidence without reading request-supplied filesystem paths; `/hl7/bundle` writes redacted evidence bundles under a configured server root and can opt into v2 bundle-internal artifacts; `/hl7/replay` verifies configured-root bundles and can opt into the v2 replay report shape; `/hl7/ack-policy` returns policy-driven ACK/NAK decisions backed by validation reports. |
-| Python | Exposes parse, JSON conversion, normalize, validation report dict/JSON parity, corpus summary/fingerprint/diff dict parity, safe-analysis redaction dict output, evidence bundle creation, and replay verification. |
+| Server | `/hl7/validate` exposes the shared validation issue fields, preserves legacy `errors` / `warnings`, and can include `validation_report_v2` when `report_schema_version` is `2`; `/hl7/validate-redacted` applies safe-analysis redaction, returns a validation report plus redaction receipt, can include the same v2 validation artifact, and can write configured quarantine output for failed validation; `/hl7/corpus/summarize`, `/hl7/corpus/fingerprint`, and `/hl7/corpus/diff` produce inline corpus evidence without reading request-supplied filesystem paths; `/hl7/bundle` writes redacted evidence bundles under a configured server root and can opt into v2 bundle-internal artifacts; `/hl7/replay` verifies configured-root bundles and can opt into the v2 replay report shape; `/hl7/ack-policy` returns policy-driven ACK/NAK decisions backed by validation reports; evidence workflow logs hash message-control and bundle identifiers and avoid raw HL7, profile YAML, redaction policy TOML, and configured filesystem roots by default. |
+| Python | Exposes parse, JSON conversion, normalize, validation report dict/JSON parity, corpus summary/fingerprint/diff dict parity, safe-analysis redaction dict output, evidence bundle creation, and replay verification. Validation, corpus, redaction, bundle, and replay APIs support opt-in v2 shapes where those contracts exist. |
 
 `ValidationReport.profile` is a surface-local display label, not a canonical
 profile identity. The CLI uses the supplied profile path, while the server and
@@ -86,20 +89,21 @@ The CLI output contract is stable enough for CI and automation:
 
 Evidence JSON null, omitted-field, and empty-array semantics are documented in
 [`schemas/README.md`](../../schemas/README.md#evidence-null-and-empty-semantics).
-The next provenance/versioning contract is planned in
+The provenance/versioning compatibility rules are maintained in
 [`evidence-provenance-versioning.md`](evidence-provenance-versioning.md).
 
 ## Remaining Contract Hardening Gaps
 
-The v1.3.0 evidence loop has schema-backed JSON artifacts, golden fixtures,
-CLI output semantics, bundle manifest verification, server edge-guard routes,
-Python parity, and workflow guides. Remaining hardening work should narrow the
-few places where provenance or identity is still implicit:
+The v1.3.0 evidence loop and current post-release hardening line have
+schema-backed JSON artifacts, golden fixtures, CLI output semantics, bundle
+manifest verification, server edge-guard routes, redacted structured server
+logs, Python parity, and workflow guides. Remaining hardening work should
+narrow the few places where provenance or identity is still implicit:
 
 - `schema_version` or artifact-specific version naming for every machine
   artifact. The compatibility plan is documented in
   [`evidence-provenance-versioning.md`](evidence-provenance-versioning.md);
-  implementation still requires explicit v2 schema/type work.
+  remaining implementation should continue through explicit v2 schema/type work.
 - `tool_version` where users need provenance outside an environment file.
 - Shared library types for any CLI-local report promoted beyond CLI-only use.
 

--- a/docs/architecture/evidence-provenance-versioning.md
+++ b/docs/architecture/evidence-provenance-versioning.md
@@ -1,11 +1,10 @@
 # Evidence Provenance And Versioning
 
-This document defines the next contract-hardening step for evidence artifacts.
-It is a plan, not a live schema change. The v1.3.0 evidence loop is already
-schema-backed and golden-tested, but not every standalone artifact embeds enough
-version and producer information to remain self-describing when copied out of a
-bundle, sent through a pipeline, or compared across CLI, server, Rust, and
-Python producers.
+This document defines the provenance and versioning compatibility rules for
+evidence artifacts. It began as the v2 migration plan; most high-value v2
+schemas and producer paths now exist, but the rule still matters: v1 defaults
+remain compatible, and provenance-bearing shapes are explicit opt-ins unless a
+release intentionally changes the default.
 
 ## Current Rule
 
@@ -51,7 +50,7 @@ exception:
 ```
 
 Artifacts that already have domain version fields keep those fields. For
-example, a future corpus fingerprint should carry both `schema_version` and
+example, a corpus fingerprint v2 artifact carries both `schema_version` and
 `fingerprint_version`; the former identifies the JSON contract, while the latter
 identifies the fingerprinting algorithm.
 
@@ -94,9 +93,9 @@ Rules:
 | `ProfileLintReport` | Shared Rust type with no embedded version fields by default. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI lint output can emit v2 when requested. |
 | `ProfileTestReport` | CLI-local type with embedded validation reports. | A target v2 schema exists, and CLI test output can emit v2 when requested. Promote to a shared type only if server/Python need it. |
 | `ProfileExplainReport` | CLI-local report with profile hash but no artifact/tool version by default. | A target v2 schema exists, and CLI explain output can emit v2 when requested. |
-| `CorpusSummary` | Shared Rust/Python/CLI type with no embedded version fields by default. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python summary output can emit v2 when requested. |
-| `CorpusFingerprint` | Has `fingerprint_version`, `tool_version`, and profile hash metadata. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python fingerprint output can emit v2 when requested. |
-| `CorpusDiffReport` | Has `diff_version`, `tool_version`, and profile hash metadata. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python diff output can emit v2 when requested. |
+| `CorpusSummary` | Shared Rust/Python/CLI type with no embedded version fields by default. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python/server summary output can emit v2 when requested. |
+| `CorpusFingerprint` | Has `fingerprint_version`, `tool_version`, and profile hash metadata. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python/server fingerprint output can emit v2 when requested. |
+| `CorpusDiffReport` | Has `diff_version`, `tool_version`, and profile hash metadata. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python/server diff output can emit v2 when requested. |
 | `SafeAnalysisRedactionOutput` | Has input/policy hashes and nested receipt; no output-level schema/tool version by default. | A v1 outer schema exists for current CLI/Python default outputs. CLI and Python redaction output can emit the target v2 schema with top-level provenance when requested. |
 | `RedactionReceipt` | Shared receipt schema without embedded version fields by default. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python/server redaction output can emit v2 when requested. CLI/Python/server bundle artifacts can also emit v2 receipts through explicit bundle artifact schema opt-in. |
 | `FieldPathTraceReport` | Bundle artifact with a v1 JSON Schema but no embedded version fields. | A target v2 bundle-artifact schema and fixture exist. CLI/Python/server bundle writers can emit v2 field-path traces through explicit bundle artifact schema opt-in. |
@@ -106,9 +105,9 @@ Rules:
 | `EvidenceBundleEnvironment` | Has `bundle_version`, `tool_name`, `tool_version`, input/profile/policy hashes, validation summary, replay command, and a v1 JSON Schema. | A target v2 schema and fixture exist with `schema_version`; CLI/Python/server bundle writers can emit v2 environments through explicit bundle artifact schema opt-in. |
 | `EvidenceReplayReport` | Has `replay_version`, `bundle_version`, `tool_name`, and `tool_version` by default. | A target v2 schema exists, Rust exposes an explicit v2 conversion helper, and CLI/Python/server replay output can emit v2 when requested. |
 
-## Migration Sequence
+## Migration Sequence Status
 
-Do the migration in narrow PRs:
+The migration is intentionally narrow and additive:
 
 1. Add v2 schemas and v2 golden fixtures for the highest-value shared reports:
    `ValidationReport`, `ProfileLintReport`, `ProfileExplainReport`,
@@ -138,10 +137,12 @@ Do the migration in narrow PRs:
    `CorpusSummary`, `CorpusFingerprint`, and `CorpusDiffReport` now have
    explicit v2 conversion helpers. `hl7v2 corpus summarize` / `hl7v2 corpus
    fingerprint` / `hl7v2 corpus diff` can opt into v2 JSON/YAML output with
-   `--schema-version 2`, and Python can opt into the same shapes with
+   `--schema-version 2`, Python can opt into the same shapes with
    `corpus_summary(..., schema_version=2)`,
    `corpus_fingerprint(..., schema_version=2)`, and
-   `corpus_diff(..., schema_version=2)`. Defaults remain v1-compatible.
+   `corpus_diff(..., schema_version=2)`, and server inline corpus endpoints can
+   opt in with the corresponding `*_schema_version: 2` request fields. Defaults
+   remain v1-compatible.
    `RedactionReceipt` now has an explicit v2 conversion helper. `hl7v2 redact
    --format json --schema-version 2`, Python `redact(..., schema_version=2)`,
    and server `/hl7/validate-redacted` requests with
@@ -176,7 +177,9 @@ Do the migration in narrow PRs:
 4. Update server responses only after OpenAPI examples and integration tests
    cover the v2 shape.
 5. Update Python dictionaries and `to_json()` outputs after the Rust and CLI
-   contracts are stable.
+   contracts are stable. Python now exposes opt-in v2 validation, corpus,
+   redaction, bundle, and replay outputs. Profile explain/test remain CLI-local
+   report types until a future parity PR promotes them.
 6. Keep v1 schemas and fixtures for at least two minor releases after v2 output
    becomes the default.
 
@@ -196,7 +199,6 @@ Do the migration in narrow PRs:
 
 ## Non-Goals
 
-This plan does not require immediate v2 output in the CLI, server, Rust library,
-or Python binding. It also does not redefine validation issue codes, redaction
-policy semantics, ACK/NAK policy, or corpus diff algorithms. Those are separate
-contract changes.
+This compatibility policy does not make v2 the default output shape. It also
+does not redefine validation issue codes, redaction policy semantics, ACK/NAK
+policy, or corpus diff algorithms. Those are separate contract changes.

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -2,7 +2,8 @@
 
 Date: 2026-05-08
 
-Updated: 2026-05-09 after the v1.3.0 Evidence Loop release hardening pass.
+Updated: 2026-05-09 after the v1.3.0 Evidence Loop release hardening pass and
+the redacted structured server logging pass.
 
 ## Purpose
 
@@ -13,8 +14,9 @@ the v1.3.0 contract-hardening pass.
 
 The goal is to keep the next hardening work concrete. The loop now has JSON
 Schemas, golden fixtures, CLI output semantics, bundle manifest verification,
-server parity, and Python bundle/replay APIs; the remaining gaps are narrower
-provenance and identity details.
+server parity, redacted structured server logs, and Python bundle/replay APIs;
+the remaining gaps are narrower contract-index, deployment-proof, and
+distribution-readiness details.
 
 ## Current Product Loop
 
@@ -41,23 +43,26 @@ server-side replay verification through `/hl7/replay`, policy-driven ACK/NAK
 decisions through `/hl7/ack-policy`, and configured quarantine output for
 failed redacted validation. It also exposes inline corpus summary,
 fingerprint, and diff endpoints under `/hl7/corpus/*`; these accept message
-content directly and do not read filesystem paths from request bodies. Python
+content directly and do not read filesystem paths from request bodies. Server
+evidence workflow logs hash message-control and bundle identifiers and avoid
+raw HL7, profile YAML, redaction policy TOML, and configured filesystem roots by
+default. Python
 exposes parse, JSON conversion, normalization, validation report dict/JSON
 parity, corpus summary/fingerprint/diff dict outputs, and safe-analysis
-redaction output.
+redaction output, bundle creation, and replay verification.
 
 ## Artifact Status
 
 | Artifact | Current state | Main gap |
 | --- | --- | --- |
 | `DoctorReport` | CLI `hl7v2 doctor --format json` reports tool version plus first-run diagnostic checks for CLI version, sample parse, MLLP framing, optional profile, optional server reachability, and Python binding availability. `hl7v2 doctor --format json --schema-version 2` adds embedded schema/tool provenance. | JSON Schemas and golden fixtures exist for v1 and opt-in v2. Defaults remain v1-compatible. |
-| `ValidationReport` | Shared Rust type used by CLI, Python, and server validation response fields, including `/hl7/validate-redacted`. Includes stable issue code, severity, path, rule ID, message, segment index, and field index. | JSON Schema and golden fixture exist; no embedded artifact `schema_version` or `tool_version`. |
+| `ValidationReport` | Shared Rust type used by CLI, Python, and server validation response fields, including `/hl7/validate-redacted`. Includes stable issue code, severity, path, rule ID, message, segment index, and field index. | JSON Schemas and golden fixtures exist for v1 and opt-in v2. CLI/Python can emit v2 directly, and server responses can include nested `validation_report_v2` when requested. Defaults remain v1-compatible. |
 | `ProfileLintReport` | Shared Rust type from profile linting. CLI emits text/JSON/YAML by default, with opt-in v2 output for embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
 | `ProfileTestReport` | CLI report with fixture cases, pass/fail status, embedded validation reports, and optional expected-report comparison; opt-in v2 output adds embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
 | `ProfileExplainReport` | CLI report with profile SHA-256, structure, version, segments, constraints, tables, rules, and lint summary; opt-in v2 output adds embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
-| `CorpusSummary` | Shared Rust corpus summary type. CLI emits text/JSON/YAML and Python returns the same dict shape by default, with opt-in v2 output for embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
-| `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; `profile: null` and empty-array semantics are documented in the schema README. |
-| `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. CLI emits text/JSON/YAML and Python returns the same dict shape. | JSON Schema and golden fixture exist; `profile: null` and empty-array semantics are documented in the schema README. |
+| `CorpusSummary` | Shared Rust corpus summary type. CLI emits text/JSON/YAML, Python returns the same dict shape, and server `/hl7/corpus/summarize` produces inline corpus evidence. | JSON Schemas and golden fixtures exist for v1 and opt-in v2. CLI/Python/server can request v2 output while defaults remain v1-compatible. |
+| `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. CLI emits text/JSON/YAML, Python returns the same dict shape, and server `/hl7/corpus/fingerprint` produces inline corpus evidence. | JSON Schemas and golden fixtures exist for v1 and opt-in v2; `profile: null` and empty-array semantics are documented in the schema README. |
+| `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. CLI emits text/JSON/YAML, Python returns the same dict shape, and server `/hl7/corpus/diff` produces inline corpus evidence. | JSON Schemas and golden fixtures exist for v1 and opt-in v2; `profile: null` and empty-array semantics are documented in the schema README. |
 | `SafeAnalysisRedactionOutput` | CLI `hl7v2 redact --format json` and Python `redact()` return input and policy SHA-256 values, message type, redacted HL7 text, and a nested redaction receipt. | JSON Schema and fixtures exist for the default v1-compatible output, the transitional v1 outer shape with a nested v2 receipt, and opt-in v2 output with top-level `schema_version`, `tool_name`, and `tool_version`. Defaults remain v1-compatible. |
 | `RedactionReceipt` | CLI, server, and Python receipts record PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | JSON Schemas, golden fixtures, and synthetic PHI leak-sentinel tests exist for v1 and opt-in v2. Defaults remain v1-compatible; v2 adds embedded `schema_version`, `tool_name`, and `tool_version`. |
 | `EvidenceBundleSummary` | CLI stdout JSON summary, Python `bundle()` output, and server `/hl7/bundle` JSON response include `bundle_version`, output directory/id, message type, validation status, redaction status, and artifact list. | v1 and v2 JSON Schemas plus golden fixtures exist. CLI and Python can opt into v2 provenance with `schema_version = 2`; server keeps the v1 response shape by default. |
@@ -65,7 +70,7 @@ redaction output.
 | `QuarantineOutputSummary` | Server `/hl7/validate-redacted` can return a root-relative quarantine output id, reason, validation issue count, and artifact list when `[quarantine]` is enabled and validation fails. | Server-local response type; v1 and opt-in v2 JSON Schemas exist. Requests with `quarantine_schema_version: 2` include `quarantine_v2` with provenance while preserving the v1 `quarantine` field. Full-bundle mode reuses bundle artifacts. |
 | `EvidenceBundleManifest` | Bundle `manifest.json` records bundle-relative artifact paths, roles, SHA-256 hashes, and the generating tool name (`hl7v2-cli`, `hl7v2-server`, or `hl7v2-python`). | v1 and v2 JSON Schemas and golden fixtures exist. CLI and Python bundle writers can emit v2 manifests, and replay verifies both v1 and v2 manifest catalogs and hashes before using artifacts. |
 | `EvidenceReplayReport` | CLI, Python, and server reports include `replay_version`, `bundle_version`, `tool_name`, `tool_version`, replay checks, reproduction status, and optional regenerated validation report. | v1 and v2 JSON Schemas plus golden fixtures exist. CLI and Python can opt into v2 with `schema_version = 2`; server `/hl7/replay` can opt into v2 with `replay_report_schema_version: 2`; replay fails closed on malformed manifests, missing artifacts, and hash mismatches. |
-| Python validation report | `report.valid`, `message_type`, `profile`, `segment_count`, `issue_count`, `to_dict()`, and `to_json()` mirror `ValidationReport`. | Python exposes validation reports, corpus summary/fingerprint/diff dict APIs, safe-analysis redaction output, bundle creation, and replay verification. |
+| Python validation report | `report.valid`, `message_type`, `profile`, `segment_count`, `issue_count`, `to_dict()`, and `to_json()` mirror `ValidationReport`; `to_dict(2)` and `to_json(2)` emit opt-in v2 provenance. | Python exposes validation reports, corpus summary/fingerprint/diff dict APIs, safe-analysis redaction output, bundle creation, and replay verification with opt-in v2 shapes where those contracts exist. |
 
 ## Surface Parity
 
@@ -73,7 +78,7 @@ redaction output.
 | --- | --- |
 | Rust | Shared validation, profile lint, corpus summary/fingerprint/diff, parse, normalize, write, ACK, redaction module APIs, and Python-facing bundle/replay evidence APIs. Profile test and profile explain reports remain CLI-local. |
 | CLI | Complete current loop: doctor, profile lint/test/explain, validation, corpus summarize/fingerprint/diff, redact, bundle, and replay. |
-| Server | Validation report parity for `/hl7/validate`; redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle` with opt-in v2 bundle-internal artifacts; configured-root replay verification for `/hl7/replay`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; inline corpus summary/fingerprint/diff endpoints under `/hl7/corpus/*`. |
+| Server | Validation report parity for `/hl7/validate`; redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle` with opt-in v2 bundle-internal artifacts; configured-root replay verification for `/hl7/replay`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; inline corpus summary/fingerprint/diff endpoints under `/hl7/corpus/*`; redacted structured evidence logs with hashed message-control and bundle identifiers. |
 | Python | Minimum API parity for parse, `to_json`, normalize, validation reports, corpus summary/fingerprint/diff dict outputs, safe-analysis redaction output, bundle creation, and replay verification. |
 
 One validation parity detail is intentionally documented as a label convention:
@@ -104,15 +109,16 @@ Current behavior is script-grade:
 
 ## Known Contract Gaps
 
-The evidence loop is contract-grade enough for the v1.3.0 release: schemas,
-goldens, CLI output semantics, manifest verification, server edge-guard routes,
-Python parity, user guides, and documented evidence null/empty semantics are in
-place. Remaining hardening work:
+The evidence loop is contract-grade enough for the v1.3.0 release and current
+post-release hardening line: schemas, goldens, CLI output semantics, manifest
+verification, server edge-guard routes, redacted structured logs, Python parity,
+user guides, and documented evidence null/empty semantics are in place.
+Remaining hardening work:
 
-1. Add artifact version and tool version fields consistently.
+1. Keep closing the few artifact/version identity gaps that remain.
    The compatibility plan is documented in
    [`../architecture/evidence-provenance-versioning.md`](../architecture/evidence-provenance-versioning.md);
-   implementation should happen through explicit v2 schema/type PRs, not
+   implementation should continue through explicit v2 schema/type PRs, not
    silent v1 shape changes.
 2. Expand PHI leak sentinels beyond the current synthetic patient/contact
    fixture family as new evidence surfaces or policy modes are added.
@@ -132,6 +138,6 @@ place. Remaining hardening work:
 ## Result
 
 The evidence loop is real enough to harden. The next work should not add broad
-new features first; it should make the existing artifacts stable contracts with
-schemas, goldens, version fields, CLI output semantics, manifest verification,
-and parity plans for server and Python surfaces.
+new features first; it should make the existing artifacts easier to operate and
+audit with a single contract index, repeatable schema checks, deployment proof,
+and Python distribution proof.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -72,8 +72,8 @@ The first target v2 evidence schemas are `doctor-report-v2.schema.json`,
 `evidence-bundle-environment-v2.schema.json`, `field-path-trace-v2.schema.json`,
 and `evidence-replay-v2.schema.json`. They add embedded `schema_version`,
 `tool_name`, and `tool_version` fields where the artifact did not already carry
-tool provenance, while keeping their v1 counterparts valid until
-implementation PRs explicitly move producer output shapes.
+tool provenance. Producer paths use explicit v2 opt-ins as documented below,
+while v1 counterparts remain the default compatible shapes.
 Doctor reports can opt into their target v2 shape with
 `hl7v2 doctor --format json --schema-version 2`; defaults remain v1.
 Validation reports can opt into their target v2 shape with
@@ -95,7 +95,9 @@ shapes with `hl7v2 corpus summarize --format json --schema-version 2`,
 diff --format json --schema-version 2`. Python exposes the same opt-in shapes
 with `corpus_summary(..., schema_version=2)`,
 `corpus_fingerprint(..., schema_version=2)`, and
-`corpus_diff(..., schema_version=2)`; defaults remain v1.
+`corpus_diff(..., schema_version=2)`. Server inline corpus endpoints expose the
+same opt-in shapes through `summary_schema_version`, `fingerprint_schema_version`,
+and `diff_schema_version` request fields; defaults remain v1.
 Redaction receipts can opt into their target v2 shape with
 `hl7v2 redact --format json --schema-version 2`, Python
 `redact(..., schema_version=2)`, or server `/hl7/validate-redacted` requests
@@ -115,7 +117,9 @@ Evidence bundle summaries can opt into their target v2 shape with
 default.
 Evidence replay reports can opt into their target v2 shape with
 `hl7v2 replay ... --format json --schema-version 2`, and Python exposes the
-same shape with `replay(..., schema_version=2)`.
+same shape with `replay(..., schema_version=2)`. Server `/hl7/replay`
+responses can include the same v2 shape when requests set
+`"replay_report_schema_version": 2`.
 Bundle-internal `manifest.json`, `environment.json`, `field-paths.json`, and
 `redaction-receipt.json` can opt into their v2 shapes when CLI bundles are
 created with `hl7v2 bundle ... --schema-version 2` or Python bundles are


### PR DESCRIPTION
## Summary
- refresh evidence-loop status docs after #530 landed on main
- distinguish published v1.3.0 from current post-release evidence hardening
- document redacted structured server logs, server inline corpus v2 request fields, and Python opt-in v2 parity

## Validation
- git diff --check
- cargo +1.93.0 fmt --all -- --check
- cargo +1.93.0 run -p xtask -- publish-plan
- $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
