### PR TITLE
xtask: add file and doc policy rails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Checklist
 
-- [ ] I agree to the [Contributor License Agreement](CLA.md) for this contribution.
+- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
 - [ ] `cargo run -p xtask -- gate --check` passes locally.
 - [ ] `cargo run -p xtask -- check-lint-policy` passes.
 - [ ] `cargo run -p xtask -- check-no-panic-family` passes.

--- a/.qoder/quests/hl7v2-advanced-features-implementation.md
+++ b/.qoder/quests/hl7v2-advanced-features-implementation.md
@@ -12,8 +12,7 @@ This design follows a normative approach with specific implementation requiremen
 > and that status document disagree, **docs/STATUS.md wins**.
 
 **Quick Links**:
-- [ROADMAP.md](../ROADMAP.md) - Complete v1.2.0 - v2.0.0 roadmap with timelines
-- [ROADMAP.md](../../ROADMAP.md) - Detailed task breakdown and sprint planning
+- [ROADMAP.md](../../ROADMAP.md) - Complete roadmap and historical planning context
 - [docs/STATUS.md](../../docs/STATUS.md) - Current implementation status of all features
 
 ## 1.1 Current Implementation Status

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -663,14 +663,14 @@ cargo run --bin hl7v2-server
 
 - **Issues**: https://github.com/EffortlessMetrics/hl7v2-rs/issues
 - **Documentation**: [README.md](README.md), [docs/STATUS.md](docs/STATUS.md)
-- **API Spec**: [schemas/openapi/hl7v2-api.yaml](schemas/openapi/hl7v2-api.yaml)
+- **API Spec**: [api/openapi/hl7v2-api-v1.yaml](api/openapi/hl7v2-api-v1.yaml)
 
 ## Related Documentation
 
 - [README.md](README.md) - Project overview and features
 - [docs/STATUS.md](docs/STATUS.md) - Implementation roadmap
 - [NIX_USAGE.md](NIX_USAGE.md) - Nix flake usage guide
-- [OpenAPI Specification](schemas/openapi/hl7v2-api.yaml) - Complete API reference
+- [OpenAPI Specification](api/openapi/hl7v2-api-v1.yaml) - Complete API reference
 - [Example Profiles](examples/profiles/README.md) - Conformance profile examples
 
 ## License

--- a/crates/hl7v2-server/tests/README.md
+++ b/crates/hl7v2-server/tests/README.md
@@ -339,7 +339,7 @@ Planned test additions:
 
 ## Related Documentation
 
-- [OpenAPI Specification](../../../schemas/openapi/hl7v2-api.yaml) - API contract
+- [OpenAPI Specification](../../../api/openapi/hl7v2-api-v1.yaml) - API contract
 - [Example Profiles](../../../examples/profiles/) - Sample conformance profiles
 - [ADR-006](../../../docs/adr/0012-rate-limiting-and-backpressure.md) - Rate limiting strategy
 - [Server Documentation](../README.md) - Server configuration and deployment

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -130,6 +130,24 @@ using Trusted Publishing from the `testpypi` GitHub environment, then installs
 tests. The workflow uses `id-token: write` only for the publish job and does
 not use repository PyPI tokens.
 
