### PR TITLE
docs: refresh gRPC current state

### DIFF
--- a/crates/hl7v2-server/GRPC_IMPLEMENTATION.md
+++ b/crates/hl7v2-server/GRPC_IMPLEMENTATION.md
@@ -1,29 +1,68 @@
 # gRPC Server Implementation
 
-This crate will implement the gRPC server for the HL7v2 toolkit.
+This crate implements the `HL7Service` gRPC API for HL7 v2 parsing,
+validation, normalization, ACK generation, streaming parse, and redacted
+validation evidence workflows.
 
-## Overview
+## Contract Source
 
-Issue #157 identified that a comprehensive protobuf schema exists at `api/proto/hl7v2.proto`
-but has no implementation. This branch will implement the gRPC service.
+The canonical protobuf contract is:
 
-## Implementation Plan
+```text
+api/proto/hl7v2/v1/hl7v2.proto
+```
 
-1. Add tonic/prost dependencies
-2. Set up build.rs for protobuf code generation
-3. Implement HL7Service trait
-4. Integrate with existing HTTP server
+The packaged crate copy is:
 
-## Proto Schema
+```text
+crates/hl7v2-server/proto/hl7v2/v1/hl7v2.proto
+```
 
-The proto file defines 6 RPCs:
-- Parse
-- Validate
-- GenerateAck
-- Normalize
-- ParseStream (streaming)
-- HealthCheck
+`build.rs` uses the workspace contract when it is available and falls back to
+the packaged copy for crate packaging. The packaging drift test verifies both
+copies stay synchronized.
 
-## Status
+## Implemented RPCs
 
-🚧 Work in progress - see PR for details.
+| RPC | Status | Notes |
+| --- | --- | --- |
+| `Parse` | Implemented | Parses raw or MLLP-framed HL7 bytes into protobuf message fields and metadata. |
+| `ParseStream` | Implemented | Parses one request message into one response message; per-message parse or MLLP failures return error payloads without failing the whole stream. Malformed gRPC frames still return a tonic `Status`. |
+| `Validate` | Implemented | Validates raw or MLLP-framed HL7 against an inline profile. Preserves legacy `valid`, `errors`, `warnings`, and `summary` fields while also returning `validation_report`; `report_schema_version = 2` adds `validation_report_v2`. |
+| `ValidateRedacted` | Implemented | Applies an inline safe-analysis redaction policy before validation. Always returns v1 `validation_report` and `redaction_receipt`, can include v2 validation and redaction receipt artifacts, and includes `redacted_hl7` only when requested. |
+| `GenerateAck` | Implemented | Generates ACK messages using the canonical `hl7v2` ACK facade. |
+| `Normalize` | Implemented | Normalizes delimiter output and can optionally MLLP-frame the response. |
+| `HealthCheck` | Implemented | Reports serving status and crate version. |
+
+## Evidence Semantics
+
+The gRPC service keeps v1-compatible response fields by default. Provenance
+fields are additive and opt in:
+
+```text
+ValidateRequest.report_schema_version = 2
+ValidateRedactedRequest.report_schema_version = 2
+ValidateRedactedRequest.redaction_receipt_schema_version = 2
+```
+
+For `ValidateRedacted`, schema versions `0` and `1` use the default v1 shape,
+`2` returns the requested v2 artifact, and other values return
+`InvalidArgument`.
+
+`ValidateRedacted` fails closed when the redaction policy is invalid or misses a
+present built-in sensitive path. The redacted HL7 body is omitted unless
+`include_redacted_hl7` is set. The RPC does not write quarantine output; REST
+`/hl7/validate-redacted` owns configured quarantine behavior.
+
+## Validation
+
+Useful checks for gRPC contract changes:
+
+```powershell
+npx -y @bufbuild/buf lint api/proto
+npx -y @bufbuild/buf breaking api/proto --against "https://github.com/EffortlessMetrics/hl7v2-rs.git#branch=main,subdir=api/proto"
+cargo +1.93.0 test -p hl7v2-server --test proto_packaging_test
+cargo +1.93.0 test -p hl7v2-server --test grpc_contract_tests
+cargo +1.93.0 check -p hl7v2-server --all-features --all-targets
+cargo +1.93.0 clippy -p hl7v2-server --all-targets -- -D warnings
+```

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -21,6 +21,13 @@ Useful release-candidate workflows include:
 - `POST /hl7/ack-policy` for policy-driven ACK/NAK decisions.
 - `/metrics` for Prometheus metrics.
 
+The gRPC service implements `Parse`, `ParseStream`, `Validate`,
+`ValidateRedacted`, `GenerateAck`, `Normalize`, and `HealthCheck`.
+`Validate` and `ValidateRedacted` return the shared validation report fields;
+`ValidateRedacted` also returns a redaction receipt and keeps the redacted HL7
+payload opt-in. See [GRPC_IMPLEMENTATION.md](GRPC_IMPLEMENTATION.md) for the
+current protobuf and test contract notes.
+
 The stable Prometheus contract includes HTTP request metrics plus evidence-loop
 counters for parse failures, validation failures, redaction failures, bundles
 created, replay attempts/failures, and inline corpus diffs. Labels are bounded

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -2,8 +2,9 @@
 
 Date: 2026-05-08
 
