### PR TITLE
fix: align server bundle replay message type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed server evidence bundles so replay reproduces messages whose `MSH.9`
+  includes a third message-structure component such as `ADT^A01^ADT_A01`.
+
+### Documentation
+
+- Verified and refreshed the validation sidecar guide with live server replay
+  output and the current inline corpus diff response shape.
+
 ---
 
 ## [1.3.0] - 2026-05-09

--- a/crates/hl7v2-server/src/evidence.rs
+++ b/crates/hl7v2-server/src/evidence.rs
@@ -138,7 +138,7 @@ pub fn write_evidence_bundle(
         }
     })?;
 
-    let message_type = message_type(redacted_message);
+    let message_type = validation_report.message_type.clone();
     let field_trace = build_field_path_trace(redacted_message, redaction_receipt);
     let environment = EvidenceBundleEnvironment {
         bundle_version: BUNDLE_VERSION.to_string(),

--- a/crates/hl7v2-server/tests/replay_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/replay_endpoint_test.rs
@@ -34,6 +34,51 @@ constraints:
     required: true
 "#;
 
+const TRIPLET_MESSAGE: &str = "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01^ADT_A01|ABC123|P|2.5.1\rPID|1||123456^^^HOSP^MR||||19800101|X||Caucasian\r";
+
+const TRIPLET_PROFILE: &str = r#"
+message_structure: "GENERIC"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+  - id: "PID"
+constraints:
+  - path: "PID.3"
+    required: true
+valuesets:
+  - path: "PID.8"
+    name: "HL70001"
+    codes:
+      - "F"
+      - "M"
+      - "O"
+      - "U"
+      - "A"
+      - "N"
+"#;
+
+const TRIPLET_POLICY: &str = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "patient identifier"
+
+[[rules]]
+path = "PID.5"
+action = "drop"
+reason = "patient name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "date of birth"
+
+[[rules]]
+path = "PID.8"
+action = "retain"
+reason = "administrative sex is required to reproduce validation"
+"#;
+
 struct TempRoot {
     path: PathBuf,
 }
@@ -103,13 +148,23 @@ async fn post_json(app: axum::Router, uri: &str, body: Value) -> (StatusCode, Va
 }
 
 async fn create_bundle(root: &TempRoot, bundle_id: &str) {
+    create_bundle_with_input(root, bundle_id, PHI_MESSAGE, PROFILE, POLICY).await;
+}
+
+async fn create_bundle_with_input(
+    root: &TempRoot,
+    bundle_id: &str,
+    message: &str,
+    profile: &str,
+    policy: &str,
+) -> Value {
     let body = json!({
-        "message": PHI_MESSAGE,
-        "profile": PROFILE,
-        "redaction_policy": POLICY,
+        "message": message,
+        "profile": profile,
+        "redaction_policy": policy,
         "bundle_id": bundle_id
     });
-    let (status, _value, body_text) = post_json(
+    let (status, value, body_text) = post_json(
         test_router(Some(root.path().to_path_buf())),
         "/hl7/bundle",
         body,
@@ -117,6 +172,7 @@ async fn create_bundle(root: &TempRoot, bundle_id: &str) {
     .await;
 
     assert_eq!(status, StatusCode::CREATED, "{body_text}");
+    value
 }
 
 fn replay_body(bundle_id: &str) -> Value {
@@ -175,6 +231,47 @@ async fn test_replay_endpoint_schema_version_two_returns_v2_replay_report() {
     assert_eq!(report["tool_name"], "hl7v2-server");
     assert_eq!(report["reproduced"], true);
     assert_no_phi(&body_text);
+}
+
+#[tokio::test]
+async fn test_replay_endpoint_reproduces_bundle_when_msh9_has_message_structure_component() {
+    let root = TempRoot::new("msh9-triplet");
+    let bundle_id = "case-triplet";
+    let summary = create_bundle_with_input(
+        &root,
+        bundle_id,
+        TRIPLET_MESSAGE,
+        TRIPLET_PROFILE,
+        TRIPLET_POLICY,
+    )
+    .await;
+    assert_eq!(summary["message_type"], "ADT^A01");
+
+    let (status, report, body_text) = post_json(
+        test_router(Some(root.path().to_path_buf())),
+        "/hl7/replay",
+        json!({
+            "bundle_id": bundle_id,
+            "replay_report_schema_version": 2
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(report["schema_version"], "2");
+    assert_eq!(report["reproduced"], true, "{body_text}");
+    assert_eq!(report["message_type"], "ADT^A01");
+    assert_eq!(report["validation_valid"], false);
+    assert!(
+        report["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check["name"] == "environment-match" && check["status"] == "pass"),
+        "{body_text}"
+    );
+    assert_no_phi(&body_text);
+    assert!(!body_text.contains(root.path().to_string_lossy().as_ref()));
 }
 
 #[tokio::test]

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -21,6 +21,7 @@ cargo run -q -p hl7v2-server -- --print-config
 | `POST /hl7/validate-redacted` | Validate after safe-analysis redaction and optionally quarantine failures. |
 | `POST /hl7/corpus/*` | Summarize, fingerprint, and diff inline message sets without request path reads. |
 | `POST /hl7/bundle` | Create server-side redacted evidence bundles under a configured root. |
+| `POST /hl7/replay` | Verify server-created bundles by id and return a replay report. |
 | `POST /hl7/ack-policy` | Generate ACK/NAK responses from parse and validation results. |
 | `GET /metrics` | Expose Prometheus metrics for sidecar observation. |
 
@@ -130,10 +131,12 @@ Expected fields:
 ```json
 {
   "bind_address": "127.0.0.1:18080",
+  "max_body_size": 10485760,
   "api_key_configured": true,
   "profile_paths": [
     "profiles/generic.yaml"
   ],
+  "config_source": "target/hl7v2-sidecar/server.toml",
   "bundle_output_root_configured": true,
   "ack_policy": {
     "mode": "original",
@@ -174,8 +177,8 @@ cargo run -q -p hl7v2-server
 
 The server binds `127.0.0.1:18080` from the config above.
 
-For a container smoke check from the repository root, use the checked-in
-Compose stack:
+For a container smoke check from the repository root, start Docker first and use
+the checked-in Compose stack:
 
 ```bash
 docker compose -f infrastructure/docker/docker-compose.yml up --build -d
@@ -333,12 +336,27 @@ Expected fields:
     "after": 1,
     "delta": 0
   },
-  "validation_issue_code_counts": []
+  "field_presence": [
+    {
+      "path": "PID.5",
+      "message_count_delta": 1
+    }
+  ],
+  "validation_issue_code_counts": [
+    {
+      "value": "value_not_in_set",
+      "before": 1,
+      "after": 0,
+      "delta": -1
+    }
+  ]
 }
 ```
 
 Use `/hl7/corpus/summarize` for aggregate counts and
-`/hl7/corpus/fingerprint` for a deterministic feed signature.
+`/hl7/corpus/fingerprint` for a deterministic feed signature. In this fixture,
+the after message is cleaner than the before message: `PID.5` appears and the
+`PID.8` value-set issue disappears.
 
 ## 7. Create a Server-Side Evidence Bundle
 
@@ -369,7 +387,7 @@ Expected fields:
 {
   "bundle_version": "1",
   "output_dir": "case-001",
-  "message_type": "ADT^A01^ADT_A01",
+  "message_type": "ADT^A01",
   "redaction_phi_removed": true,
   "artifacts": [
     "message.redacted.hl7",
@@ -390,7 +408,59 @@ If the endpoint returns `503 BUNDLE_OUTPUT_NOT_CONFIGURED`, set
 `[server].bundle_output_root` or `HL7V2_BUNDLE_OUTPUT_ROOT` to an existing
 writable directory and restart the server.
 
-## 8. Generate ACK/NAK from Policy
+## 8. Replay the Server Bundle
+
+Replay verifies bundle integrity and regenerates the validation report from the
+stored redacted message and profile:
+
+```powershell
+$body = @{
+    bundle_id = "case-001"
+    replay_report_schema_version = 2
+} | ConvertTo-Json -Depth 8
+
+Invoke-RestMethod `
+    -Method Post `
+    -Uri http://127.0.0.1:18080/hl7/replay `
+    -Headers @{ "X-API-Key" = "dev-secret" } `
+    -ContentType "application/json" `
+    -Body $body |
+    ConvertTo-Json -Depth 20 |
+    Set-Content target/hl7v2-sidecar/reports/replay-report.json
+```
+
+Expected fields:
+
+```json
+{
+  "schema_version": "2",
+  "replay_version": "1",
+  "message_type": "ADT^A01",
+  "reproduced": true,
+  "validation_valid": false,
+  "validation_issue_count": 1,
+  "checks": [
+    {
+      "name": "manifest-hashes",
+      "status": "pass"
+    },
+    {
+      "name": "report-match",
+      "status": "pass"
+    },
+    {
+      "name": "environment-match",
+      "status": "pass"
+    }
+  ]
+}
+```
+
+If replay does not reproduce, treat the packet as untrusted. The report tells
+you whether the failure is a missing artifact, manifest/hash mismatch,
+parse/profile problem, report drift, or environment mismatch.
+
+## 9. Generate ACK/NAK from Policy
 
 Use `/hl7/ack-policy` when the sidecar needs to decide an ACK from the same
 validation evidence:
@@ -432,7 +502,7 @@ For the invalid sample, expected fields include:
 
 Enhanced mode uses `CA` and `CR` instead of `AA` and `AR`.
 
-## 9. Observe the Sidecar
+## 10. Observe the Sidecar
 
 Check liveness and metrics:
 


### PR DESCRIPTION
## Summary

- Align server evidence bundle `message_type` with the typed validation report so replay can reproduce bundles when `MSH.9` includes a third message-structure component such as `ADT^A01^ADT_A01`.
- Add a replay endpoint regression test for that triplet `MSH.9` case.
- Refresh the validation sidecar guide with verified live-server output for config, inline corpus diff, server bundle, and server replay.

## Validation

- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 test -p hl7v2-server --test replay_endpoint_test`
- `cargo +1.93.0 test -p hl7v2-server --test bundle_endpoint_test`
- `cargo +1.93.0 run -p xtask -- evidence-schema-check`
- `cargo +1.93.0 run -p xtask -- docs --no-open`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 test -p hl7v2-server --all-features`
- `cargo +1.93.0 clippy -p hl7v2-server --all-targets --all-features -- -D warnings`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Manual sidecar proof

Verified the documented source-checkout sidecar flow with `HL7V2_CONFIG=target/hl7v2-sidecar/server.toml`, `HL7V2_API_KEY=dev-secret`, and `HL7V2_PROFILE_PATHS=profiles/generic.yaml`:

- `cargo +1.93.0 run -q -p hl7v2-server -- --print-config`
- `GET /ready`
- `POST /hl7/validate-redacted`
- `POST /hl7/corpus/diff`
- `POST /hl7/bundle`
- `POST /hl7/replay`
- `POST /hl7/ack-policy`
- `GET /health`
- `GET /metrics`

The Docker Compose smoke command was also attempted, but Docker Desktop was not running locally (`dockerDesktopLinuxEngine` pipe missing). The guide now states Docker must be started first.

## Publish surface

`cargo +1.93.0 run -p xtask -- publish-plan` remains:

1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`