### PR TITLE
python: add TestPyPI proof workflow

### DIFF
--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -1,0 +1,149 @@
+name: Python TestPyPI Proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_testpypi:
+        description: "Publish the built wheel to TestPyPI and install it back"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-testpypi-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+jobs:
+  wheel_proof:
+    name: Build and smoke wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      package_version: ${{ steps.package.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: python-testpypi-ubuntu-py3.13
+
+      - name: Install maturin
+        run: python -m pip install --upgrade pip "maturin==1.13.1"
+
+      - name: Resolve package version
+        id: package
+        shell: bash
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import subprocess
+
+          metadata = json.loads(
+              subprocess.check_output(
+                  ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+                  text=True,
+              )
+          )
+          package = next(
+              pkg for pkg in metadata["packages"] if pkg["name"] == "hl7v2-python"
+          )
+          print(f"version={package['version']}")
+          PY
+
+      - name: Build wheel
+        run: maturin build --release --out dist
+
+      - name: Install built wheel in fresh venv
+        shell: bash
+        run: |
+          python -m venv .venv-local-wheel
+          . .venv-local-wheel/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install --force-reinstall dist/*.whl
+          python tests/python_smoke/smoke.py
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-testpypi-wheel
+          path: dist/*.whl
+          retention-days: 7
+
+  publish_testpypi:
+    name: Publish to TestPyPI
+    needs: wheel_proof
+    if: ${{ inputs.publish_to_testpypi }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/hl7v2-python/${{ needs.wheel_proof.outputs.package_version }}/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: python-testpypi-wheel
+          path: dist
+
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+
+  install_from_testpypi:
+    name: Install from TestPyPI and smoke
+    needs:
+      - wheel_proof
+      - publish_testpypi
+    if: ${{ inputs.publish_to_testpypi }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install published wheel from TestPyPI
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.wheel_proof.outputs.package_version }}
+        run: |
+          python -m venv .venv-testpypi
+          . .venv-testpypi/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install \
+            --index-url https://test.pypi.org/simple/ \
+            --no-deps \
+            --force-reinstall \
+            "hl7v2-python==${PACKAGE_VERSION}"
+          python tests/python_smoke/smoke.py

--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ bundle creation, and replay verification. Validation, corpus, redaction,
 bundle, and replay APIs also support the same opt-in v2 evidence shapes used by
 the CLI/server contracts where those surfaces expose v2 output.
 
+TestPyPI proof is manual-first through the `Python TestPyPI Proof` workflow and
+does not change the Rust publish graph. See
+[`docs/guides/python-testpypi-release-proof.md`](docs/guides/python-testpypi-release-proof.md).
+
 ## Performance Characteristics
 
 - Parsing throughput: ≥100k small messages/minute on NVMe (typical ADT/ORU ~200 bytes)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -80,6 +80,28 @@ release is approved.
 
 For GitHub Actions based releases, use the manual `Publish to crates.io` workflow. It prints the derived order first and only publishes when `execute=true` is selected and the `CARGO_REGISTRY_TOKEN` secret is configured.
 
+### Python TestPyPI Proof
+
+`hl7v2-python` is not part of the Rust crates.io publish graph. Prove the
+Python package separately before any PyPI release:
+
+```powershell
+python -m pip install --upgrade pip "maturin==1.13.1"
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
+maturin build --release --out dist
+python -m pip install --force-reinstall (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+python tests\python_smoke\smoke.py
+```
+
+Then use the manual `Python TestPyPI Proof` workflow. Run it first with
+`publish_to_testpypi=false`; if that passes and the TestPyPI Trusted Publisher
+is configured, rerun with `publish_to_testpypi=true` to upload and install the
+same version back from TestPyPI.
+
+The workflow uses Trusted Publishing from the `testpypi` GitHub environment and
+does not require a repository PyPI token. See
+[`docs/guides/python-testpypi-release-proof.md`](docs/guides/python-testpypi-release-proof.md).
+
 ### 6. Create GitHub Release
 
 Create a release on GitHub based on the tag, copying the relevant entries from `CHANGELOG.md`. Attach the CLI binaries for major platforms.

--- a/crates/hl7v2-python/README.md
+++ b/crates/hl7v2-python/README.md
@@ -6,6 +6,9 @@ This package is intentionally outside the crates.io Rust publish graph. Build
 and validate it through the Python/maturin lane before any PyPI or TestPyPI
 release.
 
+The Python distribution name is `hl7v2-python`; the import module is `hl7v2`.
+Treat that split as public package identity for TestPyPI/PyPI proofs.
+
 ## Build
 
 ```bash
@@ -126,3 +129,14 @@ print(replay_v2["schema_version"])
 The current Python surface intentionally starts with the minimum evidence loop:
 parse, JSON export, normalize, validate, corpus summary/fingerprint/diff,
 safe-analysis redaction, evidence bundle creation, and replay verification.
+
+## TestPyPI Proof
+
+Use the manual **Python TestPyPI Proof** GitHub Actions workflow when proving an
+external Python package upload. It defaults to a non-publishing wheel build and
+smoke test. With `publish_to_testpypi=true`, it publishes to TestPyPI through
+Trusted Publishing and installs the same version back from TestPyPI before
+running `tests/python_smoke/smoke.py`.
+
+Setup and stop conditions are documented in
+[`docs/guides/python-testpypi-release-proof.md`](../../docs/guides/python-testpypi-release-proof.md).

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -116,6 +116,19 @@ installed and imported. This workflow does not publish to PyPI.
    - Runs `tests/python_smoke/smoke.py`
    - Uploads the wheel as a short-retention smoke artifact
 
+### `.github/workflows/python-testpypi.yml` - Python TestPyPI Proof
+
+Manual-only workflow for the separate `hl7v2-python` distribution lane. The
+default dispatch builds the wheel, installs it into a fresh virtual
+environment, runs `tests/python_smoke/smoke.py`, and uploads the wheel as a
+short-retention artifact without publishing.
+
+When `publish_to_testpypi=true` is selected, the workflow publishes to TestPyPI
+using Trusted Publishing from the `testpypi` GitHub environment, then installs
+`hl7v2-python==<workspace version>` back from TestPyPI and reruns the smoke
+test. The workflow uses `id-token: write` only for the publish job and does not
+use repository PyPI tokens.
+
 ## Viewing CI Results
 
 ### GitHub Actions
@@ -143,6 +156,7 @@ The following artifacts are generated and available for download:
 | coverage.yml | tarpaulin-coverage | Tarpaulin coverage reports |
 | coverage.yml | llvm-coverage | LLVM coverage reports |
 | python-wheels.yml | python-wheel-* | Smoke-test wheels for the Python binding lane |
+| python-testpypi.yml | python-testpypi-wheel | Manual TestPyPI proof wheel artifact |
 
 ## Manual Triggers
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -41,7 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-09.md`.
-- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The binding is verified through a maturin wheel build/install/import smoke lane before any PyPI or TestPyPI release.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The binding is verified through a maturin wheel build/install/import smoke lane, with a manual TestPyPI proof workflow available before any production PyPI release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1` and `v1.3.0` tags point at their release heads.
 
@@ -61,7 +61,7 @@ final Rust package graph.
 | Evidence contracts | ✅ Stable | JSON schemas and golden fixtures guard the machine-readable evidence artifacts. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
 | Server edge guard | ✅ Stable | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/replay`, `/hl7/ack-policy`, inline corpus endpoints, quarantine hooks, and redacted structured evidence logs. |
-| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph. |
+| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph; TestPyPI proof is manual-first and separate from production PyPI. |
 
 ## v1.3.0 Readiness Checklist
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,3 +9,4 @@ feeds.
 | [Vendor Upgrade Diff](vendor-upgrade-diff.md) | You need to compare before/after HL7 corpora and produce drift evidence for a migration, vendor change, or CI gate. |
 | [Safe Support Bundle](safe-support-bundle.md) | You need to redact one failing message, bundle the evidence, and prove someone else can replay it safely. |
 | [Deploy Validation Sidecar](deploy-validation-sidecar.md) | You need to run `hl7v2-server` as a small edge guard with readiness, redacted validation, ACK policy, quarantine, bundles, and metrics. |
+| [Python TestPyPI Release Proof](python-testpypi-release-proof.md) | You need to prove the separate `hl7v2-python` packaging lane through TestPyPI without changing the Rust crates.io graph. |

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -1,0 +1,101 @@
+# Python TestPyPI Release Proof
+
+Use this guide when you need to prove the `hl7v2-python` binding as a Python
+package before any production PyPI release. This lane is separate from the Rust
+crates.io release graph.
+
+## Package Identity
+
+| Field | Value |
+| --- | --- |
+| Python distribution | `hl7v2-python` |
+| Python import module | `hl7v2` |
+| Rust package | `hl7v2-python` |
+| crates.io publish policy | `publish = false` |
+| TestPyPI workflow | `.github/workflows/python-testpypi.yml` |
+| GitHub environment | `testpypi` |
+
+Do not publish `hl7v2-python` to crates.io. The Rust release graph remains
+`hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+
+## One-Time TestPyPI Setup
+
+Use TestPyPI Trusted Publishing. Do not add repository tokens unless a separate
+security review chooses token-based publishing.
+
+Configure a pending publisher in TestPyPI with:
+
+| TestPyPI field | Value |
+| --- | --- |
+| Project name | `hl7v2-python` |
+| Owner | `EffortlessMetrics` |
+| Repository name | `hl7v2-rs` |
+| Workflow filename | `python-testpypi.yml` |
+| Environment name | `testpypi` |
+
+In GitHub, create an environment named `testpypi`. Add reviewer protection if
+you want a second human confirmation before upload.
+
+## Local Wheel Proof
+
+Run this before the manual TestPyPI workflow:
+
+```powershell
+python -m pip install --upgrade pip "maturin==1.13.1"
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
+maturin build --release --out dist
+python -m pip install --force-reinstall (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+python tests\python_smoke\smoke.py
+```
+
+Expected result:
+
+```text
+hl7v2-python smoke ok version=<version> segments=2
+```
+
+## Manual TestPyPI Proof
+
+Run the **Python TestPyPI Proof** workflow manually.
+
+First run with:
+
+```text
+publish_to_testpypi = false
+```
+
+This builds the wheel, installs it into a fresh virtual environment, runs the
+Python smoke test, and uploads the wheel as a short-retention artifact. It does
+not publish.
+
+After the local wheel proof and non-publishing workflow pass, rerun with:
+
+```text
+publish_to_testpypi = true
+```
+
+This does three things:
+
+1. Builds and smoke-tests the wheel.
+2. Publishes the wheel to TestPyPI using Trusted Publishing.
+3. Installs `hl7v2-python==<workspace version>` back from TestPyPI in a fresh
+   virtual environment and reruns `tests/python_smoke/smoke.py`.
+
+TestPyPI does not allow overwriting an existing file for the same version. If
+the upload fails because the version already exists, stop and choose a new
+workspace version for the next proof attempt. Do not use `skip-existing` for
+release proof, because that can accidentally test an older artifact.
+
+## Stop Conditions
+
+A TestPyPI proof is complete only when all of these are true:
+
+- The local wheel proof passes.
+- The manual workflow with `publish_to_testpypi=false` passes.
+- The manual workflow with `publish_to_testpypi=true` uploads the current
+  version to TestPyPI.
+- The install-back job installs from `https://test.pypi.org/simple/` and runs
+  `tests/python_smoke/smoke.py` successfully.
+
+This is still not a production PyPI release. Treat it as packaging evidence for
+the separate Python lane.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -127,7 +127,10 @@ owner = "hl7v2-python"
 surface = "python-binding"
 classification = "production"
 reason = "Maturin build metadata for the hl7v2-python wheel lane; the binding stays outside the Rust crates.io graph."
-covered_by = [".github/workflows/python-wheels.yml"]
+covered_by = [
+    ".github/workflows/python-wheels.yml",
+    ".github/workflows/python-testpypi.yml",
+]
 
 [[allow]]
 path = "justfile"
@@ -344,7 +347,11 @@ owner = "hl7v2-python"
 surface = "tests"
 classification = "test"
 reason = "Python binding smoke tests verify wheel install, import, parse, and JSON conversion."
-covered_by = [".github/workflows/python-wheels.yml", "python tests/python_smoke/smoke.py"]
+covered_by = [
+    ".github/workflows/python-wheels.yml",
+    ".github/workflows/python-testpypi.yml",
+    "python tests/python_smoke/smoke.py",
+]
 
 [[allow]]
 glob = "tests/server_smoke/**"


### PR DESCRIPTION
## Summary
- add a manual `Python TestPyPI Proof` workflow for the separate `hl7v2-python` distribution lane
- keep default dispatch non-publishing, with an explicit `publish_to_testpypi=true` path for Trusted Publishing and install-back smoke proof
- document TestPyPI setup, package identity, stop conditions, and the fact that this does not change the Rust crates.io graph

## Validation
- `npx -y yaml-lint .github/workflows/python-testpypi.yml`
- `git diff --cached --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- local Python proof in a fresh temp venv:
  - `python -m pip install --upgrade pip "maturin==1.13.1"`
  - `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"`
  - `python -m maturin build --release --out <temp>/dist`
  - `python -m venv <temp>/venv`
  - `<temp>/venv/Scripts/python.exe -m pip install --force-reinstall <temp>/dist/*.whl`
  - `<temp>/venv/Scripts/python.exe tests/python_smoke/smoke.py`

## Security / release notes
- The publish job is manual-only and uses `id-token: write` only in the TestPyPI publish job.
- The workflow uses Trusted Publishing from the `testpypi` GitHub environment and does not add PyPI/TestPyPI API tokens.
- No TestPyPI upload was executed locally; the external upload/install-back path requires TestPyPI pending publisher configuration and manual workflow dispatch.
- `hl7v2-python` remains `publish = false` for crates.io.
