### PR TITLE
server: enforce gRPC API key auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tonic 0.12.3",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -41,10 +41,15 @@ tempfile = "3.19"
 hl7v2-test-utils = { path = "../hl7v2-test-utils" }
 cucumber = { version = "0.22", default-features = false, features = ["macros"] }
 futures = "0.3"
+tonic = { workspace = true }
 
 [[test]]
 name = "integration_tests"
 path = "tests/integration_tests.rs"
+
+[[test]]
+name = "serve_grpc_contract_test"
+path = "tests/serve_grpc_contract_test.rs"
 
 [[test]]
 name = "bdd_tests"

--- a/crates/hl7v2-cli/src/serve.rs
+++ b/crates/hl7v2-cli/src/serve.rs
@@ -5,13 +5,15 @@
 //! - gRPC server (optional, behind feature flag)
 //! - Graceful shutdown via Ctrl+C
 
+use std::ffi::OsString;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-use hl7v2_server::Server;
+use hl7v2_server::{Server, ServerConfig};
 
 /// Server mode from CLI
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -46,7 +48,7 @@ pub async fn run_server(
 
     match server_mode {
         ServerMode::Http => run_http_server(&bind_address, max_body_size).await,
-        ServerMode::Grpc => run_grpc_server(&bind_address).await,
+        ServerMode::Grpc => run_grpc_server(&bind_address, max_body_size).await,
     }
 }
 
