### PR TITLE
server: add docker compose sidecar smoke

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+target
+dist
+*.log
+*.tmp
+issue-bundle
+target_*
+node_modules
+.venv
+__pycache__

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -68,70 +68,19 @@ docker run -p 8080:8080 hl7v2-rs:latest
 
 ### Docker Compose
 
-Create `docker-compose.yml`:
-
-```yaml
-version: '3.8'
-
-services:
-  hl7v2-server:
-    image: hl7v2-server:latest
-    ports:
-      - "8080:8080"
-    environment:
-      BIND_ADDRESS: "0.0.0.0:8080"
-      HL7V2_MAX_CONCURRENT: "200"
-      RUST_LOG: "info"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          cpus: '2.0'
-          memory: 512M
-        reservations:
-          cpus: '0.5'
-          memory: 128M
-
-  prometheus:
-    image: prom/prometheus:latest
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-    depends_on:
-      - hl7v2-server
-
-  grafana:
-    image: grafana/grafana:latest
-    ports:
-      - "3000:3000"
-    volumes:
-      - grafana_data:/var/lib/grafana
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-changeme}
-    depends_on:
-      - prometheus
-
-volumes:
-  prometheus_data:
-  grafana_data:
-```
-
-Start the stack:
+The checked-in Compose file runs the standalone `hl7v2-server` sidecar with
+configured bundle and quarantine roots:
 
 ```bash
-docker-compose up -d
+docker compose -f infrastructure/docker/docker-compose.yml up --build -d
+python tests/server_smoke/smoke.py
+docker compose -f infrastructure/docker/docker-compose.yml down -v
 ```
+
+The smoke script checks `/health`, `/ready`, `/hl7/validate-redacted`,
+`/hl7/bundle`, `/hl7/replay`, and `/hl7/corpus/diff` against the running
+sidecar. It uses `HL7V2_SERVER_URL` and `HL7V2_API_KEY` when set, defaulting to
+the local Compose values in `infrastructure/docker/sidecar.env.example`.
 
 ## Kubernetes Deployment
 

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -174,6 +174,18 @@ cargo run -q -p hl7v2-server
 
 The server binds `127.0.0.1:18080` from the config above.
 
+For a container smoke check from the repository root, use the checked-in
+Compose stack:
+
+```bash
+docker compose -f infrastructure/docker/docker-compose.yml up --build -d
+python tests/server_smoke/smoke.py
+docker compose -f infrastructure/docker/docker-compose.yml down -v
+```
+
+The smoke script exercises health, readiness, redacted validation, bundle,
+replay, and corpus diff against the running sidecar.
+
 ## 4. Check Readiness
 
 Readiness is the deployment gate:

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -1,72 +1,34 @@
-# Multi-stage Dockerfile for optimized hl7v2-rs builds
+# Multi-stage Dockerfile for the standalone HL7v2 validation sidecar.
 
-# Stage 1: Build
-FROM rust:1.93-alpine AS builder
+FROM rust:1.93-bookworm AS builder
 
-# Install build dependencies
-RUN apk add --no-cache \
-    musl-dev \
-    openssl-dev \
-    pkgconfig
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Copy manifest files only (for better caching)
-COPY Cargo.toml Cargo.lock ./
-COPY crates/hl7v2/Cargo.toml ./crates/hl7v2/Cargo.toml
-COPY crates/hl7v2-bench/Cargo.toml ./crates/hl7v2-bench/Cargo.toml
-COPY crates/hl7v2-python/Cargo.toml ./crates/hl7v2-python/Cargo.toml
-COPY crates/hl7v2-cli/Cargo.toml ./crates/hl7v2-cli/Cargo.toml
-COPY crates/hl7v2-server/Cargo.toml ./crates/hl7v2-server/Cargo.toml
-COPY crates/hl7v2-e2e-tests/Cargo.toml ./crates/hl7v2-e2e-tests/Cargo.toml
-COPY crates/hl7v2-test-utils/Cargo.toml ./crates/hl7v2-test-utils/Cargo.toml
-COPY xtask/Cargo.toml ./xtask/Cargo.toml
+COPY . .
 
-# Fetch dependencies (cached layer)
-RUN cargo fetch --locked
+RUN cargo build --release --locked -p hl7v2-server
 
