### PR TITLE
ci: add server Docker smoke workflow

### DIFF
--- a/.github/workflows/server-smoke.yml
+++ b/.github/workflows/server-smoke.yml
@@ -1,0 +1,70 @@
+name: Server Docker Smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/server-smoke.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/hl7v2/**"
+      - "crates/hl7v2-server/**"
+      - "infrastructure/docker/**"
+      - "profiles/**"
+      - "tests/server_smoke/**"
+      - "docs/guides/deploy-validation-sidecar.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/server-smoke.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/hl7v2/**"
+      - "crates/hl7v2-server/**"
+      - "infrastructure/docker/**"
+      - "profiles/**"
+      - "tests/server_smoke/**"
+      - "docs/guides/deploy-validation-sidecar.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: server-docker-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  COMPOSE_PROJECT_NAME: hl7v2-sidecar-ci
+  HL7V2_API_KEY: dev-secret
+  HL7V2_SERVER_URL: http://127.0.0.1:8080
+
+jobs:
+  compose-smoke:
+    name: Compose Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Show Docker Compose version
+        run: docker compose version
+
+      - name: Validate Compose configuration
+        run: docker compose -f infrastructure/docker/docker-compose.yml config
+
+      - name: Build and start sidecar
+        run: docker compose -f infrastructure/docker/docker-compose.yml up --build -d
+
+      - name: Run server smoke proof
+        run: python tests/server_smoke/smoke.py
+
+      - name: Print sidecar logs on failure
+        if: failure()
+        run: docker compose -f infrastructure/docker/docker-compose.yml logs --no-color
+
+      - name: Stop sidecar
+        if: always()
+        run: docker compose -f infrastructure/docker/docker-compose.yml down -v

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -129,6 +129,19 @@ using Trusted Publishing from the `testpypi` GitHub environment, then installs
 test. The workflow uses `id-token: write` only for the publish job and does not
 use repository PyPI tokens.
 
+### `.github/workflows/server-smoke.yml` - Server Docker Smoke
+
+Path-scoped and manual workflow for the deployable validation sidecar. It
+validates `infrastructure/docker/docker-compose.yml`, starts the checked-in
+Compose stack, runs `tests/server_smoke/smoke.py`, prints container logs on
+failure, and tears the stack down with volumes removed.
+
+The smoke script exercises `/health`, `/ready`, `/hl7/validate-redacted`,
+`/hl7/bundle`, `/hl7/replay`, and `/hl7/corpus/diff` against the running
+container. It uses the local `dev-secret` API key from
+`infrastructure/docker/sidecar.env.example`; do not replace that with a real
+deployment secret.
+
 ## Viewing CI Results
 
 ### GitHub Actions
@@ -183,6 +196,20 @@ The coverage workflow can be manually triggered:
 2. Click **Run workflow**
 3. Choose whether to upload to Codecov
 4. Click **Run workflow**
+
+### Server Docker Smoke
+
+The server smoke workflow can be manually triggered when validating sidecar
+deployment behavior:
+
+1. Go to **Actions** > **Server Docker Smoke**
+2. Click **Run workflow**
+3. Select the branch to test
+4. Click **Run workflow**
+
+The same workflow also runs on PRs and `main` pushes that change the server,
+canonical library, Docker sidecar files, profiles, smoke script, or sidecar
+deployment guide.
 
 ## Caching Strategy
 

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -189,6 +189,10 @@ docker compose -f infrastructure/docker/docker-compose.yml down -v
 The smoke script exercises health, readiness, redacted validation, bundle,
 replay, and corpus diff against the running sidecar.
 
+The same Compose proof is available in GitHub Actions as the path-scoped
+**Server Docker Smoke** workflow. Use the manual trigger when you need hosted
+deployment proof without changing the main CI matrix.
+
 ## 4. Check Readiness
 
 Readiness is the deployment gate:


### PR DESCRIPTION
## Summary
- add a path-scoped/manual `Server Docker Smoke` workflow for the deployable sidecar
- validate the checked-in Compose stack, boot it, run `tests/server_smoke/smoke.py`, print logs on failure, and tear down volumes
- document the workflow in CI docs and link it from the deployment sidecar guide

## Validation
- `docker compose -f infrastructure/docker/docker-compose.yml config`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`

## Notes
- Local live Compose boot could not run because the Docker Desktop Linux engine was not available on this machine. The new hosted workflow is the intended deployment proof for the containerized sidecar.
- `actionlint` and `go` are not installed locally; workflow YAML was parsed with PyYAML and will be validated by GitHub Actions on the PR.
