### PR TITLE
test: share PHI leak sentinels across evidence surfaces

### DIFF
--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -21,124 +21,16 @@ use common::{
     is_valid_json, minimal_profile, read_file, simple_template, strict_profile,
     truncated_hl7_message,
 };
+use hl7v2_test_utils::{
+    PHI_LEAK_SENTINEL_MESSAGE, PHI_LEAK_SENTINEL_POLICY, RAW_INPUT_FILE_SENTINEL,
+    RAW_POLICY_FILE_SENTINEL, assert_no_phi_leak_sentinels_or_paths,
+};
 
 fn is_sha256_hex(value: &str) -> bool {
     value.len() == 64
         && value
             .bytes()
             .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
-}
-
-const PHI_LEAK_SENTINEL_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||MRN-777-ALPHA^^^HOSP^MR||Signal^Patricia||19661224|M|||742 Evergreen Terrace||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
-
-const PHI_LEAK_SENTINEL_POLICY: &str = r#"
-[[rules]]
-path = "PID.3"
-action = "hash"
-reason = "patient identifier"
-
-[[rules]]
-path = "PID.5"
-action = "drop"
-reason = "patient name"
-
-[[rules]]
-path = "PID.7"
-action = "drop"
-reason = "date of birth"
-
-[[rules]]
-path = "PID.11"
-action = "drop"
-reason = "patient address"
-
-[[rules]]
-path = "PID.13"
-action = "drop"
-reason = "patient phone"
-
-[[rules]]
-path = "NK1.2"
-action = "drop"
-reason = "next of kin name"
-
-[[rules]]
-path = "NK1.4"
-action = "drop"
-reason = "next of kin address"
-
-[[rules]]
-path = "NK1.5"
-action = "drop"
-reason = "next of kin phone"
-
-[[rules]]
-path = "MSH.9"
-action = "retain"
-reason = "message type is needed for analysis"
-
-[[rules]]
-path = "MSH.10"
-action = "retain"
-reason = "control id is needed for replay correlation"
-
-[[rules]]
-path = "OBX.3"
-action = "retain"
-reason = "observation identifier is needed for analysis"
-
-[[rules]]
-path = "OBX.5"
-action = "retain"
-reason = "non-PHI synthetic observation value shape is needed for analysis"
-"#;
-
-const PHI_LEAK_SENTINELS: &[(&str, &str)] = &[
-    ("patient name", "Signal^Patricia"),
-    ("MRN", "MRN-777-ALPHA^^^HOSP^MR"),
-    ("date of birth", "19661224"),
-    ("address", "742 Evergreen Terrace"),
-    ("phone", "5558675309"),
-    ("next of kin name", "Watcher^Nora"),
-    ("next of kin address", "900 Support Way"),
-    ("next of kin phone", "5550001234"),
-];
-
-fn assert_no_phi_leak_sentinels(context: &str, content: &str) {
-    for (label, value) in PHI_LEAK_SENTINELS {
-        assert!(
-            !content.contains(value),
-            "{context} leaked {label}: {value}"
-        );
-    }
-}
-
-fn assert_no_phi_leak_sentinels_or_paths(
-    context: &str,
-    content: &str,
-    message_path: &std::path::Path,
-    policy_path: &std::path::Path,
-) {
-    assert_no_phi_leak_sentinels(context, content);
-
-    let message_path = message_path.to_string_lossy();
-    assert!(
-        !content.contains(message_path.as_ref()),
-        "{context} leaked raw input file path"
-    );
-    assert!(
-        !content.contains("raw-phi-input-sentinel.hl7"),
-        "{context} leaked raw input file name"
-    );
-    let policy_path = policy_path.to_string_lossy();
-    assert!(
-        !content.contains(policy_path.as_ref()),
-        "{context} leaked raw policy file path"
-    );
-    assert!(
-        !content.contains("raw-policy-sentinel.toml"),
-        "{context} leaked raw policy file name"
-    );
 }
 
 // =========================================================================