-# Copy source code
-COPY crates/ ./crates/
-COPY examples/ ./examples/
-COPY xtask/ ./xtask/
+FROM debian:bookworm-slim AS runtime
 
-# Build release binary
-RUN cargo build --release --locked -p hl7v2-cli
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 hl7v2 \
+    && useradd --uid 1000 --gid hl7v2 --create-home --shell /usr/sbin/nologin hl7v2 \
+    && mkdir -p /etc/hl7v2 /var/lib/hl7v2/bundles /var/lib/hl7v2/quarantine /var/lib/hl7v2/profiles \
+    && chown -R hl7v2:hl7v2 /etc/hl7v2 /var/lib/hl7v2
 
-# Stage 2: Runtime
-FROM alpine:latest
+COPY --from=builder /app/target/release/hl7v2-server /usr/local/bin/hl7v2-server
 
-# Install runtime dependencies
-RUN apk add --no-cache \
-    ca-certificates \
-    libgcc \
-    openssl
-
-# Create non-root user
-RUN addgroup -g 1000 hl7v2 && \
-    adduser -D -u 1000 -G hl7v2 hl7v2
-
-# Copy binary from builder
-COPY --from=builder /app/target/release/hl7v2-cli /usr/local/bin/hl7v2
-
-# Copy configuration and profiles
-COPY profiles/ /var/lib/hl7v2/profiles/
-COPY schemas/ /var/lib/hl7v2/schemas/
-
-# Set up directories
-RUN mkdir -p /etc/hl7v2 /var/log/hl7v2 && \
-    chown -R hl7v2:hl7v2 /var/lib/hl7v2 /var/log/hl7v2
-
-# Switch to non-root user
 USER hl7v2
 
-# Expose ports
-EXPOSE 8080 2575
+EXPOSE 8080
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD ["/usr/local/bin/hl7v2", "health"] || exit 1
+    CMD curl -fsS http://localhost:8080/ready >/dev/null || exit 1
 
-# Default command
-ENTRYPOINT ["/usr/local/bin/hl7v2"]
-CMD ["server", "--config", "/etc/hl7v2/config.toml"]
+ENTRYPOINT ["hl7v2-server"]

--- a/infrastructure/docker/config/server.toml
+++ b/infrastructure/docker/config/server.toml
@@ -1,0 +1,19 @@
+# Local sidecar smoke configuration.
+
+[server]
+host = "0.0.0.0"
+port = 8080
+bundle_output_root = "/var/lib/hl7v2/bundles"
+
+[ack]
+mode = "original"
+accept_on = "valid"
+reject_on = ["parse_error", "validation_error"]
+include_error_text = true
+
+[quarantine]
+enabled = true
+path = "/var/lib/hl7v2/quarantine"
+write_redacted = true
+write_report = true
+write_bundle = true

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -1,151 +1,33 @@
-version: '3.8'
+name: hl7v2-sidecar
 
 services:
-  # HL7v2-rs server
   hl7v2-server:
     build:
       context: ../..
       dockerfile: infrastructure/docker/Dockerfile
-    container_name: hl7v2-server
+    image: hl7v2-server:local
     ports:
-      - "8080:8080"   # HTTP
-      - "8443:8443"   # HTTPS
-      - "2575:2575"   # MLLP
-      - "9090:9090"   # gRPC
+      - "8080:8080"
     environment:
-      - RUST_LOG=info
-      - RUST_BACKTRACE=1
-      - HL7V2_CONFIG=/etc/hl7v2/config.toml
+      BIND_ADDRESS: "0.0.0.0:8080"
+      HL7V2_CONFIG: "/etc/hl7v2/server.toml"
+      HL7V2_API_KEY: "${HL7V2_API_KEY:-dev-secret}"
+      HL7V2_PROFILE_PATHS: "/var/lib/hl7v2/profiles/generic.yaml"
+      RUST_LOG: "hl7v2_server=info,tower_http=warn"
+      RUST_LOG_FORMAT: "json"
     volumes:
-      - ./config:/etc/hl7v2:ro
-      - ./profiles:/var/lib/hl7v2/profiles:ro
-      - hl7v2-logs:/var/log/hl7v2
+      - ./config/server.toml:/etc/hl7v2/server.toml:ro
+      - ../../profiles:/var/lib/hl7v2/profiles:ro
+      - hl7v2-bundles:/var/lib/hl7v2/bundles
+      - hl7v2-quarantine:/var/lib/hl7v2/quarantine
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    networks:
-      - hl7v2-net
-    restart: unless-stopped
-
-  # PostgreSQL for profile caching and audit logs
-  postgres:
-    image: postgres:16-alpine
-    container_name: hl7v2-postgres
-    environment:
-      POSTGRES_DB: hl7v2
-      POSTGRES_USER: hl7v2
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./init-db.sql:/docker-entrypoint-initdb.d/init.sql:ro
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U hl7v2"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/ready"]
       interval: 10s
       timeout: 5s
-      retries: 5
-    networks:
-      - hl7v2-net
-    restart: unless-stopped
-
-  # Redis for distributed caching
-  redis:
-    image: redis:7-alpine
-    container_name: hl7v2-redis
-    ports:
-      - "6379:6379"
-    volumes:
-      - redis-data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - hl7v2-net
-    restart: unless-stopped
-
-  # Prometheus for metrics
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: hl7v2-prometheus
-    ports:
-      - "9091:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-    networks:
-      - hl7v2-net
-    restart: unless-stopped
-
-  # Grafana for visualization
-  grafana:
-    image: grafana/grafana:latest
-    container_name: hl7v2-grafana
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
-    volumes:
-      - grafana-data:/var/lib/grafana
-      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
-      - ./grafana/datasources:/etc/grafana/provisioning/datasources:ro
-    depends_on:
-      - prometheus
-    networks:
-      - hl7v2-net
-    restart: unless-stopped
-
-  # Jaeger for distributed tracing
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: hl7v2-jaeger
-    ports:
-      - "6831:6831/udp"  # Jaeger agent
-      - "16686:16686"    # Jaeger UI
-      - "14268:14268"    # Jaeger collector
-    environment:
-      - COLLECTOR_ZIPKIN_HOST_PORT=:9411
-    networks:
-      - hl7v2-net
-    restart: unless-stopped
-
-  # Open Policy Agent for policy enforcement
-  opa:
-    image: openpolicyagent/opa:latest
-    container_name: hl7v2-opa
-    ports:
-      - "8181:8181"
-    volumes:
-      - ../policies:/policies:ro
-    command:
-      - "run"
-      - "--server"
-      - "--addr=0.0.0.0:8181"
-      - "/policies"
-    networks:
-      - hl7v2-net
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
 
 volumes:
-  postgres-data:
-  redis-data:
-  prometheus-data:
-  grafana-data:
-  hl7v2-logs:
-
-networks:
-  hl7v2-net:
-    driver: bridge
+  hl7v2-bundles:
+  hl7v2-quarantine:

--- a/infrastructure/docker/sidecar.env.example
+++ b/infrastructure/docker/sidecar.env.example
@@ -1,0 +1,7 @@
+# Local docker-compose sidecar defaults.
+#
+# Copy or source this file only for local smoke testing. Do not commit real
+# deployment secrets.
+
+HL7V2_API_KEY=dev-secret
+HL7V2_SERVER_URL=http://127.0.0.1:8080

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -61,6 +61,15 @@ reason = "Spectral linting rules for the OpenAPI definition."
 covered_by = [".github/workflows/contracts.yml"]
 
 [[allow]]
+path = ".dockerignore"
+kind = "repo_config"
+owner = "platform"
+surface = "deployment"
+classification = "config"
+reason = "Docker build-context ignore list keeps local artifacts and generated outputs out of sidecar image builds."
+covered_by = ["docker compose -f infrastructure/docker/docker-compose.yml config"]
+
+[[allow]]
 path = ".tokeignore"
 kind = "repo_config"
 owner = "EffortlessMetrics"
@@ -330,6 +339,15 @@ surface = "tests"
 classification = "test"
 reason = "Python binding smoke tests verify wheel install, import, parse, and JSON conversion."
 covered_by = [".github/workflows/python-wheels.yml", "python tests/python_smoke/smoke.py"]
+
+[[allow]]
+glob = "tests/server_smoke/**"
+kind = "server_smoke_test"
+owner = "hl7v2-server"
+surface = "tests"
+classification = "test"
+reason = "Stdlib Python smoke harness verifies the deployed sidecar evidence loop over HTTP."
+covered_by = ["python tests/server_smoke/smoke.py"]
 
 # ---------------------------------------------------------------------------
 # Governance receipts (docs/ subtree)

