### PR TITLE
docs: record v1.4.0 publish receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. `hl7v2-python` remains a separate Python/maturin binding lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -24,8 +24,8 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
-| **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published to crates.io; Python remains a separate binding lane |
-| **Evidence Loop** | Stable | v1.3.0 is the published Evidence Loop baseline; current main is the unreleased v1.4 candidate with opt-in v2 provenance, schema gates, server sidecar hardening, Python/TestPyPI proof, PHI sentinels, and replay fixes |
+| **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published to crates.io; Python remains a separate binding lane |
+| **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release with opt-in v2 provenance, schema gates, server sidecar hardening, Python/TestPyPI proof, PHI sentinels, and replay fixes |
 
 ## Features
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-09
-> **Project Status**: v1.3.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` prepares the unpublished v1.4.0 evidence-contract package line.
+> **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 
 ## Core Components
 
@@ -15,7 +15,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2-python` | 🟡 Experimental | Smoke | PyO3 binding package held out of the crates.io Rust publish graph; validated through the Python/maturin wheel smoke lane before any PyPI release. |
 | retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
-## Published Feature Set (v1.3.0)
+## Published Feature Set (v1.4.0)
 
 ### 🚀 Connectivity
 - ✅ **MLLP Over TCP**: Fully implemented async client and server.
@@ -27,7 +27,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **API Authentication**: Constant-time API Key validation.
 - ✅ **Rate Limiting**: Per-IP throttling to prevent DoS.
 - ✅ **Prometheus Metrics**: Throughput, latency, and error tracking.
-- ✅ **Audit Ready**: Server metrics and structured runtime logs are available. Redacted evidence-workflow logs with hashed message-control and bundle identifiers are part of the unreleased v1.4.0 candidate.
+- ✅ **Audit Ready**: Server metrics and structured runtime logs are available. Redacted evidence-workflow logs with hashed message-control and bundle identifiers are part of v1.4.0.
 
 ### 🧪 Quality Assurance
 - ✅ **BDD Tests**: Real validation scenarios verified with Cucumber.
@@ -37,24 +37,21 @@ This document provides a transparent view of which features are fully implemente
 
 ## Release and Publish Readiness
 
-- ✅ **Main workflows**: required CI success, Coverage, Security, Python Wheels, and API Contracts are green on the v1.3.0 release head. Extended tests passed in the main CI run; benchmark artifacts remain a non-publish performance lane.
+- ✅ **Main workflows**: required CI success, Security, Python Wheels, and API Contracts are green on the v1.4.0 release head. Coverage is unchanged/skipped for this docs/package release lane. Extended tests and benchmark artifacts remain non-publish performance lanes.
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-- ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.3.0 are published and visible in the crates.io index. See `docs/audits/publish-2026-05-09.md`.
-- ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-2026-05-09.md`.
-- 🟡 **Current main release candidate**: current `main` is prepared as v1.4.0 and has a local dry-run receipt. It is not tagged, released on GitHub, or published to crates.io yet. Run hosted CI/API Contracts on the release PR and rerun dependency-ordered dry-runs during the real upload sequence.
-- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.3.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release.
+- ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
+- ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
-- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1` and `v1.3.0` tags point at their release heads.
+- ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
 
-## Evidence Loop Release And Current Main
+## Evidence Contracts Release And Current Main
 
-v1.3.0 is the Evidence Loop release line around deterministic HL7 interface
-evidence. It is tagged, released on GitHub, and uploaded to crates.io for the
-final Rust package graph.
+v1.4.0 is the Evidence Contracts and Server Sidecar release line around
+deterministic HL7 interface evidence. It is tagged, released on GitHub, and
+uploaded to crates.io for the final Rust package graph.
 
-Current `main` is prepared as the v1.4.0 package line but is not yet published
-as v1.4.0. It contains post-v1.3.0
-evidence-contract hardening: opt-in v2 provenance producers, maintained schema
+Current `main` contains opt-in v2 provenance producers, maintained schema
 validation through `xtask evidence-schema-check`, server replay and inline
 corpus endpoints, redacted structured evidence logs, Docker sidecar smoke
 coverage, broader PHI sentinel tests, Python/TestPyPI proof, and the server
@@ -67,10 +64,10 @@ bundle replay message-type fix.
 | Profiles as code | ✅ Stable | `profile lint`, `profile test`, and `profile explain` produce machine-readable profile evidence. |
 | Corpus observability | ✅ Stable | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. |
 | Safe support packets | ✅ Stable | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
-| Evidence contracts | ✅ Stable | v1.3.0 shipped the evidence loop baseline; current main adds opt-in v2 provenance schemas/producers and an `xtask evidence-schema-check` gate. |
+| Evidence contracts | ✅ Stable | v1.4.0 ships opt-in v2 provenance schemas/producers and an `xtask evidence-schema-check` gate. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
-| Server edge guard | ✅ Stable | v1.3.0 shipped the sidecar baseline. Current main adds `/hl7/replay`, inline corpus endpoints, bundle artifact schema opt-in, redacted structured evidence logs, evidence metrics, Docker smoke coverage, and the bundle replay message-type fix. |
-| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. Current main adds v2 parity, PHI sentinel coverage, Python evidence docs, and a manual TestPyPI proof workflow. Python remains outside the crates.io Rust publish graph. |
+| Server edge guard | ✅ Stable | v1.4.0 ships `/hl7/replay`, inline corpus endpoints, bundle artifact schema opt-in, redacted structured evidence logs, evidence metrics, Docker smoke coverage, and the bundle replay message-type fix. |
+| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. v1.4.0 adds v2 parity, PHI sentinel coverage, Python evidence docs, and a manual TestPyPI proof workflow. Python remains outside the crates.io Rust publish graph. |
 
 ## v1.3.0 Readiness Checklist
 
