### PR TITLE
server: sanitize sensitive evidence errors

### DIFF
--- a/crates/hl7v2-server/src/evidence.rs
+++ b/crates/hl7v2-server/src/evidence.rs
@@ -58,6 +58,8 @@ pub struct EvidenceBundleWriteRequest<'a> {
     pub root: &'a Path,
     /// Caller-supplied safe bundle identifier.
     pub bundle_id: &'a str,
+    /// Public output label returned in response summaries.
+    pub public_output_dir: Option<&'a str>,
     /// Original request message bytes.
     pub raw_input: &'a [u8],
     /// Profile YAML included in the bundle.
@@ -107,6 +109,7 @@ pub fn write_evidence_bundle(
     let EvidenceBundleWriteRequest {
         root,
         bundle_id,
+        public_output_dir,
         raw_input,
         profile_yaml,
         policy_text,
@@ -128,13 +131,9 @@ pub fn write_evidence_bundle(
     let bundle_dir = bundle_path_for_id(root, bundle_id)?;
     fs::create_dir(&bundle_dir).map_err(|error| {
         if error.kind() == std::io::ErrorKind::AlreadyExists {
-            EvidenceBundleError::Conflict(format!(
-                "bundle output directory already exists for bundle_id '{bundle_id}'"
-            ))
+            EvidenceBundleError::Conflict("bundle output directory already exists".to_string())
         } else {
-            EvidenceBundleError::Io(format!(
-                "could not create bundle output directory for bundle_id '{bundle_id}': {error}"
-            ))
+            EvidenceBundleError::Io(format!("could not create bundle output directory: {error}"))
         }
     })?;
 
@@ -213,7 +212,7 @@ pub fn write_evidence_bundle(
 
     Ok(EvidenceBundleSummary {
         bundle_version: BUNDLE_VERSION.to_string(),
-        output_dir: bundle_id.to_string(),
+        output_dir: public_output_dir.unwrap_or(bundle_id).to_string(),
         message_type,
         validation_valid: validation_report.valid,
         validation_issue_count: validation_report.issue_count,
@@ -249,6 +248,7 @@ pub fn write_quarantine_output(
         let bundle = write_evidence_bundle(EvidenceBundleWriteRequest {
             root,
             bundle_id: output_id,
+            public_output_dir: None,
             raw_input,
             profile_yaml,
             policy_text,

--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -112,7 +112,7 @@ impl Hl7Service for Hl7ServiceImpl {
             .map_err(|e| Status::invalid_argument(format!("Failed to parse HL7: {}", e)))?;
 
         let profile = hl7v2::load_profile(&req.profile)
-            .map_err(|e| Status::invalid_argument(format!("Failed to load profile: {}", e)))?;
+            .map_err(|_error| Status::invalid_argument(crate::PROFILE_LOAD_SAFE_MESSAGE))?;
 
         let issues = hl7v2::validate(&message, &profile);
         let report = hl7v2::ValidationReport::from_issues(
@@ -216,7 +216,7 @@ impl Hl7Service for Hl7ServiceImpl {
         let redacted_hl7 = hl7v2::write(&message);
 
         let profile = hl7v2::load_profile_checked(&req.profile)
-            .map_err(|e| Status::invalid_argument(format!("Failed to load profile: {e}")))?;
+            .map_err(|_error| Status::invalid_argument(crate::PROFILE_LOAD_SAFE_MESSAGE))?;
 
         let issues = hl7v2::validate(&message, &profile);
         let report = hl7v2::ValidationReport::from_issues(

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use crate::PROFILE_LOAD_SAFE_MESSAGE;
 use crate::audit::{self, MessageLogContext};
 use crate::models::*;
 use crate::redaction::redact_message;
@@ -99,8 +100,7 @@ pub async fn validate_handler(
 
     // Load the profile before validation. Profile load failures are client
     // errors, not successful validation results.
-    let profile = hl7v2::load_profile_checked(&request.profile)
-        .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
+    let profile = hl7v2::load_profile_checked(&request.profile).map_err(AppError::from)?;
 
     // Perform validation using the profile
     let issues = hl7v2::validate(&message, &profile);
@@ -197,8 +197,7 @@ pub async fn validate_redacted_handler(
     let redacted_hl7 = String::from_utf8(hl7v2::write(&message))
         .map_err(|error| AppError::Internal(format!("redacted message was not UTF-8: {error}")))?;
 
-    let profile = hl7v2::load_profile_checked(&request.profile)
-        .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
+    let profile = hl7v2::load_profile_checked(&request.profile).map_err(AppError::from)?;
     let issues = hl7v2::validate(&message, &profile);
     let validation_report = hl7v2::ValidationReport::from_issues(
         &message,
@@ -293,8 +292,7 @@ pub async fn bundle_handler(
     let redacted_hl7 = String::from_utf8(hl7v2::write(&message))
         .map_err(|error| AppError::Internal(format!("redacted message was not UTF-8: {error}")))?;
 
-    let profile = hl7v2::load_profile_checked(&request.profile)
-        .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
+    let profile = hl7v2::load_profile_checked(&request.profile).map_err(AppError::from)?;
     let issues = hl7v2::validate(&message, &profile);
     let validation_report =
         hl7v2::ValidationReport::from_issues(&message, Some("profile.yaml".to_string()), issues);
@@ -307,6 +305,7 @@ pub async fn bundle_handler(
         crate::evidence::write_evidence_bundle(crate::evidence::EvidenceBundleWriteRequest {
             root: bundle_output_root,
             bundle_id: &request.bundle_id,
+            public_output_dir: Some(&audit::hash_identifier(&request.bundle_id)),
             raw_input: &raw_input,
             profile_yaml: &request.profile,
             policy_text: &request.redaction_policy,
@@ -331,7 +330,7 @@ pub async fn bundle_handler(
         issue_count = summary.validation_issue_count,
         redaction_status = audit::redaction_status(summary.redaction_phi_removed),
         redaction_phi_removed = summary.redaction_phi_removed,
-        bundle_id_hash = %audit::hash_identifier(&summary.output_dir),
+        bundle_id_hash = %audit::hash_identifier(&request.bundle_id),
         artifact_count = summary.artifacts.len(),
         artifact_schema_version,
         "wrote redacted evidence bundle"
@@ -356,10 +355,9 @@ pub async fn replay_handler(
 
     if !bundle_dir.is_dir() {
         crate::metrics::record_replay_result(false);
-        return Err(AppError::BundleNotFound(format!(
-            "bundle_id '{}' was not found",
-            request.bundle_id
-        )));
+        return Err(AppError::BundleNotFound(
+            "bundle id was not found".to_string(),
+        ));
     }
 
     let report = hl7v2::evidence::replay_evidence_bundle(&bundle_dir, "hl7v2-server");
@@ -539,8 +537,7 @@ pub async fn ack_policy_handler(
         crate::metrics::operation::ACK_POLICY,
     ) {
         Ok(message) => {
-            let profile = hl7v2::load_profile_checked(&request.profile)
-                .map_err(|e| AppError::ProfileLoad(e.to_string()))?;
+            let profile = hl7v2::load_profile_checked(&request.profile).map_err(AppError::from)?;
             let issues = hl7v2::validate(&message, &profile);
             let report = hl7v2::ValidationReport::from_issues(
                 &message,
@@ -852,8 +849,7 @@ fn attach_profile_to_fingerprint(
     profile_yaml: &str,
     messages: &[CorpusMessageInput],
 ) -> Result<hl7v2::synthetic::corpus::CorpusFingerprintProfile, AppError> {
-    let profile = hl7v2::load_profile_checked(profile_yaml)
-        .map_err(|error| AppError::ProfileLoad(error.to_string()))?;
+    let profile = hl7v2::load_profile_checked(profile_yaml).map_err(AppError::from)?;
     let metadata = hl7v2::synthetic::corpus::CorpusFingerprintProfile {
         path: "<inline-profile>".to_string(),
         sha256: compute_sha256(profile_yaml),
@@ -870,8 +866,7 @@ fn validation_issue_counts_for_messages(
     messages: &[CorpusMessageInput],
     profile_yaml: &str,
 ) -> Result<Vec<hl7v2::synthetic::corpus::CorpusCount>, AppError> {
-    let profile = hl7v2::load_profile_checked(profile_yaml)
-        .map_err(|error| AppError::ProfileLoad(error.to_string()))?;
+    let profile = hl7v2::load_profile_checked(profile_yaml).map_err(AppError::from)?;
     Ok(validation_issue_counts_for_loaded_profile(
         messages, &profile,
     ))
@@ -1244,8 +1239,13 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code, message) = match self {
             AppError::Parse(msg) => (StatusCode::BAD_REQUEST, "PARSE_ERROR", msg),
-            // Profile load error is a client error since the profile is provided in the request
-            AppError::ProfileLoad(msg) => (StatusCode::BAD_REQUEST, "PROFILE_LOAD_ERROR", msg),
+            // Profile load error is a client error since the profile is provided in the request.
+            // Keep the public message stable and avoid echoing parser detail derived from profile YAML.
+            AppError::ProfileLoad(_) => (
+                StatusCode::BAD_REQUEST,
+                "PROFILE_LOAD_ERROR",
+                PROFILE_LOAD_SAFE_MESSAGE.to_string(),
+            ),
             AppError::Validation(msg) => (StatusCode::BAD_REQUEST, "VALIDATION_ERROR", msg),
             AppError::Redaction(msg) => (StatusCode::BAD_REQUEST, "REDACTION_ERROR", msg),
             AppError::BundleOutputNotConfigured => (
@@ -1293,7 +1293,9 @@ impl std::fmt::Display for AppError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AppError::Parse(msg) => write!(f, "Parse error: {}", msg),
-            AppError::ProfileLoad(msg) => write!(f, "Profile load error: {}", msg),
+            AppError::ProfileLoad(_) => {
+                write!(f, "Profile load error: {PROFILE_LOAD_SAFE_MESSAGE}")
+            }
             AppError::Validation(msg) => write!(f, "Validation error: {}", msg),
             AppError::Redaction(msg) => write!(f, "Redaction error: {}", msg),
             AppError::BundleOutputNotConfigured => {
@@ -1325,8 +1327,8 @@ impl From<hl7v2::Error> for AppError {
 }
 
 impl From<hl7v2::conformance::profile::ProfileLoadError> for AppError {
-    fn from(err: hl7v2::conformance::profile::ProfileLoadError) -> Self {
-        AppError::ProfileLoad(err.to_string())
+    fn from(_err: hl7v2::conformance::profile::ProfileLoadError) -> Self {
+        AppError::ProfileLoad(PROFILE_LOAD_SAFE_MESSAGE.to_string())
     }
 }
 

--- a/crates/hl7v2-server/src/lib.rs
+++ b/crates/hl7v2-server/src/lib.rs
@@ -59,6 +59,9 @@ pub mod redaction;
 pub mod routes;
 pub mod server;
 
+pub(crate) const PROFILE_LOAD_SAFE_MESSAGE: &str =
+    "profile could not be loaded; run profile lint for details";
+
 pub use models::{
     AckPolicyAcceptOn, AckPolicyConfig, AckPolicyMode, AckPolicyRejectCondition, QuarantineConfig,
 };

--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -147,18 +147,23 @@ async fn post_bundle_with_schema_version(
 #[tokio::test]
 async fn test_bundle_endpoint_writes_redacted_evidence_bundle() {
     let root = TempRoot::new("success");
-    let bundle_id = "case-001";
+    let bundle_id = "MRN-SECRET-123";
 
     let (status, summary, body_text) =
         post_bundle(test_router(Some(root.path().to_path_buf())), bundle_id).await;
 
     assert_eq!(status, StatusCode::CREATED);
     assert_eq!(summary["bundle_version"], "1");
-    assert_eq!(summary["output_dir"], bundle_id);
+    assert!(
+        summary["output_dir"].as_str().is_some_and(is_sha256_hex),
+        "server bundle response should expose a hash label, not the raw caller bundle id"
+    );
+    assert_ne!(summary["output_dir"], bundle_id);
     assert_eq!(summary["message_type"], "ADT^A01");
     assert_eq!(summary["validation_valid"], true);
     assert_eq!(summary["redaction_phi_removed"], true);
     assert!(!body_text.contains(root.path().to_string_lossy().as_ref()));
+    assert!(!body_text.contains(bundle_id));
     assert_no_phi(&body_text);
 
     let bundle_dir = root.path().join(bundle_id);
@@ -236,7 +241,7 @@ async fn test_bundle_endpoint_writes_redacted_evidence_bundle() {
 #[tokio::test]
 async fn test_bundle_endpoint_schema_version_two_writes_v2_internal_artifacts() {
     let root = TempRoot::new("v2-artifacts");
-    let bundle_id = "case-v2";
+    let bundle_id = "MRN-SECRET-123";
 
     let (status, summary, body_text) =
         post_bundle_with_schema_version(test_router(Some(root.path().to_path_buf())), bundle_id, 2)
@@ -244,7 +249,9 @@ async fn test_bundle_endpoint_schema_version_two_writes_v2_internal_artifacts() 
 
     assert_eq!(status, StatusCode::CREATED);
     assert_eq!(summary["bundle_version"], "1");
-    assert_eq!(summary["output_dir"], bundle_id);
+    assert!(summary["output_dir"].as_str().is_some_and(is_sha256_hex));
+    assert_ne!(summary["output_dir"], bundle_id);
+    assert!(!body_text.contains(bundle_id));
     assert_no_phi(&body_text);
 
     let bundle_dir = root.path().join(bundle_id);
@@ -338,14 +345,19 @@ async fn test_bundle_endpoint_rejects_unsafe_bundle_id_without_writing() {
 #[tokio::test]
 async fn test_bundle_endpoint_rejects_existing_bundle_id() {
     let root = TempRoot::new("existing");
-    fs::create_dir(root.path().join("case-001")).unwrap();
+    let sensitive_bundle_id = "MRN-SECRET-123";
+    fs::create_dir(root.path().join(sensitive_bundle_id)).unwrap();
 
-    let (status, body, body_text) =
-        post_bundle(test_router(Some(root.path().to_path_buf())), "case-001").await;
+    let (status, body, body_text) = post_bundle(
+        test_router(Some(root.path().to_path_buf())),
+        sensitive_bundle_id,
+    )
+    .await;
 
     assert_eq!(status, StatusCode::CONFLICT);
     assert_eq!(body["code"], "BUNDLE_EXISTS");
     assert_no_phi(&body_text);
+    assert!(!body_text.contains(sensitive_bundle_id));
 }
 
 fn assert_no_phi(content: &str) {

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -294,10 +294,12 @@ constraints:
     #[tokio::test]
     async fn test_grpc_validate_invalid_profile_returns_invalid_argument() {
         let service = service();
+        let sensitive_profile =
+            "patient_name: Jane Secret\nmrn: MRN-SECRET-123\ninvalid: yaml: structure:";
 
         let request = Request::new(ValidateRequest {
             message: SAMPLE_MSG.to_vec(),
-            profile: "invalid: yaml: structure:".to_string(),
+            profile: sensitive_profile.to_string(),
             mllp_framed: false,
             options: None,
             report_schema_version: 0,
@@ -309,7 +311,13 @@ constraints:
             .expect_err("Malformed profile should fail the RPC");
 
         assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("Failed to load profile"));
+        assert_eq!(
+            err.message(),
+            "profile could not be loaded; run profile lint for details"
+        );
+        assert!(!err.message().contains("Jane Secret"));
+        assert!(!err.message().contains("MRN-SECRET-123"));
+        assert!(!err.message().contains(sensitive_profile));
     }
 
     #[tokio::test]
@@ -453,6 +461,36 @@ constraints:
 
         assert!(inner.validation_report.expect("report should exist").valid);
         assert!(inner.redacted_hl7.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_grpc_validate_redacted_invalid_profile_does_not_echo_profile_text() {
+        let service = service();
+        let sensitive_profile =
+            "patient_name: Jane Secret\nmrn: MRN-SECRET-123\ninvalid: yaml: structure:";
+        let request = Request::new(ValidateRedactedRequest {
+            message: PHI_MESSAGE.as_bytes().to_vec(),
+            profile: sensitive_profile.to_string(),
+            redaction_policy: REDACTION_POLICY.to_string(),
+            mllp_framed: false,
+            include_redacted_hl7: false,
+            report_schema_version: 0,
+            redaction_receipt_schema_version: 0,
+        });
+
+        let err = service
+            .validate_redacted(request)
+            .await
+            .expect_err("Malformed profile should fail the RPC");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert_eq!(
+            err.message(),
+            "profile could not be loaded; run profile lint for details"
+        );
+        assert!(!err.message().contains("Jane Secret"));
+        assert!(!err.message().contains("MRN-SECRET-123"));
+        assert!(!err.message().contains(sensitive_profile));
     }
 
     #[tokio::test]

--- a/crates/hl7v2-server/tests/replay_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/replay_endpoint_test.rs
@@ -335,17 +335,19 @@ async fn test_replay_endpoint_rejects_unsafe_bundle_id() {
 #[tokio::test]
 async fn test_replay_endpoint_returns_not_found_for_missing_bundle_id() {
     let root = TempRoot::new("missing");
+    let sensitive_bundle_id = "MRN-SECRET-123";
 
     let (status, body, body_text) = post_json(
         test_router(Some(root.path().to_path_buf())),
         "/hl7/replay",
-        replay_body("missing-case"),
+        replay_body(sensitive_bundle_id),
     )
     .await;
 
     assert_eq!(status, StatusCode::NOT_FOUND);
     assert_eq!(body["code"], "BUNDLE_NOT_FOUND");
     assert_no_phi(&body_text);
+    assert!(!body_text.contains(sensitive_bundle_id));
     assert!(!body_text.contains(root.path().to_string_lossy().as_ref()));
 }
 

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -108,10 +108,12 @@ async fn test_validate_malformed_message_returns_error() {
 #[tokio::test]
 async fn test_validate_invalid_profile_yaml_returns_error() {
     let app = common::create_test_router();
+    let sensitive_profile =
+        "patient_name: Jane Secret\nmrn: MRN-SECRET-123\ninvalid: yaml: structure:";
 
     let request_body = json!({
         "message": common::fixtures::MINIMAL_VALID,
-        "profile": "invalid: yaml: structure:",
+        "profile": sensitive_profile,
         "mllp_framed": false
     });
 
@@ -120,8 +122,16 @@ async fn test_validate_invalid_profile_yaml_returns_error() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let body_json: Value = serde_json::from_str(&body_text).unwrap();
     assert_eq!(body_json["code"], "PROFILE_LOAD_ERROR");
+    assert_eq!(
+        body_json["message"],
+        "profile could not be loaded; run profile lint for details"
+    );
+    assert!(!body_text.contains("Jane Secret"));
+    assert!(!body_text.contains("MRN-SECRET-123"));
+    assert!(!body_text.contains(sensitive_profile));
 }
 
 #[tokio::test]
@@ -143,8 +153,15 @@ segments:
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
-    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let body_json: Value = serde_json::from_str(&body_text).unwrap();
     assert_eq!(body_json["code"], "PROFILE_LOAD_ERROR");
+    assert_eq!(
+        body_json["message"],
+        "profile could not be loaded; run profile lint for details"
+    );
+    assert!(!body_text.contains("missing field"));
+    assert!(!body_text.contains("segments"));
 }
 
 #[tokio::test]

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -257,6 +257,38 @@ async fn test_validate_redacted_report_is_generated_from_redacted_message() {
 }
 
 #[tokio::test]
+async fn test_validate_redacted_invalid_profile_does_not_echo_profile_text() {
+    let app = common::create_test_router();
+    let sensitive_profile =
+        "patient_name: Jane Secret\nmrn: MRN-SECRET-123\ninvalid: yaml: structure:";
+    let request_body = json!({
+        "message": PHI_MESSAGE,
+        "profile": sensitive_profile,
+        "redaction_policy": REDACTION_POLICY
+    });
+
+    let response = app
+        .oneshot(validate_redacted_request(request_body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let body_json: Value = serde_json::from_str(&body_text).unwrap();
+
+    assert_eq!(body_json["code"], "PROFILE_LOAD_ERROR");
+    assert_eq!(
+        body_json["message"],
+        "profile could not be loaded; run profile lint for details"
+    );
+    assert!(!body_text.contains("Jane Secret"));
+    assert!(!body_text.contains("MRN-SECRET-123"));
+    assert!(!body_text.contains(sensitive_profile));
+    assert_no_phi(&body_text);
+}
+
+#[tokio::test]
 async fn test_validate_redacted_fails_closed_when_policy_misses_sensitive_fields() {
     let app = common::create_test_router();
     let incomplete_policy = r#"

--- a/crates/hl7v2/src/conformance/profile/mod.rs
+++ b/crates/hl7v2/src/conformance/profile/mod.rs
@@ -545,7 +545,7 @@ pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
             return ProfileLintReport::from_issues(vec![ProfileLintIssue::error(
                 "yaml_parse_error",
                 None,
-                err.to_string(),
+                profile_lint_yaml_error_message("profile YAML could not be parsed", err.location()),
             )]);
         }
     };
@@ -559,7 +559,10 @@ pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
             issues.push(ProfileLintIssue::error(
                 "profile_load_error",
                 None,
-                err.to_string(),
+                profile_lint_yaml_error_message(
+                    "profile YAML could not be loaded as a profile",
+                    err.location(),
+                ),
             ));
             return ProfileLintReport::from_issues(issues);
         }
@@ -567,6 +570,20 @@ pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
 
     lint_profile(&profile, &mut issues);
     ProfileLintReport::from_issues(issues)
+}
+
+fn profile_lint_yaml_error_message(
+    summary: &'static str,
+    location: Option<serde_yaml::Location>,
+) -> String {
+    match location {
+        Some(location) => format!(
+            "{summary} at line {}, column {}",
+            location.line(),
+            location.column()
+        ),
+        None => summary.to_string(),
+    }
 }
 
 fn lint_unknown_profile_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileLintIssue>) {

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -368,6 +368,25 @@ table_precedence:
     }
 
     #[test]
+    fn test_lint_profile_yaml_sanitizes_yaml_error_messages() {
+        let y = "patient_name: Jane Secret\nmrn: MRN-SECRET-123\ninvalid: yaml: structure:";
+
+        let report = lint_profile_yaml(y);
+
+        assert!(!report.valid);
+        assert_eq!(report.error_count, 1);
+        assert_eq!(report.issues[0].code, "yaml_parse_error");
+        assert!(
+            report.issues[0]
+                .message
+                .contains("profile YAML could not be parsed")
+        );
+        assert!(!report.issues[0].message.contains("Jane Secret"));
+        assert!(!report.issues[0].message.contains("MRN-SECRET-123"));
+        assert!(!report.issues[0].message.contains(y));
+    }
+
+    #[test]
     fn test_lint_profile_yaml_warns_for_ignored_top_level_keys() {
         let y = r#"
 message_structure: "ADT_A01"

--- a/tests/server_smoke/smoke.py
+++ b/tests/server_smoke/smoke.py
@@ -139,6 +139,14 @@ def assert_no_phi(label: str, value: Any) -> None:
         raise SmokeFailure(f"{label} leaked PHI sentinels: {', '.join(leaked)}")
 
 
+def is_sha256_hex(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
 def wait_for_ready() -> dict[str, Any]:
     deadline = time.monotonic() + TIMEOUT_SECONDS
     last_error: Exception | None = None
@@ -209,8 +217,8 @@ def main() -> int:
             "bundle_artifact_schema_version": 2,
         },
     )
-    if bundle.get("output_dir") != bundle_id:
-        raise SmokeFailure(f"bundle output id mismatch: {bundle}")
+    if not is_sha256_hex(bundle.get("output_dir")) or bundle.get("output_dir") == bundle_id:
+        raise SmokeFailure(f"bundle output label was not a redacted hash: {bundle}")
     if bundle.get("validation_valid") is not True:
         raise SmokeFailure(f"bundle validation was not valid: {bundle}")
     assert_no_phi("bundle response", bundle)
@@ -244,7 +252,7 @@ def main() -> int:
 
     print(
         "hl7v2-server smoke ok "
-        f"url={BASE_URL} bundle_id={bundle_id} checks={len(ready.get('checks', []))}"
+        f"url={BASE_URL} bundle_label={bundle.get('output_dir')} checks={len(ready.get('checks', []))}"
     )
     return 0
 


### PR DESCRIPTION
## Summary
- sanitize profile-load failures for HTTP and gRPC server surfaces so inline profile parser detail is not echoed to callers
- sanitize profile-lint YAML parse/load issue messages while retaining line/column context
- stop echoing caller-supplied bundle IDs in bundle summaries, conflict errors, and replay not-found responses; expose a hash label instead

## Security surface
- Trust boundary: caller-supplied profile YAML and bundle IDs on HTTP/gRPC evidence endpoints.
- Negative coverage asserts malformed profiles and sensitive bundle IDs are not echoed in responses.
- Bundle storage still uses the validated safe path segment under the configured root; public summaries/log hashes use the caller ID hash.

## Validation
- cargo +1.93.0 test -p hl7v2 --all-features test_lint_profile_yaml_sanitizes_yaml_error_messages
- cargo +1.93.0 test -p hl7v2-server --test bundle_endpoint_test
- cargo +1.93.0 test -p hl7v2-server --test replay_endpoint_test
- cargo +1.93.0 test -p hl7v2-server --test validate_endpoint_test
- cargo +1.93.0 test -p hl7v2-server --test validate_redacted_endpoint_test
- cargo +1.93.0 test -p hl7v2-server --test grpc_contract_tests
- cargo +1.93.0 test -p hl7v2-server --test corpus_endpoint_test
- cargo +1.93.0 test -p hl7v2-server --test ack_policy_endpoint_test
- cargo +1.93.0 check -p hl7v2-server --all-targets
- cargo +1.93.0 fmt --all -- --check
- cargo +1.93.0 run -p xtask -- publish-plan
- $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
