### PR TITLE
server: avoid profile path leaks in readiness

### DIFF
--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -337,20 +337,21 @@ fn profile_readiness_check(profile_paths: &[String]) -> ReadinessCheck {
         return ReadinessCheck::pass("configured_profiles", "no configured profiles");
     }
 
-    for path in profile_paths {
+    for (index, path) in profile_paths.iter().enumerate() {
+        let profile_number = index.saturating_add(1);
         match fs::read_to_string(path) {
             Ok(content) => {
                 if let Err(error) = hl7v2::load_profile_checked(&content) {
                     return ReadinessCheck::fail(
                         "configured_profiles",
-                        format!("profile {path} did not load: {error}"),
+                        format!("configured profile {profile_number} did not load: {error}"),
                     );
                 }
             }
             Err(error) => {
                 return ReadinessCheck::fail(
                     "configured_profiles",
-                    format!("profile {path} could not be read: {error}"),
+                    format!("configured profile {profile_number} could not be read: {error}"),
                 );
             }
         }
@@ -808,7 +809,31 @@ segments:
             .expect("configured profile check should exist");
 
         assert_eq!(check.status, crate::models::ReadinessCheckStatus::Fail);
-        assert!(check.message.contains("missing-profile.yaml"));
+        assert!(check.message.contains("configured profile 1"));
+        assert!(!check.message.contains("missing-profile.yaml"));
+    }
+
+    #[test]
+    fn readiness_checks_fail_invalid_configured_profile_without_exposing_path() {
+        let path = temp_file_path("invalid-ready-profile.yaml");
+        fs::write(&path, "message_structure: [").expect("profile fixture should be written");
+        let path_text = path.display().to_string();
+        let config = ServerConfig {
+            profile_paths: vec![path_text.clone()],
+            ..ServerConfig::default()
+        };
+        let check = config
+            .readiness_checks()
+            .into_iter()
+            .find(|check| check.name == "configured_profiles")
+            .expect("configured profile check should exist");
+
+        assert_eq!(check.status, crate::models::ReadinessCheckStatus::Fail);
+        assert!(check.message.contains("configured profile 1"));
+        assert!(!check.message.contains(&path_text));
+        assert!(!check.message.contains("invalid-ready-profile.yaml"));
+
+        fs::remove_file(path).expect("profile fixture should be removed");
     }
 
     #[test]

--- a/crates/hl7v2-server/tests/health_endpoints_test.rs
+++ b/crates/hl7v2-server/tests/health_endpoints_test.rs
@@ -230,6 +230,63 @@ async fn test_ready_endpoint_returns_503_when_startup_check_failed() {
 }
 
 #[tokio::test]
+async fn test_ready_endpoint_does_not_expose_configured_profile_path_when_not_ready() {
+    let profile_path = std::env::temp_dir()
+        .join("hl7v2-sensitive-profile-root")
+        .join("missing-profile.yaml")
+        .display()
+        .to_string();
+    let config = hl7v2_server::ServerConfig {
+        profile_paths: vec![profile_path.clone()],
+        ..Default::default()
+    };
+    let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
+    let state = Arc::new(hl7v2_server::AppState {
+        start_time: Instant::now(),
+        metrics_handle: Arc::new(metrics_handle),
+        api_key: None,
+        cors_allowed_origins: Default::default(),
+        readiness_checks: config.readiness_checks(),
+        bundle_output_root: None,
+        ack_policy: Default::default(),
+        quarantine: Default::default(),
+    });
+    let app = hl7v2_server::build_router(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(!body_text.contains(&profile_path));
+    assert!(!body_text.contains("missing-profile.yaml"));
+
+    let ready: ReadyResponse = serde_json::from_str(&body_text).unwrap();
+    assert!(!ready.ready);
+    let check = ready
+        .checks
+        .iter()
+        .find(|check| check.name == "configured_profiles");
+    assert!(check.is_some(), "configured profile check should exist");
+    let check = check.unwrap();
+    assert_eq!(check.status, ReadinessCheckStatus::Fail);
+    assert!(check.message.contains("configured profile 1"));
+}
+
+#[tokio::test]
 async fn test_metrics_endpoint_returns_200() {
     let app = common::create_test_router();
 

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -215,7 +215,9 @@ Expected checks include:
 
 If `/ready` returns `503`, do not send traffic. Fix the failed check first:
 profile path, bundle root, quarantine root, bind address, or validation-report
-self-check.
+self-check. The public readiness response identifies failed configured profile
+checks by position instead of echoing local profile paths; use `--print-config`
+locally when you need to inspect the configured path list.
 
 ## 5. Validate After Redaction
 


### PR DESCRIPTION
## Summary
- stop `/ready` from echoing configured profile filesystem paths when profile readiness fails
- keep profile readiness checks load-bearing by reporting the failing configured profile by ordinal
- document the readiness safety behavior in the validation sidecar guide

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-server --test health_endpoints_test`
- `cargo +1.93.0 test -p hl7v2-server readiness`
- `cargo +1.93.0 test -p hl7v2-server --test config_print_test`
- `cargo +1.93.0 clippy -p hl7v2-server --all-targets -- -D warnings`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`