@@ -60,11 +62,7 @@ async fn run_http_server(
     // Create shutdown signal
     let shutdown = setup_shutdown_signal();
 
-    // Build server configuration
-    let server = Server::builder()
-        .bind(bind_address)
-        .max_body_size(max_body_size)
-        .build();
+    let server = build_server_from_cli_args(bind_address, max_body_size)?;
 
     info!("Server configuration:");
     info!("  Bind address: {}", bind_address);
@@ -99,14 +97,101 @@ async fn run_http_server(
 }
 
 /// Run the gRPC server.
-async fn run_grpc_server(bind_address: &str) -> Result<(), Box<dyn std::error::Error>> {
-    warn!("gRPC server mode is not yet implemented");
-    info!("gRPC server would bind to: {}", bind_address);
+async fn run_grpc_server(
+    bind_address: &str,
+    max_body_size: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Starting HL7 v2 gRPC server on {}", bind_address);
 
-    // Feature: Implement gRPC server when tonic integration is ready
-    // This would use the hl7v2-server crate's gRPC functionality
+    let shutdown = setup_shutdown_signal();
+    let server = build_server_from_cli_args(bind_address, max_body_size)?;
 
-    Err("gRPC server mode is not yet implemented. Use --mode http for now.".into())
+    info!("Server configuration:");
+    info!("  Bind address: {}", bind_address);
+    info!("  Transport: gRPC");
+    info!("  RPCs:");
+    info!("    Parse, ParseStream, Validate, ValidateRedacted");
+    info!("    GenerateAck, Normalize, HealthCheck");
+    info!("");
+    info!("Press Ctrl+C to shutdown gracefully");
+
+    tokio::select! {
+        result = server.serve_grpc() => {
+            match result {
+                Ok(()) => info!("gRPC server shutdown normally"),
+                Err(e) => {
+                    error!("gRPC server error: {}", e);
+                    return Err(e.into());
+                }
+            }
+        }
+        _ = shutdown => {
+            info!("Shutdown signal received, stopping gRPC server...");
+        }
+    }
+
+    info!("gRPC server stopped");
+    Ok(())
+}
+
+fn build_server_from_cli_args(
+    bind_address: &str,
+    max_body_size: usize,
+) -> Result<Server, Box<dyn std::error::Error>> {
+    let config = server_config_from_cli_args(bind_address, max_body_size)?;
+    Ok(Server::new(config))
+}
+
+fn server_config_from_cli_args(
+    bind_address: &str,
+    max_body_size: usize,
+) -> Result<ServerConfig, Box<dyn std::error::Error>> {
+    let config_path = std::env::var_os("HL7V2_CONFIG").map(std::path::PathBuf::from);
+    server_config_from_cli_sources(
+        CliServerConfigSources {
+            config_path: config_path.as_deref(),
+            api_key: std::env::var("HL7V2_API_KEY").ok(),
+            cors_allowed_origins: std::env::var("HL7V2_CORS_ALLOWED_ORIGINS").ok(),
+            profile_paths: std::env::var_os("HL7V2_PROFILE_PATHS"),
+            bundle_output_root: std::env::var_os("HL7V2_BUNDLE_OUTPUT_ROOT"),
+        },
+        bind_address,
+        max_body_size,
+    )
+}
+
+struct CliServerConfigSources<'a> {
+    config_path: Option<&'a Path>,
+    api_key: Option<String>,
+    cors_allowed_origins: Option<String>,
+    profile_paths: Option<OsString>,
+    bundle_output_root: Option<OsString>,
+}
+
+fn server_config_from_cli_sources(
+    sources: CliServerConfigSources<'_>,
+    bind_address: &str,
+    max_body_size: usize,
+) -> Result<ServerConfig, Box<dyn std::error::Error>> {
+    let config = ServerConfig::from_sources(
+        sources.config_path,
+        None,
+        sources.api_key,
+        sources.cors_allowed_origins,
+        sources.profile_paths,
+        sources.bundle_output_root,
+    )?;
+    Ok(apply_cli_server_args(config, bind_address, max_body_size))
+}
+
+fn apply_cli_server_args(
+    mut config: ServerConfig,
+    bind_address: &str,
+    max_body_size: usize,
+) -> ServerConfig {
+    config.bind_address = bind_address.to_string();
+    config.max_body_size = max_body_size;
+    config
 }
 
 /// Setup Ctrl+C shutdown signal handler.
@@ -154,14 +239,99 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_grpc_not_implemented() {
-        let result = run_grpc_server("127.0.0.1:50051").await;
+    async fn test_grpc_invalid_bind_address_fails_before_serving() {
+        let result = run_grpc_server("not-a-bind-address", 1024).await;
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("not yet implemented")
+                .contains("Invalid bind address")
+        );
+    }
+
+    #[test]
+    fn test_cli_server_args_preserve_security_and_evidence_config() {
+        let config = ServerConfig {
+            api_key: Some("grpc-secret".to_string()),
+            bundle_output_root: Some(std::path::PathBuf::from("bundle-root")),
+            quarantine: hl7v2_server::models::QuarantineConfig {
+                enabled: true,
+                path: Some(std::path::PathBuf::from("quarantine-root")),
+                write_redacted: true,
+                write_report: true,
+                write_bundle: true,
+            },
+            ..ServerConfig::default()
+        };
+
+        let config = apply_cli_server_args(config, "127.0.0.1:50051", 65_536);
+
+        assert_eq!(config.bind_address, "127.0.0.1:50051");
+        assert_eq!(config.max_body_size, 65_536);
+        assert_eq!(config.api_key.as_deref(), Some("grpc-secret"));
+        assert_eq!(
+            config.bundle_output_root,
+            Some(std::path::PathBuf::from("bundle-root"))
+        );
+        assert!(config.quarantine.enabled);
+        assert_eq!(
+            config.quarantine.path,
+            Some(std::path::PathBuf::from("quarantine-root"))
+        );
+    }
+
+    #[test]
+    fn test_cli_server_sources_load_security_and_evidence_config_before_cli_bind_override() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let config_path = dir.path().join("server.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[server]
+host = "0.0.0.0"
+port = 18080
+api_key = "file-secret"
+bundle_output_root = "file-bundles"
+
+[quarantine]
+enabled = true
+path = "file-quarantine"
+write_redacted = true
+write_report = true
+write_bundle = true
+"#,
+        )
+        .expect("config should be written");
+
+        let config = server_config_from_cli_sources(
+            CliServerConfigSources {
+                config_path: Some(&config_path),
+                api_key: Some("env-secret".to_string()),
+                cors_allowed_origins: Some("https://example.test".to_string()),
+                profile_paths: None,
+                bundle_output_root: Some(OsString::from("env-bundles")),
+            },
+            "127.0.0.1:50051",
+            65_536,
+        )
+        .expect("config sources should load");
+
+        assert_eq!(config.bind_address, "127.0.0.1:50051");
+        assert_eq!(config.max_body_size, 65_536);
+        assert_eq!(config.api_key.as_deref(), Some("env-secret"));
+        assert_eq!(
+            config.bundle_output_root,
+            Some(std::path::PathBuf::from("env-bundles"))
+        );
+        assert!(config.quarantine.enabled);
+        assert_eq!(
+            config.quarantine.path,
+            Some(std::path::PathBuf::from("file-quarantine"))
+        );
+        assert_eq!(
+            config.cors_allowed_origins,
+            hl7v2_server::server::CorsAllowedOrigins::list(["https://example.test"])
         );
     }
 }

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -4869,11 +4869,19 @@ mod serve_command {
     }
 
     #[test]
