### PR TITLE
test: execute Python evidence guide smoke

### DIFF
--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -81,6 +81,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --force-reinstall dist/*.whl
           python tests/python_smoke/smoke.py
+          python tests/python_smoke/evidence_workflow_guide.py
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7
@@ -147,3 +148,4 @@ jobs:
             --force-reinstall \
             "hl7v2-python==${PACKAGE_VERSION}"
           python tests/python_smoke/smoke.py
+          python tests/python_smoke/evidence_workflow_guide.py

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -11,6 +11,7 @@ on:
       - "crates/hl7v2/**"
       - "crates/hl7v2-python/**"
       - "tests/python_smoke/**"
+      - "docs/guides/python-evidence-workflow.md"
       - ".github/workflows/python-wheels.yml"
   pull_request:
     branches: [main]
@@ -22,6 +23,7 @@ on:
       - "crates/hl7v2/**"
       - "crates/hl7v2-python/**"
       - "tests/python_smoke/**"
+      - "docs/guides/python-evidence-workflow.md"
       - ".github/workflows/python-wheels.yml"
 
 permissions:
@@ -77,6 +79,9 @@ jobs:
 
       - name: Run import smoke test
         run: python tests/python_smoke/smoke.py
+
+      - name: Run Python evidence guide smoke test
+        run: python tests/python_smoke/evidence_workflow_guide.py
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -114,20 +114,21 @@ installed and imported. This workflow does not publish to PyPI.
    - Builds a wheel with maturin
    - Installs the built wheel
    - Runs `tests/python_smoke/smoke.py`
+   - Runs `tests/python_smoke/evidence_workflow_guide.py`
    - Uploads the wheel as a short-retention smoke artifact
 
 ### `.github/workflows/python-testpypi.yml` - Python TestPyPI Proof
 
 Manual-only workflow for the separate `hl7v2-python` distribution lane. The
 default dispatch builds the wheel, installs it into a fresh virtual
-environment, runs `tests/python_smoke/smoke.py`, and uploads the wheel as a
-short-retention artifact without publishing.
+environment, runs `tests/python_smoke/smoke.py` plus the Python evidence guide
+smoke, and uploads the wheel as a short-retention artifact without publishing.
 
 When `publish_to_testpypi=true` is selected, the workflow publishes to TestPyPI
 using Trusted Publishing from the `testpypi` GitHub environment, then installs
-`hl7v2-python==<workspace version>` back from TestPyPI and reruns the smoke
-test. The workflow uses `id-token: write` only for the publish job and does not
-use repository PyPI tokens.
+`hl7v2-python==<workspace version>` back from TestPyPI and reruns both smoke
+tests. The workflow uses `id-token: write` only for the publish job and does
+not use repository PyPI tokens.
 
 ### `.github/workflows/server-smoke.yml` - Server Docker Smoke
 

--- a/docs/guides/python-evidence-workflow.md
+++ b/docs/guides/python-evidence-workflow.md
@@ -179,6 +179,12 @@ Run it:
 python target\hl7v2-python-evidence\workflow.py
 ```
 
+The checked-in Python wheel workflows also execute this guide block directly:
+
+```powershell
+python tests\python_smoke\evidence_workflow_guide.py
+```
+
 Expected output has the same evidence semantics as the CLI and server:
 
 ```json

--- a/tests/python_smoke/evidence_workflow_guide.py
+++ b/tests/python_smoke/evidence_workflow_guide.py
@@ -1,0 +1,97 @@
+"""Execute the Python evidence workflow guide's checked example.
+
+This keeps docs/guides/python-evidence-workflow.md tied to the installed
+hl7v2-python wheel instead of letting the long guide script drift from the
+binding API.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import re
+import sys
+from pathlib import Path
+
+
+GUIDE_PATH = Path("docs/guides/python-evidence-workflow.md")
+SCRIPT_MARKER = 'ROOT = Path("target/hl7v2-python-evidence")'
+
+
+def extract_workflow_script() -> str:
+    """Extract the guide's end-to-end Python workflow block."""
+    guide = GUIDE_PATH.read_text(encoding="utf-8")
+    for block in re.findall(r"```python\n(.*?)\n```", guide, flags=re.DOTALL):
+        if SCRIPT_MARKER in block:
+            return block
+    raise RuntimeError(f"could not find Python workflow block in {GUIDE_PATH}")
+
+
+def main() -> int:
+    script = extract_workflow_script()
+    stdout = io.StringIO()
+
+    namespace = {
+        "__builtins__": __builtins__,
+        "__file__": str(GUIDE_PATH),
+        "__name__": "__main__",
+    }
+    with contextlib.redirect_stdout(stdout):
+        exec(compile(script, str(GUIDE_PATH), "exec"), namespace)
+
+    raw_output = stdout.getvalue().strip()
+    try:
+        summary = json.loads(raw_output)
+    except json.JSONDecodeError as error:
+        print(f"guide workflow did not emit JSON: {raw_output}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+    expected = {
+        "after_message_count": 1,
+        "bundle_artifacts": 10,
+        "diff_field_presence_deltas": 0,
+        "redaction_phi_removed": True,
+        "replay_reproduced": True,
+        "validation_issue_codes": ["value_not_in_set"],
+        "validation_valid": False,
+    }
+
+    mismatches = {
+        key: {"expected": value, "actual": summary.get(key)}
+        for key, value in expected.items()
+        if summary.get(key) != value
+    }
+    if mismatches:
+        print(
+            "guide workflow summary mismatches: "
+            + json.dumps(mismatches, sort_keys=True),
+            file=sys.stderr,
+        )
+        return 1
+
+    version = summary.get("version")
+    if not isinstance(version, str) or not version:
+        print(f"guide workflow did not report an installed version: {summary}", file=sys.stderr)
+        return 1
+
+    reports_dir = Path("target/hl7v2-python-evidence/reports")
+    for artifact in [
+        "validation-report-v2.json",
+        "corpus-summary-v2.json",
+        "corpus-fingerprint-v2.json",
+        "corpus-diff-v2.json",
+        "redaction-output-v2.json",
+        "bundle-summary-v2.json",
+        "replay-report-v2.json",
+    ]:
+        if not (reports_dir / artifact).is_file():
+            print(f"guide workflow did not write {artifact}", file=sys.stderr)
+            return 1
+
+    print(f"python evidence workflow guide ok version={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python smoke runner that extracts and executes the end-to-end script from `docs/guides/python-evidence-workflow.md`
- run that guide smoke in the Python wheel workflow and both TestPyPI proof paths
- document the guide-smoke coverage in the Python evidence guide and CI pipeline docs

## Validation
- `python -m py_compile tests\python_smoke\evidence_workflow_guide.py`
- PyYAML parse of `.github/workflows/python-wheels.yml` and `.github/workflows/python-testpypi.yml`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- isolated venv: `maturin build --release --out dist`, install wheel, `python tests\python_smoke\smoke.py`, `python tests\python_smoke\evidence_workflow_guide.py`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 run -p xtask -- publish-plan`

## Notes
- `hl7v2-python` remains outside the crates.io Rust publish graph.