+### Markdown Local-Link Policy
+
+The local documentation-link rail is:
+
+```powershell
+cargo +1.93.0 run -p xtask -- check-doc-links
+```
+
+It scans tracked and untracked non-ignored Markdown files outside
+generated/vendor directories and fails when explicit relative local links point
+at missing repository targets, escape the workspace, or rely on
+case-insensitive path matching. The full `xtask gate --check` path runs this
+after the non-Rust file policy check, which also scans tracked and untracked
+non-ignored files, so release and audit receipts do not depend on an ad hoc
+local script. `xtask gate --check --changed` also runs this rail for
+crate-scoped Markdown changes so a broken link in a crate README cannot bypass
+the changed-crate shortcut.
+
 ### `.github/workflows/server-smoke.yml` - Server Docker Smoke
 
 Path-scoped and manual workflow for the deployable validation sidecar. It

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -21,8 +21,8 @@ LICENSE, NOTICE         license files
 .gitattributes          git metadata
 ```
 
-Everything else under version control that is a programming or configuration
-surface needs an explicit entry.
+Everything else in the tracked or untracked non-ignored source tree that is a
+programming or configuration surface needs an explicit entry.
 
 ## Allowlist schema
 
@@ -85,9 +85,10 @@ cargo run -p xtask -- check-file-policy
 
 Failure modes:
 
-- **non-Rust file under version control with no matching entry** — fail.
-- **allowlist entry whose glob matches no tracked file** — fail (unless
-  `retired = true`).
+- **tracked or untracked non-ignored non-Rust file with no matching entry** —
+  fail.
+- **allowlist entry whose glob matches no tracked or untracked non-ignored
+  file** — fail (unless `retired = true`).
 - **allowlist entry past `expires`** — fail.
 - **production / test / tooling entry without `covered_by`** — fail.
 

--- a/docs/MICROCRATE_ANALYSIS.md
+++ b/docs/MICROCRATE_ANALYSIS.md
@@ -35,7 +35,7 @@ The following microcrates have been successfully extracted as part of the SRP re
 
 **Status:** Complete
 
-**Location:** [`crates/hl7v2-network/`](../crates/hl7v2-network/)
+**Location:** `crates/hl7v2-network/`
 
 **Extracted from:** `hl7v2-core/src/network/`
 
@@ -61,7 +61,7 @@ async fn send_message() -> Result<(), Box<dyn std::error::Error>> {
         .connect_timeout(Duration::from_secs(5))
         .read_timeout(Duration::from_secs(30))
         .build();
-    
+
     client.connect("127.0.0.1:2575".parse()?).await?;
     let ack = client.send_message(&message).await?;
     client.close().await?;
@@ -77,7 +77,7 @@ async fn send_message() -> Result<(), Box<dyn std::error::Error>> {
 
 **Status:** Complete
 
-**Location:** [`crates/hl7v2-stream/`](../crates/hl7v2-stream/)
+**Location:** `crates/hl7v2-stream/`
 
 **Extracted from:** `hl7v2-core/src/lib.rs` (StreamParser, Event types)
 
@@ -129,7 +129,7 @@ while let Ok(Some(event)) = parser.next_event() {
 
 **Status:** Complete
 
-**Location:** [`crates/hl7v2-validation/`](../crates/hl7v2-validation/)
+**Location:** `crates/hl7v2-validation/`
 
 **Extracted from:** `hl7v2-prof/src/lib.rs`
 
@@ -170,7 +170,7 @@ assert!(is_valid);
 
 **Status:** Complete
 
-**Location:** [`crates/hl7v2-ack/`](../crates/hl7v2-ack/)
+**Location:** `crates/hl7v2-ack/`
 
 **Extracted from:** `hl7v2-gen/src/lib.rs`
 
@@ -219,7 +219,7 @@ let ack_message = ack(&original_message, AckCode::AA).unwrap();
 
 **Status:** Complete
 
-**Location:** [`crates/hl7v2-faker/`](../crates/hl7v2-faker/)
+**Location:** `crates/hl7v2-faker/`
 
 **Extracted from:** `hl7v2-gen/src/lib.rs`
 
@@ -267,6 +267,11 @@ let mrn = faker.mrn();
 ---
 
 ## Migration Guide
+
+> Historical note: this migration guide documents the former microcrate
+> topology. The current implementation lives under the canonical `hl7v2` crate;
+> current module mappings are maintained in
+> [`docs/architecture/module-map.md`](architecture/module-map.md).
 
 ### For Users of `hl7v2-core`
 
@@ -334,15 +339,15 @@ These crates already follow SRP well:
 
 | Crate | Responsibility | Assessment |
 |-------|---------------|------------|
-| [`hl7v2-model`](../crates/hl7v2-model) | Core data types | ✅ Excellent - minimal dependencies |
-| [`hl7v2-parser`](../crates/hl7v2-parser) | Message parsing | ✅ Good - focused on parsing |
-| [`hl7v2-writer`](../crates/hl7v2-writer) | Message serialization | ✅ Good - focused on writing |
-| [`hl7v2-escape`](../crates/hl7v2-escape) | Escape sequence handling | ✅ Excellent - single purpose |
-| [`hl7v2-mllp`](../crates/hl7v2-mllp) | MLLP framing | ✅ Excellent - single purpose |
-| [`hl7v2-path`](../crates/hl7v2-path) | Path parsing | ✅ Excellent - single purpose |
-| [`hl7v2-datetime`](../crates/hl7v2-datetime) | Date/time handling | ✅ Excellent - focused |
-| [`hl7v2-datatype`](../crates/hl7v2-datatype) | Data type validation | ✅ Good - could expand |
-| [`hl7v2-batch`](../crates/hl7v2-batch) | Batch handling | ✅ Good - focused |
+| `hl7v2-model` | Core data types | ✅ Excellent - minimal dependencies |
+| `hl7v2-parser` | Message parsing | ✅ Good - focused on parsing |
+| `hl7v2-writer` | Message serialization | ✅ Good - focused on writing |
+| `hl7v2-escape` | Escape sequence handling | ✅ Excellent - single purpose |
+| `hl7v2-mllp` | MLLP framing | ✅ Excellent - single purpose |
+| `hl7v2-path` | Path parsing | ✅ Excellent - single purpose |
+| `hl7v2-datetime` | Date/time handling | ✅ Excellent - focused |
+| `hl7v2-datatype` | Data type validation | ✅ Good - could expand |
+| `hl7v2-batch` | Batch handling | ✅ Good - focused |
 
 ### Crates Needing Decomposition
 
@@ -988,7 +993,7 @@ The following additional microcrate extraction opportunities have been identifie
 
 #### 8. `hl7v2-query` - Path-Based Field Access
 
-**Extract from:** [`hl7v2-parser/src/lib.rs`](../crates/hl7v2-parser/src/lib.rs) (lines 211-279)
+**Extract from:** `hl7v2-parser/src/lib.rs` (lines 211-279)
 
 **Rationale:**
 - Path-based field access (`get`, `get_presence`) is a distinct concern from parsing
@@ -1020,7 +1025,7 @@ pub fn parse_path(path: &str) -> Result<ParsedPath, PathError>;
 
 #### 9. `hl7v2-json` - JSON Serialization
 
-**Extract from:** [`hl7v2-writer/src/lib.rs`](../crates/hl7v2-writer/src/lib.rs) (lines 245-320)
+**Extract from:** `hl7v2-writer/src/lib.rs` (lines 245-320)
 
 **Rationale:**
 - JSON serialization is a distinct output format from HL7 wire format
@@ -1056,7 +1061,7 @@ pub fn field_to_json(field: &Field) -> serde_json::Value;
 
 #### 10. `hl7v2-template` - Template-Based Generation
 
-**Extract from:** [`hl7v2-gen/src/lib.rs`](../crates/hl7v2-gen/src/lib.rs) (lines 39-405)
+**Extract from:** `hl7v2-gen/src/lib.rs` (lines 39-405)
 
 **Rationale:**
 - Template parsing and message generation is distinct from faker/test data
@@ -1096,7 +1101,7 @@ pub fn generate_single(template: &Template, rng: &mut StdRng) -> Result<Message,
 
 #### 11. `hl7v2-normalize` - Message Normalization
 
-**Extract from:** [`hl7v2-writer/src/lib.rs`](../crates/hl7v2-writer/src/lib.rs) (lines 210-234)
+**Extract from:** `hl7v2-writer/src/lib.rs` (lines 210-234)
 
 **Rationale:**
 - Normalization is a transformation concern, not writing
@@ -1129,7 +1134,7 @@ pub fn is_canonical(msg: &Message) -> bool;
 
 #### 12. `hl7v2-corpus` - Test Corpus Generation
 
-**Extract from:** [`hl7v2-gen/src/lib.rs`](../crates/hl7v2-gen/src/lib.rs) (lines 496-630)
+**Extract from:** `hl7v2-gen/src/lib.rs` (lines 496-630)
 
 **Rationale:**
 - Corpus generation is testing infrastructure, not production code
@@ -1167,7 +1172,7 @@ pub fn generate_golden_hashes(template: &Template, seed: u64, count: usize) -> R
 
 #### 13. `hl7v2-profile-defs` - Profile Type Definitions
 
-**Extract from:** [`hl7v2-prof/src/lib.rs`](../crates/hl7v2-prof/src/lib.rs) (lines 52-254)
+**Extract from:** `hl7v2-prof/src/lib.rs` (lines 52-254)
 
 **Rationale:**
 - Profile type definitions are pure data structures

--- a/docs/TESTING_ANALYSIS.md
+++ b/docs/TESTING_ANALYSIS.md
@@ -1,11 +1,17 @@
 # HL7 v2 Rust Workspace - Testing Analysis
 
-**Generated:** 2026-02-24  
+**Generated:** 2026-02-24
 **Total Crates Analyzed:** 26
 
 > Historical note: this analysis predates the post-1.2.1 crate-surface collapse
 > and local shim-folder retirement. It is retained as a dated testing receipt;
-> current Rust consumers should use `hl7v2` and its module paths.
+> current Rust consumers should use `hl7v2` and its module paths. Links to
+> retired crate folders are preserved as historical references, not live
+> navigation. Do not use the microcrate test inventory, priority labels, or
+> missing-test findings below as current project status; use
+> [STATUS.md](STATUS.md), [CI_PIPELINE.md](CI_PIPELINE.md), and
+> [audits/current-source-tree-evidence-objective-gap-audit.md](audits/current-source-tree-evidence-objective-gap-audit.md)
+> for the current testing and evidence receipts.
 
 ## Executive Summary
 
@@ -71,7 +77,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 6 | [`lib.rs:385-469`](../crates/hl7v2-ack/src/lib.rs:385) |
+| Unit | 6 | `crates/hl7v2-ack/src/lib.rs:385` |
 
 **Unit Test Coverage:**
 - `test_ack_code_display` - ACK code display formatting
@@ -103,7 +109,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 5 | [`lib.rs:465-511`](../crates/hl7v2-batch/src/lib.rs:465) |
+| Unit | 5 | `crates/hl7v2-batch/src/lib.rs:465` |
 
 **Unit Test Coverage:**
 - `test_parse_simple_messages` - Simple message parsing
@@ -138,7 +144,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Benchmark | 4 | [`benches/`](../crates/hl7v2-bench/benches/) |
+| Benchmark | 4 | `crates/hl7v2-bench/benches/` |
 
 **Benchmark Coverage:**
 - `escape.rs` - Escape/unescape performance
@@ -205,9 +211,9 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 19+ | [`lib.rs:59-160`](../crates/hl7v2-core/src/lib.rs:59), [`tests.rs`](../crates/hl7v2-core/src/tests.rs) |
-| Integration | 1 | [`tests/bdd_tests.rs`](../crates/hl7v2-core/tests/bdd_tests.rs) |
-| BDD | 3 | [`features/`](../crates/hl7v2-core/features/) |
+| Unit | 19+ | `crates/hl7v2-core/src/lib.rs:59`, `crates/hl7v2-core/src/tests.rs` |
+| Integration | 1 | `crates/hl7v2-core/tests/bdd_tests.rs` |
+| BDD | 3 | `crates/hl7v2-core/features/` |
 
 **BDD Feature Files:**
 - `parsing.feature` - Message parsing scenarios
@@ -249,7 +255,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 13 | [`lib.rs:314-481`](../crates/hl7v2-corpus/src/lib.rs:314) |
+| Unit | 13 | `crates/hl7v2-corpus/src/lib.rs:314` |
 
 **Unit Test Coverage:**
 - `test_corpus_config_default` - Default configuration
@@ -288,7 +294,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 12 | [`lib.rs:573-674`](../crates/hl7v2-datatype/src/lib.rs:573) |
+| Unit | 12 | `crates/hl7v2-datatype/src/lib.rs:573` |
 
 **Unit Test Coverage:**
 - `test_validate_datatype_date` - Date validation
@@ -325,7 +331,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 10 | [`lib.rs:388-499`](../crates/hl7v2-datetime/src/lib.rs:388) |
+| Unit | 10 | `crates/hl7v2-datetime/src/lib.rs:388` |
 
 **Unit Test Coverage:**
 - `test_parse_hl7_date` - Date parsing
@@ -357,7 +363,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 17 | [`lib.rs:226-373`](../crates/hl7v2-escape/src/lib.rs:226) |
+| Unit | 17 | `crates/hl7v2-escape/src/lib.rs:226` |
 
 **Unit Test Coverage:**
 - `test_escape_field_separator` - Field separator escaping
@@ -400,7 +406,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 20 | [`lib.rs:497-682`](../crates/hl7v2-faker/src/lib.rs:497) |
+| Unit | 20 | `crates/hl7v2-faker/src/lib.rs:497` |
 
 **Unit Test Coverage:**
 - `test_name_generation_male` - Male name generation
@@ -449,7 +455,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 28 | [`lib.rs:47-688`](../crates/hl7v2-gen/src/lib.rs:47) |
+| Unit | 28 | `crates/hl7v2-gen/src/lib.rs:47` |
 
 **Unit Test Coverage:**
 - Message generation tests
@@ -480,7 +486,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 8 | [`lib.rs:205-371`](../crates/hl7v2-json/src/lib.rs:205) |
+| Unit | 8 | `crates/hl7v2-json/src/lib.rs:205` |
 
 **Unit Test Coverage:**
 - `test_to_json_simple_message` - Simple message JSON
@@ -511,7 +517,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 9 | [`lib.rs:245-361`](../crates/hl7v2-mllp/src/lib.rs:245) |
+| Unit | 9 | `crates/hl7v2-mllp/src/lib.rs:245` |
 
 **Unit Test Coverage:**
 - `test_wrap_mllp` - MLLP wrapping
@@ -543,7 +549,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 10 | [`lib.rs:425-504`](../crates/hl7v2-model/src/lib.rs:425) |
+| Unit | 10 | `crates/hl7v2-model/src/lib.rs:425` |
 
 **Unit Test Coverage:**
 - `test_delims_default` - Default delimiters
@@ -581,7 +587,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 9 | [`lib.rs:80+`](../crates/hl7v2-network/src/lib.rs:80), [`codec.rs:189+`](../crates/hl7v2-network/src/codec.rs:189), [`client.rs:242+`](../crates/hl7v2-network/src/client.rs:242) |
+| Unit | 9 | `crates/hl7v2-network/src/lib.rs:80`, `crates/hl7v2-network/src/codec.rs:189`, `crates/hl7v2-network/src/client.rs:242` |
 
 **Unit Test Coverage:**
 - Codec encode/decode tests
@@ -613,7 +619,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 4 | [`lib.rs:36-80`](../crates/hl7v2-normalize/src/lib.rs:36) |
+| Unit | 4 | `crates/hl7v2-normalize/src/lib.rs:36` |
 
 **Unit Test Coverage:**
 - `normalize_preserves_custom_delimiters_when_not_canonical` - Custom delimiter preservation
@@ -643,7 +649,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 6 | [`lib.rs:583-677`](../crates/hl7v2-parser/src/lib.rs:583) |
+| Unit | 6 | `crates/hl7v2-parser/src/lib.rs:583` |
 
 **Unit Test Coverage:**
 - `test_parse_simple_message` - Simple message parsing
@@ -673,7 +679,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 10 | [`lib.rs:253-331`](../crates/hl7v2-path/src/lib.rs:253) |
+| Unit | 10 | `crates/hl7v2-path/src/lib.rs:253` |
 
 **Unit Test Coverage:**
 - `test_parse_simple_path` - Simple path parsing
@@ -712,8 +718,8 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 7+ | [`tests.rs:1+`](../crates/hl7v2-prof/src/tests.rs:1), [`debug_test.rs`](../crates/hl7v2-prof/src/debug_test.rs), [`simple_test.rs`](../crates/hl7v2-prof/src/simple_test.rs) |
-| Integration | 1 | [`tests/simple_test.rs`](../crates/hl7v2-prof/tests/simple_test.rs) |
+| Unit | 7+ | `crates/hl7v2-prof/src/tests.rs:1`, `crates/hl7v2-prof/src/debug_test.rs`, `crates/hl7v2-prof/src/simple_test.rs` |
+| Integration | 1 | `crates/hl7v2-prof/tests/simple_test.rs` |
 
 **Unit Test Coverage:**
 - `test_load_simple_profile` - Profile loading
@@ -741,7 +747,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 11 | [`lib.rs:425-757`](../crates/hl7v2-query/src/lib.rs:425) |
+| Unit | 11 | `crates/hl7v2-query/src/lib.rs:425` |
 
 **Unit Test Coverage:**
 - `test_parse_field_and_rep` - Field and repetition parsing
@@ -788,7 +794,7 @@ This document provides a comprehensive analysis of the testing status across all
 | Type | Count | Location |
 |------|-------|----------|
 | Unit | 9 | Various source files |
-| Integration | 5 | [`tests/`](../crates/hl7v2-server/tests/) |
+| Integration | 5 | `crates/hl7v2-server/tests/` |
 
 **Integration Test Files:**
 - `health_endpoints_test.rs` - Health/readiness endpoints
@@ -816,7 +822,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 2 | [`lib.rs:275-349`](../crates/hl7v2-stream/src/lib.rs:275) |
+| Unit | 2 | `crates/hl7v2-stream/src/lib.rs:275` |
 
 **Unit Test Coverage:**
 - `test_streaming_parser` - Basic streaming
@@ -849,8 +855,8 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 21 | [`lib.rs:511-952`](../crates/hl7v2-template/src/lib.rs:511) |
-| Integration | 1 | [`tests/generation_integration.rs`](../crates/hl7v2-template/tests/generation_integration.rs) |
+| Unit | 21 | `crates/hl7v2-template/src/lib.rs:511` |
+| Integration | 1 | `crates/hl7v2-template/tests/generation_integration.rs` |
 
 **Unit Test Coverage:**
 - Message generation tests
@@ -883,11 +889,11 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 5 | [`lib.rs:235-308`](../crates/hl7v2-template-values/src/lib.rs:235) |
-| Integration | 1 | [`tests/bdd_tests.rs`](../crates/hl7v2-template-values/tests/bdd_tests.rs) |
-| BDD | 1 | [`features/value_sources.feature`](../crates/hl7v2-template-values/features/value_sources.feature) |
-| Property | 2 | [`lib.rs:283-303`](../crates/hl7v2-template-values/src/lib.rs:283) |
-| Fuzz | 1 | [`fuzz/fuzz_targets/value_source.rs`](../crates/hl7v2-template-values/fuzz/fuzz_targets/value_source.rs) |
+| Unit | 5 | `crates/hl7v2-template-values/src/lib.rs:235` |
+| Integration | 1 | `crates/hl7v2-template-values/tests/bdd_tests.rs` |
+| BDD | 1 | `crates/hl7v2-template-values/features/value_sources.feature` |
+| Property | 2 | `crates/hl7v2-template-values/src/lib.rs:283` |
+| Fuzz | 1 | `crates/hl7v2-template-values/fuzz/fuzz_targets/value_source.rs` |
 
 **Test Coverage:**
 - Fixed value generation
@@ -918,7 +924,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 10 | [`lib.rs:913-994`](../crates/hl7v2-validation/src/lib.rs:913) |
+| Unit | 10 | `crates/hl7v2-validation/src/lib.rs:913` |
 
 **Unit Test Coverage:**
 - `test_is_date` - Date validation
@@ -955,7 +961,7 @@ This document provides a comprehensive analysis of the testing status across all
 **Current Tests:**
 | Type | Count | Location |
 |------|-------|----------|
-| Unit | 6 | [`lib.rs:282-447`](../crates/hl7v2-writer/src/lib.rs:282) |
+| Unit | 6 | `crates/hl7v2-writer/src/lib.rs:282` |
 
 **Unit Test Coverage:**
 - `test_write_simple_message` - Simple message writing

--- a/docs/adr/0013-authentication-strategy.md
+++ b/docs/adr/0013-authentication-strategy.md
@@ -68,6 +68,6 @@ Planned for v2.0.0:
 
 ## References
 
-- [ADR-006: Rate Limiting and Backpressure Strategy](ADR-006-rate-limiting-and-backpressure.md)
+- [ADR-012: Rate Limiting and Backpressure Strategy](0012-rate-limiting-and-backpressure.md)
 - [Axum Middleware Documentation](https://docs.rs/axum/latest/axum/middleware/index.html)
 - [HIPAA Security Rule: Technical Safeguards](https://www.hhs.gov/hipaa/for-professionals/security/guidance/index.html)

--- a/docs/adr/0014-observability-architecture.md
+++ b/docs/adr/0014-observability-architecture.md
@@ -66,6 +66,6 @@ Separate endpoints are provided to distinguish between "process is alive" and "p
 
 ## References
 
-- [ADR-006: Rate Limiting and Backpressure Strategy](ADR-006-rate-limiting-and-backpressure.md)
+- [ADR-012: Rate Limiting and Backpressure Strategy](0012-rate-limiting-and-backpressure.md)
 - [Prometheus Documentation](https://prometheus.io/docs/introduction/overview/)
 - [Rust Tracing Ecosystem](https://tracing.rs/tracing/)

--- a/justfile
+++ b/justfile
@@ -62,6 +62,7 @@ policy-check:
     cargo run -p xtask -- check-lint-policy
     cargo run -p xtask -- check-no-panic-family
     cargo run -p xtask -- check-file-policy
+    cargo run -p xtask -- check-doc-links
 
 # Print policy rollout, debt, no-panic, and file-policy summary
 policy-report:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
@@ -99,8 +99,10 @@ enum Commands {
         #[command(subcommand)]
         action: NoPanicAction,
     },
-    /// Verify the non-Rust file allowlist against tracked files
+    /// Verify the non-Rust file allowlist against tracked and untracked non-ignored files
     CheckFilePolicy,
+    /// Verify explicit local Markdown links point at checked-in repository targets
+    CheckDocLinks,
     /// Verify CI lane whitelist: coverage, required fields, expensive-default exceptions
     CheckCiLaneWhitelist,
     /// Validate checked-in evidence fixtures against their JSON schemas
@@ -154,6 +156,7 @@ fn main() -> Result<()> {
             NoPanicAction::Propose { include_staged } => no_panic_propose(include_staged)?,
         },
         Commands::CheckFilePolicy => check_file_policy()?,
+        Commands::CheckDocLinks => check_doc_links()?,
         Commands::CheckCiLaneWhitelist => check_ci_lane_whitelist()?,
         Commands::EvidenceSchemaCheck => evidence_schema_check()?,
     }
@@ -164,12 +167,15 @@ fn main() -> Result<()> {
 fn gate(check: bool, changed_only: bool, only: Option<String>) -> Result<()> {
     println!("🚀 Running gate checks...");
 
-    let (changed_only, crates) = if changed_only {
+    let (changed_only, crates, changed_docs_require_link_check) = if changed_only {
         match get_changed_scope()? {
-            ChangedScope::Crates(c) => (true, c),
+            ChangedScope::Crates {
+                crates,
+                has_markdown,
+            } => (true, crates, has_markdown),
             ChangedScope::Workspace => {
                 println!("Non-crate files changed. Running full workspace gate.");
-                (false, vec![])
+                (false, vec![], false)
             }
             ChangedScope::None => {
                 println!("No files changed. Skipping checks.");
@@ -177,7 +183,7 @@ fn gate(check: bool, changed_only: bool, only: Option<String>) -> Result<()> {
             }
         }
     } else {
-        (false, vec![])
+        (false, vec![], false)
     };
 
     let run_fmt = only.as_deref().is_none_or(|s| s == "fmt");
@@ -191,6 +197,11 @@ fn gate(check: bool, changed_only: bool, only: Option<String>) -> Result<()> {
         check_no_panic_family(false)?;
         println!("Checking non-Rust file policy...");
         check_file_policy()?;
+        println!("Checking Markdown local links...");
+        check_doc_links()?;
+    } else if changed_docs_require_link_check {
+        println!("Checking Markdown local links for crate-scoped doc changes...");
+        check_doc_links()?;
     }
 
     if run_fmt {
@@ -1485,9 +1496,13 @@ fn display_repo_path(path: &Path, root: &Path) -> String {
         .replace('\\', "/")
 }
 
+#[derive(Debug, PartialEq, Eq)]
 enum ChangedScope {
     /// Only `crates/<name>/` files changed — scoped gate possible
-    Crates(Vec<String>),
+    Crates {
+        crates: Vec<String>,
+        has_markdown: bool,
+    },
     /// Non-crate files changed — full workspace gate required
     Workspace,
     /// Nothing changed
@@ -1495,14 +1510,30 @@ enum ChangedScope {
 }
 
 fn get_changed_scope() -> Result<ChangedScope> {
-    let files = git_output(&["diff", "--name-only", "HEAD"])?;
+    let diff_files = git_output(&["diff", "--name-only", "HEAD"])?;
+    let untracked_files = git_output(&["ls-files", "--others", "--exclude-standard"])?;
+    Ok(changed_scope_from_git_listings(
+        &diff_files,
+        &untracked_files,
+    ))
+}
+
+fn changed_scope_from_git_listings(diff_files: &str, untracked_files: &str) -> ChangedScope {
+    changed_scope_from_paths(diff_files.lines().chain(untracked_files.lines()))
+}
+
+fn changed_scope_from_paths<'a>(paths: impl IntoIterator<Item = &'a str>) -> ChangedScope {
     let mut changed_crates = HashSet::new();
     let mut has_non_crate_files = false;
+    let mut has_markdown = false;
 
-    for line in files.lines() {
+    for line in paths {
         let line = line.trim();
         if line.is_empty() {
             continue;
+        }
+        if line.ends_with(".md") {
+            has_markdown = true;
         }
         if line.starts_with("crates/") {
             let parts: Vec<&str> = line.split('/').collect();
@@ -1515,14 +1546,19 @@ fn get_changed_scope() -> Result<ChangedScope> {
     }
 
     if changed_crates.is_empty() && !has_non_crate_files {
-        return Ok(ChangedScope::None);
+        return ChangedScope::None;
     }
 
     if has_non_crate_files {
-        return Ok(ChangedScope::Workspace);
+        return ChangedScope::Workspace;
     }
 
-    Ok(ChangedScope::Crates(changed_crates.into_iter().collect()))
+    let mut crates: Vec<String> = changed_crates.into_iter().collect();
+    crates.sort();
+    ChangedScope::Crates {
+        crates,
+        has_markdown,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2544,12 +2580,8 @@ fn check_file_policy() -> Result<()> {
     let entries = parse_file_policy_allowlist(&allowlist_text)?;
     enforce_file_policy_expirations(&entries)?;
 
-    let tracked = git_output(&["ls-files"])?;
-    let files: Vec<String> = tracked
-        .lines()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let tracked = git_output(&["ls-files", "--cached", "--others", "--exclude-standard"])?;
+    let files = file_policy_inventory_from_git_listing(&tracked);
 
     let mut unmatched: Vec<String> = Vec::new();
     let mut entry_hits: Vec<usize> = vec![0; entries.len()];
@@ -2600,7 +2632,7 @@ fn check_file_policy() -> Result<()> {
     if !stale.is_empty() {
         for entry in &stale {
             eprintln!(
-                "file-policy: stale entry pattern={} (no tracked file matched)",
+                "file-policy: stale entry pattern={} (no tracked or untracked non-ignored file matched)",
                 entry.pattern
             );
         }
@@ -2611,11 +2643,19 @@ fn check_file_policy() -> Result<()> {
     }
 
     println!(
-        "✅ file policy: {} tracked file(s) checked, {} allowlist entr(ies)",
+        "✅ file policy: {} tracked/untracked non-ignored file(s) checked, {} allowlist entr(ies)",
         files.len(),
         entries.len()
     );
     Ok(())
+}
+
+fn file_policy_inventory_from_git_listing(listing: &str) -> Vec<String> {
+    listing
+        .lines()
+        .map(|s| s.trim().replace('\\', "/"))
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 fn file_is_auto_allowed(path: &str) -> bool {
@@ -2641,6 +2681,412 @@ fn file_is_auto_allowed(path: &str) -> bool {
         return true;
     }
     false
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MarkdownLocalLink {
+    line: usize,
+    target: String,
+}
+
+fn check_doc_links() -> Result<()> {
+    println!("🔎 Checking Markdown local links...");
+    let root = env::current_dir()?;
+    let inventory = git_doc_link_inventory(&root)?;
+    let stats = check_doc_links_with_inventory(&root, &inventory)?;
+    println!(
+        "✅ doc links: {} Markdown file(s), {} local link(s) checked",
+        stats.markdown_files, stats.checked_links
+    );
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DocLinkCheckStats {
+    markdown_files: usize,
+    checked_links: usize,
+}
+
+#[derive(Debug)]
+struct DocLinkInventory {
+    markdown_files: Vec<PathBuf>,
+    target_paths: BTreeSet<String>,
+}
+
+#[cfg(test)]
+fn check_doc_links_at(root: &Path) -> Result<DocLinkCheckStats> {
+    let inventory = filesystem_doc_link_inventory(root)?;
+    check_doc_links_with_inventory(root, &inventory)
+}
+
+fn check_doc_links_with_inventory(
+    root: &Path,
+    inventory: &DocLinkInventory,
+) -> Result<DocLinkCheckStats> {
+    let mut missing = Vec::new();
+    let mut checked_links = 0usize;
+
+    for path in &inventory.markdown_files {
+        let text = fs::read_to_string(path)?;
+        let rel = relative_slash_path(root, path)?;
+        for link in markdown_local_links(&text) {
+            checked_links = checked_links.saturating_add(1);
+            match resolve_doc_link_target(root, path, &link.target)? {
+                Some(target) if inventory.target_paths.contains(&target) => {}
+                Some(_) => {
+                    missing.push(format!(
+                        "{}:{} missing local link target `{}`",
+                        rel, link.line, link.target
+                    ));
+                }
+                None => {
+                    missing.push(format!(
+                        "{}:{} local link target escapes the repository `{}`",
+                        rel, link.line, link.target
+                    ));
+                }
+            }
+        }
+    }
+
+    if !missing.is_empty() {
+        for item in missing.iter().take(40) {
+            eprintln!("doc-links: {item}");
+        }
+        if missing.len() > 40 {
+            eprintln!(
+                "doc-links: ... and {} more missing local link(s)",
+                missing.len().saturating_sub(40)
+            );
+        }
+        return Err(anyhow!(
+            "{} Markdown local link(s) point at missing files",
+            missing.len()
+        ));
+    }
+
+    Ok(DocLinkCheckStats {
+        markdown_files: inventory.markdown_files.len(),
+        checked_links,
+    })
+}
+
+fn git_doc_link_inventory(root: &Path) -> Result<DocLinkInventory> {
+    let output = git_output(&["ls-files", "--cached", "--others", "--exclude-standard"])?;
+    doc_link_inventory_from_repo_paths(root, output.lines())
+}
+
+#[cfg(test)]
+fn filesystem_doc_link_inventory(root: &Path) -> Result<DocLinkInventory> {
+    let mut inventory = DocLinkInventory {
+        markdown_files: Vec::new(),
+        target_paths: BTreeSet::new(),
+    };
+    collect_filesystem_doc_link_inventory(root, root, &mut inventory)?;
+    inventory.markdown_files.sort();
+    Ok(inventory)
+}
+
+fn doc_link_inventory_from_repo_paths<'a>(
+    root: &Path,
+    paths: impl IntoIterator<Item = &'a str>,
+) -> Result<DocLinkInventory> {
+    let mut inventory = DocLinkInventory {
+        markdown_files: Vec::new(),
+        target_paths: BTreeSet::new(),
+    };
+
+    for raw in paths {
+        let rel = raw.trim().replace('\\', "/");
+        if rel.is_empty() || should_skip_doc_link_rel(&rel) {
+            continue;
+        }
+        insert_doc_link_target_path(&mut inventory.target_paths, &rel);
+        if rel.ends_with(".md") {
+            inventory.markdown_files.push(root.join(slash_path(&rel)));
+        }
+    }
+
+    inventory.markdown_files.sort();
+    Ok(inventory)
+}
+
+fn insert_doc_link_target_path(targets: &mut BTreeSet<String>, rel: &str) {
+    targets.insert(rel.to_string());
+    let mut parent = Path::new(rel).parent();
+    while let Some(path) = parent {
+        let as_string = path.to_string_lossy().replace('\\', "/");
+        if as_string.is_empty() {
+            break;
+        }
+        targets.insert(as_string);
+        parent = path.parent();
+    }
+}
+
+#[cfg(test)]
+fn collect_filesystem_doc_link_inventory(
+    root: &Path,
+    dir: &Path,
+    inventory: &mut DocLinkInventory,
+) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+
+        if path.is_dir() {
+            if should_skip_doc_link_dir(name) {
+                continue;
+            }
+            let rel = relative_slash_path(root, &path)?;
+            inventory.target_paths.insert(rel);
+            collect_filesystem_doc_link_inventory(root, &path, inventory)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+            let rel = relative_slash_path(root, &path)?;
+            inventory.target_paths.insert(rel);
+            inventory.markdown_files.push(path);
+        } else {
+            let rel = relative_slash_path(root, &path)?;
+            inventory.target_paths.insert(rel);
+        }
+    }
+    Ok(())
+}
+
+fn should_skip_doc_link_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | "target"
+            | "node_modules"
+            | ".venv"
+            | "venv"
+            | ".mypy_cache"
+            | ".pytest_cache"
+            | "generated"
+            | "vendor"
+    )
+}
+
+fn should_skip_doc_link_rel(rel: &str) -> bool {
+    rel.split('/').any(should_skip_doc_link_dir)
+}
+
+fn markdown_local_links(text: &str) -> Vec<MarkdownLocalLink> {
+    let mut links = Vec::new();
+    let mut in_fence = false;
+    for (line_index, line) in text.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        if let Some(raw) = markdown_reference_definition_target(line)
+            && let Some(target) = markdown_link_target(raw)
+            && is_local_markdown_target(&target)
+        {
+            links.push(MarkdownLocalLink {
+                line: line_index.saturating_add(1),
+                target,
+            });
+        }
+
+        let mut offset = 0usize;
+        while let Some(search) = line.get(offset..) {
+            let Some(open_rel) = search.find('[') else {
+                break;
+            };
+            let open = offset.saturating_add(open_rel);
+            if open > 0 && line.as_bytes().get(open.saturating_sub(1)) == Some(&b'!') {
+                offset = open.saturating_add(1);
+                continue;
+            }
+            let Some(open_tail) = line.get(open..) else {
+                break;
+            };
+            let Some(close_rel) = open_tail.find("](") else {
+                break;
+            };
+            let target_start = open.saturating_add(close_rel).saturating_add(2);
+            let Some(target_tail) = line.get(target_start..) else {
+                break;
+            };
+            let Some(close_paren_rel) = target_tail.find(')') else {
+                break;
+            };
+            let target_end = target_start.saturating_add(close_paren_rel);
+            let Some(raw) = line.get(target_start..target_end).map(str::trim) else {
+                break;
+            };
+            if let Some(target) = markdown_link_target(raw)
+                && is_local_markdown_target(&target)
+            {
+                links.push(MarkdownLocalLink {
+                    line: line_index.saturating_add(1),
+                    target,
+                });
+            }
+            offset = target_end.saturating_add(1);
+        }
+    }
+    links
+}
+
+fn markdown_reference_definition_target(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix('[')?;
+    let (_, target) = rest.split_once("]:")?;
+    Some(target.trim())
+}
+
+fn markdown_link_target(raw: &str) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    let target = if let Some(rest) = raw.strip_prefix('<') {
+        let end = rest.find('>')?;
+        rest.get(..end)?
+    } else {
+        raw.split_whitespace().next()?
+    };
+    let fragment_index = target.find('#');
+    let query_index = target.find('?');
+    let path_end = match (fragment_index, query_index) {
+        (Some(fragment), Some(query)) => fragment.min(query),
+        (Some(fragment), None) => fragment,
+        (None, Some(query)) => query,
+        (None, None) => target.len(),
+    };
+    let path = target.get(..path_end)?;
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+fn is_local_markdown_target(target: &str) -> bool {
+    if target.starts_with('#') || target.starts_with('/') || target.starts_with('\\') {
+        return false;
+    }
+    let lower = target.to_ascii_lowercase();
+    if lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with("mailto:")
+        || lower.starts_with("file:")
+        || lower.starts_with("app://")
+    {
+        return false;
+    }
+    if let Some((scheme, _)) = target.split_once(':')
+        && !scheme.is_empty()
+        && scheme
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
+    {
+        return false;
+    }
+    true
+}
+
+fn percent_decode_path(path: &str) -> PathBuf {
+    let bytes = path.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0usize;
+    while let Some(&byte) = bytes.get(index) {
+        if byte == b'%'
+            && let (Some(high), Some(low)) = (
+                bytes
+                    .get(index.saturating_add(1))
+                    .and_then(|b| hex_value(*b)),
+                bytes
+                    .get(index.saturating_add(2))
+                    .and_then(|b| hex_value(*b)),
+            )
+        {
+            decoded.push(high.saturating_mul(16).saturating_add(low));
+            index = index.saturating_add(3);
+            continue;
+        }
+        decoded.push(byte);
+        index = index.saturating_add(1);
+    }
+    PathBuf::from(String::from_utf8_lossy(&decoded).replace('/', std::path::MAIN_SEPARATOR_STR))
+}
+
+fn resolve_doc_link_target(root: &Path, source: &Path, target: &str) -> Result<Option<String>> {
+    let base = source
+        .parent()
+        .unwrap_or(root)
+        .strip_prefix(root)
+        .map_err(|err| {
+            anyhow!(
+                "source {} is not under workspace root {}: {err}",
+                source.display(),
+                root.display()
+            )
+        })?;
+    let combined = base.join(percent_decode_path(target));
+    let Some(normalized) = normalize_repo_relative_path(&combined) else {
+        return Ok(None);
+    };
+    if normalized.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(normalized.to_string_lossy().replace('\\', "/")))
+}
+
+fn normalize_repo_relative_path(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
+}
+
+fn slash_path(path: &str) -> PathBuf {
+    PathBuf::from(path.replace('/', std::path::MAIN_SEPARATOR_STR))
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => byte.checked_sub(b'0'),
+        b'a'..=b'f' => byte
+            .checked_sub(b'a')
+            .and_then(|value| value.checked_add(10)),
+        b'A'..=b'F' => byte
+            .checked_sub(b'A')
+            .and_then(|value| value.checked_add(10)),
+        _ => None,
+    }
+}
+
+fn relative_slash_path(root: &Path, path: &Path) -> Result<String> {
+    let rel = path.strip_prefix(root).map_err(|err| {
+        anyhow!(
+            "path {} is not under workspace root {}: {err}",
+            path.display(),
+            root.display()
+        )
+    })?;
+    Ok(rel.to_string_lossy().replace('\\', "/"))
 }
 
 fn parse_file_policy_allowlist(text: &str) -> Result<Vec<FilePolicyEntry>> {
@@ -3320,6 +3766,7 @@ fn check_ci_lane_whitelist() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn publish_order_uses_workspace_dependency_order() -> Result<()> {
@@ -3512,6 +3959,270 @@ mod tests {
         }
     }
 
+    // ---- changed gate scope ---------------------------------------------
+
+    #[test]
+    fn changed_scope_detects_crate_rust_changes_without_doc_links() {
+        let scope =
+            changed_scope_from_paths(["crates/hl7v2/src/lib.rs", "crates/hl7v2-cli/src/main.rs"]);
+
+        assert_eq!(
+            scope,
+            ChangedScope::Crates {
+                crates: vec!["hl7v2".to_string(), "hl7v2-cli".to_string()],
+                has_markdown: false
+            }
+        );
+    }
+
+    #[test]
+    fn changed_scope_marks_crate_markdown_for_doc_link_check() {
+        let scope = changed_scope_from_paths(["crates/hl7v2/README.md"]);
+
+        assert_eq!(
+            scope,
+            ChangedScope::Crates {
+                crates: vec!["hl7v2".to_string()],
+                has_markdown: true
+            }
+        );
+    }
+
+    #[test]
+    fn changed_scope_includes_untracked_git_listing_entries() {
+        let scope = changed_scope_from_git_listings("", "crates/hl7v2/README.md\n");
+
+        assert_eq!(
+            scope,
+            ChangedScope::Crates {
+                crates: vec!["hl7v2".to_string()],
+                has_markdown: true
+            }
+        );
+    }
+
+    #[test]
+    fn changed_scope_promotes_non_crate_files_to_workspace() {
+        let scope = changed_scope_from_paths(["docs/CI_PIPELINE.md"]);
+
+        assert_eq!(scope, ChangedScope::Workspace);
+    }
+
+    #[test]
+    fn changed_scope_reports_none_for_empty_diff() {
+        let scope = changed_scope_from_paths(["", "   "]);
+
+        assert_eq!(scope, ChangedScope::None);
+    }
+
+    // ---- doc links -------------------------------------------------------
+
+    #[test]
+    fn markdown_local_links_extracts_only_local_inline_targets() {
+        let markdown = "\
+[local](docs/guide.md)
+![image](images/logo.png)
+[remote](https://example.com/docs/guide.md)
+[anchor](#section)
+[mail](mailto:team@example.com)
+[with title](docs/titled.md \"Title\")
+[angle](<docs/has space.md>)
+[encoded](docs/space%20file.md#section)
+[query](docs/query.md?plain=1)
+```markdown
+[fenced](docs/fenced.md)
+```
+[ref]: docs/ref.md
+";
+
+        let links = markdown_local_links(markdown);
+
+        assert_eq!(
+            links,
+            vec![
+                MarkdownLocalLink {
+                    line: 1,
+                    target: "docs/guide.md".to_string()
+                },
+                MarkdownLocalLink {
+                    line: 6,
+                    target: "docs/titled.md".to_string()
+                },
+                MarkdownLocalLink {
+                    line: 7,
+                    target: "docs/has space.md".to_string()
+                },
+                MarkdownLocalLink {
+                    line: 8,
+                    target: "docs/space%20file.md".to_string()
+                },
+                MarkdownLocalLink {
+                    line: 9,
+                    target: "docs/query.md".to_string()
+                },
+                MarkdownLocalLink {
+                    line: 13,
+                    target: "docs/ref.md".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn check_doc_links_accepts_existing_relative_and_percent_encoded_targets() -> Result<()> {
+        let root = doc_link_temp_root("valid")?;
+        fs::create_dir_all(root.join("docs"))?;
+        fs::write(
+            root.join("README.md"),
+            "[ok](docs/ok.md)\n[encoded](docs/space%20file.md#section)\n",
+        )?;
+        fs::write(root.join("docs/ok.md"), "# OK\n")?;
+        fs::write(root.join("docs/space file.md"), "# Encoded\n")?;
+
+        let stats = check_doc_links_at(&root)?;
+
+        let expected = DocLinkCheckStats {
+            markdown_files: 3,
+            checked_links: 2,
+        };
+        if stats != expected {
+            return Err(anyhow!(
+                "expected doc link stats {expected:?}, got {stats:?}"
+            ));
+        }
+        remove_doc_link_temp_root(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn check_doc_links_reports_missing_relative_targets() -> Result<()> {
+        let root = doc_link_temp_root("missing")?;
+        fs::write(root.join("README.md"), "[missing](docs/missing.md)\n")?;
+
+        let err = check_doc_links_at(&root)
+            .err()
+            .ok_or_else(|| anyhow!("missing doc link should fail"))?;
+
+        if !err
+            .to_string()
+            .contains("1 Markdown local link(s) point at missing files")
+        {
+            return Err(anyhow!("unexpected error: {err}"));
+        }
+        remove_doc_link_temp_root(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn check_doc_links_rejects_repo_escape_targets() -> Result<()> {
+        let root = doc_link_temp_root("escape")?;
+        fs::write(root.join("README.md"), "[escape](../outside.md)\n")?;
+
+        let err = check_doc_links_at(&root)
+            .err()
+            .ok_or_else(|| anyhow!("escaping doc link should fail"))?;
+
+        if !err
+            .to_string()
+            .contains("1 Markdown local link(s) point at missing files")
+        {
+            return Err(anyhow!("unexpected error: {err}"));
+        }
+        remove_doc_link_temp_root(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn check_doc_links_requires_case_exact_repo_targets() -> Result<()> {
+        let root = doc_link_temp_root("case")?;
+        fs::create_dir_all(root.join("docs"))?;
+        fs::write(root.join("README.md"), "[case](Docs/ok.md)\n")?;
+        fs::write(root.join("docs/ok.md"), "# OK\n")?;
+
+        let err = check_doc_links_at(&root)
+            .err()
+            .ok_or_else(|| anyhow!("case-mismatched doc link should fail"))?;
+
+        if !err
+            .to_string()
+            .contains("1 Markdown local link(s) point at missing files")
+        {
+            return Err(anyhow!("unexpected error: {err}"));
+        }
+        remove_doc_link_temp_root(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn doc_link_inventory_includes_markdown_sources_and_parent_dirs() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let inventory = doc_link_inventory_from_repo_paths(
+            &root,
+            [
+                "README.md",
+                "docs/guides/first.md",
+                "docs/guides/assets/logo.svg",
+                "target/generated.md",
+                "generated/output.md",
+                "vendor/README.md",
+            ],
+        )?;
+
+        let markdown: Vec<String> = inventory
+            .markdown_files
+            .iter()
+            .map(|path| relative_slash_path(&root, path))
+            .collect::<Result<_>>()?;
+
+        if markdown != vec!["README.md", "docs/guides/first.md"] {
+            return Err(anyhow!("unexpected Markdown inventory: {markdown:?}"));
+        }
+        for expected in [
+            "README.md",
+            "docs",
+            "docs/guides",
+            "docs/guides/first.md",
+            "docs/guides/assets",
+            "docs/guides/assets/logo.svg",
+        ] {
+            if !inventory.target_paths.contains(expected) {
+                return Err(anyhow!("missing inventory target: {expected}"));
+            }
+        }
+        if inventory.target_paths.contains("target/generated.md") {
+            return Err(anyhow!("target directory should be skipped"));
+        }
+        if inventory.target_paths.contains("generated/output.md")
+            || inventory.target_paths.contains("vendor/README.md")
+        {
+            return Err(anyhow!("generated/vendor directories should be skipped"));
+        }
+        Ok(())
+    }
+
+    fn doc_link_temp_root(name: &str) -> Result<PathBuf> {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_nanos()
+            .to_string();
+        let root = env::temp_dir().join(format!(
+            "hl7v2-rs-xtask-doc-links-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        if root.exists() {
+            fs::remove_dir_all(&root)?;
+        }
+        fs::create_dir_all(&root)?;
+        Ok(root)
+    }
+
+    fn remove_doc_link_temp_root(root: &Path) -> Result<()> {
+        if root.exists() {
+            fs::remove_dir_all(root)?;
+        }
+        Ok(())
+    }
+
     // ---- glob_match ------------------------------------------------------
 
     #[test]
@@ -3541,6 +4252,25 @@ mod tests {
     }
 
     // ---- file-policy auto-allow -----------------------------------------
+
+    #[test]
+    fn file_policy_inventory_keeps_untracked_git_listing_entries() {
+        let listing = "\
+Cargo.toml
+docs\\README.md
+.github/workflows/python-pypi.yml
+
+";
+
+        assert_eq!(
+            file_policy_inventory_from_git_listing(listing),
+            vec![
+                "Cargo.toml",
+                "docs/README.md",
+                ".github/workflows/python-pypi.yml"
+            ]
+        );
+    }
 
     #[test]
     fn auto_allow_covers_rust_and_repo_metadata() {


### PR DESCRIPTION
## Summary
- add `xtask check-doc-links` and wire it into full gate plus crate-scoped Markdown changed-gate runs
- make file policy scan tracked and untracked non-ignored files
- fix existing stale local Markdown links so the new rail is green on current source tree

## Validation
- `cargo +1.93.0 test -p xtask`
- `cargo +1.93.0 run -p xtask -- check-doc-links`
- `cargo +1.93.0 run -p xtask -- check-file-policy`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed`