### PR TITLE
server: define evidence metrics contract

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -296,11 +296,22 @@ HL7V2_CONFIG=/etc/hl7v2/config.toml hl7v2-server
 The server exposes metrics at `/metrics`:
 
 **Key Metrics:**
-- `hl7v2_requests_total` - Total request count by endpoint and status
-- `hl7v2_request_duration_seconds` - Request latency histogram
-- `hl7v2_active_connections` - Current active connections
-- `hl7v2_parse_errors_total` - Parse error count
-- `hl7v2_validation_errors_total` - Validation error count
+- `hl7v2_requests_total` - HTTP request count by endpoint and status.
+- `hl7v2_request_duration_seconds` - HTTP request latency histogram by endpoint.
+- `hl7v2_messages_parsed_total` - Messages parsed by bounded evidence operation.
+- `hl7v2_messages_validated_total` - Messages validated by bounded evidence operation.
+- `hl7v2_message_size_bytes` - Input HL7 message size histogram.
+- `hl7v2_parse_failures_total` - Parse failures by bounded evidence operation.
+- `hl7v2_validation_failures_total` - Validation failures by bounded evidence operation.
+- `hl7v2_redaction_failures_total` - Redaction failures by bounded evidence operation.
+- `hl7v2_bundles_created_total` - Evidence bundles created by the server.
+- `hl7v2_replays_total` - Evidence replay attempts.
+- `hl7v2_replay_failures_total` - Replay attempts that did not reproduce.
+- `hl7v2_corpus_diffs_total` - Inline corpus diff requests completed by the server.
+
+Metric labels are intentionally low-cardinality. The server does not use raw
+HL7 payloads, profile YAML, redaction policies, local paths, raw message control
+IDs, raw bundle IDs, or patient identifiers as metric labels.
 
 **Prometheus Configuration:**
 
@@ -323,7 +334,7 @@ scrape_configs:
 Import dashboards from `infrastructure/grafana/`:
 
 1. **HL7v2 Server Overview**: Request rates, latencies, error rates
-2. **HL7v2 Validation**: Validation success/failure rates, profile usage
+2. **HL7v2 Validation**: Validation success/failure rates by bounded operation
 3. **HL7v2 Performance**: P50/P95/P99 latencies, throughput
 
 ### Health Checks

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -21,6 +21,13 @@ Useful release-candidate workflows include:
 - `POST /hl7/ack-policy` for policy-driven ACK/NAK decisions.
 - `/metrics` for Prometheus metrics.
 
