### PR TITLE
docs: refresh evidence loop status

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ curl http://localhost:8080/metrics  # Prometheus metrics
 ```
 
 See the [OpenAPI specification](api/openapi/hl7v2-api-v1.yaml) for complete API documentation.
+Server corpus endpoints take inline message arrays and safe labels; they do not
+read filesystem paths supplied in request bodies.
 Server evidence workflow logs are structured and PHI-conscious. Set
 `RUST_LOG_FORMAT=json` for JSON records; logged identifiers such as message
 control IDs and bundle IDs are hashed, and raw HL7, profile YAML, redaction
@@ -314,7 +316,7 @@ hl7v2 ack <input.hl7> --code AE > error_ack.hl7
 
 ### HTTP/REST API Server (`hl7v2-server`)
 
-- **RESTful API**: Parse, validate, redact, bundle, replay, acknowledge, normalize, and inspect inline corpus evidence over HTTP
+- **RESTful API**: Parse, validate, redact, bundle, replay, acknowledge, normalize, and inspect inline-message corpus evidence over HTTP without request-supplied filesystem paths
 - **Health & Readiness**: Production-ready health checks
 - **Prometheus metrics**: Request counts, latencies, error rates
 - **Redacted structured logs**: Evidence workflow logs hash message control IDs and bundle IDs while avoiding raw HL7, profile YAML, redaction policy TOML, and configured filesystem roots by default

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -66,7 +66,7 @@ bundle replay message-type fix.
 | Safe support packets | ✅ Stable | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
 | Evidence contracts | ✅ Stable | v1.4.0 ships opt-in v2 provenance schemas/producers and an `xtask evidence-schema-check` gate. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
-| Server edge guard | ✅ Stable | v1.4.0 ships `/hl7/replay`, inline corpus endpoints, bundle artifact schema opt-in, redacted structured evidence logs, evidence metrics, Docker smoke coverage, and the bundle replay message-type fix. |
+| Server edge guard | ✅ Stable | v1.4.0 ships `/hl7/replay`, inline-message corpus endpoints that do not read request filesystem paths, bundle artifact schema opt-in, redacted structured evidence logs with hashed message-control and bundle identifiers, evidence metrics, Docker smoke coverage, and the bundle replay message-type fix. |
 | Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. v1.4.0 adds v2 parity, PHI sentinel coverage, Python evidence docs, and a manual TestPyPI proof workflow. Python remains outside the crates.io Rust publish graph. |
 
 ## v1.3.0 Readiness Checklist

--- a/docs/architecture/evidence-artifacts.md
+++ b/docs/architecture/evidence-artifacts.md
@@ -3,7 +3,8 @@
 This document maps the current evidence-loop artifacts and their contract
 status. It is a current-state reference for the schema, golden-fixture, CLI
 output-contract, server parity, redacted server logging, and Python parity
-surfaces in the v1.3.0 evidence loop and current post-release hardening line.
+surfaces in the v1.4.0 Evidence Contracts and Server Sidecar release line and
+current main.
 For a compact schema/fixture/producer map, see the
 [Evidence Contract Index](../contracts/evidence-contract-index.md).
 
@@ -96,11 +97,12 @@ The provenance/versioning compatibility rules are maintained in
 
 ## Remaining Contract Hardening Gaps
 
-The v1.3.0 evidence loop and current post-release hardening line have
-schema-backed JSON artifacts, golden fixtures, CLI output semantics, bundle
-manifest verification, server edge-guard routes, redacted structured server
-logs, Python parity, and workflow guides. Remaining hardening work should
-narrow the few places where provenance or identity is still implicit:
+The v1.4.0 release line and current main have schema-backed JSON artifacts,
+golden fixtures, CLI output semantics, bundle manifest verification, server
+edge-guard routes, redacted structured server logs, Python parity, workflow
+guides, and a maintained evidence-schema gate. Remaining hardening work should
+keep provenance and identity explicit as new artifacts or producer surfaces are
+added:
 
 - `schema_version` or artifact-specific version naming for every machine
   artifact. The compatibility plan is documented in

--- a/docs/architecture/evidence-provenance-versioning.md
+++ b/docs/architecture/evidence-provenance-versioning.md
@@ -113,8 +113,8 @@ The migration is intentionally narrow and additive:
    `ValidationReport`, `ProfileLintReport`, `ProfileExplainReport`,
    `CorpusSummary`, `CorpusFingerprint`, `CorpusDiffReport`, and
    `RedactionReceipt`. These artifacts now have target v2 schemas and
-   fixtures; producers still emit the current v1 shapes until migrated
-   explicitly.
+   fixtures; producers expose explicit opt-in v2 paths while defaults remain
+   v1-compatible.
 2. Add additive Rust fields behind explicit v2 serializers or conversion
    helpers. Do not break callers that still expect the v1 shapes.
    `DoctorReport` now has an explicit v2 wrapper, and `hl7v2 doctor` can opt

--- a/docs/audits/evidence-loop-current-state.md
+++ b/docs/audits/evidence-loop-current-state.md
@@ -6,18 +6,25 @@ Updated: 2026-05-09 after the v1.3.0 Evidence Loop release hardening pass,
 the redacted structured server logging pass, and post-v1.4.0 gRPC
 `ParseStream` / `ValidateRedacted` parity work.
 
+Refreshed: 2026-05-10 after the CI economics governance lane merged and the
+evidence loop docs, schemas, guides, sidecar smoke, metrics, and Python
+TestPyPI proof surfaces were inspected as current-main artifacts.
+
 ## Purpose
 
 This audit records the evidence-loop state after the product-usefulness lane
 added first-run diagnostics, typed validation reports, profile commands, corpus
 observability, safe redaction, evidence bundle/replay, Python API parity, and
-the v1.3.0 contract-hardening pass.
+the v1.4.0 evidence-contract hardening pass.
 
 The goal is to keep the next hardening work concrete. The loop now has JSON
 Schemas, golden fixtures, CLI output semantics, bundle manifest verification,
-server parity, redacted structured server logs, Python bundle/replay APIs, and
-gRPC parse-stream plus redacted-validation evidence parity; the remaining gaps
-are narrower deployment-proof and distribution-readiness details.
+server parity, redacted structured server logs, Python bundle/replay APIs, gRPC
+parse-stream plus redacted-validation evidence parity, deployment proof, and
+manual Python distribution-proof rails now exist. Remaining gaps are narrower:
+new evidence surfaces must keep using explicit contract versions, and the
+TestPyPI upload/install-back mode remains a separate manual proof before any
+production PyPI decision.
 
 ## Current Product Loop
 
@@ -114,17 +121,18 @@ Current behavior is script-grade:
 
 ## Known Contract Gaps
 
-The evidence loop is contract-grade enough for the v1.3.0 release and current
-post-release hardening line: schemas, goldens, CLI output semantics, manifest
-verification, server edge-guard routes, redacted structured logs, Python parity,
-user guides, and documented evidence null/empty semantics are in place.
+The evidence loop is contract-grade enough for the v1.4.0 release line and
+current main: schemas, goldens, CLI output semantics, manifest verification,
+server edge-guard routes, redacted structured logs, Python parity, user guides,
+deployment smoke rails, and documented evidence null/empty semantics are in
+place.
 Remaining hardening work:
 
-1. Keep closing the few artifact/version identity gaps that remain.
+1. Keep v2 outputs explicit opt-ins and preserve v1 default compatibility.
    The compatibility plan is documented in
    [`../architecture/evidence-provenance-versioning.md`](../architecture/evidence-provenance-versioning.md);
-   implementation should continue through explicit v2 schema/type PRs, not
-   silent v1 shape changes.
+   new provenance-bearing fields should continue through explicit schema/type
+   work, not silent v1 shape changes.
 2. Expand PHI leak sentinels beyond the current synthetic patient/contact
    fixture family as new evidence surfaces or policy modes are added.
 3. Promote shared report types out of CLI-local structs when server or Python
@@ -137,12 +145,15 @@ Remaining hardening work:
 | Inspected CLI command definitions and formatters | Pass | `doctor`, `profile`, `corpus`, `redact`, `bundle`, and `replay` commands are present. |
 | Inspected shared Rust validation and corpus types | Pass | `ValidationReport`, `ProfileLintReport`, `CorpusSummary`, `CorpusFingerprint`, and `CorpusDiffReport` are library types. |
 | Inspected server validation handlers and response models | Pass | `/hl7/validate` builds `ValidationReport`; `/hl7/validate-redacted` returns a validation report plus redaction receipt. |
+| Inspected server inline corpus handlers and models | Pass | `/hl7/corpus/summarize`, `/hl7/corpus/fingerprint`, and `/hl7/corpus/diff` accept inline message arrays and labels, not request-supplied filesystem paths. |
+| Inspected redacted structured log helpers | Pass | Evidence workflow logs hash message-control, bundle, and fixture identifiers and avoid raw HL7, profile YAML, redaction policy TOML, configured filesystem roots, and raw bundle IDs. |
 | Inspected Python binding API | Pass | Python exposes parse, JSON conversion, normalization, validation report dict/JSON access, corpus summary/fingerprint/diff dict outputs, safe-analysis redaction output, bundle creation, and replay verification. |
 | Checked existing integration tests | Pass | CLI tests cover JSON outputs, redaction no-PHI assertions, bundle artifacts, replay success, replay drift failure, and missing-artifact failure. |
 
 ## Result
 
-The evidence loop is real enough to harden. The next work should not add broad
-new features first; it should make the existing artifacts easier to operate and
-audit with a single contract index, repeatable schema checks, deployment proof,
-and Python distribution proof.
+The evidence loop is real and documented enough to operate as the current trust
+surface. The next work should stay narrow: preserve the contract index and
+`evidence-schema-check` gate, keep deployment and PHI sentinel coverage current
+as server behavior changes, and run the publishing TestPyPI proof before any
+production PyPI decision.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -100,7 +100,8 @@ with `corpus_summary(..., schema_version=2)`,
 `corpus_fingerprint(..., schema_version=2)`, and
 `corpus_diff(..., schema_version=2)`. Server inline corpus endpoints expose the
 same opt-in shapes through `summary_schema_version`, `fingerprint_schema_version`,
-and `diff_schema_version` request fields; defaults remain v1.
+and `diff_schema_version` request fields; requests carry inline messages and
+safe labels, not filesystem corpus paths; defaults remain v1.
 Redaction receipts can opt into their target v2 shape with
 `hl7v2 redact --format json --schema-version 2`, Python
 `redact(..., schema_version=2)`, or server `/hl7/validate-redacted` requests


### PR DESCRIPTION
## Summary
- refresh the evidence-loop status docs from the old v1.3.0 hardening wording to the v1.4.0/current-main surface
- document that server corpus endpoints use inline message payloads and do not read request-supplied filesystem paths
- clarify that v2 evidence shapes are explicit opt-ins while v1 remains the default-compatible shape
- add audit evidence rows for server inline corpus handlers and redacted structured log helpers

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`