### PR TITLE
docs: prepare v1.4.0 release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in v2 provenance contracts and producer paths across validation,
+  profile, corpus, redaction, bundle, replay, quarantine, and doctor evidence
+  artifacts while keeping v1 defaults compatible.
+- Added server sidecar hardening after v1.3.0: inline corpus evidence
+  endpoints, server replay, bundle artifact schema opt-in, readiness path-leak
+  protection, redacted structured evidence logs, evidence metrics, and Docker
+  Compose smoke coverage.
+- Added Python evidence hardening: validation/corpus/redaction/bundle/replay
+  v2 parity, cross-surface PHI sentinel coverage, a manual TestPyPI proof
+  workflow, and a Python evidence workflow guide.
+- Added `cargo run -p xtask -- evidence-schema-check` as the maintained local
+  evidence fixture/schema validation rail.
+
 ### Fixed
 
 - Fixed server evidence bundles so replay reproduces messages whose `MSH.9`
@@ -18,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Verified and refreshed the validation sidecar guide with live server replay
   output and the current inline corpus diff response shape.
+- Added current-state and contract-index documentation for the post-v1.3.0
+  evidence-contract line.
 
 ---
 
@@ -50,11 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verifies manifest hashes before comparing regenerated evidence.
 - Current release documentation positions v1.3.0 as the published Evidence
   Loop release for the final Rust package graph.
-
-### Fixed
-
-- Aligned evidence bundle replay message-type handling with the bundle
-  contract so replay reports reproduce the stored validation report.
 
 ---
 
@@ -239,13 +251,15 @@ See [docs/STATUS.md](docs/STATUS.md) for complete status.
 
 ## Future Releases
 
-### v1.3.0 Evidence Loop Release
+### v1.4.0 Evidence Contracts and Server Sidecar
 