-    fn test_serve_grpc_not_implemented() {
+    fn test_serve_grpc_rejects_invalid_bind_address() {
         let mut cmd = cli_command();
-        cmd.args(["serve", "--mode", "grpc", "--port", "50051"])
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains("not yet implemented"));
+        cmd.args([
+            "serve",
+            "--mode",
+            "grpc",
+            "--host",
+            "not-a-bind-address",
+            "--port",
+            "50051",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid bind address"));
     }
 }

--- a/crates/hl7v2-cli/tests/serve_grpc_contract_test.rs
+++ b/crates/hl7v2-cli/tests/serve_grpc_contract_test.rs
@@ -1,0 +1,156 @@
+//! Transport-level tests for `hl7v2 serve --mode grpc`.
+
+#![expect(
+    clippy::expect_used,
+    reason = "integration test process cleanup and metadata setup use concise assertions"
+)]
+
+use hl7v2_server::grpc::proto::ParseRequest;
+use hl7v2_server::grpc::proto::hl7_service_client::Hl7ServiceClient;
+use std::error::Error;
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+use tokio::time::sleep;
+use tonic::metadata::MetadataValue;
+use tonic::transport::Channel;
+use tonic::{Code, Request};
+
+const SAMPLE_MSG: &[u8] = b"MSH|^~\\&|SENDING|FAC|RECV|FAC|202501010000||ADT^A01|MSG0001|P|2.5\rPID|1||123456^^^MR||Doe^John";
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn new(child: Child) -> Self {
+        Self { child }
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        self.child.try_wait()
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            drop(self.child.kill());
+        }
+        drop(self.child.wait());
+    }
+}
+
+#[tokio::test]
+async fn cli_grpc_serve_enforces_configured_api_key() {
+    let api_key = "grpc-cli-secret";
+    let port = unused_local_port().expect("test should allocate a local port");
+    let mut server = ChildGuard::new(
+        Command::new(assert_cmd::cargo::cargo_bin("hl7v2-cli"))
+            .args([
+                "serve",
+                "--mode",
+                "grpc",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &port.to_string(),
+            ])
+            .env("HL7V2_API_KEY", api_key)
+            .env_remove("HL7V2_CONFIG")
+            .env_remove("HL7V2_CORS_ALLOWED_ORIGINS")
+            .env_remove("HL7V2_PROFILE_PATHS")
+            .env_remove("HL7V2_BUNDLE_OUTPUT_ROOT")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("test should spawn the canonical hl7v2 CLI binary"),
+    );
+
+    let endpoint = format!("http://127.0.0.1:{port}");
+    let mut client = connect_grpc(&endpoint, &mut server)
+        .await
+        .expect("CLI gRPC server should accept connections");
+
+    let missing_key_error = client
+        .parse(ParseRequest {
+            message: SAMPLE_MSG.to_vec(),
+            mllp_framed: false,
+            options: None,
+        })
+        .await
+        .expect_err("missing CLI-configured gRPC API key should be rejected");
+
+    assert_eq!(missing_key_error.code(), Code::Unauthenticated);
+    assert!(missing_key_error.message().contains("API key"));
+    assert!(!missing_key_error.message().contains(api_key));
+
+    let mut wrong_key_request = Request::new(ParseRequest {
+        message: SAMPLE_MSG.to_vec(),
+        mllp_framed: false,
+        options: None,
+    });
+    wrong_key_request.metadata_mut().insert(
+        "x-api-key",
+        MetadataValue::try_from("wrong-grpc-cli-secret").expect("test API key is valid"),
+    );
+    let wrong_key_error = client
+        .parse(wrong_key_request)
+        .await
+        .expect_err("wrong CLI-configured gRPC API key should be rejected");
+
+    assert_eq!(wrong_key_error.code(), Code::Unauthenticated);
+    assert!(wrong_key_error.message().contains("API key"));
+    assert!(!wrong_key_error.message().contains(api_key));
+    assert!(!wrong_key_error.message().contains("wrong-grpc-cli-secret"));
+
+    let mut request = Request::new(ParseRequest {
+        message: SAMPLE_MSG.to_vec(),
+        mllp_framed: false,
+        options: None,
+    });
+    request.metadata_mut().insert(
+        "x-api-key",
+        MetadataValue::try_from(api_key).expect("test API key is valid"),
+    );
+
+    let response = client
+        .parse(request)
+        .await
+        .expect("valid CLI-configured gRPC API key should be accepted")
+        .into_inner();
+
+    assert!(response.success);
+    assert_eq!(
+        response
+            .metadata
+            .expect("metadata should be returned")
+            .message_type,
+        "ADT^A01"
+    );
+}
+
+async fn connect_grpc(
+    endpoint: &str,
+    server: &mut ChildGuard,
+) -> Result<Hl7ServiceClient<Channel>, Box<dyn Error>> {
+    for _ in 0..80 {
+        if let Some(status) = server.try_wait()? {
+            return Err(
+                format!("gRPC CLI server exited before accepting connections: {status}").into(),
+            );
+        }
+
+        match Hl7ServiceClient::connect(endpoint.to_string()).await {
+            Ok(client) => return Ok(client),
+            Err(_) => sleep(Duration::from_millis(50)).await,
+        }
+    }
+
+    Err(format!("gRPC CLI server did not accept connections at {endpoint}").into())
+}
+
+fn unused_local_port() -> Result<u16, Box<dyn Error>> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -51,7 +51,7 @@ subtle = "2.6.1"
 tonic = { workspace = true }
 prost = { workspace = true }
 prost-types = "0.13"
