### PR TITLE
docs: record Python TestPyPI nonpublish proof

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -41,7 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
-- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the TestPyPI upload/install-back mode has not been run.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
 

--- a/docs/audits/python-testpypi-nonpublish-proof-2026-05-09.md
+++ b/docs/audits/python-testpypi-nonpublish-proof-2026-05-09.md
@@ -1,0 +1,52 @@
+# Python TestPyPI Non-Publishing Proof
+
+Date: 2026-05-09
+
+This receipt records the manual `Python TestPyPI Proof` workflow run in
+non-publishing mode. It proves the hosted wheel build, fresh-venv install, and
+Python evidence smoke checks for the separate `hl7v2-python` lane. It does not
+publish to TestPyPI or PyPI.
+
+## Run
+
+| Field | Value |
+| --- | --- |
+| Workflow | `Python TestPyPI Proof` |
+| Workflow file | `.github/workflows/python-testpypi.yml` |
+| Trigger | `workflow_dispatch` |
+| Input | `publish_to_testpypi=false` |
+| Branch | `main` |
+| Commit | `171264eddb4786caeab8a99c3c4b8a52294ec53a` |
+| Run ID | `25613226162` |
+| Run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25613226162> |
+| Result | `success` |
+
+## Verified Jobs
+
+| Job | Result | Evidence |
+| --- | --- | --- |
+| `Build and smoke wheel` | `success` | Built the wheel, installed it into a fresh virtual environment, ran `tests/python_smoke/smoke.py`, ran `tests/python_smoke/evidence_workflow_guide.py`, and uploaded the wheel artifact. |
+| `Publish to TestPyPI` | `skipped` | Expected because `publish_to_testpypi=false`. |
+| `Install from TestPyPI and smoke` | `skipped` | Expected because no TestPyPI upload was requested. |
+
+Observed completed job ID:
+
+```text
+Build and smoke wheel: 75186830790
+```
+
+## Boundaries
+
+- `hl7v2-python` remains `publish = false` for crates.io.
+- This proof did not upload to TestPyPI.
+- This proof did not install back from TestPyPI.
+- This proof did not publish to production PyPI.
+- A full TestPyPI distribution proof still requires a separate manual workflow
+  run with `publish_to_testpypi=true` after the TestPyPI trusted-publisher
+  setup is confirmed.
+
+## Current Status
+
+The hosted non-publishing Python distribution proof is complete for current
+`main`. The remaining Python distribution question is whether and when to run
+the publishing TestPyPI proof and then decide on production PyPI.

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -68,6 +68,9 @@ This builds the wheel, installs it into a fresh virtual environment, runs the
 Python smoke test, and uploads the wheel as a short-retention artifact. It does
 not publish.
 
+The 2026-05-09 run of this non-publishing mode passed on `main`; see
+[`docs/audits/python-testpypi-nonpublish-proof-2026-05-09.md`](../audits/python-testpypi-nonpublish-proof-2026-05-09.md).
+
 After the local wheel proof and non-publishing workflow pass, rerun with:
 
 ```text
@@ -99,3 +102,7 @@ A TestPyPI proof is complete only when all of these are true:
 
 This is still not a production PyPI release. Treat it as packaging evidence for
 the separate Python lane.
+
+Current status: the non-publishing proof is complete for current `main`; the
+TestPyPI upload/install-back mode remains intentionally unrun until a separate
+distribution decision confirms the trusted-publisher setup and version.


### PR DESCRIPTION
## Summary
- record the manual non-publishing `Python TestPyPI Proof` workflow run on `main`
- update status and the TestPyPI guide to distinguish the passed build/install/smoke proof from the still-unrun TestPyPI upload/install-back path
- keep `hl7v2-python` outside the Rust crates.io graph

## Evidence
- Workflow run: https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25613226162
- `Build and smoke wheel`: success
- `Publish to TestPyPI`: skipped as expected for `publish_to_testpypi=false`
- `Install from TestPyPI and smoke`: skipped as expected for `publish_to_testpypi=false`

## Validation
- `gh run watch 25613226162 --interval 20 --exit-status`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `cargo +1.93.0 run -p xtask -- publish-plan`
