### PR TITLE
docs: add Python evidence workflow guide

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,4 +9,5 @@ feeds.
 | [Vendor Upgrade Diff](vendor-upgrade-diff.md) | You need to compare before/after HL7 corpora and produce drift evidence for a migration, vendor change, or CI gate. |
 | [Safe Support Bundle](safe-support-bundle.md) | You need to redact one failing message, bundle the evidence, and prove someone else can replay it safely. |
 | [Deploy Validation Sidecar](deploy-validation-sidecar.md) | You need to run `hl7v2-server` as a small edge guard with readiness, redacted validation, ACK policy, quarantine, bundles, and metrics. |
+| [Python Evidence Workflow](python-evidence-workflow.md) | You want to use the Python binding for validation reports, corpus diffs, redaction, bundles, and replay in notebooks or QA scripts. |
 | [Python TestPyPI Release Proof](python-testpypi-release-proof.md) | You need to prove the separate `hl7v2-python` packaging lane through TestPyPI without changing the Rust crates.io graph. |

--- a/docs/guides/python-evidence-workflow.md
+++ b/docs/guides/python-evidence-workflow.md
@@ -1,0 +1,225 @@
+# Python Evidence Workflow
+
+This guide shows the Python binding as an analyst and QA workflow over the same
+evidence contracts used by the Rust crate, CLI, and server. It keeps the Python
+lane focused on deterministic artifacts: validation reports, corpus summaries,
+corpus diffs, redaction receipts, bundles, and replay reports.
+
+The examples use synthetic messages. They are safe to run from a source checkout
+after installing a locally built `hl7v2-python` wheel.
+
+## Install From A Local Wheel
+
+From the repository root:
+
+```powershell
+python -m pip install --upgrade pip "maturin==1.13.1"
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
+maturin build --release --out dist
+python -m pip install --force-reinstall (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+```
+
+The Python distribution is `hl7v2-python`; the import module is `hl7v2`.
+
+```python
+import hl7v2
+
+print(hl7v2.__version__)
+```
+
+## End-To-End Script
+
+Create `target/hl7v2-python-evidence/workflow.py`:
+
+```python
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import hl7v2
+
+
+ROOT = Path("target/hl7v2-python-evidence")
+shutil.rmtree(ROOT, ignore_errors=True)
+(ROOT / "before").mkdir(parents=True)
+(ROOT / "after").mkdir(parents=True)
+(ROOT / "reports").mkdir()
+
+profile_yaml = """
+message_structure: "GENERIC"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+  - id: "PID"
+constraints:
+  - path: "PID.3"
+    required: true
+  - path: "PID.5"
+    components:
+      min: 2
+valuesets:
+  - path: "PID.8"
+    name: "HL70001"
+    codes:
+      - "F"
+      - "M"
+      - "O"
+      - "U"
+      - "A"
+      - "N"
+"""
+
+redaction_policy = """
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "date of birth"
+
+[[rules]]
+path = "MSH.9"
+action = "retain"
+reason = "message type"
+
+[[rules]]
+path = "MSH.10"
+action = "retain"
+reason = "message control id"
+"""
+
+before_message = (
+    "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ADT^A01|CTRL100|P|2.5\r"
+    "PID|1||MRN-100^^^HOSP^MR||Example^Valid||19700101|M"
+)
+
+after_message = (
+    "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090201||ADT^A01|CTRL200|P|2.5\r"
+    "PID|1||MRN-200^^^HOSP^MR||Example^Invalid||19700101|X"
+)
+
+(ROOT / "before" / "site-a-001.hl7").write_text(before_message, encoding="utf-8")
+(ROOT / "after" / "site-a-001.hl7").write_text(after_message, encoding="utf-8")
+
+report = hl7v2.validate(after_message, profile_yaml)
+report_v2 = report.to_dict(2)
+
+summary_v2 = hl7v2.corpus_summary(str(ROOT / "after"), schema_version=2)
+fingerprint_v2 = hl7v2.corpus_fingerprint(
+    str(ROOT / "after"),
+    profile_yaml=profile_yaml,
+    schema_version=2,
+)
+diff_v2 = hl7v2.corpus_diff(
+    str(ROOT / "before"),
+    str(ROOT / "after"),
+    profile_yaml=profile_yaml,
+    schema_version=2,
+)
+
+redaction_v2 = hl7v2.redact(after_message, redaction_policy, schema_version=2)
+bundle_v2 = hl7v2.bundle(
+    after_message,
+    profile_yaml,
+    redaction_policy,
+    str(ROOT / "issue-bundle"),
+    schema_version=2,
+)
+replay_v2 = hl7v2.replay(str(ROOT / "issue-bundle"), schema_version=2)
+
+artifacts = {
+    "validation-report-v2.json": report_v2,
+    "corpus-summary-v2.json": summary_v2,
+    "corpus-fingerprint-v2.json": fingerprint_v2,
+    "corpus-diff-v2.json": diff_v2,
+    "redaction-output-v2.json": redaction_v2,
+    "bundle-summary-v2.json": bundle_v2,
+    "replay-report-v2.json": replay_v2,
+}
+
+for name, artifact in artifacts.items():
+    (ROOT / "reports" / name).write_text(
+        json.dumps(artifact, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+print(
+    json.dumps(
+        {
+            "version": hl7v2.__version__,
+            "validation_valid": report_v2["valid"],
+            "validation_issue_codes": [
+                issue["code"] for issue in report_v2["issues"]
+            ],
+            "after_message_count": summary_v2["message_count"],
+            "diff_field_presence_deltas": len(diff_v2["field_presence"]),
+            "redaction_phi_removed": redaction_v2["receipt"]["phi_removed"],
+            "bundle_artifacts": len(bundle_v2["artifacts"]),
+            "replay_reproduced": replay_v2["reproduced"],
+        },
+        indent=2,
+        sort_keys=True,
+    )
+)
+```
+
+Run it:
+
+```powershell
+python target\hl7v2-python-evidence\workflow.py
+```
+
+Expected output has the same evidence semantics as the CLI and server:
+
+```json
+{
+  "after_message_count": 1,
+  "bundle_artifacts": 10,
+  "diff_field_presence_deltas": 0,
+  "redaction_phi_removed": true,
+  "replay_reproduced": true,
+  "validation_issue_codes": [
+    "value_not_in_set"
+  ],
+  "validation_valid": false,
+  "version": "1.3.0"
+}
+```
+
+The exact `version` follows the installed wheel.
+
+## Outputs
+
+The script writes machine-readable artifacts under:
+
+```text
+target/hl7v2-python-evidence/reports/
+```
+
+The evidence bundle is written under:
+
+```text
+target/hl7v2-python-evidence/issue-bundle/
+```
+
+The bundle contains the redacted HL7 message, validation report, field-path
+trace, redaction receipt, environment metadata, manifest, README, and replay
+scripts. Replay verifies the manifest hashes before trusting bundle artifacts.
+
+## Safety Notes
+
+- Redaction receipts prove configured policy actions, not universal PHI absence.
+- User-authored profile YAML is included in bundles as supplied.
+- Bundle paths and replay reports should not expose local filesystem roots.
+- Use `schema_version=2` when you need provenance fields such as
+  `schema_version`, `tool_name`, and `tool_version`.


### PR DESCRIPTION
## Summary
- add a task guide for using the `hl7v2-python` binding as a Python evidence workflow
- cover validation report v2, corpus summary/fingerprint/diff v2, safe-analysis redaction, bundle creation, and replay verification
- link the guide from the guides index

## Validation
- extracted the full Python code block from `docs/guides/python-evidence-workflow.md`
- built a fresh local wheel with `python -m maturin build --release --out <temp>/dist`
- installed the wheel into a fresh temp virtual environment
- ran the extracted workflow script successfully against the installed wheel
- `git diff --cached --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 run -p xtask -- publish-plan`

## Notes
- This is docs-only and does not change the Python API or Rust publish graph.
