### PR TITLE
docs: add source-tree truth audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
 | **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published to crates.io; Python remains a separate binding lane |
-| **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release with opt-in v2 provenance, schema gates, server sidecar hardening, Python/TestPyPI proof, PHI sentinels, and replay fixes |
+| **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release with opt-in v2 provenance, schema gates, server sidecar hardening, non-publishing Python/TestPyPI proof, PHI sentinels, and replay fixes |
 
 ## Features
 
@@ -83,6 +83,8 @@ For support escalation without raw message PHI, see the
 [Safe Support Bundle guide](docs/guides/safe-support-bundle.md).
 For sidecar deployment, see the
 [Deploy Validation Sidecar guide](docs/guides/deploy-validation-sidecar.md).
+For the full documentation map, including current sources of truth and
+historical receipts, see [docs/README.md](docs/README.md).
 
 ### HTTP/REST API Server
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,86 @@
+# Documentation Index
+
+This directory contains current operating documentation, release receipts, and
+historical project records. For live behavior and package-surface truth, start
+with the current sources below before reading older planning documents.
+
+## Current Sources
+
+| Need | Start here |
+| --- | --- |
+| Current release and feature status | [STATUS.md](STATUS.md) |
+| Contributor workflow | [../CONTRIBUTING.md](../CONTRIBUTING.md), [../DEVELOPMENT.md](../DEVELOPMENT.md) |
+| Task-focused evidence workflows | [guides/README.md](guides/README.md) |
+| Machine-readable evidence artifacts | [contracts/evidence-contract-index.md](contracts/evidence-contract-index.md) |
+| Evidence artifact semantics and provenance | [architecture/evidence-artifacts.md](architecture/evidence-artifacts.md), [architecture/evidence-provenance-versioning.md](architecture/evidence-provenance-versioning.md) |
+| JSON schemas | [../schemas/README.md](../schemas/README.md) |
+| Current Rust module and package surface | [architecture/module-map.md](architecture/module-map.md) |
+| HTTP and gRPC API usage | [API_GUIDE.md](API_GUIDE.md) |
+| CI and release validation lanes | [CI_PIPELINE.md](CI_PIPELINE.md) |
+| Release process | [../RELEASE_PROCESS.md](../RELEASE_PROCESS.md) |
+| Lint, file, and panic-family policies | [CLIPPY_POLICY.md](CLIPPY_POLICY.md), [FILE_POLICY.md](FILE_POLICY.md), [NO_PANIC_POLICY.md](NO_PANIC_POLICY.md) |
+
+## Evidence Guides
+
+| Guide | Workflow |
+| --- | --- |
+| [First 10 Minutes](guides/first-10-minutes.md) | Install, diagnose, validate, summarize, bundle, and replay. |
+| [Vendor Upgrade Diff](guides/vendor-upgrade-diff.md) | Compare before/after corpora and interpret drift. |
+| [Safe Support Bundle](guides/safe-support-bundle.md) | Redact and package replayable support evidence. |
+| [Deploy Validation Sidecar](guides/deploy-validation-sidecar.md) | Run `hl7v2-server` as an edge guard. |
+| [Python Evidence Workflow](guides/python-evidence-workflow.md) | Use the Python binding for validation reports, corpus diffs, redaction, bundles, and replay. |
+| [Python TestPyPI Release Proof](guides/python-testpypi-release-proof.md) | Prove the separate Python packaging lane without changing the Rust crates.io graph. |
+
+## Release And Proof Receipts
+
+| Receipt | Use for |
+| --- | --- |
+| [v1.4.0 Evidence Contracts release notes](releases/v1.4.0-evidence-contracts.md) | Published release scope and user-facing changes. |
+| [v1.4.0 objective audit](audits/v1.4.0-objective-completion-audit.md) | Release-snapshot prompt-to-artifact map for the evidence-layer objective and remaining boundaries. |
+| [Current source-tree truth audit](audits/current-source-tree-evidence-objective-gap-audit.md) | Current package-state receipt and split-plan boundary for unmerged local evidence-lane work. |
+| [v1.4.0 publish dry-run receipt](audits/publish-dry-run-v1.4.0-2026-05-09.md) | Package verification before upload. |
+| [v1.4.0 publish receipt](audits/publish-v1.4.0-2026-05-09.md) | Dependency-ordered crates.io publication proof. |
+| [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps `hl7v2-python` outside the Rust crates.io graph. |
+
+## Current Boundaries
+
+- `docs/STATUS.md` is the current-state source of truth.
+- The v1.4.0 objective audit is a release-snapshot receipt, not proof that the
+  full long-range evidence-layer objective is finished.
+- `hl7v2-python` remains a separate Python packaging lane until a production
+  PyPI release is intentionally proven and executed.
+- gRPC coverage is useful but still narrower than the full HTTP evidence
+  surface; use `docs/API_GUIDE.md` and `docs/STATUS.md` for current endpoint
+  claims.
+
+## Historical Documents
+
+These documents are retained for traceability. They should not override the
+current package surface, module map, status document, evidence schemas, or
+guides. Some historical receipts preserve links or paths to retired crate
+folders as evidence of the state they recorded; use the current sources above
+for live navigation.
+
+| Historical document | Use for |
+| --- | --- |
+| [TESTING_ARCHITECTURE.md](TESTING_ARCHITECTURE.md) | Historical testing architecture narrative. Examples are updated where practical, but the rollout story predates the crate collapse. |
+| [TESTING_ANALYSIS.md](TESTING_ANALYSIS.md) and [TESTING_SUMMARY.md](TESTING_SUMMARY.md) | Dated testing snapshots from the former microcrate topology. |
+| [MICROCRATE_ANALYSIS.md](MICROCRATE_ANALYSIS.md) | Historical analysis of the retired microcrate structure. |
+| [ISSUES_AND_NEXT_STEPS.md](ISSUES_AND_NEXT_STEPS.md) | Pre-release planning snapshot, not the current work queue. |
+| [TASK_COMPLETION_SUMMARY.md](TASK_COMPLETION_SUMMARY.md) | Earlier documentation alignment receipt. |
+| [../ROADMAP.md](../ROADMAP.md) | Historical roadmap snapshot; current status lives in `docs/STATUS.md`. |
+| [../TESTING.md](../TESTING.md) | Historical root testing guide; current gates live in `DEVELOPMENT.md` and `docs/CI_PIPELINE.md`. |
+| [../SESSION_SUMMARY.md](../SESSION_SUMMARY.md) | Historical session receipt from 2025-11-19. |
+| [plans/](plans/) and [audits/](audits/) | Historical plans and verification receipts. |
+
+## Package Surface
+
+The current Rust product surface is:
+
+- `hl7v2`
+- `hl7v2-server`
+- `hl7v2-cli`
+
+`hl7v2-python` remains a separate Python/maturin lane and is not part of the
+Rust crates.io publish graph. Historical old microcrate names may exist on
+crates.io, but they are not the product surface for new code.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-09
+> **Last Updated**: 2026-05-10
 > **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 
 ## Core Components
@@ -41,7 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
-- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the TestPyPI upload/install-back mode has not been run.
+- 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the TestPyPI upload/install-back mode and production PyPI release have not been run. A 2026-05-10 package-state check found no visible `hl7v2-python` package on TestPyPI or production PyPI.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
 
@@ -56,6 +56,11 @@ validation through `xtask evidence-schema-check`, server replay and inline
 corpus endpoints, redacted structured evidence logs, Docker sidecar smoke
 coverage, broader PHI sentinel tests, Python/TestPyPI proof, and the server
 bundle replay message-type fix.
+
+For navigation across current docs, historical receipts, and evidence workflow
+guides, start with [the documentation index](README.md). For the current
+source-tree truth audit and local workbench split boundary, see
+[`docs/audits/current-source-tree-evidence-objective-gap-audit.md`](audits/current-source-tree-evidence-objective-gap-audit.md).
 
 | Area | Status | Notes |
 |------|--------|-------|
@@ -87,6 +92,7 @@ Release notes: [`docs/releases/v1.4.0-evidence-contracts.md`](releases/v1.4.0-ev
 Dry-run receipt: [`docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`](audits/publish-dry-run-v1.4.0-2026-05-09.md).
 Publish receipt: [`docs/audits/publish-v1.4.0-2026-05-09.md`](audits/publish-v1.4.0-2026-05-09.md).
 Objective audit: [`docs/audits/v1.4.0-objective-completion-audit.md`](audits/v1.4.0-objective-completion-audit.md).
+Current source-tree truth audit: [`docs/audits/current-source-tree-evidence-objective-gap-audit.md`](audits/current-source-tree-evidence-objective-gap-audit.md).
 
 - ✅ **Publish plan**: `cargo run -p xtask -- publish-plan` resolves `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Evidence schemas**: `cargo run -p xtask -- evidence-schema-check` passes on the v1.4.0 package line.

--- a/docs/audits/current-source-tree-evidence-objective-gap-audit.md
+++ b/docs/audits/current-source-tree-evidence-objective-gap-audit.md
@@ -1,0 +1,79 @@
+# Current Source Tree Evidence Objective Gap Audit
+
+Date: 2026-05-10
+
+This audit records the current durable repository state and the boundary around
+the broad local evidence-lane workbench that still needs to be split. It is not
+a release receipt, does not replace `docs/STATUS.md`, and does not claim
+TestPyPI or production PyPI publication.
+
+## Durability Boundary
+
+The default branch is the durable source of truth. A large local workbench
+contains useful validated work across docs, xtask rails, Python publishing
+policy, gRPC auth/config, sensitive-output sanitization, and Python evidence
+schema smoke coverage, but it is not durable until it is split into focused PRs
+and merged.
+
+The audit distinction is:
+
+- **Published release state**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0
+  are published to crates.io.
+- **Separate Python lane**: `hl7v2-python` remains outside the Rust crates.io
+  graph.
+- **Current local workbench**: broad, dirty, and intentionally not reviewable as
+  one PR.
+- **External Python package state**: no visible TestPyPI or production PyPI
+  `hl7v2-python` package was found during this audit.
+
+## Package-State Receipt
+
+| Surface | Result |
+| --- | --- |
+| `cargo +1.93.0 info hl7v2@1.4.0 --registry crates-io` | Reported `hl7v2` version `1.4.0` with crates.io URL. |
+| `cargo +1.93.0 info hl7v2-server@1.4.0 --registry crates-io` | Reported `hl7v2-server` version `1.4.0` with crates.io URL. |
+| `cargo +1.93.0 info hl7v2-cli@1.4.0 --registry crates-io` | Reported `hl7v2-cli` version `1.4.0` with crates.io URL. |
+| `https://pypi.org/pypi/hl7v2-python/json` | Returned `404`. |
+| `https://test.pypi.org/pypi/hl7v2-python/json` | Returned `404`. |
+
+## Split Plan
+
+The local workbench should be retired through narrow PRs, not merged as a
+single patch:
+
+| Order | Branch | Scope |
+| ---: | --- | --- |
+| 1 | `docs/source-tree-truth-audit` | Source-tree audit, status wording, docs navigation, and external package-state receipts. |
+| 2 | `xtask/file-doc-policy-rails` | Untracked file policy, doc-link changed-gate behavior, and generated/vendor skip coverage. |
+| 3 | `xtask/python-publish-policy` | PyPI/TestPyPI policy hardening, TOML-backed `pyproject.toml`, and Trusted Publishing guards. |
+| 4 | `server/grpc-auth-config` | gRPC `x-api-key`, CLI `serve --mode grpc` shared config path, and transport auth tests. |
+| 5 | `server/sensitive-error-sanitization` | Profile-load/lint sanitization plus bundle/replay ID no-echo behavior. |
+| 6 | `python/evidence-schema-smoke` | Python guide validates generated v2 artifacts and bundle internals against checked-in schemas. |
+| 7 | `docs/final-source-tree-gap-audit` | Final audit refresh after PRs 1-6 land. |
+
+## Stop Conditions
+
+- Do not publish `hl7v2-python` to crates.io.
+- Do not run production PyPI without explicit release approval.
+- Do not claim TestPyPI upload/install-back proof until the publishing mode
+  uploads the current package and installs it back from TestPyPI.
+- Keep the Rust publish graph as `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- Keep CI-economics work separate from evidence-product behavior.
+
+## Verification Performed For This Audit
+
+| Check | Result |
+| --- | --- |
+| `gh pr list --state open --limit 20 --json number,title,headRefName,isDraft,mergeStateStatus,statusCheckRollup` | Returned `[]` before this PR was opened. |
+| `cargo +1.93.0 info hl7v2@1.4.0 --registry crates-io` | Passed. |
+| `cargo +1.93.0 info hl7v2-server@1.4.0 --registry crates-io` | Passed. |
+| `cargo +1.93.0 info hl7v2-cli@1.4.0 --registry crates-io` | Passed. |
+| `Invoke-WebRequest https://pypi.org/pypi/hl7v2-python/json` | Returned `404`. |
+| `Invoke-WebRequest https://test.pypi.org/pypi/hl7v2-python/json` | Returned `404`. |
+
+## Conclusion
+
+The repo is in a good post-release state, but the next durable work is
+disposition, not more feature construction. The broad local workbench should be
+split and reviewed in the PR sequence above before any TestPyPI publishing
+proof is attempted from `main`.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,6 +3,9 @@
 Task-focused guides for using HL7v2 as an evidence layer around real HL7 v2
 feeds.
 
+For the broader documentation map and historical receipt boundaries, see
+[../README.md](../README.md).
+
 | Guide | Use when |
 | --- | --- |
 | [First 10 Minutes](first-10-minutes.md) | You want to verify the CLI, validate a message, inspect a tiny corpus, and create a replayable evidence bundle. |


### PR DESCRIPTION
## Summary
- add a docs index that points contributors to current status, evidence contracts, guides, and historical receipts
- add a current source-tree truth audit that records the broad local workbench boundary and the focused PR split plan
- refresh README/status wording so Python/TestPyPI claims stay explicit about non-publishing proof and absent PyPI/TestPyPI packages

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Notes
- `cargo +1.93.0 run -p xtask -- check-doc-links` is not available on current main yet; that rail belongs to the later xtask split.
- External package-state checks during this audit returned 404 for `hl7v2-python` on both PyPI and TestPyPI.