--- a/tests/server_smoke/smoke.py
+++ b/tests/server_smoke/smoke.py
@@ -1,0 +1,255 @@
+"""Smoke test for a running hl7v2-server sidecar.
+
+The script intentionally uses only Python's standard library so it can run
+against a locally built Docker Compose sidecar without installing test
+dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+BASE_URL = os.environ.get("HL7V2_SERVER_URL", "http://127.0.0.1:8080").rstrip("/")
+API_KEY = os.environ.get("HL7V2_API_KEY", "dev-secret")
+TIMEOUT_SECONDS = float(os.environ.get("HL7V2_SERVER_SMOKE_TIMEOUT", "45"))
+
+PHI_MESSAGE = (
+    "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\r"
+    "PID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\r"
+    "NK1|1|Watcher^Nora||900 Support Way|5550001234\r"
+    "OBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r"
+)
+
+ORU_MESSAGE = (
+    "MSH|^~\\&|LAB|L|EHR|E|202605030101||ORU^R01|CTRL124|P|2.5\r"
+    "PID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r"
+    "OBR|1|ORD123|FIL456|718-7^Hemoglobin^LN\r"
+    "OBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r"
+)
+
+PROFILE = """
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+    max_uses: 1
+  - id: "PID"
+    required: true
+    max_uses: 1
+constraints:
+  - path: "PID.3"
+    required: true
+"""
+
+REDACTION_POLICY = """
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "hash patient identifier for support analysis"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "drop patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "drop date of birth"
+
+[[rules]]
+path = "PID.11"
+action = "drop"
+reason = "drop patient address"
+
+[[rules]]
+path = "PID.13"
+action = "drop"
+reason = "drop patient phone"
+
+[[rules]]
+path = "NK1.2"
+action = "drop"
+reason = "drop next-of-kin name"
+
+[[rules]]
+path = "NK1.4"
+action = "drop"
+reason = "drop next-of-kin address"
+
+[[rules]]
+path = "NK1.5"
+action = "drop"
+reason = "drop next-of-kin phone"
+"""
+
+PHI_SENTINELS = [
+    "Doe^John",
+    "123 Main St",
+    "5558675309",
+    "Watcher^Nora",
+    "900 Support Way",
+    "5550001234",
+]
+
+
+class SmokeFailure(RuntimeError):
+    """Raised when the sidecar smoke proof fails."""
+
+
+def request_json(method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if API_KEY:
+        headers["X-API-Key"] = API_KEY
+    request = Request(f"{BASE_URL}{path}", data=data, headers=headers, method=method)
+
+    try:
+        with urlopen(request, timeout=5) as response:
+            payload = response.read().decode("utf-8")
+    except HTTPError as error:
+        payload = error.read().decode("utf-8", errors="replace")
+        raise SmokeFailure(f"{method} {path} returned {error.code}: {payload}") from error
+    except URLError as error:
+        raise SmokeFailure(f"{method} {path} failed: {error}") from error
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as error:
+        raise SmokeFailure(f"{method} {path} returned non-JSON: {payload}") from error
+
+
+def assert_no_phi(label: str, value: Any) -> None:
+    text = json.dumps(value, sort_keys=True)
+    leaked = [sentinel for sentinel in PHI_SENTINELS if sentinel in text]
+    if leaked:
+        raise SmokeFailure(f"{label} leaked PHI sentinels: {', '.join(leaked)}")
+
+
+def wait_for_ready() -> dict[str, Any]:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            ready = request_json("GET", "/ready")
+            if ready.get("ready") is True:
+                return ready
+            last_error = SmokeFailure(f"/ready returned not-ready: {ready}")
+        except Exception as error:  # noqa: BLE001 - surface last startup failure in smoke output
+            last_error = error
+        time.sleep(1)
+
+    raise SmokeFailure(f"server did not become ready: {last_error}")
+
+
+def wait_for_health() -> dict[str, Any]:
+    deadline = time.monotonic() + TIMEOUT_SECONDS
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            health = request_json("GET", "/health")
+            if health.get("status") == "healthy":
+                return health
+            last_error = SmokeFailure(f"/health returned non-healthy status: {health}")
+        except Exception as error:  # noqa: BLE001 - surface last startup failure in smoke output
+            last_error = error
+        time.sleep(1)
+
+    raise SmokeFailure(f"server did not become healthy: {last_error}")
+
+
+def main() -> int:
+    wait_for_health()
+    ready = wait_for_ready()
+    if not any(check.get("name") == "validation_report" for check in ready.get("checks", [])):
+        raise SmokeFailure("/ready did not include validation_report self-check")
+
+    redacted = request_json(
+        "POST",
+        "/hl7/validate-redacted",
+        {
+            "message": PHI_MESSAGE,
+            "profile": PROFILE,
+            "redaction_policy": REDACTION_POLICY,
+            "include_redacted_hl7": True,
+            "report_schema_version": 2,
+            "redaction_receipt_schema_version": 2,
+        },
+    )
+    if redacted.get("validation_report", {}).get("valid") is not True:
+        raise SmokeFailure(f"redacted validation was not valid: {redacted}")
+    if redacted.get("redaction_receipt", {}).get("phi_removed") is not True:
+        raise SmokeFailure(f"redaction receipt did not remove PHI: {redacted}")
+    assert_no_phi("validate-redacted response", redacted)
+
+    bundle_id = f"smoke-{uuid.uuid4().hex}"
+    bundle = request_json(
+        "POST",
+        "/hl7/bundle",
+        {
+            "message": PHI_MESSAGE,
+            "profile": PROFILE,
+            "redaction_policy": REDACTION_POLICY,
+            "bundle_id": bundle_id,
+            "bundle_artifact_schema_version": 2,
+        },
+    )
+    if bundle.get("output_dir") != bundle_id:
+        raise SmokeFailure(f"bundle output id mismatch: {bundle}")
+    if bundle.get("validation_valid") is not True:
+        raise SmokeFailure(f"bundle validation was not valid: {bundle}")
+    assert_no_phi("bundle response", bundle)
+
+    replay = request_json(
+        "POST",
+        "/hl7/replay",
+        {"bundle_id": bundle_id, "replay_report_schema_version": 2},
+    )
+    if replay.get("schema_version") != "2" or replay.get("reproduced") is not True:
+        raise SmokeFailure(f"replay did not reproduce bundle: {replay}")
+    assert_no_phi("replay response", replay)
+
+    diff = request_json(
+        "POST",
+        "/hl7/corpus/diff",
+        {
+            "before": [{"id": "before-adt", "message": PHI_MESSAGE}],
+            "after": [
+                {"id": "after-adt", "message": PHI_MESSAGE},
+                {"id": "after-oru", "message": ORU_MESSAGE},
+            ],
+            "diff_schema_version": 2,
+        },
+    )
+    if diff.get("schema_version") != "2":
+        raise SmokeFailure(f"corpus diff did not return v2 schema: {diff}")
+    if "ORU^R01" not in diff.get("new_message_types", []):
+        raise SmokeFailure(f"corpus diff did not report new ORU^R01 type: {diff}")
+    assert_no_phi("corpus diff response", diff)
+
+    print(
+        "hl7v2-server smoke ok "
+        f"url={BASE_URL} bundle_id={bundle_id} checks={len(ready.get('checks', []))}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SmokeFailure as error:
+        print(f"hl7v2-server smoke failed: {error}", file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary
- switch the Docker image from the CLI wrapper to the standalone `hl7v2-server` sidecar binary
- replace the old compose stack with a minimal sidecar compose file using configured bundle/quarantine roots and JSON logs
- add a stdlib Python server smoke script that checks health, readiness, redacted validation, bundle, replay, and corpus diff against a running sidecar
- update deployment docs to point at the checked-in compose/smoke path

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `python -m py_compile tests/server_smoke/smoke.py`
- `python -c "import tomllib, pathlib; tomllib.loads(pathlib.Path('infrastructure/docker/config/server.toml').read_text()); print('server toml ok')"`
- `docker compose -f infrastructure/docker/docker-compose.yml config`
- local real-server smoke with `cargo +1.93.0 run -q -p hl7v2-server` on port 18081 and `python tests/server_smoke/smoke.py`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`

## Known gap
- I could not run `docker compose up --build` locally because Docker Desktop's Linux engine was not running in this environment. The compose file renders successfully, and the smoke script passed against a real locally started `hl7v2-server` process with the same endpoint/config shape.