-tokio-stream = "0.1.18"
+tokio-stream = { version = "0.1.18", features = ["net"] }
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -3,6 +3,11 @@
 use crate::models::{
     AckPolicyConfig, PublicQuarantineConfig, QuarantineConfig, ReadinessCheck, ReadyResponse,
 };
+use crate::{
+    Result,
+    grpc::{Hl7ServiceImpl, proto::hl7_service_server::Hl7ServiceServer},
+    routes::build_router,
+};
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
@@ -11,11 +16,11 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
+use subtle::ConstantTimeEq;
 use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::transport::Server as TonicServer;
 use tracing::info;
-
-use crate::Result;
-use crate::routes::build_router;
 
 /// Application state shared across handlers
 #[derive(Clone)]
@@ -532,6 +537,76 @@ impl Server {
         .await?;
 
         Ok(())
+    }
+
+    /// Run the gRPC server.
+    pub async fn serve_grpc(self) -> Result<()> {
+        let addr: SocketAddr = self
+            .config
+            .bind_address
+            .parse()
+            .map_err(|error| crate::Error::Config(format!("Invalid bind address: {error}")))?;
+
+        let listener = TcpListener::bind(&addr).await?;
+        self.serve_grpc_with_listener(listener).await
+    }
+
+    /// Run the gRPC server using an already-bound listener.
+    ///
+    /// This is primarily useful for tests that need an OS-assigned port.
+    pub async fn serve_grpc_with_listener(self, listener: TcpListener) -> Result<()> {
+        let addr = listener.local_addr()?;
+        info!("gRPC server listening on {}", addr);
+
+        let max_message_size = self.config.max_body_size;
+        let api_key = self.state.api_key.clone();
+        let service = Hl7ServiceServer::new(Hl7ServiceImpl::new(self.state))
+            .max_decoding_message_size(max_message_size)
+            .max_encoding_message_size(max_message_size);
+        let service =
+            tonic::service::interceptor::InterceptedService::new(service, move |request| {
+                grpc_auth_interceptor(request, api_key.as_deref())
+            });
+
+        TonicServer::builder()
+            .add_service(service)
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .map_err(|error| crate::Error::Internal(format!("gRPC server error: {error}")))?;
+
+        Ok(())
+    }
+}
+
+#[expect(
+    clippy::result_large_err,
+    reason = "tonic interceptor callbacks must return tonic::Status on authentication failures"
+)]
+fn grpc_auth_interceptor(
+    request: tonic::Request<()>,
+    expected_key: Option<&str>,
+) -> std::result::Result<tonic::Request<()>, tonic::Status> {
+    const API_KEY_METADATA: &str = "x-api-key";
+
+    let Some(expected_key) = expected_key else {
+        return Ok(request);
+    };
+
+    let provided_key = request
+        .metadata()
+        .get(API_KEY_METADATA)
+        .and_then(|value| value.to_str().ok());
+
+    match provided_key {
+        Some(key) if key.as_bytes().ct_eq(expected_key.as_bytes()).into() => Ok(request),
+        Some(_) => {
+            tracing::warn!("Invalid gRPC API key provided");
+            Err(tonic::Status::unauthenticated("valid API key required"))
+        }
+        None => {
+            tracing::warn!("No gRPC API key provided");
+            Err(tonic::Status::unauthenticated("valid API key required"))
+        }
     }
 }
 

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -563,10 +563,12 @@ impl Server {
         let service = Hl7ServiceServer::new(Hl7ServiceImpl::new(self.state))
             .max_decoding_message_size(max_message_size)
             .max_encoding_message_size(max_message_size);
-        let service =
-            tonic::service::interceptor::InterceptedService::new(service, move |request| {
-                grpc_auth_interceptor(request, api_key.as_deref())
-            });
+        let service = tonic::service::interceptor::InterceptedService::new(
+            service,
+            GrpcAuthInterceptor {
+                expected_key: api_key,
+            },
+        );
 
         TonicServer::builder()
             .add_service(service)
@@ -575,6 +577,20 @@ impl Server {
             .map_err(|error| crate::Error::Internal(format!("gRPC server error: {error}")))?;
 
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct GrpcAuthInterceptor {
+    expected_key: Option<String>,
+}
+
+impl tonic::service::Interceptor for GrpcAuthInterceptor {
+    fn call(
+        &mut self,
+        request: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
+        grpc_auth_interceptor(request, self.expected_key.as_deref())
     }
 }
 

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -11,6 +11,7 @@
 #[cfg(test)]
 mod tests {
     use hl7v2_server::grpc::Hl7ServiceImpl;
+    use hl7v2_server::grpc::proto::hl7_service_client::Hl7ServiceClient;
     use hl7v2_server::grpc::proto::hl7_service_server::Hl7Service;
     use hl7v2_server::grpc::proto::{
         GenerateAckRequest, HealthCheckRequest, NormalizeOptions, NormalizeRequest, ParseRequest,
@@ -26,10 +27,14 @@ mod tests {
     use metrics_exporter_prometheus::PrometheusBuilder;
     use prost::Message as ProstMessage;
     use std::sync::Arc;
+    use std::time::Duration;
     use std::time::Instant;
+    use tokio::net::TcpListener;
+    use tokio::time::sleep;
     use tokio_stream::StreamExt;
     use tonic::codec::{Codec, ProstCodec, Streaming};
     use tonic::codegen::Bytes;
+    use tonic::metadata::MetadataValue;
     use tonic::{Code, Request};
 
     /// Helper to create a mock AppState
@@ -627,6 +632,148 @@ reason = "hash patient identifier"
             health_check_response::ServingStatus::Serving as i32
         );
         assert_eq!(inner.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn test_grpc_transport_server_serves_health_check() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener
+            .local_addr()
+            .expect("test listener should have a local address");
+        let server = hl7v2_server::Server::builder()
+            .bind(addr.to_string())
+            .build();
+        let server_task =
+            tokio::spawn(async move { server.serve_grpc_with_listener(listener).await });
+
+        let endpoint = format!("http://{addr}");
+        let mut client = None;
+        for _ in 0..20 {
+            match Hl7ServiceClient::connect(endpoint.clone()).await {
+                Ok(value) => {
+                    client = Some(value);
+                    break;
+                }
+                Err(_) => sleep(Duration::from_millis(25)).await,
+            }
+        }
+        let mut client = client.expect("gRPC transport server should accept connections");
+
+        let response = client
+            .health_check(Request::new(HealthCheckRequest {}))
+            .await
+            .expect("HealthCheck should succeed")
+            .into_inner();
+
+        assert_eq!(
+            response.status,
+            health_check_response::ServingStatus::Serving as i32
+        );
+        assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_grpc_transport_rejects_missing_api_key_when_configured() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener
+            .local_addr()
+            .expect("test listener should have a local address");
+        let server = hl7v2_server::Server::builder()
+            .bind(addr.to_string())
+            .api_key(Some("grpc-secret".to_string()))
+            .build();
+        let server_task =
+            tokio::spawn(async move { server.serve_grpc_with_listener(listener).await });
+
+        let endpoint = format!("http://{addr}");
+        let mut client = None;
+        for _ in 0..20 {
+            match Hl7ServiceClient::connect(endpoint.clone()).await {
+                Ok(value) => {
+                    client = Some(value);
+                    break;
+                }
+                Err(_) => sleep(Duration::from_millis(25)).await,
+            }
+        }
+        let mut client = client.expect("gRPC transport server should accept connections");
+
+        let err = client
+            .parse(Request::new(ParseRequest {
+                message: SAMPLE_MSG.to_vec(),
+                mllp_framed: false,
+                options: None,
+            }))
+            .await
+            .expect_err("missing gRPC API key should be rejected");
+
+        assert_eq!(err.code(), Code::Unauthenticated);
+        assert!(err.message().contains("API key"));
+        assert_no_phi(err.message());
+
+        server_task.abort();
+    }
+
+    #[tokio::test]
+    async fn test_grpc_transport_accepts_valid_api_key_when_configured() {
+        let api_key = "grpc-secret";
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener should bind");
+        let addr = listener
+            .local_addr()
+            .expect("test listener should have a local address");
+        let server = hl7v2_server::Server::builder()
+            .bind(addr.to_string())
+            .api_key(Some(api_key.to_string()))
+            .build();
+        let server_task =
+            tokio::spawn(async move { server.serve_grpc_with_listener(listener).await });
+
+        let endpoint = format!("http://{addr}");
+        let mut client = None;
+        for _ in 0..20 {
+            match Hl7ServiceClient::connect(endpoint.clone()).await {
+                Ok(value) => {
+                    client = Some(value);
+                    break;
+                }
+                Err(_) => sleep(Duration::from_millis(25)).await,
+            }
+        }
+        let mut client = client.expect("gRPC transport server should accept connections");
+        let mut request = Request::new(ParseRequest {
+            message: SAMPLE_MSG.to_vec(),
+            mllp_framed: false,
+            options: None,
+        });
+        request.metadata_mut().insert(
+            "x-api-key",
+            MetadataValue::try_from(api_key).expect("test API key metadata should be valid"),
+        );
+
+        let response = client
+            .parse(request)
+            .await
+            .expect("valid gRPC API key should be accepted")
+            .into_inner();
+
+        assert!(response.success);
+        assert_eq!(
+            response
+                .metadata
+                .expect("metadata should exist")
+                .message_type,
+            "ADT^A01"
+        );
+
+        server_task.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- implement the CLI gRPC serve path using the shared `ServerConfig::from_sources` configuration path
- enforce configured `HL7V2_API_KEY` on gRPC requests with `x-api-key` metadata
- add transport-level server tests and CLI process tests for missing, wrong, and valid gRPC API keys

## Validation
- cargo +1.93.0 test -p hl7v2-server --test grpc_contract_tests test_grpc_transport
- cargo +1.93.0 test -p hl7v2-cli --test serve_grpc_contract_test
- cargo +1.93.0 test -p hl7v2-cli --bin hl7v2-cli serve::tests::test_cli_server
- cargo +1.93.0 check -p hl7v2-server -p hl7v2-cli --all-targets
- cargo +1.93.0 run -p xtask -- publish-plan
- git diff --check
- cargo +1.93.0 fmt --all -- --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed

## Security notes
- gRPC authentication denies missing or invalid metadata when an API key is configured.
- Rejection messages do not echo provided or expected API keys.
- This PR does not change HTTP authentication behavior.