### PR TITLE
release: prepare v1.4.0 dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.4.0] - 2026-05-09
+
 ### Added
 
 - Added opt-in v2 provenance contracts and producer paths across validation,
@@ -31,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Prepared the v1.4.0 package line and publish dry-run receipt for the final
+  Rust crates.io graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - Verified and refreshed the validation sidecar guide with live server replay
   output and the current inline corpus diff response shape.
 - Added current-state and contract-index documentation for the post-v1.3.0
@@ -250,18 +256,6 @@ See [docs/STATUS.md](docs/STATUS.md) for complete status.
 ---
 
 ## Future Releases
-
-### v1.4.0 Evidence Contracts and Server Sidecar
-
-- Promote the current post-v1.3.0 evidence-contract candidate once final
-  release validation passes: evidence schema checks, full gate, API contract
-  checks, Rust publish dry-runs for `hl7v2`, `hl7v2-server`, and `hl7v2-cli`,
-  and Python wheel smoke proof.
-- Keep `hl7v2-python` on the Python/maturin lane instead of the Rust
-  crates.io publish graph. Use the manual TestPyPI proof workflow before any
-  production PyPI release.
-
-### Later releases
 
 - Continue server sidecar hardening, Python distribution proof, profile
   conformance quality, and compatibility-shim policy cleanup as separate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "async-lock",
  "bytes",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-bench"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "criterion",
  "futures",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-e2e-tests"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-examples"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "hl7v2",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-python"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "hl7v2",
  "pyo3",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-server"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-test-utils"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "hl7v2",
  "insta",
@@ -5556,7 +5556,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.93"
 
@@ -193,7 +193,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-hl7v2 = { version = "1.3.0", path = "crates/hl7v2", features = [
+hl7v2 = { version = "1.4.0", path = "crates/hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.3.0
+  version: 1.4.0
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-bench/Cargo.toml
+++ b/crates/hl7v2-bench/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "parsing"]
 
 [dependencies]
 # Library surface under benchmark
-hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
@@ -73,4 +73,3 @@ harness = false
 [[bench]]
 name = "template"
 harness = false
-

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml.workspace = true
 sha2.workspace = true
-hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
@@ -27,7 +27,7 @@ hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
     "network",
     "synthetic",
 ] }
-hl7v2-server = { version = "1.3.0", path = "../hl7v2-server" }
+hl7v2-server = { version = "1.4.0", path = "../hl7v2-server" }
 sysinfo = "0.38.2"
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/hl7v2-e2e-tests/Cargo.toml
+++ b/crates/hl7v2-e2e-tests/Cargo.toml
@@ -12,15 +12,15 @@ repository.workspace = true
 
 [dependencies]
 # Local crates - full system integration
-hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
     "stream",
     "network",
 ] }