@@ -2201,14 +2093,11 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
     #[test]
     fn test_redact_json_does_not_emit_phi_leak_sentinels_or_paths() {
         let dir = create_temp_dir();
-        let message_file = create_temp_hl7_with_content(
-            &dir,
-            "raw-phi-input-sentinel.hl7",
-            PHI_LEAK_SENTINEL_MESSAGE,
-        );
+        let message_file =
+            create_temp_hl7_with_content(&dir, RAW_INPUT_FILE_SENTINEL, PHI_LEAK_SENTINEL_MESSAGE);
         let policy_file = create_temp_file(
             &dir,
-            "raw-policy-sentinel.toml",
+            RAW_POLICY_FILE_SENTINEL,
             PHI_LEAK_SENTINEL_POLICY.as_bytes(),
         );
 
@@ -2730,15 +2619,12 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
     #[test]
     fn test_bundle_artifacts_do_not_emit_phi_leak_sentinels_or_paths() {
         let dir = create_temp_dir();
-        let message_file = create_temp_hl7_with_content(
-            &dir,
-            "raw-phi-input-sentinel.hl7",
-            PHI_LEAK_SENTINEL_MESSAGE,
-        );
+        let message_file =
+            create_temp_hl7_with_content(&dir, RAW_INPUT_FILE_SENTINEL, PHI_LEAK_SENTINEL_MESSAGE);
         let profile_file = create_temp_profile(&dir, "profile.yaml", minimal_profile());
         let policy_file = create_temp_file(
             &dir,
-            "raw-policy-sentinel.toml",
+            RAW_POLICY_FILE_SENTINEL,
             PHI_LEAK_SENTINEL_POLICY.as_bytes(),
         );
         let bundle_dir = dir.path().join("issue-bundle");
@@ -3164,9 +3050,9 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
         let dir = create_temp_dir();
         let (bundle_dir, message_file, policy_file) = create_replayable_bundle_with_inputs(
             &dir,
-            "raw-phi-input-sentinel.hl7",
+            RAW_INPUT_FILE_SENTINEL,
             PHI_LEAK_SENTINEL_MESSAGE,
-            "raw-policy-sentinel.toml",
+            RAW_POLICY_FILE_SENTINEL,
             PHI_LEAK_SENTINEL_POLICY,
         );
 

--- a/crates/hl7v2-server/src/audit.rs
+++ b/crates/hl7v2-server/src/audit.rs
@@ -118,6 +118,7 @@ fn joined_components(message: &hl7v2::Message, path: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hl7v2_test_utils::{PHI_LEAK_SENTINEL_MESSAGE, assert_no_phi_leak_sentinels};
 
     const SAMPLE_MESSAGE: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John\r";
     const MISSING_CONTROL_ID: &str =
@@ -151,6 +152,17 @@ mod tests {
         assert_eq!(hash.len(), 64);
         assert!(!hash.contains("Doe"));
         assert!(!hash.contains("123456"));
+    }
+
+    #[test]
+    fn message_log_context_does_not_echo_phi_leak_sentinels() {
+        let message = hl7v2::parse(PHI_LEAK_SENTINEL_MESSAGE.as_bytes())
+            .expect("sentinel message should parse");
+        let context = MessageLogContext::from_message(&message);
+
+        assert_eq!(context.message_type, "ADT^A01");
+        assert_eq!(context.message_control_id_hash.len(), 64);
+        assert_no_phi_leak_sentinels("message log context", &format!("{context:?}"));
     }
 
     #[test]

--- a/crates/hl7v2-server/tests/ack_policy_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/ack_policy_endpoint_test.rs
@@ -13,13 +13,13 @@ use axum::{
 use hl7v2_server::{
     AckPolicyConfig, AckPolicyMode, AppState, CorsAllowedOrigins, ServerConfig, build_router,
 };
+use hl7v2_test_utils::{PHI_LEAK_SENTINEL_MESSAGE as SAMPLE_MSG, assert_no_phi_leak_sentinels};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use std::sync::Arc;
 use std::time::Instant;
 use tower::ServiceExt;
 
-const SAMPLE_MSG: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r";
 const VALID_PROFILE: &str = r#"
 message_structure: "ADT_A01"
 version: "2.5"
@@ -200,7 +200,5 @@ async fn test_ack_policy_still_requires_auth_when_configured() {
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in ["Doe^John", "123456^^^HOSP^MR", "19700101"] {
-        assert!(!content.contains(sentinel), "content leaked {sentinel}");
-    }
+    assert_no_phi_leak_sentinels("ack-policy response", content);
 }

--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -11,6 +11,10 @@ use axum::{
     http::{Request, StatusCode},
 };
 use hl7v2_server::{AppState, CorsAllowedOrigins, build_router};
+use hl7v2_test_utils::{
+    PHI_LEAK_SENTINEL_MESSAGE as PHI_MESSAGE, PHI_LEAK_SENTINEL_POLICY as POLICY,
+    assert_no_phi_leak_sentinels,
+};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use std::fs;
@@ -18,8 +22,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tower::ServiceExt;
-
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
 
 const PROFILE: &str = r#"
 message_structure: ADT_A01
@@ -30,68 +32,6 @@ segments:
 constraints:
   - path: PID.3
     required: true
-"#;
-
-const POLICY: &str = r#"
-[[rules]]
-path = "PID.3"
-action = "hash"
-reason = "patient identifier"
-
-[[rules]]
-path = "PID.5"
-action = "drop"
-reason = "patient name"
-
-[[rules]]
-path = "PID.7"
-action = "drop"
-reason = "date of birth"
-
-[[rules]]
-path = "PID.11"
-action = "drop"
-reason = "patient address"
-
-[[rules]]
-path = "PID.13"
-action = "drop"
-reason = "patient phone"
-
-[[rules]]
-path = "NK1.2"
-action = "drop"
-reason = "next-of-kin name"
-
-[[rules]]
-path = "NK1.4"
-action = "drop"
-reason = "next-of-kin address"
-
-[[rules]]
-path = "NK1.5"
-action = "drop"
-reason = "next-of-kin phone"
-
-[[rules]]
-path = "MSH.9"
-action = "retain"
-reason = "message type is needed for analysis"
-
-[[rules]]
-path = "MSH.10"
-action = "retain"
-reason = "control id is needed for replay correlation"
-
-[[rules]]
-path = "OBX.3"
-action = "retain"
-reason = "observation identifier is needed for analysis"
-
-[[rules]]
-path = "OBX.5"
-action = "retain"
-reason = "synthetic observation value shape is needed for analysis"
 "#;
 
 struct TempRoot {
@@ -409,18 +349,7 @@ async fn test_bundle_endpoint_rejects_existing_bundle_id() {
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in [
-        "Doe^John",
-        "123456^^^HOSP^MR",
-        "19700101",
-        "123 Main St",
-        "5558675309",
-        "Watcher^Nora",
-        "900 Support Way",
-        "5550001234",
-    ] {
-        assert!(!content.contains(sentinel), "content leaked {sentinel}");
-    }
+    assert_no_phi_leak_sentinels("bundle response or artifact", content);
 }
 
 fn is_sha256_hex(value: &str) -> bool {

--- a/crates/hl7v2-server/tests/quarantine_output_hooks_test.rs
+++ b/crates/hl7v2-server/tests/quarantine_output_hooks_test.rs
@@ -11,6 +11,10 @@ use axum::{
     http::{Request, StatusCode},
 };
 use hl7v2_server::{AppState, CorsAllowedOrigins, QuarantineConfig, build_router};
+use hl7v2_test_utils::{
+    PHI_LEAK_SENTINEL_MESSAGE as PHI_MESSAGE, PHI_LEAK_SENTINEL_POLICY as REDACTION_POLICY,
+    assert_no_phi_leak_sentinels,
+};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use std::fs;
@@ -18,8 +22,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tower::ServiceExt;
-
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
 
 const VALID_PROFILE: &str = r#"
 message_structure: "ADT_A01"
@@ -49,68 +51,6 @@ segments:
 constraints:
   - path: "PID.5"
     required: true
-"#;
-
-const REDACTION_POLICY: &str = r#"
-[[rules]]
-path = "PID.3"
-action = "hash"
-reason = "patient identifier"
-
-[[rules]]
-path = "PID.5"
-action = "drop"
-reason = "patient name"
-
-[[rules]]
-path = "PID.7"
-action = "drop"
-reason = "date of birth"
-
-[[rules]]
-path = "PID.11"
-action = "drop"
-reason = "patient address"
-
-[[rules]]
-path = "PID.13"
-action = "drop"
-reason = "patient phone"
-
-[[rules]]
-path = "NK1.2"
-action = "drop"
-reason = "next-of-kin name"
-
-[[rules]]
-path = "NK1.4"
-action = "drop"
-reason = "next-of-kin address"
-
-[[rules]]
-path = "NK1.5"
-action = "drop"
-reason = "next-of-kin phone"
-
-[[rules]]
-path = "MSH.9"
-action = "retain"
-reason = "message type is needed for analysis"
-
-[[rules]]
-path = "MSH.10"
-action = "retain"
-reason = "control id is needed for replay correlation"
-
-[[rules]]
-path = "OBX.3"
-action = "retain"
-reason = "observation identifier is needed for analysis"
-
-[[rules]]
-path = "OBX.5"
-action = "retain"
-reason = "synthetic observation value shape is needed for analysis"
 "#;
 
 struct TempRoot {
@@ -381,16 +321,5 @@ async fn test_quarantine_hook_fails_closed_without_configured_path() {
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in [
-        "Doe^John",
-        "123456^^^HOSP^MR",
-        "19700101",
-        "123 Main St",
-        "5558675309",
-        "Watcher^Nora",
-        "900 Support Way",
-        "5550001234",
-    ] {
-        assert!(!content.contains(sentinel), "content leaked {sentinel}");
-    }
+    assert_no_phi_leak_sentinels("quarantine response or artifact", content);
 }

--- a/crates/hl7v2-server/tests/replay_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/replay_endpoint_test.rs
@@ -11,6 +11,10 @@ use axum::{
     http::{Request, StatusCode},
 };
 use hl7v2_server::{AppState, CorsAllowedOrigins, build_router};
+use hl7v2_test_utils::{
+    PHI_LEAK_SENTINEL_MESSAGE as PHI_MESSAGE, PHI_LEAK_SENTINEL_POLICY as POLICY,
+    assert_no_phi_leak_sentinels,
+};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use std::fs;
@@ -18,8 +22,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tower::ServiceExt;
-
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
 
 const PROFILE: &str = r#"
 message_structure: ADT_A01
@@ -30,68 +32,6 @@ segments:
 constraints:
   - path: PID.3
     required: true
-"#;
-
-const POLICY: &str = r#"
-[[rules]]
-path = "PID.3"
-action = "hash"
-reason = "patient identifier"
-
-[[rules]]
-path = "PID.5"
-action = "drop"
-reason = "patient name"
-
-[[rules]]
-path = "PID.7"
-action = "drop"
-reason = "date of birth"
-
-[[rules]]
-path = "PID.11"
-action = "drop"
-reason = "patient address"
-
-[[rules]]
-path = "PID.13"
-action = "drop"
-reason = "patient phone"
-
-[[rules]]
-path = "NK1.2"
-action = "drop"
-reason = "next-of-kin name"
-
-[[rules]]
-path = "NK1.4"
-action = "drop"
-reason = "next-of-kin address"
-
-[[rules]]
-path = "NK1.5"
-action = "drop"
-reason = "next-of-kin phone"
-
-[[rules]]
-path = "MSH.9"
-action = "retain"
-reason = "message type is needed for analysis"
-
-[[rules]]
-path = "MSH.10"
-action = "retain"
-reason = "control id is needed for replay correlation"
-
-[[rules]]
-path = "OBX.3"
-action = "retain"
-reason = "observation identifier is needed for analysis"
-
-[[rules]]
-path = "OBX.5"
-action = "retain"
-reason = "synthetic observation value shape is needed for analysis"
 "#;
 
 struct TempRoot {
@@ -339,19 +279,5 @@ async fn test_replay_endpoint_rejects_unsupported_schema_version() {
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in [
-        "Doe^John",
-        "123456^^^HOSP^MR",
-        "19700101",
-        "123 Main St",
-        "5558675309",
-        "Watcher^Nora",
-        "900 Support Way",
-        "5550001234",
-    ] {
-        assert!(
-            !content.contains(sentinel),
-            "content leaked PHI sentinel {sentinel}"
-        );
-    }
+    assert_no_phi_leak_sentinels("replay response", content);
 }

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -10,55 +10,15 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use hl7v2_test_utils::{
+    PHI_LEAK_SENTINEL_MESSAGE as PHI_MESSAGE, PHI_LEAK_SENTINEL_POLICY as REDACTION_POLICY,
+    assert_no_phi_leak_sentinels,
+};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
 mod common;
-
-const PHI_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M|||123 Main St||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
-
-const REDACTION_POLICY: &str = r#"
-[[rules]]
-path = "PID.3"
-action = "hash"
-reason = "hash patient identifier for support analysis"
-
-[[rules]]
-path = "PID.5"
-action = "drop"
-reason = "drop patient name"
-
-[[rules]]
-path = "PID.7"
-action = "drop"
-reason = "drop date of birth"
-
-[[rules]]
-path = "PID.11"
-action = "drop"
-reason = "drop patient address"
-
-[[rules]]
-path = "PID.13"
-action = "drop"
-reason = "drop patient phone"
-
-[[rules]]
-path = "NK1.2"
-action = "drop"
-reason = "drop next-of-kin name"
-
-[[rules]]
-path = "NK1.4"
-action = "drop"
-reason = "drop next-of-kin address"
-
-[[rules]]
-path = "NK1.5"
-action = "drop"
-reason = "drop next-of-kin phone"
-"#;
 
 const VALIDATION_PROFILE: &str = r#"
 message_structure: "ADT_A01"
@@ -328,16 +288,5 @@ reason = "hash patient identifier"
 }
 
 fn assert_no_phi(content: &str) {
-    for sentinel in [
-        "Doe^John",
-        "123456^^^HOSP^MR",
-        "19700101",
-        "123 Main St",
-        "5558675309",
-        "Watcher^Nora",
-        "900 Support Way",
-        "5550001234",
-    ] {
-        assert!(!content.contains(sentinel), "content leaked {sentinel}");
-    }
+    assert_no_phi_leak_sentinels("validate-redacted response", content);
 }

--- a/crates/hl7v2-test-utils/src/lib.rs
+++ b/crates/hl7v2-test-utils/src/lib.rs
@@ -43,7 +43,11 @@ pub use assertions::{
 pub use builders::{MessageBuilder, SegmentBuilder};
 pub use fixtures::SampleMessages;
 pub use mocks::{MockMessageHandler, MockMllpServer};
-pub use security_fixtures::deterministic_api_key;
+pub use security_fixtures::{
+    PHI_LEAK_SENTINEL_MESSAGE, PHI_LEAK_SENTINEL_POLICY, PHI_LEAK_SENTINELS,
+    RAW_INPUT_FILE_SENTINEL, RAW_POLICY_FILE_SENTINEL, assert_no_phi_leak_sentinels,
+    assert_no_phi_leak_sentinels_or_paths, deterministic_api_key,
+};
 
 /// Prelude module for convenient imports
 pub mod prelude {
@@ -54,7 +58,11 @@ pub mod prelude {
     pub use crate::builders::{MessageBuilder, SegmentBuilder};
     pub use crate::fixtures::SampleMessages;
     pub use crate::mocks::{MockMessageHandler, MockMllpServer};
-    pub use crate::security_fixtures::deterministic_api_key;
+    pub use crate::security_fixtures::{
+        PHI_LEAK_SENTINEL_MESSAGE, PHI_LEAK_SENTINEL_POLICY, PHI_LEAK_SENTINELS,
+        RAW_INPUT_FILE_SENTINEL, RAW_POLICY_FILE_SENTINEL, assert_no_phi_leak_sentinels,
+        assert_no_phi_leak_sentinels_or_paths, deterministic_api_key,
+    };
 }
 
 #[cfg(test)]

--- a/crates/hl7v2-test-utils/src/security_fixtures.rs
+++ b/crates/hl7v2-test-utils/src/security_fixtures.rs
@@ -2,6 +2,138 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+/// Synthetic HL7 message containing deterministic PHI leak sentinels.
+///
+/// The values are intentionally memorable and fake. Tests use this fixture to
+/// prove redaction/evidence outputs do not echo PHI-bearing fields.
+pub const PHI_LEAK_SENTINEL_MESSAGE: &str = "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||MRN-777-ALPHA^^^HOSP^MR||Signal^Patricia||19661224|M|||742 Evergreen Terrace||5558675309\rNK1|1|Watcher^Nora||900 Support Way|5550001234\rOBX|1|NM|718-7^Hemoglobin^LN||13.2|g/dL\r";
+
+/// Safe-analysis policy that protects every PHI sentinel in
+/// [`PHI_LEAK_SENTINEL_MESSAGE`] while retaining non-PHI analysis shape.
+pub const PHI_LEAK_SENTINEL_POLICY: &str = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "date of birth"
+
+[[rules]]
+path = "PID.11"
+action = "drop"
+reason = "patient address"
+
+[[rules]]
+path = "PID.13"
+action = "drop"
+reason = "patient phone"
+
+[[rules]]
+path = "NK1.2"
+action = "drop"
+reason = "next of kin name"
+
+[[rules]]
+path = "NK1.4"
+action = "drop"
+reason = "next of kin address"
+
+[[rules]]
+path = "NK1.5"
+action = "drop"
+reason = "next of kin phone"
+
+[[rules]]
+path = "MSH.9"
+action = "retain"
+reason = "message type is needed for analysis"
+
+[[rules]]
+path = "MSH.10"
+action = "retain"
+reason = "control id is needed for replay correlation"
+
+[[rules]]
+path = "OBX.3"
+action = "retain"
+reason = "observation identifier is needed for analysis"
+
+[[rules]]
+path = "OBX.5"
+action = "retain"
+reason = "non-PHI synthetic observation value shape is needed for analysis"
+"#;
+
+/// File name used to catch raw input path leakage in generated evidence.
+pub const RAW_INPUT_FILE_SENTINEL: &str = "raw-phi-input-sentinel.hl7";
+
+/// File name used to catch raw policy path leakage in generated evidence.
+pub const RAW_POLICY_FILE_SENTINEL: &str = "raw-policy-sentinel.toml";
+
+/// PHI-bearing values that must not appear in receipts, traces, reports, logs,
+/// replay output, or metadata.
+pub const PHI_LEAK_SENTINELS: &[(&str, &str)] = &[
+    ("patient name", "Signal^Patricia"),
+    ("MRN", "MRN-777-ALPHA^^^HOSP^MR"),
+    ("date of birth", "19661224"),
+    ("address", "742 Evergreen Terrace"),
+    ("phone", "5558675309"),
+    ("next of kin name", "Watcher^Nora"),
+    ("next of kin address", "900 Support Way"),
+    ("next of kin phone", "5550001234"),
+];
+
+/// Assert that `content` contains none of the shared PHI leak sentinel values.
+///
+/// This is a regression tripwire for synthetic fixtures, not a general PHI
+/// detector.
+pub fn assert_no_phi_leak_sentinels(context: &str, content: &str) {
+    for (label, value) in PHI_LEAK_SENTINELS {
+        assert!(
+            !content.contains(value),
+            "{context} leaked {label}: {value}"
+        );
+    }
+}
+
+/// Assert that `content` contains neither PHI sentinels nor raw file paths.
+pub fn assert_no_phi_leak_sentinels_or_paths(
+    context: &str,
+    content: &str,
+    message_path: &Path,
+    policy_path: &Path,
+) {
+    assert_no_phi_leak_sentinels(context, content);
+
+    let message_path = message_path.to_string_lossy();
+    assert!(
+        !content.contains(message_path.as_ref()),
+        "{context} leaked raw input file path"
+    );
+    assert!(
+        !content.contains(RAW_INPUT_FILE_SENTINEL),
+        "{context} leaked raw input file name"
+    );
+    let policy_path = policy_path.to_string_lossy();
+    assert!(
+        !content.contains(policy_path.as_ref()),
+        "{context} leaked raw policy file path"
+    );
+    assert!(
+        !content.contains(RAW_POLICY_FILE_SENTINEL),
+        "{context} leaked raw policy file name"
+    );
+}
 
 /// Returns a deterministic API key for tests.
 ///
@@ -15,7 +147,10 @@ pub fn deterministic_api_key(seed: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::deterministic_api_key;
+    use super::{
+        PHI_LEAK_SENTINEL_MESSAGE, PHI_LEAK_SENTINEL_POLICY, assert_no_phi_leak_sentinels,
+        deterministic_api_key,
+    };
 
     #[test]
     fn test_deterministic_api_key_is_stable() {
@@ -25,5 +160,26 @@ mod tests {
 
         assert_eq!(first, second);
         assert_ne!(first, third);
+    }
+
+    #[test]
+    fn test_phi_sentinel_policy_mentions_all_sensitive_paths() {
+        for path in [
+            "PID.3", "PID.5", "PID.7", "PID.11", "PID.13", "NK1.2", "NK1.4", "NK1.5",
+        ] {
+            assert!(
+                PHI_LEAK_SENTINEL_POLICY.contains(path),
+                "sentinel policy is missing {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_phi_sentinel_assertion_allows_redacted_shape() {
+        assert_no_phi_leak_sentinels(
+            "redacted shape",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||hash:sha256:abc||||M|||",
+        );
+        assert!(PHI_LEAK_SENTINEL_MESSAGE.contains("Signal^Patricia"));
     }
 }

--- a/tests/python_smoke/smoke.py
+++ b/tests/python_smoke/smoke.py
@@ -589,6 +589,16 @@ reason = "Patient identifier"
         )
         evidence_text += json.dumps(replay)
         evidence_text += json.dumps(replay_v2)
+        evidence_text += json.dumps(bundle_v2)
+        evidence_text += "\n".join(
+            (bundle_v2_dir / artifact).read_text(encoding="utf-8")
+            for artifact in [
+                "field-paths.json",
+                "redaction-receipt.json",
+                "environment.json",
+                "manifest.json",
+            ]
+        )
         try:
             assert_no_phi_leak_sentinels_or_paths(
                 "Python bundle/replay evidence",

--- a/tests/server_smoke/smoke.py
+++ b/tests/server_smoke/smoke.py
@@ -94,6 +94,8 @@ reason = "drop next-of-kin phone"
 
 PHI_SENTINELS = [
     "Doe^John",
+    "123456^^^HOSP^MR",
+    "19700101",
     "123 Main St",
     "5558675309",
     "Watcher^Nora",


### PR DESCRIPTION
## Summary
- centralize deterministic PHI leak sentinel message, redaction policy, path sentinels, and assertions in `hl7v2-test-utils`
- reuse the shared sentinel fixture across CLI and server evidence tests for redact, bundle, replay, quarantine, ACK policy, and validate-redacted outputs
- add structured audit context coverage and tighten Python/server smoke sentinel scans

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `python -m py_compile tests\python_smoke\smoke.py tests\server_smoke\smoke.py`
- `cargo +1.93.0 test -p hl7v2-test-utils security_fixtures`
- `cargo +1.93.0 test -p hl7v2-server audit`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests phi_leak`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests`
- `cargo +1.93.0 clippy -p hl7v2-test-utils -p hl7v2-server -p hl7v2-cli --all-targets --all-features -- -D warnings`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`