+The stable Prometheus contract includes HTTP request metrics plus evidence-loop
+counters for parse failures, validation failures, redaction failures, bundles
+created, replay attempts/failures, and inline corpus diffs. Labels are bounded
+operation/status values only; raw HL7 payloads, profile YAML, redaction policies,
+local paths, raw bundle IDs, raw message control IDs, and patient identifiers
+are not metric labels.
+
 The server reuses the same evidence contracts as the CLI and `hl7v2` library
 instead of defining a server-only report language.
 

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -44,7 +44,11 @@ pub async fn parse_handler(
     State(_state): State<Arc<AppState>>,
     Json(request): Json<ParseRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
+    let message = parse_request_message_with_metrics(
+        request.message.as_bytes(),
+        request.mllp_framed,
+        crate::metrics::operation::PARSE,
+    )?;
 
     // Extract metadata
     let metadata = extract_metadata(&message)?;
@@ -83,7 +87,11 @@ pub async fn validate_handler(
     Json(request): Json<ValidateRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let report_schema_version = requested_report_schema_version(request.report_schema_version)?;
-    let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
+    let message = parse_request_message_with_metrics(
+        request.message.as_bytes(),
+        request.mllp_framed,
+        crate::metrics::operation::VALIDATE,
+    )?;
 
     // Extract metadata
     let metadata = extract_metadata(&message)?;
@@ -101,6 +109,7 @@ pub async fn validate_handler(
         Some(profile.message_structure.clone()),
         issues.clone(),
     );
+    crate::metrics::record_validation_result(crate::metrics::operation::VALIDATE, report.valid);
     let validation_report_v2 = (report_schema_version == 2)
         .then(|| validation_report_v2_for_server(&report, &request.profile, &profile));
 
@@ -174,10 +183,17 @@ pub async fn validate_redacted_handler(
     let quarantine_schema_version =
         requested_quarantine_schema_version(request.quarantine_schema_version)?;
     let raw_input = request.message.into_bytes();
-    let mut message = parse_request_message(&raw_input, request.mllp_framed)?;
+    let mut message = parse_request_message_with_metrics(
+        &raw_input,
+        request.mllp_framed,
+        crate::metrics::operation::VALIDATE_REDACTED,
+    )?;
     let log_context = MessageLogContext::from_message(&message);
-    let receipt =
-        redact_message(&mut message, &request.redaction_policy).map_err(AppError::Redaction)?;
+    let receipt = redact_message_with_metrics(
+        &mut message,
+        &request.redaction_policy,
+        crate::metrics::operation::VALIDATE_REDACTED,
+    )?;
     let redacted_hl7 = String::from_utf8(hl7v2::write(&message))
         .map_err(|error| AppError::Internal(format!("redacted message was not UTF-8: {error}")))?;
 
@@ -188,6 +204,10 @@ pub async fn validate_redacted_handler(
         &message,
         Some(profile.message_structure.clone()),
         issues,
+    );
+    crate::metrics::record_validation_result(
+        crate::metrics::operation::VALIDATE_REDACTED,
+        validation_report.valid,
     );
     let validation_report_v2 = (report_schema_version == 2)
         .then(|| validation_report_v2_for_server(&validation_report, &request.profile, &profile));
@@ -259,10 +279,17 @@ pub async fn bundle_handler(
         .ok_or(AppError::BundleOutputNotConfigured)?;
 
     let raw_input = request.message.into_bytes();
-    let mut message = parse_request_message(&raw_input, request.mllp_framed)?;
+    let mut message = parse_request_message_with_metrics(
+        &raw_input,
+        request.mllp_framed,
+        crate::metrics::operation::BUNDLE,
+    )?;
     let log_context = MessageLogContext::from_message(&message);
-    let receipt =
-        redact_message(&mut message, &request.redaction_policy).map_err(AppError::Redaction)?;
+    let receipt = redact_message_with_metrics(
+        &mut message,
+        &request.redaction_policy,
+        crate::metrics::operation::BUNDLE,
+    )?;
     let redacted_hl7 = String::from_utf8(hl7v2::write(&message))
         .map_err(|error| AppError::Internal(format!("redacted message was not UTF-8: {error}")))?;
 
@@ -271,6 +298,10 @@ pub async fn bundle_handler(
     let issues = hl7v2::validate(&message, &profile);
     let validation_report =
         hl7v2::ValidationReport::from_issues(&message, Some("profile.yaml".to_string()), issues);
+    crate::metrics::record_validation_result(
+        crate::metrics::operation::BUNDLE,
+        validation_report.valid,
+    );
 
     let summary =
         crate::evidence::write_evidence_bundle(crate::evidence::EvidenceBundleWriteRequest {
@@ -286,6 +317,7 @@ pub async fn bundle_handler(
             artifact_schema_version,
         })
         .map_err(AppError::from)?;
+    crate::metrics::record_bundle_created();
 
     tracing::info!(
         target: "hl7v2_server::evidence",
@@ -323,6 +355,7 @@ pub async fn replay_handler(
         .map_err(AppError::from)?;
 
     if !bundle_dir.is_dir() {
+        crate::metrics::record_replay_result(false);
         return Err(AppError::BundleNotFound(format!(
             "bundle_id '{}' was not found",
             request.bundle_id
@@ -330,6 +363,7 @@ pub async fn replay_handler(
     }
 
     let report = hl7v2::evidence::replay_evidence_bundle(&bundle_dir, "hl7v2-server");
+    crate::metrics::record_replay_result(report.reproduced);
     let message_type = report.message_type.as_deref().unwrap_or("unknown");
     let validation_status = report
         .validation_valid
@@ -431,6 +465,7 @@ pub async fn corpus_diff_handler(
 
     let diff =
         hl7v2::synthetic::corpus::diff_corpus_fingerprints(&before_fingerprint, &after_fingerprint);
+    crate::metrics::record_corpus_diff();
     let response = if schema_version == 2 {
         serde_json::to_value(diff.to_v2("hl7v2-server"))
     } else {
@@ -446,7 +481,11 @@ pub async fn ack_handler(
     State(_state): State<Arc<AppState>>,
     Json(request): Json<AckRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let message = parse_request_message(request.message.as_bytes(), request.mllp_framed)?;
+    let message = parse_request_message_with_metrics(
+        request.message.as_bytes(),
+        request.mllp_framed,
+        crate::metrics::operation::ACK,
+    )?;
     let log_context = MessageLogContext::from_message(&message);
     let ack_code = map_ack_code(request.code);
 
@@ -494,28 +533,35 @@ pub async fn ack_policy_handler(
     let raw_input = request.message.into_bytes();
     let policy = &state.ack_policy;
 
-    let (message, validation_report, decision) =
-        match parse_request_message(&raw_input, request.mllp_framed) {
-            Ok(message) => {
-                let profile = hl7v2::load_profile_checked(&request.profile)
-                    .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
-                let issues = hl7v2::validate(&message, &profile);
-                let report = hl7v2::ValidationReport::from_issues(
-                    &message,
-                    Some(profile.message_structure.clone()),
-                    issues,
-                );
-                let decision = ack_policy_decision_for_validation(policy, &report)?;
-                (message, Some(report), decision)
-            }
-            Err(error) if policy.rejects(AckPolicyRejectCondition::ParseError) => {
-                let message = parse_msh_for_ack_policy(&raw_input, request.mllp_framed)
-                    .map_err(|_fallback_error| error)?;
-                let decision = ack_policy_reject_decision(policy, AckPolicyReason::ParseError, 0);
-                (message, None, decision)
-            }
-            Err(error) => return Err(error),
-        };
+    let (message, validation_report, decision) = match parse_request_message_with_metrics(
+        &raw_input,
+        request.mllp_framed,
+        crate::metrics::operation::ACK_POLICY,
+    ) {
+        Ok(message) => {
+            let profile = hl7v2::load_profile_checked(&request.profile)
+                .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
+            let issues = hl7v2::validate(&message, &profile);
+            let report = hl7v2::ValidationReport::from_issues(
+                &message,
+                Some(profile.message_structure.clone()),
+                issues,
+            );
+            crate::metrics::record_validation_result(
+                crate::metrics::operation::ACK_POLICY,
+                report.valid,
+            );
+            let decision = ack_policy_decision_for_validation(policy, &report)?;
+            (message, Some(report), decision)
+        }
+        Err(error) if policy.rejects(AckPolicyRejectCondition::ParseError) => {
+            let message = parse_msh_for_ack_policy(&raw_input, request.mllp_framed)
+                .map_err(|_fallback_error| error)?;
+            let decision = ack_policy_reject_decision(policy, AckPolicyReason::ParseError, 0);
+            (message, None, decision)
+        }
+        Err(error) => return Err(error),
+    };
     let log_context = MessageLogContext::from_message(&message);
 
     let ack_code = ack_code_from_policy_decision(&decision)?;
@@ -584,8 +630,14 @@ pub async fn normalize_handler(
 
     let normalized_bytes = hl7v2::normalize(input, request.options.canonical_delimiters)
         .map_err(|e| AppError::Parse(format!("Normalize error: {}", e)))?;
-    let normalized_message = hl7v2::parse(&normalized_bytes)
-        .map_err(|e| AppError::Parse(format!("Normalized message parse error: {}", e)))?;
+    let normalized_message = hl7v2::parse(&normalized_bytes).map_err(|e| {
+        crate::metrics::record_parse_failure(crate::metrics::operation::NORMALIZE);
+        AppError::Parse(format!("Normalized message parse error: {}", e))
+    })?;
+    crate::metrics::record_parse_success(
+        crate::metrics::operation::NORMALIZE,
+        normalized_bytes.len(),
+    );
     let metadata = extract_metadata(&normalized_message)?;
     let log_context = MessageLogContext::from_message(&normalized_message);
 
@@ -624,6 +676,37 @@ fn parse_request_message(
             .map_err(|e| AppError::Parse(format!("MLLP parse error: {}", e)))
     } else {
         hl7v2::parse(message_bytes).map_err(|e| AppError::Parse(format!("Parse error: {}", e)))
+    }
+}
+
+fn parse_request_message_with_metrics(
+    message_bytes: &[u8],
+    mllp_framed: bool,
+    operation: &'static str,
+) -> Result<hl7v2::Message, AppError> {
+    match parse_request_message(message_bytes, mllp_framed) {
+        Ok(message) => {
+            crate::metrics::record_parse_success(operation, message_bytes.len());
+            Ok(message)
+        }
+        Err(error) => {
+            crate::metrics::record_parse_failure(operation);
+            Err(error)
+        }
+    }
+}
+
+fn redact_message_with_metrics(
+    message: &mut hl7v2::Message,
+    policy_toml: &str,
+    operation: &'static str,
+) -> Result<RedactionReceipt, AppError> {
+    match redact_message(message, policy_toml) {
+        Ok(receipt) => Ok(receipt),
+        Err(error) => {
+            crate::metrics::record_redaction_failure(operation);
+            Err(AppError::Redaction(error))
+        }
     }
 }
 

--- a/crates/hl7v2-server/src/metrics.rs
+++ b/crates/hl7v2-server/src/metrics.rs
@@ -9,8 +9,15 @@
 //! - `hl7v2_request_duration_seconds`: Request duration histogram by endpoint
 //! - `hl7v2_messages_parsed_total`: Total number of messages successfully parsed
 //! - `hl7v2_messages_validated_total`: Total number of messages validated
-//! - `hl7v2_validation_errors_total`: Total number of validation errors
-//! - `hl7v2_parse_errors_total`: Total number of parse errors
+//! - `hl7v2_parse_failures_total`: Parse failures by bounded operation label
+//! - `hl7v2_validation_failures_total`: Validation failures by bounded operation label
+//! - `hl7v2_redaction_failures_total`: Redaction failures by bounded operation label
+//! - `hl7v2_bundles_created_total`: Evidence bundles created by the server
+//! - `hl7v2_replays_total`: Evidence replay attempts
+//! - `hl7v2_replay_failures_total`: Evidence replay attempts that did not reproduce
+//! - `hl7v2_corpus_diffs_total`: Inline corpus diff requests completed by the server
+//! - `hl7v2_parse_errors_total`: Compatibility parse error counter
+//! - `hl7v2_validation_errors_total`: Compatibility validation error counter
 //!
 //! ## Usage
 //!
@@ -22,7 +29,7 @@
 //!
 //! // Record metrics
 //! metrics::record_request("/hl7/parse", "200", 0.05);
-//! metrics::increment_messages_parsed();
+//! metrics::record_parse_success(metrics::operation::PARSE, 256);
 //! ```
 
 use axum::{
@@ -36,6 +43,32 @@ use std::sync::{Arc, OnceLock};
 /// Global metrics handle, initialized once
 static METRICS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
 
+/// Bounded operation labels for evidence workflow metrics.
+///
+/// These labels are deliberately static and low-cardinality. Do not use raw
+/// request data, profile names, message IDs, bundle IDs, file paths, or route
+/// parameters as metric labels.
+pub mod operation {
+    /// `POST /hl7/ack`.
+    pub const ACK: &str = "ack";
+    /// `POST /hl7/ack-policy`.
+    pub const ACK_POLICY: &str = "ack_policy";
+    /// `POST /hl7/bundle`.
+    pub const BUNDLE: &str = "bundle";
+    /// `POST /hl7/corpus/diff`.
+    pub const CORPUS_DIFF: &str = "corpus_diff";
+    /// `POST /hl7/normalize`.
+    pub const NORMALIZE: &str = "normalize";
+    /// `POST /hl7/parse`.
+    pub const PARSE: &str = "parse";
+    /// `POST /hl7/replay`.
+    pub const REPLAY: &str = "replay";
+    /// `POST /hl7/validate`.
+    pub const VALIDATE: &str = "validate";
+    /// `POST /hl7/validate-redacted`.
+    pub const VALIDATE_REDACTED: &str = "validate_redacted";
+}
+
 /// Initialize the Prometheus metrics recorder
 ///
 /// This should be called once at application startup before any metrics are recorded.
@@ -47,6 +80,8 @@ static METRICS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
 pub fn init_metrics_recorder() -> PrometheusHandle {
     METRICS_HANDLE
         .get_or_init(|| {
+            describe_metrics();
+
             PrometheusBuilder::new()
                 .set_buckets_for_metric(
                     Matcher::Full("hl7v2_request_duration_seconds".to_string()),
@@ -59,6 +94,62 @@ pub fn init_metrics_recorder() -> PrometheusHandle {
                 .expect("Failed to install Prometheus recorder")
         })
         .clone()
+}
+
+fn describe_metrics() {
+    metrics::describe_counter!(
+        "hl7v2_requests_total",
+        "Total HTTP requests by endpoint and HTTP status code."
+    );
+    metrics::describe_histogram!(
+        "hl7v2_request_duration_seconds",
+        "HTTP request latency in seconds by endpoint."
+    );
+    metrics::describe_counter!(
+        "hl7v2_messages_parsed_total",
+        "HL7 messages parsed successfully by server evidence workflows."
+    );
+    metrics::describe_counter!(
+        "hl7v2_messages_validated_total",
+        "HL7 messages validated by server evidence workflows."
+    );
+    metrics::describe_histogram!(
+        "hl7v2_message_size_bytes",
+        "Input HL7 message size in bytes."
+    );
+    metrics::describe_counter!(
+        "hl7v2_parse_failures_total",
+        "Parse failures by bounded server operation label."
+    );
+    metrics::describe_counter!(
+        "hl7v2_validation_failures_total",
+        "Validation failures by bounded server operation label."
+    );
+    metrics::describe_counter!(
+        "hl7v2_redaction_failures_total",
+        "Redaction failures by bounded server operation label."
+    );
+    metrics::describe_counter!(
+        "hl7v2_bundles_created_total",
+        "Evidence bundles created by the server."
+    );
+    metrics::describe_counter!("hl7v2_replays_total", "Evidence replay attempts.");
+    metrics::describe_counter!(
+        "hl7v2_replay_failures_total",
+        "Evidence replay attempts that did not reproduce."
+    );
+    metrics::describe_counter!(
+        "hl7v2_corpus_diffs_total",
+        "Inline corpus diff requests completed by the server."
+    );
+    metrics::describe_counter!(
+        "hl7v2_parse_errors_total",
+        "Compatibility counter for parse errors."
+    );
+    metrics::describe_counter!(
+        "hl7v2_validation_errors_total",
+        "Compatibility counter for validation errors."
+    );
 }
 
 /// Record an HTTP request
@@ -80,24 +171,70 @@ pub fn record_request(endpoint: &str, status: &str, duration_seconds: f64) {
     .record(duration_seconds);
 }
 
+/// Record a successfully parsed HL7 message for an evidence workflow.
+pub fn record_parse_success(operation: &'static str, size_bytes: usize) {
+    metrics::counter!("hl7v2_messages_parsed_total", "operation" => operation).increment(1);
+    record_message_size(size_bytes);
+}
+
+/// Record a parse failure for an evidence workflow.
+pub fn record_parse_failure(operation: &'static str) {
+    metrics::counter!("hl7v2_parse_failures_total", "operation" => operation).increment(1);
+    metrics::counter!("hl7v2_parse_errors_total").increment(1);
+}
+
+/// Record a validation result for an evidence workflow.
+pub fn record_validation_result(operation: &'static str, valid: bool) {
+    metrics::counter!("hl7v2_messages_validated_total", "operation" => operation).increment(1);
+
+    if !valid {
+        metrics::counter!("hl7v2_validation_failures_total", "operation" => operation).increment(1);
+        metrics::counter!("hl7v2_validation_errors_total").increment(1);
+    }
+}
+
+/// Record a redaction failure for an evidence workflow.
+pub fn record_redaction_failure(operation: &'static str) {
+    metrics::counter!("hl7v2_redaction_failures_total", "operation" => operation).increment(1);
+}
+
+/// Record a successfully written evidence bundle.
+pub fn record_bundle_created() {
+    metrics::counter!("hl7v2_bundles_created_total").increment(1);
+}
+
+/// Record an evidence replay attempt.
+pub fn record_replay_result(reproduced: bool) {
+    metrics::counter!("hl7v2_replays_total").increment(1);
+
+    if !reproduced {
+        metrics::counter!("hl7v2_replay_failures_total").increment(1);
+    }
+}
+
+/// Record a completed inline corpus diff request.
+pub fn record_corpus_diff() {
+    metrics::counter!("hl7v2_corpus_diffs_total").increment(1);
+}
+
 /// Increment the count of successfully parsed messages
 pub fn increment_messages_parsed() {
-    metrics::counter!("hl7v2_messages_parsed_total").increment(1);
+    metrics::counter!("hl7v2_messages_parsed_total", "operation" => "unspecified").increment(1);
 }
 
 /// Increment the count of validated messages
 pub fn increment_messages_validated() {
-    metrics::counter!("hl7v2_messages_validated_total").increment(1);
+    metrics::counter!("hl7v2_messages_validated_total", "operation" => "unspecified").increment(1);
 }
 
 /// Increment the count of validation errors
 pub fn increment_validation_errors() {
-    metrics::counter!("hl7v2_validation_errors_total").increment(1);
+    record_validation_result("unspecified", false);
 }
 
 /// Increment the count of parse errors
 pub fn increment_parse_errors() {
-    metrics::counter!("hl7v2_parse_errors_total").increment(1);
+    record_parse_failure("unspecified");
 }
 
 /// Record message size in bytes
@@ -180,6 +317,10 @@ mod tests {
         increment_messages_validated();
         increment_validation_errors();
         increment_parse_errors();
+        record_redaction_failure(operation::VALIDATE_REDACTED);
+        record_bundle_created();
+        record_replay_result(false);
+        record_corpus_diff();
         // No panic means success
     }
 
@@ -188,5 +329,40 @@ mod tests {
         // Test recording message size
         record_message_size(1024);
         // No panic means success
+    }
+
+    #[test]
+    fn test_evidence_contract_metrics_render() {
+        let handle = init_metrics_recorder();
+
+        record_request("/hl7/validate", "200", 0.015);
+        record_parse_success(operation::PARSE, 256);
+        record_parse_failure(operation::VALIDATE);
+        record_validation_result(operation::VALIDATE, false);
+        record_redaction_failure(operation::BUNDLE);
+        record_bundle_created();
+        record_replay_result(false);
+        record_corpus_diff();
+
+        let output = handle.render();
+        for metric_name in [
+            "hl7v2_requests_total",
+            "hl7v2_request_duration_seconds",
+            "hl7v2_messages_parsed_total",
+            "hl7v2_messages_validated_total",
+            "hl7v2_message_size_bytes",
+            "hl7v2_parse_failures_total",
+            "hl7v2_validation_failures_total",
+            "hl7v2_redaction_failures_total",
+            "hl7v2_bundles_created_total",
+            "hl7v2_replays_total",
+            "hl7v2_replay_failures_total",
+            "hl7v2_corpus_diffs_total",
+        ] {
+            assert!(
+                output.contains(metric_name),
+                "Prometheus output should include {metric_name}; output was: {output}"
+            );
+        }
     }
 }

--- a/crates/hl7v2-server/tests/health_endpoints_test.rs
+++ b/crates/hl7v2-server/tests/health_endpoints_test.rs
@@ -344,3 +344,68 @@ async fn test_metrics_endpoint_returns_prometheus_format() {
         }
     );
 }
+
+#[tokio::test]
+async fn test_metrics_endpoint_exposes_evidence_contract_metrics() {
+    let app = common::create_test_router();
+
+    hl7v2_server::metrics::record_request("/hl7/validate", "200", 0.015);
+    hl7v2_server::metrics::record_parse_success(hl7v2_server::metrics::operation::PARSE, 128);
+    hl7v2_server::metrics::record_parse_failure(hl7v2_server::metrics::operation::VALIDATE);
+    hl7v2_server::metrics::record_validation_result(
+        hl7v2_server::metrics::operation::VALIDATE,
+        false,
+    );
+    hl7v2_server::metrics::record_redaction_failure(
+        hl7v2_server::metrics::operation::VALIDATE_REDACTED,
+    );
+    hl7v2_server::metrics::record_bundle_created();
+    hl7v2_server::metrics::record_replay_result(false);
+    hl7v2_server::metrics::record_corpus_diff();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+    for metric_name in [
+        "hl7v2_requests_total",
+        "hl7v2_request_duration_seconds",
+        "hl7v2_messages_parsed_total",
+        "hl7v2_messages_validated_total",
+        "hl7v2_message_size_bytes",
+        "hl7v2_parse_failures_total",
+        "hl7v2_validation_failures_total",
+        "hl7v2_redaction_failures_total",
+        "hl7v2_bundles_created_total",
+        "hl7v2_replays_total",
+        "hl7v2_replay_failures_total",
+        "hl7v2_corpus_diffs_total",
+    ] {
+        assert!(
+            body_str.contains(metric_name),
+            "metrics response should include {metric_name}; body was: {body_str}"
+        );
+    }
+
+    for forbidden in ["MRN123", "Doe", "John", "PID|"] {
+        assert!(
+            !body_str.contains(forbidden),
+            "metrics response must not contain fixture PHI sentinel {forbidden}"
+        );
+    }
+}

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -477,7 +477,7 @@ curl http://localhost:8080/ready
 **Prometheus Metrics:**
 ```bash
 curl http://localhost:8080/metrics
-# Returns: hl7v2_requests_total{method="POST",path="/hl7/parse",status="200"} 42 ...
+# Returns: hl7v2_requests_total{endpoint="/hl7/parse",status="200"} 42 ...
 ```
 
 ---

--- a/docs/adr/0014-observability-architecture.md
+++ b/docs/adr/0014-observability-architecture.md
@@ -26,9 +26,8 @@ We will adopt a **Prometheus-first** metrics strategy combined with **Structured
 We use `metrics` and `metrics-exporter-prometheus` to expose a `/metrics` endpoint.
 
 **Core Metrics Categories:**
-- **HTTP Metrics**: `hl7v2_requests_total` (labels: method, path, status), `hl7v2_request_duration_seconds`.
-- **HL7 Logic Metrics**: `hl7v2_parse_errors_total`, `hl7v2_validation_errors_total`.
-- **System Metrics**: `hl7v2_active_connections`, `hl7v2_uptime_seconds`.
+- **HTTP Metrics**: `hl7v2_requests_total` (labels: endpoint, status), `hl7v2_request_duration_seconds`.
+- **Evidence Workflow Metrics**: `hl7v2_parse_failures_total`, `hl7v2_validation_failures_total`, `hl7v2_redaction_failures_total`, `hl7v2_bundles_created_total`, `hl7v2_replays_total`, `hl7v2_replay_failures_total`, `hl7v2_corpus_diffs_total`.
 - **Resource Metrics**: `hl7v2_message_size_bytes`.
 
 ### 2. Logging (Tracing)

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -444,6 +444,27 @@ curl http://127.0.0.1:18080/metrics
 Use `/health` for process liveness. Use `/ready` for deployment readiness. Use
 the evidence endpoints for interface decisions.
 
+The Prometheus metrics contract is intentionally small and low-cardinality:
+
+```text
+hl7v2_requests_total
+hl7v2_request_duration_seconds
+hl7v2_messages_parsed_total
+hl7v2_messages_validated_total
+hl7v2_message_size_bytes
+hl7v2_parse_failures_total
+hl7v2_validation_failures_total
+hl7v2_redaction_failures_total
+hl7v2_bundles_created_total
+hl7v2_replays_total
+hl7v2_replay_failures_total
+hl7v2_corpus_diffs_total
+```
+
+Metric labels use bounded operation/status values. They do not include raw HL7
+payloads, profile YAML, redaction policies, local filesystem roots, raw bundle
+IDs, raw message control IDs, or patient identifiers.
+
 The server also emits structured evidence workflow logs for parse, validate,
 validate-redacted, bundle, replay, ACK, and ACK-policy requests. The useful
 fields are intentionally operational rather than payload-bearing:

--- a/infrastructure/grafana/README.md
+++ b/infrastructure/grafana/README.md
@@ -10,10 +10,10 @@ Production-ready Grafana dashboards for monitoring HL7v2 message processing, val
 
 **Key Metrics**:
 - **Request Rate**: Requests per second by endpoint and status code
-- **Active Connections**: Current concurrent connections with thresholds
+- **Evidence Failures**: Parse, validation, and redaction failure rate
 - **Request Latency**: P50/P95/P99 latency percentiles by endpoint
 - **HTTP Status Codes**: 2xx (success), 4xx (client error), 5xx (server error) breakdown
-- **Parse Errors**: Count of message parsing failures (last hour)
+- **Parse Failures**: Count of message parsing failures (last hour)
 - **Memory Usage**: Resident memory (RSS) over time
 - **CPU Usage**: CPU utilization percentage
 
@@ -32,9 +32,9 @@ Production-ready Grafana dashboards for monitoring HL7v2 message processing, val
 **Key Metrics**:
 - **Validation Results**: Valid vs invalid message counts (5-minute window)
 - **Validation Success Rate**: Percentage gauge with color-coded thresholds
-- **Top Profiles by Validation Rate**: Most frequently used conformance profiles
-- **Validation Errors by Type**: Error categorization over time
-- **Top 20 Validation Errors**: Table of most common errors with counts
+- **Top Operations by Validation Rate**: Bounded evidence workflow validation rates
+- **Validation Failures by Operation**: Failure categorization over time
+- **Top Validation Failure Series**: Table of common failure series with counts
 
 **Use Cases**:
 - Data quality monitoring
@@ -233,19 +233,25 @@ Place dashboard JSON files in the configured path.
 |--------|------|-------------|--------|
 | `hl7v2_requests_total` | Counter | Total HTTP requests | endpoint, status |
 | `hl7v2_request_duration_seconds` | Histogram | Request latency | endpoint |
-| `hl7v2_active_connections` | Gauge | Current active connections | - |
-| `hl7v2_parse_errors_total` | Counter | Parse error count | error_type |
-| `hl7v2_validation_errors_total` | Counter | Validation error count | error_type |
-| `process_resident_memory_bytes` | Gauge | Memory usage (RSS) | - |
-| `process_cpu_seconds_total` | Counter | CPU time | - |
+| `hl7v2_messages_parsed_total` | Counter | Messages parsed by evidence workflow | operation |
+| `hl7v2_messages_validated_total` | Counter | Messages validated by evidence workflow | operation |
+| `hl7v2_message_size_bytes` | Summary | Input HL7 message size | - |
+| `hl7v2_parse_failures_total` | Counter | Parse failures by evidence workflow | operation |
+| `hl7v2_validation_failures_total` | Counter | Validation failures by evidence workflow | operation |
+| `hl7v2_redaction_failures_total` | Counter | Redaction failures by evidence workflow | operation |
 
-### Validation Metrics
+### Evidence Workflow Metrics
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|--------|
-| `hl7v2_validation_total` | Counter | Validation attempts | profile, result |
-| `hl7v2_validation_errors_total` | Counter | Validation errors | profile, error_type |
-| `hl7v2_profile_load_time_seconds` | Histogram | Profile load time | profile |
+| `hl7v2_bundles_created_total` | Counter | Evidence bundles created by the server | - |
+| `hl7v2_replays_total` | Counter | Evidence replay attempts | - |
+| `hl7v2_replay_failures_total` | Counter | Replay attempts that did not reproduce | - |
+| `hl7v2_corpus_diffs_total` | Counter | Inline corpus diff requests completed by the server | - |
+
+Labels must stay low-cardinality. Do not add raw HL7 payloads, profile YAML,
+redaction policy TOML, local filesystem roots, raw message control IDs, raw
+bundle IDs, or patient identifiers as labels.
 
 ## Alerting
 
@@ -303,9 +309,9 @@ groups:
       - alert: HL7v2LowValidationSuccessRate
         expr: |
           (
-            sum(rate(hl7v2_validation_total{result="valid"}[10m]))
+            sum(rate(hl7v2_messages_validated_total[10m])) - sum(rate(hl7v2_validation_failures_total[10m]))
             /
-            sum(rate(hl7v2_validation_total[10m]))
+            sum(rate(hl7v2_messages_validated_total[10m]))
           ) < 0.90
         for: 10m
         labels:

--- a/infrastructure/grafana/alerts/hl7v2-server.yml
+++ b/infrastructure/grafana/alerts/hl7v2-server.yml
@@ -124,9 +124,9 @@ groups:
       - alert: HL7v2LowValidationSuccessRate
         expr: |
           (
-            sum(rate(hl7v2_validation_total{result="valid"}[10m]))
+            sum(rate(hl7v2_messages_validated_total[10m])) - sum(rate(hl7v2_validation_failures_total[10m]))
             /
-            sum(rate(hl7v2_validation_total[10m]))
+            sum(rate(hl7v2_messages_validated_total[10m]))
           ) < 0.90
         for: 10m
         labels:
@@ -142,9 +142,9 @@ groups:
       - alert: HL7v2CriticalValidationSuccessRate
         expr: |
           (
-            sum(rate(hl7v2_validation_total{result="valid"}[10m]))
+            sum(rate(hl7v2_messages_validated_total[10m])) - sum(rate(hl7v2_validation_failures_total[10m]))
             /
-            sum(rate(hl7v2_validation_total[10m]))
+            sum(rate(hl7v2_messages_validated_total[10m]))
           ) < 0.50
         for: 5m
         labels:
@@ -159,7 +159,7 @@ groups:
       # High parse error rate
       - alert: HL7v2HighParseErrorRate
         expr: |
-          rate(hl7v2_parse_errors_total[5m]) > 1
+          sum(rate(hl7v2_parse_failures_total[5m])) > 1
         for: 5m
         labels:
           severity: warning
@@ -167,26 +167,12 @@ groups:
           team: platform
         annotations:
           summary: "High parse error rate (>1/s)"
-          description: "Parse error rate is {{ $value }} errors/second for {{ $labels.error_type }}"
+          description: "Parse failure rate is {{ $value }} failures/second."
           runbook_url: "https://github.com/EffortlessMetrics/hl7v2-rs/wiki/Runbook-Parse-Errors"
 
   - name: hl7v2_capacity
     interval: 1m
     rules:
-      # Approaching concurrency limit
-      - alert: HL7v2ApproachingConcurrencyLimit
-        expr: |
-          hl7v2_active_connections > 80
-        for: 5m
-        labels:
-          severity: warning
-          component: hl7v2-server
-          team: platform
-        annotations:
-          summary: "Approaching concurrency limit (>80 connections)"
-          description: "Active connections: {{ $value }} (limit: 100)"
-          runbook_url: "https://github.com/EffortlessMetrics/hl7v2-rs/wiki/Runbook-Capacity"
-
       # High 503 rate (backpressure activated)
       - alert: HL7v2HighBackpressureRate
         expr: |

--- a/infrastructure/grafana/dashboards/hl7v2-server-overview.json
+++ b/infrastructure/grafana/dashboards/hl7v2-server-overview.json
@@ -144,12 +144,12 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "hl7v2_active_connections{job=\"hl7v2-server\"}",
-          "legendFormat": "Active Connections",
+          "expr": "sum(rate(hl7v2_parse_failures_total[5m])) + sum(rate(hl7v2_validation_failures_total[5m])) + sum(rate(hl7v2_redaction_failures_total[5m]))",
+          "legendFormat": "Evidence Failures",
           "refId": "A"
         }
       ],
-      "title": "Active Connections",
+      "title": "Evidence Failure Rate",
       "type": "gauge"
     },
     {
@@ -410,12 +410,12 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "increase(hl7v2_parse_errors_total{job=\"hl7v2-server\"}[1h])",
-          "legendFormat": "Parse Errors (1h)",
+          "expr": "increase(hl7v2_parse_failures_total{job=\"hl7v2-server\"}[1h])",
+          "legendFormat": "Parse Failures (1h)",
           "refId": "A"
         }
       ],
-      "title": "Parse Errors (Last Hour)",
+      "title": "Parse Failures (Last Hour)",
       "type": "gauge"
     },
     {

--- a/infrastructure/grafana/dashboards/hl7v2-validation.json
+++ b/infrastructure/grafana/dashboards/hl7v2-validation.json
@@ -107,12 +107,12 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(hl7v2_validation_total{result=\"valid\"}[5m]))",
+          "expr": "sum(increase(hl7v2_messages_validated_total[5m])) - sum(increase(hl7v2_validation_failures_total[5m]))",
           "legendFormat": "Valid",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(hl7v2_validation_total{result=\"invalid\"}[5m]))",
+          "expr": "sum(increase(hl7v2_validation_failures_total[5m]))",
           "legendFormat": "Invalid",
           "refId": "B"
         }
@@ -170,7 +170,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(hl7v2_validation_total{result=\"valid\"}[5m])) / sum(rate(hl7v2_validation_total[5m])) * 100",
+          "expr": "(sum(rate(hl7v2_messages_validated_total[5m])) - sum(rate(hl7v2_validation_failures_total[5m]))) / sum(rate(hl7v2_messages_validated_total[5m])) * 100",
           "legendFormat": "Success Rate",
           "refId": "A"
         }
@@ -246,12 +246,12 @@
       },
       "targets": [
         {
-          "expr": "topk(10, sum by (profile) (rate(hl7v2_validation_total[5m])))",
-          "legendFormat": "{{profile}}",
+          "expr": "topk(10, sum by (operation) (rate(hl7v2_messages_validated_total[5m])))",
+          "legendFormat": "{{operation}}",
           "refId": "A"
         }
       ],
-      "title": "Top Profiles by Validation Rate",
+      "title": "Top Operations by Validation Rate",
       "type": "timeseries"
     },
     {
@@ -322,12 +322,12 @@
       },
       "targets": [
         {
-          "expr": "sum by (error_type) (increase(hl7v2_validation_errors_total[1h]))",
-          "legendFormat": "{{error_type}}",
+          "expr": "sum by (operation) (increase(hl7v2_validation_failures_total[1h]))",
+          "legendFormat": "{{operation}}",
           "refId": "A"
         }
       ],
-      "title": "Validation Errors by Type (1h)",
+      "title": "Validation Failures by Operation (1h)",
       "type": "timeseries"
     },
     {
@@ -372,13 +372,13 @@
       },
       "targets": [
         {
-          "expr": "topk(20, increase(hl7v2_validation_errors_total[1h]))",
+          "expr": "topk(20, increase(hl7v2_validation_failures_total[1h]))",
           "format": "table",
           "instant": true,
           "refId": "A"
         }
       ],
-      "title": "Top 20 Validation Errors",
+      "title": "Top Validation Failure Series",
       "transformations": [
         {
           "id": "organize",
@@ -392,8 +392,7 @@
             "indexByName": {},
             "renameByName": {
               "Value": "Count",
-              "error_type": "Error Type",
-              "profile": "Profile"
+              "operation": "Operation"
             }
           }
         }
@@ -417,5 +416,5 @@
   "title": "HL7v2 - Validation Dashboard",
   "uid": "hl7v2-validation",
   "version": 1,
-  "description": "HL7v2 message validation metrics showing success rates, error types, and profile usage"
+  "description": "HL7v2 message validation metrics showing success rates and bounded evidence operation failures"
 }


### PR DESCRIPTION
## Summary
- define a stable Prometheus evidence metrics contract for hl7v2-server, including parse/validation/redaction failures, bundle creation, replay attempts/failures, corpus diffs, message counts, and message size
- wire the evidence counters at server handler decision points without payload-derived metric labels
- align metrics tests, deployment docs, Grafana docs, alerts, and dashboards with the emitted metric names and low-cardinality label policy

## Validation
- `cargo +1.93.0 test -p hl7v2-server metrics`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 clippy -p hl7v2-server --all-features --all-targets -- -D warnings`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `Get-Content infrastructure/grafana/dashboards/hl7v2-validation.json -Raw | ConvertFrom-Json | Out-Null; Get-Content infrastructure/grafana/dashboards/hl7v2-server-overview.json -Raw | ConvertFrom-Json | Out-Null`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`

## Notes
- Metric labels remain bounded to endpoint/status/operation values; no raw HL7 payloads, profile YAML, redaction policy TOML, local filesystem roots, bundle IDs, message control IDs, or patient identifiers are used as labels.