-hl7v2-test-utils = { version = "1.3.0", path = "../hl7v2-test-utils" }
-hl7v2-server = { version = "1.3.0", path = "../hl7v2-server" }
+hl7v2-test-utils = { version = "1.4.0", path = "../hl7v2-test-utils" }
+hl7v2-server = { version = "1.4.0", path = "../hl7v2-server" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 
 [dependencies]
 # Local crates
-hl7v2 = { version = "1.3.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.3.0
+  version: 1.4.0
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-test-utils/Cargo.toml
+++ b/crates/hl7v2-test-utils/Cargo.toml
@@ -11,7 +11,7 @@ publish = false  # Dev-only crate
 repository.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.3.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.4.0", path = "../hl7v2", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-09
-> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is an unreleased v1.4.0 evidence-contract candidate.
+> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` prepares the unpublished v1.4.0 evidence-contract package line.
 
 ## Core Components
 
@@ -41,7 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-09.md`.
-- 🟡 **Current main release candidate**: current `main` is not published as v1.4.0 yet. Run a fresh full gate, evidence schema check, API Contracts, and dependency-ordered `cargo publish --dry-run` before tagging or uploading the next Rust release.
+- 🟡 **Current main release candidate**: current `main` is prepared as v1.4.0 and has a local dry-run receipt. It is not tagged, released on GitHub, or published to crates.io yet. Run hosted CI/API Contracts on the release PR and rerun dependency-ordered dry-runs during the real upload sequence.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.3.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1` and `v1.3.0` tags point at their release heads.
@@ -52,7 +52,8 @@ v1.3.0 is the Evidence Loop release line around deterministic HL7 interface
 evidence. It is tagged, released on GitHub, and uploaded to crates.io for the
 final Rust package graph.
 
-Current `main` is not yet published as v1.4.0. It contains post-v1.3.0
+Current `main` is prepared as the v1.4.0 package line but is not yet published
+as v1.4.0. It contains post-v1.3.0
 evidence-contract hardening: opt-in v2 provenance producers, maintained schema
 validation through `xtask evidence-schema-check`, server replay and inline
 corpus endpoints, redacted structured evidence logs, Docker sidecar smoke
@@ -86,12 +87,14 @@ Publish receipt: [`docs/audits/publish-2026-05-09.md`](audits/publish-2026-05-09
 ## v1.4.0 Candidate Checklist
 
 Draft release notes: [`docs/releases/v1.4.0-evidence-contracts.md`](releases/v1.4.0-evidence-contracts.md).
+Dry-run receipt: [`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](audits/publish-dry-run-v1.4.0-2026-05-09.md).
 
-- 🟡 **Publish plan**: `cargo run -p xtask -- publish-plan` should continue to resolve `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-- 🟡 **Evidence schemas**: `cargo run -p xtask -- evidence-schema-check` must pass on the release head.
-- 🟡 **Full gate**: `cargo run -p xtask -- gate --check` must pass on the release head.
-- 🟡 **Dry-runs**: run dependency-ordered `cargo publish --dry-run` for `hl7v2`, `hl7v2-server`, and `hl7v2-cli` before upload.
-- 🟡 **Python proof**: run maturin wheel build/install/import smoke proof, and use the manual TestPyPI proof workflow before production PyPI.
+- ✅ **Publish plan**: `cargo run -p xtask -- publish-plan` resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- ✅ **Evidence schemas**: `cargo run -p xtask -- evidence-schema-check` passes on the v1.4.0 package line.
+- ✅ **API contracts**: local OpenAPI lint, proto lint, and packaged proto/OpenAPI drift tests pass on the v1.4.0 package line.
+- ✅ **Full gate**: `cargo run -p xtask -- gate --check` passes on the v1.4.0 package line.
+- ✅ **Dry-runs**: direct `hl7v2` dry-run and workspace-patched full-graph dry-run pass. Direct dependent dry-runs correctly wait for `hl7v2` v1.4.0 to exist in the crates.io index during the real publish sequence.
+- ✅ **Python proof**: the maturin wheel build/install/import smoke proof passes for the v1.4.0 Python lane package without publishing `hl7v2-python` to crates.io.
 - 🟡 **Release notes and tag**: no `v1.4.0` tag or GitHub release exists yet.
 
 ## Historical Plans
@@ -102,5 +105,5 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 **Current published release**: v1.3.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
 **Current main**: tracks the post-v1.3.0 Evidence Loop hardening line. The
-published Rust crates remain v1.3.0 until the v1.4.0 dry-run and publish train
-is executed.
+published Rust crates remain v1.3.0 until the v1.4.0 publish train is
+executed.

--- a/docs/audits/publish-dry-run-v1.4.0-2026-05-09.md
+++ b/docs/audits/publish-dry-run-v1.4.0-2026-05-09.md
@@ -1,0 +1,150 @@
+# v1.4.0 Publish Dry-Run Receipt
+
+Date: 2026-05-09
+
+This receipt records release-candidate package verification for the v1.4.0
+Evidence Contracts and Server Sidecar line. No crates were published by these
+commands.
+
+## Version Line
+
+The workspace package line and active workspace packages were prepared as
+`1.4.0`.
+
+Verified with:
+
+```powershell
+cargo +1.93.0 metadata --format-version 1 --no-deps
+```
+
+Observed public package versions:
+
+| Package | Version |
+| ------- | ------- |
+| `hl7v2` | `1.4.0` |
+| `hl7v2-server` | `1.4.0` |
+| `hl7v2-cli` | `1.4.0` |
+
+`hl7v2-python` is also versioned as `1.4.0` for the Python/maturin lane, but
+it remains `publish = false` for crates.io.
+
+## Publish Plan
+
+```powershell
+cargo +1.93.0 run -p xtask -- publish-plan
+```
+
+Result:
+
+```text
+crates.io publish order
+ 1. hl7v2
+ 2. hl7v2-server
+ 3. hl7v2-cli
+```
+
+## Contract And Gate Checks
+
+```powershell
+cargo +1.93.0 run -p xtask -- evidence-schema-check
+npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml
+npx -y @bufbuild/buf lint api/proto
+cargo +1.93.0 test -p hl7v2-server --test proto_packaging_test
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+cargo +1.93.0 run -p xtask -- gate --check
+```
+
+Result: pass.
+
+The evidence schema gate validated 33 checked-in evidence fixtures. The API
+contract checks validated OpenAPI lint, proto lint, and packaged proto/OpenAPI
+asset drift. The full gate checked lint policy, no-panic-family policy,
+non-Rust file policy, formatting, dependency graph warmup, clippy, and test
+compilation.
+
+## Rust Dry-Runs
+
+Direct `hl7v2` dry-run:
+
+```powershell
+cargo +1.93.0 publish -p hl7v2 --dry-run --locked
+```
+
+Result: pass.
+
+```text
+Packaging hl7v2 v1.4.0
+Packaged 62 files, 912.7KiB (173.2KiB compressed)
+Verifying hl7v2 v1.4.0
+Uploading hl7v2 v1.4.0
+warning: aborting upload due to dry run
+```
+
+Workspace-patched graph dry-run:
+
+```powershell
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches
+```
+
+Result: pass.
+
+```text
+Dry-running hl7v2...
+Dry-running hl7v2-server...
+Dry-running hl7v2-cli...
+Publish dry-run checks passed!
+```
+
+Packaged artifacts:
+
+| Package | Version | Package size | Compressed |
+| ------- | ------- | ------------ | ---------- |
+| `hl7v2` | `1.4.0` | 912.7 KiB | 173.2 KiB |
+| `hl7v2-server` | `1.4.0` | 539.4 KiB | 105.9 KiB |
+| `hl7v2-cli` | `1.4.0` | 574.2 KiB | 96.5 KiB |
+
+Direct dependent dry-runs before publishing `hl7v2` are expected to stop at the
+crates.io index boundary:
+
+```powershell
+cargo +1.93.0 publish -p hl7v2-server --dry-run --locked
+cargo +1.93.0 publish -p hl7v2-cli --dry-run --locked
+```
+
+Both reported that `hl7v2 = "^1.4.0"` could not be resolved because crates.io
+currently exposes `hl7v2` `1.3.0` and `1.2.1`, not `1.4.0`.
+
+## Python Lane Proof
+
+The Python binding remains outside the Rust crates.io publish graph. The wheel
+proof was run with the build backend version required by `pyproject.toml`:
+
+```powershell
+python -m maturin --version
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'
+python -m maturin build --release --out dist
+python -m pip install --force-reinstall dist\hl7v2_python-1.4.0-cp314-cp314-win_amd64.whl
+python tests/python_smoke/smoke.py
+```
+
+Result: pass.
+
+```text
+maturin 1.13.1
+Built wheel for CPython 3.14 to dist\hl7v2_python-1.4.0-cp314-cp314-win_amd64.whl
+Successfully installed hl7v2-python-1.4.0
+hl7v2-python smoke ok version=1.4.0 segments=2
+```
+
+## Publish Boundary
+
+These checks do not publish anything. Actual publish order remains:
+
+1. `cargo +1.93.0 publish -p hl7v2`
+2. wait for `hl7v2` `1.4.0` to appear in the crates.io index
+3. `cargo +1.93.0 publish -p hl7v2-server`
+4. `cargo +1.93.0 publish -p hl7v2-cli`
+
+`hl7v2-python` should stay on the Python packaging lane unless a separate
+TestPyPI/PyPI release decision is made.

--- a/docs/guides/first-10-minutes.md
+++ b/docs/guides/first-10-minutes.md
@@ -49,7 +49,7 @@ Expected output includes local diagnostics:
 
 ```json
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "checks": [
     {
       "name": "sample-parse",

--- a/docs/guides/python-evidence-workflow.md
+++ b/docs/guides/python-evidence-workflow.md
@@ -192,7 +192,7 @@ Expected output has the same evidence semantics as the CLI and server:
     "value_not_in_set"
   ],
   "validation_valid": false,
-  "version": "1.3.0"
+  "version": "1.4.0"
 }
 ```
 

--- a/docs/releases/v1.4.0-evidence-contracts.md
+++ b/docs/releases/v1.4.0-evidence-contracts.md
@@ -1,7 +1,8 @@
 # v1.4.0 Evidence Contracts and Server Sidecar
 
-Status: draft. Current `main` is a v1.4.0 candidate, but the release has not
-been dry-run, tagged, published to crates.io, or uploaded to GitHub Releases.
+Status: draft. Current `main` is prepared as the v1.4.0 package line and has a
+local dry-run receipt, but the release has not been tagged, published to
+crates.io, or uploaded to GitHub Releases.
 
 This release candidate packages the post-v1.3.0 hardening work that turns the
 Evidence Loop into a more explicit contract surface: opt-in v2 provenance,
@@ -76,6 +77,9 @@ Before publishing v1.4.0, run and record at minimum:
 cargo +1.93.0 metadata --format-version 1 --no-deps
 cargo +1.93.0 run -p xtask -- publish-plan
 cargo +1.93.0 run -p xtask -- evidence-schema-check
+npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml
+npx -y @bufbuild/buf lint api/proto
+cargo +1.93.0 test -p hl7v2-server --test proto_packaging_test
 cargo +1.93.0 run -p xtask -- gate --check
 cargo +1.93.0 publish -p hl7v2 --dry-run
 cargo +1.93.0 publish -p hl7v2-server --dry-run
@@ -92,6 +96,9 @@ python tests/python_smoke/smoke.py
 
 The TestPyPI workflow should be run manually before any production PyPI
 release, but it is not a crates.io release blocker.
+
+Current dry-run receipt:
+[`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](../audits/publish-dry-run-v1.4.0-2026-05-09.md).
 
 ## Known Boundaries
 