-Updated: 2026-05-09 after the v1.3.0 Evidence Loop release hardening pass and
-the redacted structured server logging pass.
+Updated: 2026-05-09 after the v1.3.0 Evidence Loop release hardening pass,
+the redacted structured server logging pass, and post-v1.4.0 gRPC
+`ParseStream` / `ValidateRedacted` parity work.
 
 ## Purpose
 
@@ -14,9 +15,9 @@ the v1.3.0 contract-hardening pass.
 
 The goal is to keep the next hardening work concrete. The loop now has JSON
 Schemas, golden fixtures, CLI output semantics, bundle manifest verification,
-server parity, redacted structured server logs, and Python bundle/replay APIs;
-the remaining gaps are narrower contract-index, deployment-proof, and
-distribution-readiness details.
+server parity, redacted structured server logs, Python bundle/replay APIs, and
+gRPC parse-stream plus redacted-validation evidence parity; the remaining gaps
+are narrower deployment-proof and distribution-readiness details.
 
 ## Current Product Loop
 
@@ -46,17 +47,21 @@ fingerprint, and diff endpoints under `/hl7/corpus/*`; these accept message
 content directly and do not read filesystem paths from request bodies. Server
 evidence workflow logs hash message-control and bundle identifiers and avoid
 raw HL7, profile YAML, redaction policy TOML, and configured filesystem roots by
-default. Python
-exposes parse, JSON conversion, normalization, validation report dict/JSON
-parity, corpus summary/fingerprint/diff dict outputs, and safe-analysis
-redaction output, bundle creation, and replay verification.
+default. The gRPC service exposes `Parse`, `ParseStream`, `Validate`,
+`ValidateRedacted`, `GenerateAck`, `Normalize`, and `HealthCheck`; gRPC
+`ValidateRedacted` applies safe-analysis redaction before validation, returns
+v1 validation report and redaction receipt fields by default, and can include
+opt-in v2 provenance fields. Python exposes parse, JSON conversion,
+normalization, validation report dict/JSON parity,
+corpus summary/fingerprint/diff dict outputs, and safe-analysis redaction
+output, bundle creation, and replay verification.
 
 ## Artifact Status
 
 | Artifact | Current state | Main gap |
 | --- | --- | --- |
 | `DoctorReport` | CLI `hl7v2 doctor --format json` reports tool version plus first-run diagnostic checks for CLI version, sample parse, MLLP framing, optional profile, optional server reachability, and Python binding availability. `hl7v2 doctor --format json --schema-version 2` adds embedded schema/tool provenance. | JSON Schemas and golden fixtures exist for v1 and opt-in v2. Defaults remain v1-compatible. |
-| `ValidationReport` | Shared Rust type used by CLI, Python, and server validation response fields, including `/hl7/validate-redacted`. Includes stable issue code, severity, path, rule ID, message, segment index, and field index. | JSON Schemas and golden fixtures exist for v1 and opt-in v2. CLI/Python can emit v2 directly, and server responses can include nested `validation_report_v2` when requested. Defaults remain v1-compatible. |
+| `ValidationReport` | Shared Rust type used by CLI, Python, and server validation response fields, including REST `/hl7/validate-redacted` and gRPC `ValidateRedacted`. Includes stable issue code, severity, path, rule ID, message, segment index, and field index. | JSON Schemas and golden fixtures exist for v1 and opt-in v2. CLI/Python can emit v2 directly, and server responses can include nested `validation_report_v2` when requested. Defaults remain v1-compatible. |
 | `ProfileLintReport` | Shared Rust type from profile linting. CLI emits text/JSON/YAML by default, with opt-in v2 output for embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
 | `ProfileTestReport` | CLI report with fixture cases, pass/fail status, embedded validation reports, and optional expected-report comparison; opt-in v2 output adds embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
 | `ProfileExplainReport` | CLI report with profile SHA-256, structure, version, segments, constraints, tables, rules, and lint summary; opt-in v2 output adds embedded provenance. | JSON Schemas and golden fixtures exist for v1 and v2; defaults remain v1-compatible. |