-- Promote the current evidence-loop candidate once final release validation
-  passes: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` publish dry-runs,
-  full gate checks, API contract checks, and Python wheel smoke proof.
+- Promote the current post-v1.3.0 evidence-contract candidate once final
+  release validation passes: evidence schema checks, full gate, API contract
+  checks, Rust publish dry-runs for `hl7v2`, `hl7v2-server`, and `hl7v2-cli`,
+  and Python wheel smoke proof.
 - Keep `hl7v2-python` on the Python/maturin lane instead of the Rust
-  crates.io publish graph.
+  crates.io publish graph. Use the manual TestPyPI proof workflow before any
+  production PyPI release.
 
 ### Later releases
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
 | **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published to crates.io; Python remains a separate binding lane |
-| **Evidence Loop** | Stable | v1.3.0 includes typed reports, profile test/explain, corpus fingerprint/diff, redaction, bundle/replay, schemas, goldens, and server/Python parity; current main adds redacted structured server evidence logs |
+| **Evidence Loop** | Stable | v1.3.0 is the published Evidence Loop baseline; current main is the unreleased v1.4 candidate with opt-in v2 provenance, schema gates, server sidecar hardening, Python/TestPyPI proof, PHI sentinels, and replay fixes |
 
 ## Features
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-09
-> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is the post-v1.3.0 evidence-hardening line.
+> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is an unreleased v1.4.0 evidence-contract candidate.
 
 ## Core Components
 
@@ -27,7 +27,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **API Authentication**: Constant-time API Key validation.
 - ✅ **Rate Limiting**: Per-IP throttling to prevent DoS.
 - ✅ **Prometheus Metrics**: Throughput, latency, and error tracking.
-- ✅ **Audit Ready**: Redacted structured evidence logs with hashed message-control and bundle identifiers; JSON output is available with `RUST_LOG_FORMAT=json`.
+- ✅ **Audit Ready**: Server metrics and structured runtime logs are available. Redacted evidence-workflow logs with hashed message-control and bundle identifiers are part of the unreleased v1.4.0 candidate.
 
 ### 🧪 Quality Assurance
 - ✅ **BDD Tests**: Real validation scenarios verified with Cucumber.
@@ -41,7 +41,8 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-09.md`.
-- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The binding is verified through a maturin wheel build/install/import smoke lane, with a manual TestPyPI proof workflow available before any production PyPI release.
+- 🟡 **Current main release candidate**: current `main` is not published as v1.4.0 yet. Run a fresh full gate, evidence schema check, API Contracts, and dependency-ordered `cargo publish --dry-run` before tagging or uploading the next Rust release.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.3.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1` and `v1.3.0` tags point at their release heads.
 
@@ -51,6 +52,13 @@ v1.3.0 is the Evidence Loop release line around deterministic HL7 interface
 evidence. It is tagged, released on GitHub, and uploaded to crates.io for the
 final Rust package graph.
 
+Current `main` is not yet published as v1.4.0. It contains post-v1.3.0
+evidence-contract hardening: opt-in v2 provenance producers, maintained schema
+validation through `xtask evidence-schema-check`, server replay and inline
+corpus endpoints, redacted structured evidence logs, Docker sidecar smoke
+coverage, broader PHI sentinel tests, Python/TestPyPI proof, and the server
+bundle replay message-type fix.
+
 | Area | Status | Notes |
 |------|--------|-------|
 | First-run diagnostics | ✅ Stable | `hl7v2 doctor` verifies CLI version, sample parse, profile loading, JSON output, optional server reachability, and optional Python binding presence. |
@@ -58,10 +66,10 @@ final Rust package graph.
 | Profiles as code | ✅ Stable | `profile lint`, `profile test`, and `profile explain` produce machine-readable profile evidence. |
 | Corpus observability | ✅ Stable | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. |
 | Safe support packets | ✅ Stable | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
-| Evidence contracts | ✅ Stable | JSON schemas and golden fixtures guard the machine-readable evidence artifacts. |
+| Evidence contracts | ✅ Stable | v1.3.0 shipped the evidence loop baseline; current main adds opt-in v2 provenance schemas/producers and an `xtask evidence-schema-check` gate. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
-| Server edge guard | ✅ Stable | Server supports sanitized `--print-config`, `/ready`, `/hl7/validate-redacted`, `/hl7/bundle`, `/hl7/replay`, `/hl7/ack-policy`, inline corpus endpoints, quarantine hooks, and redacted structured evidence logs. |
-| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Python remains outside the crates.io Rust publish graph; TestPyPI proof is manual-first and separate from production PyPI. |
+| Server edge guard | ✅ Stable | v1.3.0 shipped the sidecar baseline. Current main adds `/hl7/replay`, inline corpus endpoints, bundle artifact schema opt-in, redacted structured evidence logs, evidence metrics, Docker smoke coverage, and the bundle replay message-type fix. |
+| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Current main adds v2 parity, PHI sentinel coverage, Python evidence docs, and a manual TestPyPI proof workflow. Python remains outside the crates.io Rust publish graph. |
 
 ## v1.3.0 Readiness Checklist
 
@@ -75,6 +83,17 @@ Publish receipt: [`docs/audits/publish-2026-05-09.md`](audits/publish-2026-05-09
 - ✅ **Python proof**: the maturin wheel build/install/import smoke lane passes without publishing `hl7v2-python` to crates.io.
 - ✅ **Release notes and tag**: `v1.3.0` is tagged and the GitHub release is published.
 
+## v1.4.0 Candidate Checklist
+
+Draft release notes: [`docs/releases/v1.4.0-evidence-contracts.md`](releases/v1.4.0-evidence-contracts.md).
+
+- 🟡 **Publish plan**: `cargo run -p xtask -- publish-plan` should continue to resolve `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- 🟡 **Evidence schemas**: `cargo run -p xtask -- evidence-schema-check` must pass on the release head.
+- 🟡 **Full gate**: `cargo run -p xtask -- gate --check` must pass on the release head.
+- 🟡 **Dry-runs**: run dependency-ordered `cargo publish --dry-run` for `hl7v2`, `hl7v2-server`, and `hl7v2-cli` before upload.
+- 🟡 **Python proof**: run maturin wheel build/install/import smoke proof, and use the manual TestPyPI proof workflow before production PyPI.
+- 🟡 **Release notes and tag**: no `v1.4.0` tag or GitHub release exists yet.
+
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
@@ -83,4 +102,5 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 **Current published release**: v1.3.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
 **Current main**: tracks the post-v1.3.0 Evidence Loop hardening line. The
-published Rust crates remain v1.3.0 until the next release train.
+published Rust crates remain v1.3.0 until the v1.4.0 dry-run and publish train
+is executed.

--- a/docs/releases/v1.4.0-evidence-contracts.md
+++ b/docs/releases/v1.4.0-evidence-contracts.md
@@ -1,0 +1,109 @@
+# v1.4.0 Evidence Contracts and Server Sidecar
+
+Status: draft. Current `main` is a v1.4.0 candidate, but the release has not
+been dry-run, tagged, published to crates.io, or uploaded to GitHub Releases.
+
+This release candidate packages the post-v1.3.0 hardening work that turns the
+Evidence Loop into a more explicit contract surface: opt-in v2 provenance,
+schema validation rails, server sidecar replay/corpus workflows, Python
+distribution proof, and stronger PHI regression coverage.
+
+## Publish Surface
+
+The Rust crates.io publish graph remains:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+`hl7v2-python` stays on the Python/maturin lane. The TestPyPI workflow is a
+manual proof lane and does not move the binding crate into the Rust crates.io
+publish graph.
+
+Historical implementation microcrate names are not part of this release train.
+
+## Candidate Highlights
+
+### Evidence Contracts
+
+- Opt-in v2 provenance output for validation, profile lint/test/explain,
+  corpus summary/fingerprint/diff, redaction, bundle, replay, quarantine, and
+  doctor artifacts.
+- v2 bundle-internal artifacts for manifest, environment, field-path traces,
+  and redaction receipts through explicit bundle schema-version controls.
+- `cargo run -p xtask -- evidence-schema-check` validates checked-in evidence
+  fixtures against their JSON Schemas.
+- Evidence contract index and provenance/versioning docs describe default v1
+  shapes, v2 opt-ins, producer surfaces, fixtures, and PHI notes.
+
+### Server Sidecar
+
+- Server replay endpoint for configured-root evidence bundles.
+- Inline server corpus summarize/fingerprint/diff endpoints that do not read
+  caller-supplied filesystem paths.
+- Redacted structured evidence logs with hashed message-control and bundle
+  identifiers.
+- Evidence metrics for validation failures, redaction failures, bundles,
+  replays, replay failures, and corpus diffs.
+- Docker Compose sidecar smoke assets.
+- Readiness checks avoid leaking configured profile paths.
+- Server bundle replay now reproduces messages whose `MSH.9` includes a third
+  message-structure component such as `ADT^A01^ADT_A01`.
+
+### CLI And Guides
+
+- Doctor report v2 output controls.
+- Built-in sample generation and `validate-sample` onboarding commands.
+- Updated validation sidecar guide with live source-run server output,
+  server-side replay, inline corpus diff evidence, and Docker prerequisites.
+- Python evidence workflow guide covering validation, corpus, redaction,
+  bundle, and replay APIs.
+
+### Python Lane
+
+- Python validation, corpus, redaction, bundle, and replay APIs can emit the
+  same v2 evidence shapes as the CLI/server where supported.
+- Cross-surface PHI leak sentinels cover Python redaction, bundle, and replay
+  workflows.
+- Manual TestPyPI workflow builds, installs, smokes, optionally publishes to
+  TestPyPI through trusted publishing, then installs back from TestPyPI.
+
+## Required Release Checks
+
+Before publishing v1.4.0, run and record at minimum:
+
+```powershell
+cargo +1.93.0 metadata --format-version 1 --no-deps
+cargo +1.93.0 run -p xtask -- publish-plan
+cargo +1.93.0 run -p xtask -- evidence-schema-check
+cargo +1.93.0 run -p xtask -- gate --check
+cargo +1.93.0 publish -p hl7v2 --dry-run
+cargo +1.93.0 publish -p hl7v2-server --dry-run
+cargo +1.93.0 publish -p hl7v2-cli --dry-run
+```
+
+For the Python lane:
+
+```powershell
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+python -m maturin build --release --out dist
+python tests/python_smoke/smoke.py
+```
+
+The TestPyPI workflow should be run manually before any production PyPI
+release, but it is not a crates.io release blocker.
+
+## Known Boundaries
+
+- v1 remains the default machine-readable output shape unless a command or
+  request explicitly asks for schema version 2.
+- `hl7v2-python` is not part of the Rust crates.io publish graph.
+- Old microcrate package names are not republished.
+- Server corpus endpoints accept inline messages only; they do not read
+  request-supplied filesystem paths.
+- Server bundle and replay endpoints operate under configured roots and return
+  root-relative ids, not configured filesystem roots.
+- Redaction receipts prove configured policy actions. They are not a universal
+  PHI absence certificate.
+- Profile files are user-authored and included as supplied in bundles; review
+  profiles before sharing support packets.


### PR DESCRIPTION
## Summary

- Add draft v1.4.0 release notes for the post-v1.3.0 Evidence Contracts and Server Sidecar candidate.
- Move post-v1.3.0 work into the Unreleased changelog bucket and remove the replay message-type fix from the published v1.3.0 section.
- Update README and status docs to distinguish the published v1.3.0 release from current main, which remains an unpublished v1.4.0 candidate.

## Validation

- `git diff --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 run -p xtask -- evidence-schema-check`
- `cargo +1.93.0 run -p xtask -- docs --no-open`
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Release boundary

This PR does not publish, tag, or bump versions. It records that v1.3.0 is already published and current main is only a v1.4.0 candidate until the release dry-run/publish train executes.