### PR DESCRIPTION
## Summary

- bump the workspace/package line and internal workspace dependency pins to `1.4.0`
- align the server OpenAPI metadata with the v1.4.0 package line
- record the v1.4.0 dry-run receipt and update status/release docs while keeping `hl7v2-python` outside the Rust crates.io graph

## Validation

- `cargo +1.93.0 metadata --format-version 1 --no-deps`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 run -p xtask -- evidence-schema-check`
- `npx @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml`
- `npx -y @bufbuild/buf lint api/proto`
- `cargo +1.93.0 test -p hl7v2-server --test proto_packaging_test`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests evidence_golden_fixtures -- --nocapture`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- docs --no-open`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check`
- `cargo +1.93.0 publish -p hl7v2 --dry-run --locked`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- publish-dry-run --from hl7v2 --workspace-patches`
- `cargo +1.93.0 publish -p hl7v2-server --dry-run --locked` stopped at the expected index boundary because `hl7v2` `1.4.0` is not published yet
- `cargo +1.93.0 publish -p hl7v2-cli --dry-run --locked` stopped at the expected index boundary because `hl7v2` `1.4.0` is not published yet
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; python -m maturin build --release --out dist`
- `python -m pip install --force-reinstall dist\hl7v2_python-1.4.0-cp314-cp314-win_amd64.whl; python tests\python_smoke\smoke.py`

## Publish Boundary

This PR does not publish, tag, or create a GitHub release. The Rust publish graph remains:

1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`

`hl7v2-python` stays on the Python/maturin lane and remains out of crates.io.