### PR TITLE
docs: audit v1.4.0 objective completion

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -86,6 +86,7 @@ Publish receipt: [`docs/audits/publish-2026-05-09.md`](audits/publish-2026-05-09
 Release notes: [`docs/releases/v1.4.0-evidence-contracts.md`](releases/v1.4.0-evidence-contracts.md).
 Dry-run receipt: [`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](audits/publish-dry-run-v1.4.0-2026-05-09.md).
 Publish receipt: [`docs/audits/publish-v1.4.0-2026-05-09.md`](audits/publish-v1.4.0-2026-05-09.md).
+Objective audit: [`docs/audits/v1.4.0-objective-completion-audit.md`](audits/v1.4.0-objective-completion-audit.md).
 
 - ✅ **Publish plan**: `cargo run -p xtask -- publish-plan` resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Evidence schemas**: `cargo run -p xtask -- evidence-schema-check` passes on the v1.4.0 package line.

--- a/docs/audits/v1.4.0-objective-completion-audit.md
+++ b/docs/audits/v1.4.0-objective-completion-audit.md
@@ -1,0 +1,93 @@
+# v1.4.0 Objective Completion Audit
+
+Date: 2026-05-09
+
+This audit maps the broad HL7v2 evidence-layer objective to the current
+published repository state after v1.4.0. It is intentionally narrower than a
+release note: it records which parts of the objective are backed by contracts,
+fixtures, docs, and release receipts, and which parts should remain explicit
+follow-up work.
+
+## Objective
+
+HL7v2 should be the deterministic evidence layer for HL7 v2 work. Users should
+be able to move from raw messages or corpora to profile-backed validation,
+corpus drift reports, redacted evidence bundles, replay verification, and
+sidecar/Python workflows without guessing which package, command, or artifact
+shape is authoritative.
+
+## Result
+
+v1.4.0 satisfies the release-grade Evidence Contracts and Server Sidecar
+milestone for the Rust package graph:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+The release does not close every long-range product ambition. In particular,
+gRPC remains beta with `ParseStream` unsupported, Python remains a separate
+non-crates.io distribution lane, and a few report types are intentionally
+CLI-local until another surface needs them.
+
+## Evidence Map
+
+| Objective area | Current evidence | Status |
+| --- | --- | --- |
+| Canonical Rust package surface | `docs/architecture/module-map.md` records `hl7v2`, `hl7v2-server`, and `hl7v2-cli` as the Rust publish graph, with old implementation microcrates retired locally and `hl7v2-python` kept as `publish = false`. | Complete for the current Rust package topology. |
+| Published v1.4.0 graph | `docs/audits/publish-v1.4.0-2026-05-09.md` records the dependency-ordered publish of `hl7v2`, `hl7v2-server`, and `hl7v2-cli`; `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md` records the dry-run and workspace-patched proof. | Complete for the Rust crates.io release. |
+| Evidence contract inventory | `docs/contracts/evidence-contract-index.md` maps producer surfaces, v1/v2 schemas, default shapes, opt-in controls, golden fixtures, and PHI notes for doctor, validation, profile, corpus, redaction, bundle, quarantine, manifest, environment, field-path trace, and replay artifacts. | Complete for the currently documented artifact set. |
+| Schema and fixture rail | `schemas/evidence/` contains v1 and v2 schemas for the primary evidence artifacts, `fixtures/evidence/` contains matching golden samples, and `cargo run -p xtask -- evidence-schema-check` is documented as the maintained validation gate. | Complete as a maintained local/CI rail. |
+| CLI evidence loop | `docs/architecture/evidence-artifacts.md` records the CLI loop for doctor, validation, profile lint/test/explain, corpus summarize/fingerprint/diff, redact, bundle, and replay. It also records stdout/stderr and exit-code semantics for automation. | Complete for the v1.4.0 CLI surface. |
+| Rust library evidence types | The Rust crate owns shared validation, profile lint, corpus, redaction, and evidence bundle/replay types used by the other surfaces. | Mostly complete; profile explain and profile test reports remain CLI-local by design. |
+| HTTP server sidecar evidence | `docs/API_GUIDE.md`, `docs/architecture/evidence-artifacts.md`, and `crates/hl7v2-server/tests/` cover validate, validate-redacted, bundle, replay, ACK policy, quarantine, inline corpus endpoints, metrics, readiness, and redacted structured logs. | Complete for the HTTP REST sidecar scope in v1.4.0. |
+| gRPC sidecar evidence | `docs/STATUS.md` marks the gRPC service as beta and explicitly notes that `ParseStream` is unsupported. | Partial; do not claim full HTTP/gRPC evidence-loop parity. |
+| Python evidence lane | `crates/hl7v2-python/README.md`, `docs/guides/python-evidence-workflow.md`, and the v1.4.0 release docs record Python validation, corpus, redaction, bundle, and replay parity with opt-in v2 shapes where supported. | Useful but separate; not published to crates.io, and production PyPI release remains a separate lane. |
+| Safe sharing and replay | Bundle manifest/environment/field-path/redaction artifacts have schemas and fixtures; replay verifies manifest catalogs and hashes before using artifacts. `docs/guides/safe-support-bundle.md` documents sharing limits. | Complete for deterministic redacted bundle and replay workflows. |
+| PHI-conscious operations | Contract docs require no raw HL7 payloads in reports/logs, server logs hash message-control and bundle identifiers, and docs state that redaction receipts prove configured actions rather than universal PHI absence. | Complete as a deterministic regression guard, not a universal PHI detector. |
+| User workflow proof | `docs/guides/first-10-minutes.md`, `docs/guides/vendor-upgrade-diff.md`, `docs/guides/safe-support-bundle.md`, `docs/guides/deploy-validation-sidecar.md`, and `docs/guides/python-evidence-workflow.md` show task-level use of the loop. | Complete enough for v1.4.0; keep guides tied to checked examples as behavior evolves. |
+
+## Explicit Boundaries
+
+- v1 remains the default machine-readable output shape unless a command or
+  request explicitly asks for schema version 2.
+- v2 shapes add provenance such as `schema_version`, `tool_name`, and
+  `tool_version`; they are opt-in compatibility surfaces, not silent changes to
+  v1.
+- Server corpus endpoints accept inline message content only. They must not
+  read caller-supplied filesystem paths.
+- Server bundle and replay endpoints operate under configured roots and return
+  root-relative identifiers, not configured filesystem roots.
+- Redaction receipts prove configured policy actions. They are not a universal
+  PHI absence certificate.
+- Profile YAML is user-authored and can be included in bundles as supplied; it
+  is not automatically sanitized.
+- `hl7v2-python` remains outside the Rust crates.io publish graph.
+- Historical old microcrate package names are not part of the current product
+  surface and should not be republished without a deliberate compatibility
+  release decision.
+
+## Remaining Follow-Up
+
+These items should stay visible in planning, but they are not blockers to the
+published v1.4.0 Evidence Contracts milestone:
+
+1. Decide whether gRPC should gain full evidence-loop parity or remain a beta
+   unary service with explicit unsupported streaming behavior.
+2. Continue the Python distribution lane through TestPyPI/PyPI proof without
+   moving `hl7v2-python` into the Rust crates.io graph.
+3. Promote profile explain/test report types out of CLI-local ownership only if
+   server or Python needs the same contract.
+4. Keep `cargo run -p xtask -- evidence-schema-check` as the primary local
+   schema/fixture receipt whenever evidence artifacts change.
+5. Keep the draft CI economics work separate from evidence-product semantics.
+
+## Conclusion
+
+The v1.4.0 release turns HL7v2 into a released, schema-backed evidence system
+for Rust, CLI, HTTP REST, and Python-lane workflows. It is fair to describe
+v1.4.0 as the Evidence Contracts and Server Sidecar milestone.
+
+It is not yet precise to say the entire long-range objective is complete:
+full gRPC parity, production Python distribution, and any future shared
+promotion of CLI-local profile reports remain explicit follow-up decisions.


### PR DESCRIPTION
## Summary
- add a v1.4.0 objective-completion audit mapping the evidence-layer goal to the current published state
- record explicit boundaries so v1.4.0 is described as the Evidence Contracts and Server Sidecar milestone without overclaiming the long-range objective
- link the audit from `docs/STATUS.md`

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- docs --no-open`
- `cargo +1.93.0 run -p xtask -- publish-plan`