### PR TITLE
xtask: validate evidence schema fixtures

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -12,6 +12,7 @@ on:
       - 'config/**'
       - '.spectral.yml'
       - 'buf.gen.yaml'
+      - 'xtask/**'
       - '.github/workflows/contracts.yml'
   pull_request:
     paths:
@@ -23,6 +24,7 @@ on:
       - 'config/**'
       - '.spectral.yml'
       - 'buf.gen.yaml'
+      - 'xtask/**'
       - '.github/workflows/contracts.yml'
 
 jobs:
@@ -101,6 +103,11 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
       - name: Install ajv-cli
         run: npm install -g ajv-cli ajv-formats
 
@@ -144,21 +151,7 @@ jobs:
             --spec=draft7
 
       - name: Validate Evidence Fixtures
-        run: |
-          for schema in schemas/evidence/*-v*.schema.json; do
-            name="$(basename "$schema")"
-            name="${name%.schema.json}"
-            data="fixtures/evidence/${name}.json"
-            if [ ! -f "$data" ]; then
-              legacy_name="${name%-v1}"
-              data="fixtures/evidence/${legacy_name}.json"
-            fi
-            echo "Validating $data against $schema"
-            ajv validate -c ajv-formats \
-              -s "$schema" \
-              -d "$data" \
-              --spec=draft7
-          done
+        run: cargo run -p xtask -- evidence-schema-check
 
       - name: Validate Test Data
         run: |

--- a/docs/contracts/evidence-contract-index.md
+++ b/docs/contracts/evidence-contract-index.md
@@ -18,6 +18,16 @@ Versioning rules:
 - Redaction receipts prove configured policy actions. They are not a universal
   PHI absence certificate.
 
+Schema validation is maintained by:
+
+```bash
+cargo run -p xtask -- evidence-schema-check
+```
+
+The command validates every primary evidence fixture against its matching
+`schemas/evidence/*-v*.schema.json` contract and covers documented supplemental
+fixtures such as the v1 redaction output containing a v2 nested receipt.
+
 ## Contract Map
 
 | Artifact | Producer surfaces | v1 schema | v2 schema | Default shape | v2 opt-in | Golden fixtures | PHI / logging notes |

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -269,7 +269,10 @@ owner = "api"
 surface = "tests"
 classification = "test"
 reason = "Representative evidence artifact fixtures validated against public JSON schemas."
-covered_by = [".github/workflows/contracts.yml"]
+covered_by = [
+    ".github/workflows/contracts.yml",
+    "cargo run -p xtask -- evidence-schema-check",
+]
 
 # ---------------------------------------------------------------------------
 # Profiles (HL7 message profile YAML)
@@ -303,7 +306,10 @@ owner = "api"
 surface = "production"
 classification = "production"
 reason = "Public JSON schemas for messages, profiles, configuration, and errors."
-covered_by = [".github/workflows/contracts.yml"]
+covered_by = [
+    ".github/workflows/contracts.yml",
+    "cargo run -p xtask -- evidence-schema-check",
+]
 
 # ---------------------------------------------------------------------------
 # Infrastructure (deployment-only; not built by cargo)

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -250,16 +250,7 @@ evidence fixtures, then compiles every schema:
     Path("target/contracts/config/config.example.json").write_text(json.dumps(data), encoding="utf-8")
     PY
     ajv validate -c ajv-formats -s schemas/config/hl7v2-config-v1.schema.json -d 'target/contracts/config/*.json' --spec=draft7
-    for schema in schemas/evidence/*-v*.schema.json; do
-      name="$(basename "$schema")"
-      name="${name%.schema.json}"
-      data="fixtures/evidence/${name}.json"
-      if [ ! -f "$data" ]; then
-        legacy_name="${name%-v1}"
-        data="fixtures/evidence/${legacy_name}.json"
-      fi
-      ajv validate -c ajv-formats -s "$schema" -d "$data" --spec=draft7
-    done
+    cargo run -p xtask -- evidence-schema-check
 ```
 
 ## Schema Versioning

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -101,6 +101,8 @@ enum Commands {
     },
     /// Verify the non-Rust file allowlist against tracked files
     CheckFilePolicy,
+    /// Validate checked-in evidence fixtures against their JSON schemas
+    EvidenceSchemaCheck,
 }
 
 #[derive(Subcommand)]
@@ -150,6 +152,7 @@ fn main() -> Result<()> {
             NoPanicAction::Propose { include_staged } => no_panic_propose(include_staged)?,
         },
         Commands::CheckFilePolicy => check_file_policy()?,
+        Commands::EvidenceSchemaCheck => evidence_schema_check()?,
     }
 
     Ok(())
@@ -1265,6 +1268,218 @@ fn command_exists(cmd: &str) -> bool {
             .map(|s| s.success())
             .unwrap_or(false)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Evidence schema checker
+// ---------------------------------------------------------------------------
+
+struct EvidenceSchemaTarget {
+    schema: PathBuf,
+    data: PathBuf,
+}
+
+const SUPPLEMENTAL_EVIDENCE_FIXTURES: &[(&str, &str)] = &[(
+    "safe-analysis-redaction-output-receipt-v2.json",
+    "safe-analysis-redaction-output-v1.schema.json",
+)];
+
+fn evidence_schema_check() -> Result<()> {
+    println!("🔎 Checking evidence JSON schemas...");
+
+    let root = env::current_dir()?;
+    let targets = evidence_schema_targets(&root)?;
+    if targets.is_empty() {
+        return Err(anyhow!("no evidence schema targets found"));
+    }
+
+    for target in &targets {
+        println!(
+            "Validating {} against {}",
+            display_repo_path(&target.data, &root),
+            display_repo_path(&target.schema, &root)
+        );
+        run_ajv_validate(&target.schema, &target.data)?;
+    }
+
+    println!(
+        "✅ evidence schemas: {} fixture(s) validated",
+        targets.len()
+    );
+    Ok(())
+}
+
+fn evidence_schema_targets(root: &Path) -> Result<Vec<EvidenceSchemaTarget>> {
+    let schema_dir = root.join("schemas/evidence");
+    let fixture_dir = root.join("fixtures/evidence");
+
+    let schema_names = evidence_json_schema_names(&schema_dir)?;
+    let fixture_names = evidence_json_file_names(&fixture_dir)?;
+    let mut covered_fixtures = BTreeSet::new();
+    let mut targets = Vec::new();
+
+    for schema_name in &schema_names {
+        let fixture_name = evidence_fixture_name_for_schema(schema_name, &fixture_names)?;
+        covered_fixtures.insert(fixture_name.clone());
+        targets.push(EvidenceSchemaTarget {
+            schema: schema_dir.join(schema_name),
+            data: fixture_dir.join(fixture_name),
+        });
+    }
+
+    for (fixture_name, schema_name) in SUPPLEMENTAL_EVIDENCE_FIXTURES {
+        if fixture_names.contains(*fixture_name) {
+            if !schema_names.contains(*schema_name) {
+                return Err(anyhow!(
+                    "supplemental evidence fixture {fixture_name} maps to missing schema {schema_name}"
+                ));
+            }
+            covered_fixtures.insert((*fixture_name).to_string());
+            targets.push(EvidenceSchemaTarget {
+                schema: schema_dir.join(schema_name),
+                data: fixture_dir.join(fixture_name),
+            });
+        }
+    }
+
+    let uncovered: Vec<&String> = fixture_names.difference(&covered_fixtures).collect();
+    if !uncovered.is_empty() {
+        for fixture_name in &uncovered {
+            eprintln!("evidence-schema-check: fixture has no schema mapping: {fixture_name}");
+        }
+        return Err(anyhow!(
+            "{} evidence fixture(s) have no schema mapping",
+            uncovered.len()
+        ));
+    }
+
+    targets.sort_by(|a, b| a.schema.cmp(&b.schema).then_with(|| a.data.cmp(&b.data)));
+    Ok(targets)
+}
+
+fn evidence_json_schema_names(schema_dir: &Path) -> Result<BTreeSet<String>> {
+    let mut names = BTreeSet::new();
+    for entry in fs::read_dir(schema_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.ends_with(".schema.json") && name.contains("-v") {
+            names.insert(name.to_string());
+        }
+    }
+    Ok(names)
+}
+
+fn evidence_json_file_names(fixture_dir: &Path) -> Result<BTreeSet<String>> {
+    let mut names = BTreeSet::new();
+    for entry in fs::read_dir(fixture_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.ends_with(".json") {
+            names.insert(name.to_string());
+        }
+    }
+    Ok(names)
+}
+
+fn evidence_fixture_name_for_schema(
+    schema_file_name: &str,
+    fixture_names: &BTreeSet<String>,
+) -> Result<String> {
+    let schema_name = schema_file_name
+        .strip_suffix(".schema.json")
+        .ok_or_else(|| {
+            anyhow!("evidence schema file must end with .schema.json: {schema_file_name}")
+        })?;
+    let direct = format!("{schema_name}.json");
+    if fixture_names.contains(&direct) {
+        return Ok(direct);
+    }
+
+    let mut tried = vec![direct];
+    if let Some(legacy_name) = schema_name.strip_suffix("-v1") {
+        let legacy = format!("{legacy_name}.json");
+        if fixture_names.contains(&legacy) {
+            return Ok(legacy);
+        }
+        tried.push(legacy);
+    }
+
+    Err(anyhow!(
+        "no evidence fixture found for schema {schema_file_name}; tried {}",
+        tried.join(", ")
+    ))
+}
+
+fn run_ajv_validate(schema: &Path, data: &Path) -> Result<()> {
+    let mut command = if command_exists("ajv") {
+        let mut command = Command::new(command_program("ajv"));
+        command.arg("validate");
+        command
+    } else if command_exists("npx") {
+        let mut command = Command::new(command_program("npx"));
+        command.args([
+            "-y",
+            "-p",
+            "ajv-cli",
+            "-p",
+            "ajv-formats",
+            "ajv",
+            "validate",
+        ]);
+        command
+    } else {
+        return Err(anyhow!(
+            "evidence schema check requires ajv-cli and ajv-formats; install with `npm install -g ajv-cli ajv-formats` or make npx available"
+        ));
+    };
+
+    let status = command
+        .args(["-c", "ajv-formats", "-s"])
+        .arg(schema)
+        .arg("-d")
+        .arg(data)
+        .arg("--spec=draft7")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        return Err(anyhow!(
+            "AJV validation failed for {} against {} with exit code: {:?}",
+            data.display(),
+            schema.display(),
+            status.code()
+        ));
+    }
+
+    Ok(())
+}
+
+fn command_program(cmd: &str) -> String {
+    if cfg!(windows) {
+        format!("{cmd}.cmd")
+    } else {
+        cmd.to_string()
+    }
+}
+
+fn display_repo_path(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 enum ChangedScope {
@@ -2790,6 +3005,70 @@ mod tests {
             return Ok(());
         }
         Err(anyhow!("{crate_name} should be present in publish order"))
+    }
+
+    // ---- evidence schema mapping ----------------------------------------
+
+    #[test]
+    fn evidence_schema_mapping_uses_legacy_v1_fixture_name() -> Result<()> {
+        let fixtures = BTreeSet::from(["validation-report.json".to_string()]);
+
+        let fixture =
+            evidence_fixture_name_for_schema("validation-report-v1.schema.json", &fixtures)?;
+
+        if fixture == "validation-report.json" {
+            Ok(())
+        } else {
+            Err(anyhow!("expected validation-report.json, got {fixture}"))
+        }
+    }
+
+    #[test]
+    fn evidence_schema_mapping_uses_versioned_v2_fixture_name() -> Result<()> {
+        let fixtures = BTreeSet::from(["validation-report-v2.json".to_string()]);
+
+        let fixture =
+            evidence_fixture_name_for_schema("validation-report-v2.schema.json", &fixtures)?;
+
+        if fixture == "validation-report-v2.json" {
+            Ok(())
+        } else {
+            Err(anyhow!("expected validation-report-v2.json, got {fixture}"))
+        }
+    }
+
+    #[test]
+    fn evidence_schema_mapping_reports_missing_fixture() -> Result<()> {
+        let fixtures = BTreeSet::new();
+
+        match evidence_fixture_name_for_schema("validation-report-v1.schema.json", &fixtures) {
+            Ok(fixture) => Err(anyhow!("missing fixture should fail, got {fixture}")),
+            Err(err) if err.to_string().contains("validation-report.json") => Ok(()),
+            Err(err) => Err(anyhow!(
+                "error should list the legacy fixture candidate, got {err}"
+            )),
+        }
+    }
+
+    #[test]
+    fn evidence_schema_targets_cover_supplemental_receipt_fixture() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let targets = evidence_schema_targets(&root)?;
+
+        if targets.iter().any(|target| {
+            target
+                .data
+                .ends_with("safe-analysis-redaction-output-receipt-v2.json")
+        }) {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "supplemental receipt fixture should be schema-validated"
+            ))
+        }
     }
 
     // ---- glob_match ------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `cargo run -p xtask -- evidence-schema-check` to validate evidence fixtures against `schemas/evidence/*-v*.schema.json`
- cover the transitional safe-analysis redaction fixture that carries a v2 nested receipt under the v1 top-level contract
- route the API Contracts evidence-fixture step through xtask and document the maintained command in schema/contract docs and file-policy coverage

## Validation
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p xtask evidence_schema`
- `cargo +1.93.0 run -p xtask -- evidence-schema-check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 test -p xtask`
- `cargo +1.93.0 clippy -p xtask --all-targets -- -D warnings`
- `cargo +1.93.0 run -p xtask -- check-lint-policy`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Notes
- The first changed-gate attempt without `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` stopped at the known local Python 3.14 / PyO3 0.24.2 compatibility guard. The rerun with the established ABI3 flag passed.
- #471 remains separate and untouched.