@@ -64,7 +69,7 @@ redaction output, bundle creation, and replay verification.
 | `CorpusFingerprint` | Shared Rust fingerprint type with `fingerprint_version`, `tool_version`, optional profile hash, counts, field presence/cardinality, value shapes, and validation issue-code counts. CLI emits text/JSON/YAML, Python returns the same dict shape, and server `/hl7/corpus/fingerprint` produces inline corpus evidence. | JSON Schemas and golden fixtures exist for v1 and opt-in v2; `profile: null` and empty-array semantics are documented in the schema README. |
 | `CorpusDiffReport` | Shared Rust diff type with `diff_version`, `tool_version`, optional profile hash, totals, new/removed message types and segments, field deltas, value-shape deltas, and validation issue-code deltas. CLI emits text/JSON/YAML, Python returns the same dict shape, and server `/hl7/corpus/diff` produces inline corpus evidence. | JSON Schemas and golden fixtures exist for v1 and opt-in v2; `profile: null` and empty-array semantics are documented in the schema README. |
 | `SafeAnalysisRedactionOutput` | CLI `hl7v2 redact --format json` and Python `redact()` return input and policy SHA-256 values, message type, redacted HL7 text, and a nested redaction receipt. | JSON Schema and fixtures exist for the default v1-compatible output, the transitional v1 outer shape with a nested v2 receipt, and opt-in v2 output with top-level `schema_version`, `tool_name`, and `tool_version`. Defaults remain v1-compatible. |
-| `RedactionReceipt` | CLI, server, and Python receipts record PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | JSON Schemas, golden fixtures, and synthetic PHI leak-sentinel tests exist for v1 and opt-in v2. Defaults remain v1-compatible; v2 adds embedded `schema_version`, `tool_name`, and `tool_version`. |
+| `RedactionReceipt` | CLI, server REST/gRPC, and Python receipts record PHI removal status, hash algorithm, per-path action, reason, match count, optional flag, and status. | JSON Schemas, golden fixtures, and synthetic PHI leak-sentinel tests exist for v1 and opt-in v2. Defaults remain v1-compatible; v2 adds embedded `schema_version`, `tool_name`, and `tool_version`. |
 | `EvidenceBundleSummary` | CLI stdout JSON summary, Python `bundle()` output, and server `/hl7/bundle` JSON response include `bundle_version`, output directory/id, message type, validation status, redaction status, and artifact list. | v1 and v2 JSON Schemas plus golden fixtures exist. CLI and Python can opt into v2 provenance with `schema_version = 2`; server keeps the v1 response shape by default. |
 | Bundle artifacts | CLI, Python, and server bundles write `message.redacted.hl7`, `validation-report.json`, `field-paths.json`, `profile.yaml`, `redaction-receipt.json`, `environment.json`, `replay.sh`, `replay.ps1`, `README.md`, and `manifest.json`. | Bundle README is generated and manifest-hashed. CLI/Python bundles can opt into v2 `field-paths.json`, `redaction-receipt.json`, `environment.json`, and `manifest.json` artifacts with bundle `schema_version = 2`; server bundles can opt in with `bundle_artifact_schema_version = 2`. Defaults remain v1-compatible. Profile text is user-authored and included as supplied. |
 | `QuarantineOutputSummary` | Server `/hl7/validate-redacted` can return a root-relative quarantine output id, reason, validation issue count, and artifact list when `[quarantine]` is enabled and validation fails. | Server-local response type; v1 and opt-in v2 JSON Schemas exist. Requests with `quarantine_schema_version: 2` include `quarantine_v2` with provenance while preserving the v1 `quarantine` field. Full-bundle mode reuses bundle artifacts. |
@@ -78,7 +83,7 @@ redaction output, bundle creation, and replay verification.
 | --- | --- |
 | Rust | Shared validation, profile lint, corpus summary/fingerprint/diff, parse, normalize, write, ACK, redaction module APIs, and Python-facing bundle/replay evidence APIs. Profile test and profile explain reports remain CLI-local. |
 | CLI | Complete current loop: doctor, profile lint/test/explain, validation, corpus summarize/fingerprint/diff, redact, bundle, and replay. |
-| Server | Validation report parity for `/hl7/validate`; redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; configured-root bundle creation for `/hl7/bundle` with opt-in v2 bundle-internal artifacts; configured-root replay verification for `/hl7/replay`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; inline corpus summary/fingerprint/diff endpoints under `/hl7/corpus/*`; redacted structured evidence logs with hashed message-control and bundle identifiers. |
+| Server | Validation report parity for REST `/hl7/validate` and gRPC `Validate`; REST redacted validation parity and quarantine hooks for `/hl7/validate-redacted`; gRPC redacted validation parity through `ValidateRedacted`; gRPC streaming parse through `ParseStream`; configured-root bundle creation for `/hl7/bundle` with opt-in v2 bundle-internal artifacts; configured-root replay verification for `/hl7/replay`; policy-driven ACK/NAK decisions for `/hl7/ack-policy`; inline corpus summary/fingerprint/diff endpoints under `/hl7/corpus/*`; redacted structured evidence logs with hashed message-control and bundle identifiers. |
 | Python | Minimum API parity for parse, `to_json`, normalize, validation reports, corpus summary/fingerprint/diff dict outputs, safe-analysis redaction output, bundle creation, and replay verification. |
 
 One validation parity detail is intentionally documented as a label convention:


### PR DESCRIPTION
## Summary
- replace the stale gRPC implementation-plan note with a current implemented-RPC reference
- document the gRPC contract/proto source, packaged proto sync, v2 evidence opt-ins, and redacted-validation boundaries
- refresh the server README and evidence-loop current-state audit to include ParseStream and ValidateRedacted

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`