@@ -84,10 +81,11 @@ Publish receipt: [`docs/audits/publish-2026-05-09.md`](audits/publish-2026-05-09
 - ✅ **Python proof**: the maturin wheel build/install/import smoke lane passes without publishing `hl7v2-python` to crates.io.
 - ✅ **Release notes and tag**: `v1.3.0` is tagged and the GitHub release is published.
 
-## v1.4.0 Candidate Checklist
+## v1.4.0 Readiness Checklist
 
-Draft release notes: [`docs/releases/v1.4.0-evidence-contracts.md`](releases/v1.4.0-evidence-contracts.md).
+Release notes: [`docs/releases/v1.4.0-evidence-contracts.md`](releases/v1.4.0-evidence-contracts.md).
 Dry-run receipt: [`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](audits/publish-dry-run-v1.4.0-2026-05-09.md).
+Publish receipt: [`docs/audits/publish-v1.4.0-2026-05-09.md`](audits/publish-v1.4.0-2026-05-09.md).
 
 - ✅ **Publish plan**: `cargo run -p xtask -- publish-plan` resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Evidence schemas**: `cargo run -p xtask -- evidence-schema-check` passes on the v1.4.0 package line.
@@ -95,15 +93,14 @@ Dry-run receipt: [`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](audits/pub
 - ✅ **Full gate**: `cargo run -p xtask -- gate --check` passes on the v1.4.0 package line.
 - ✅ **Dry-runs**: direct `hl7v2` dry-run and workspace-patched full-graph dry-run pass. Direct dependent dry-runs correctly wait for `hl7v2` v1.4.0 to exist in the crates.io index during the real publish sequence.
 - ✅ **Python proof**: the maturin wheel build/install/import smoke proof passes for the v1.4.0 Python lane package without publishing `hl7v2-python` to crates.io.
-- 🟡 **Release notes and tag**: no `v1.4.0` tag or GitHub release exists yet.
+- ✅ **Release notes and tag**: `v1.4.0` is tagged and the GitHub release is published.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current published release**: v1.3.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
+**Current published release**: v1.4.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
-**Current main**: tracks the post-v1.3.0 Evidence Loop hardening line. The
-published Rust crates remain v1.3.0 until the v1.4.0 publish train is
-executed.
+**Current main**: tracks the v1.4.0 Evidence Contracts and Server Sidecar
+release line.

--- a/docs/audits/publish-v1.4.0-2026-05-09.md
+++ b/docs/audits/publish-v1.4.0-2026-05-09.md
@@ -1,0 +1,94 @@
+# v1.4.0 Publish Receipt
+
+Date: 2026-05-09
+
+This receipt records the actual crates.io publication for `hl7v2-rs` v1.4.0,
+the Evidence Contracts and Server Sidecar release.
+
+The published Rust package graph is:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+`hl7v2-python` remains `publish = false` for crates.io and stays on the
+separate Python/maturin binding lane.
+
+## Release Head
+
+```text
+34941f4 release: prepare v1.4.0 dry-run (#542)
+```
+
+The `v1.4.0` tag points at this release head and was pushed to GitHub. The
+GitHub release is:
+
+```text
+https://github.com/EffortlessMetrics/hl7v2-rs/releases/tag/v1.4.0
+```
+
+## Pre-Publish Verification
+
+Release-head verification was recorded in:
+
+```text
+docs/audits/publish-dry-run-v1.4.0-2026-05-09.md
+```
+
+Hosted checks on the release PR were green before upload:
+
+```text
+CI
+API Contracts
+Python Wheels
+Security
+CodeRabbit
+GitGuardian
+```
+
+Final direct dry-runs were run in dependency order:
+
+```powershell
+cargo +1.93.0 publish -p hl7v2 --dry-run --locked
+cargo +1.93.0 publish -p hl7v2-server --dry-run --locked
+cargo +1.93.0 publish -p hl7v2-cli --dry-run --locked
+```
+
+The dependent direct dry-runs were rerun after each dependency became visible
+in the crates.io index.
+
+## Publish Commands
+
+```powershell
+cargo +1.93.0 publish -p hl7v2
+cargo +1.93.0 publish -p hl7v2-server
+cargo +1.93.0 publish -p hl7v2-cli
+```
+
+## Results
+
+Cargo reported successful upload and index availability for:
+
+| Crate | Version | Result |
+| --- | --- | --- |
+| `hl7v2` | `1.4.0` | Published |
+| `hl7v2-server` | `1.4.0` | Published |
+| `hl7v2-cli` | `1.4.0` | Published |
+
+Registry verification:
+
+```text
+hl7v2 = "1.4.0"
+hl7v2-server = "1.4.0"
+hl7v2-cli = "1.4.0"
+```
+
+`cargo +1.93.0 info` resolved each package from the public crates.io index at
+version `1.4.0`.
+
+## Status
+
+The v1.4.0 final Rust package graph is published to crates.io. Historical old
+implementation package names remain compatibility artifacts and are not the
+product surface for new code. `hl7v2-python` remains outside the Rust crates.io
+publish graph.

--- a/docs/releases/v1.4.0-evidence-contracts.md
+++ b/docs/releases/v1.4.0-evidence-contracts.md
@@ -1,13 +1,12 @@
 # v1.4.0 Evidence Contracts and Server Sidecar
 
-Status: draft. Current `main` is prepared as the v1.4.0 package line and has a
-local dry-run receipt, but the release has not been tagged, published to
-crates.io, or uploaded to GitHub Releases.
+Status: published. `v1.4.0` is tagged, released on GitHub, and published to
+crates.io for the final Rust package graph.
 
-This release candidate packages the post-v1.3.0 hardening work that turns the
-Evidence Loop into a more explicit contract surface: opt-in v2 provenance,
-schema validation rails, server sidecar replay/corpus workflows, Python
-distribution proof, and stronger PHI regression coverage.
+This release packages the post-v1.3.0 hardening work that turns the Evidence
+Loop into a more explicit contract surface: opt-in v2 provenance, schema
+validation rails, server sidecar replay/corpus workflows, Python distribution
+proof, and stronger PHI regression coverage.
 
 ## Publish Surface
 
@@ -69,9 +68,9 @@ Historical implementation microcrate names are not part of this release train.
 - Manual TestPyPI workflow builds, installs, smokes, optionally publishes to
   TestPyPI through trusted publishing, then installs back from TestPyPI.
 
-## Required Release Checks
+## Release Checks
 
-Before publishing v1.4.0, run and record at minimum:
+Before publishing v1.4.0, the release head ran and recorded:
 
 ```powershell
 cargo +1.93.0 metadata --format-version 1 --no-deps
@@ -99,6 +98,9 @@ release, but it is not a crates.io release blocker.
 
 Current dry-run receipt:
 [`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](../audits/publish-dry-run-v1.4.0-2026-05-09.md).
+
+Publish receipt:
+[`docs/audits/publish-v1.4.0-2026-05-09.md`](../audits/publish-v1.4.0-2026-05-09.md).
 
 ## Known Boundaries
 


### PR DESCRIPTION
## Summary

- record the actual v1.4.0 crates.io publish receipt
- update README/status/release docs now that v1.4.0 is tagged, released, and visible in the crates.io index
- keep `hl7v2-python` documented as a separate Python/maturin lane outside the Rust crates.io graph

## Validation

- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- docs --no-open`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 info hl7v2` resolved `1.4.0` from crates.io
- `cargo +1.93.0 info hl7v2-server` resolved `1.4.0` from crates.io
- `cargo +1.93.0 info hl7v2-cli` resolved `1.4.0` from crates.io
- `gh release view v1.4.0 --json tagName,name,publishedAt,url`

## Publish Boundary

This PR is docs-only. The v1.4.0 upload already happened in dependency order:

1. `hl7v2`
2. `hl7v2-server`
3. `hl7v2-cli`

No old microcrate names were published, and `hl7v2-python` was not published to crates.io.