### PR TITLE
python: validate evidence guide schemas

### DIFF
--- a/crates/hl7v2/src/evidence.rs
+++ b/crates/hl7v2/src/evidence.rs
@@ -377,9 +377,10 @@ pub fn write_safe_analysis_bundle(
 /// Write a safe-analysis evidence bundle with an explicit internal artifact schema version.
 ///
 /// `artifact_schema_version = 1` preserves the original bundle-internal
-/// artifact shapes. `artifact_schema_version = 2` writes v2 `manifest.json`,
-/// `environment.json`, `field-paths.json`, and `redaction-receipt.json`
-/// artifacts with embedded schema/tool provenance.
+/// artifact shapes. `artifact_schema_version = 2` writes v2
+/// `validation-report.json`, `manifest.json`, `environment.json`,
+/// `field-paths.json`, and `redaction-receipt.json` artifacts with embedded
+/// schema/tool provenance.
 ///
 /// # Errors
 ///
@@ -439,8 +440,15 @@ pub fn write_safe_analysis_bundle_with_schema_version(
     .map_err(|error| EvidenceError::Io(error.to_string()))?;
     fs::write(out.join("profile.yaml"), profile_yaml)
         .map_err(|error| EvidenceError::Io(error.to_string()))?;
-    write_json_file(&out.join("validation-report.json"), &validation_report)?;
     if artifact_schema_version == 2 {
+        write_json_file(
+            &out.join("validation-report.json"),
+            &validation_report.to_v2(
+                tool_name.to_string(),
+                env!("CARGO_PKG_VERSION").to_string(),
+                None,
+            ),
+        )?;
         write_json_file(
             &out.join("redaction-receipt.json"),
             &redaction_output
@@ -457,6 +465,7 @@ pub fn write_safe_analysis_bundle_with_schema_version(
             &out.join("redaction-receipt.json"),
             &redaction_output.receipt,
         )?;
+        write_json_file(&out.join("validation-report.json"), &validation_report)?;
         write_json_file(&out.join("field-paths.json"), &field_trace)?;
         write_json_file(&out.join("environment.json"), &environment)?;
     }
@@ -1275,6 +1284,7 @@ reason = "Date of birth"
             "expected bundle summary v1 fields",
         )?;
         for artifact in [
+            "validation-report.json",
             "manifest.json",
             "field-paths.json",
             "redaction-receipt.json",

--- a/tests/python_smoke/evidence_workflow_guide.py
+++ b/tests/python_smoke/evidence_workflow_guide.py
@@ -17,6 +17,23 @@ from pathlib import Path
 
 GUIDE_PATH = Path("docs/guides/python-evidence-workflow.md")
 SCRIPT_MARKER = 'ROOT = Path("target/hl7v2-python-evidence")'
+SCHEMA_DIR = Path("schemas/evidence")
+ARTIFACT_SCHEMAS = {
+    "validation-report-v2.json": "validation-report-v2.schema.json",
+    "corpus-summary-v2.json": "corpus-summary-v2.schema.json",
+    "corpus-fingerprint-v2.json": "corpus-fingerprint-v2.schema.json",
+    "corpus-diff-v2.json": "corpus-diff-v2.schema.json",
+    "redaction-output-v2.json": "safe-analysis-redaction-output-v2.schema.json",
+    "bundle-summary-v2.json": "evidence-bundle-v2.schema.json",
+    "replay-report-v2.json": "evidence-replay-v2.schema.json",
+}
+BUNDLE_ARTIFACT_SCHEMAS = {
+    "manifest.json": "evidence-bundle-manifest-v2.schema.json",
+    "environment.json": "evidence-bundle-environment-v2.schema.json",
+    "field-paths.json": "field-path-trace-v2.schema.json",
+    "redaction-receipt.json": "redaction-receipt-v2.schema.json",
+    "validation-report.json": "validation-report-v2.schema.json",
+}
 
 
 def extract_workflow_script() -> str:
@@ -26,6 +43,128 @@ def extract_workflow_script() -> str:
         if SCRIPT_MARKER in block:
             return block
     raise RuntimeError(f"could not find Python workflow block in {GUIDE_PATH}")
+
+
+class SchemaValidationError(ValueError):
+    """Raised when a generated evidence artifact fails its checked schema."""
+
+
+def resolve_ref(root_schema: dict, ref: str) -> dict:
+    """Resolve a local JSON Schema reference."""
+    if not ref.startswith("#/"):
+        raise SchemaValidationError(f"unsupported non-local schema ref {ref}")
+
+    current: object = root_schema
+    for part in ref[2:].split("/"):
+        if not isinstance(current, dict) or part not in current:
+            raise SchemaValidationError(f"schema ref {ref} could not resolve {part}")
+        current = current[part]
+    if not isinstance(current, dict):
+        raise SchemaValidationError(f"schema ref {ref} did not resolve to an object")
+    return current
+
+
+def instance_matches_type(instance: object, expected_type: str) -> bool:
+    """Return whether a JSON value matches a schema primitive type."""
+    if expected_type == "object":
+        return isinstance(instance, dict)
+    if expected_type == "array":
+        return isinstance(instance, list)
+    if expected_type == "string":
+        return isinstance(instance, str)
+    if expected_type == "boolean":
+        return isinstance(instance, bool)
+    if expected_type == "integer":
+        return isinstance(instance, int) and not isinstance(instance, bool)
+    if expected_type == "number":
+        return isinstance(instance, (int, float)) and not isinstance(instance, bool)
+    if expected_type == "null":
+        return instance is None
+    raise SchemaValidationError(f"unsupported schema type {expected_type}")
+
+
+def validate_schema(instance: object, schema: dict, root_schema: dict, path: str = "$") -> None:
+    """Validate the schema subset used by checked evidence artifacts."""
+    if "$ref" in schema:
+        validate_schema(instance, resolve_ref(root_schema, schema["$ref"]), root_schema, path)
+        return
+
+    if "anyOf" in schema:
+        for option in schema["anyOf"]:
+            try:
+                validate_schema(instance, option, root_schema, path)
+                return
+            except SchemaValidationError:
+                continue
+        raise SchemaValidationError(f"{path} did not match any allowed schema")
+
+    if "oneOf" in schema:
+        matches = 0
+        for option in schema["oneOf"]:
+            try:
+                validate_schema(instance, option, root_schema, path)
+            except SchemaValidationError:
+                continue
+            matches += 1
+        if matches != 1:
+            raise SchemaValidationError(f"{path} matched {matches} oneOf schemas")
+        return
+
+    if "const" in schema and instance != schema["const"]:
+        raise SchemaValidationError(
+            f"{path} expected const {schema['const']!r}, got {instance!r}"
+        )
+
+    if "enum" in schema and instance not in schema["enum"]:
+        raise SchemaValidationError(f"{path} expected one of {schema['enum']!r}")
+
+    expected = schema.get("type")
+    if expected is not None:
+        expected_types = expected if isinstance(expected, list) else [expected]
+        if not any(instance_matches_type(instance, typ) for typ in expected_types):
+            raise SchemaValidationError(
+                f"{path} expected type {expected_types!r}, got {type(instance).__name__}"
+            )
+
+    if isinstance(instance, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in instance:
+                raise SchemaValidationError(f"{path}.{key} is required")
+
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(instance) - set(properties))
+            if extra:
+                raise SchemaValidationError(f"{path} has unexpected properties {extra!r}")
+
+        for key, value in instance.items():
+            if key in properties:
+                validate_schema(value, properties[key], root_schema, f"{path}.{key}")
+
+    if isinstance(instance, list) and "items" in schema:
+        if "minItems" in schema and len(instance) < schema["minItems"]:
+            raise SchemaValidationError(f"{path} has fewer than {schema['minItems']} items")
+        for index, item in enumerate(instance):
+            validate_schema(item, schema["items"], root_schema, f"{path}[{index}]")
+
+    if "minimum" in schema and isinstance(instance, (int, float)) and instance < schema["minimum"]:
+        raise SchemaValidationError(f"{path} is below minimum {schema['minimum']}")
+
+    if "minLength" in schema and isinstance(instance, str) and len(instance) < schema["minLength"]:
+        raise SchemaValidationError(f"{path} is shorter than minLength {schema['minLength']}")
+
+    if "pattern" in schema and isinstance(instance, str):
+        if re.search(schema["pattern"], instance) is None:
+            raise SchemaValidationError(f"{path} does not match pattern {schema['pattern']!r}")
+
+
+def validate_artifact_against_schema(artifact_path: Path, schema_name: str) -> None:
+    """Validate a generated JSON artifact against a checked-in schema."""
+    schema_path = SCHEMA_DIR / schema_name
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validate_schema(artifact, schema, schema)
 
 
 def main() -> int:
@@ -76,17 +215,33 @@ def main() -> int:
         return 1
 
     reports_dir = Path("target/hl7v2-python-evidence/reports")
-    for artifact in [
-        "validation-report-v2.json",
-        "corpus-summary-v2.json",
-        "corpus-fingerprint-v2.json",
-        "corpus-diff-v2.json",
-        "redaction-output-v2.json",
-        "bundle-summary-v2.json",
-        "replay-report-v2.json",
-    ]:
-        if not (reports_dir / artifact).is_file():
+    for artifact, schema in ARTIFACT_SCHEMAS.items():
+        artifact_path = reports_dir / artifact
+        if not artifact_path.is_file():
             print(f"guide workflow did not write {artifact}", file=sys.stderr)
+            return 1
+        try:
+            validate_artifact_against_schema(artifact_path, schema)
+        except (json.JSONDecodeError, SchemaValidationError) as error:
+            print(
+                f"guide workflow artifact {artifact} failed {schema}: {error}",
+                file=sys.stderr,
+            )
+            return 1
+
+    bundle_dir = Path("target/hl7v2-python-evidence/issue-bundle")
+    for artifact, schema in BUNDLE_ARTIFACT_SCHEMAS.items():
+        artifact_path = bundle_dir / artifact
+        if not artifact_path.is_file():
+            print(f"guide workflow did not write bundle artifact {artifact}", file=sys.stderr)
+            return 1
+        try:
+            validate_artifact_against_schema(artifact_path, schema)
+        except (json.JSONDecodeError, SchemaValidationError) as error:
+            print(
+                f"guide workflow bundle artifact {artifact} failed {schema}: {error}",
+                file=sys.stderr,
+            )
             return 1
 
     print(f"python evidence workflow guide ok version={version}")


### PR DESCRIPTION
## Summary
- validate Python evidence workflow guide outputs against checked-in evidence schemas
- validate v2 bundle internals from the Python guide, including manifest, environment, field paths, redaction receipt, and validation report
- write `validation-report.json` as a v2 bundle-internal artifact when `artifact_schema_version = 2`

## Validation
- `cargo +1.93.0 test -p hl7v2 --lib --all-features evidence::tests`
- `cargo +1.93.0 check -p hl7v2-python --all-targets` failed without `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` because local Python is 3.14 and PyO3 0.24.2 supports up to 3.13 by default
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 check -p hl7v2-python --all-targets`
- `cargo +1.93.0 run -p xtask -- evidence-schema-check`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; $env:RUSTUP_TOOLCHAIN='1.93.0'; python -m maturin build -m crates/hl7v2-python/Cargo.toml --release --out dist`
- `python -m pip install --force-reinstall dist/hl7v2_python-1.4.0-cp314-cp314-win_amd64.whl`
- `python tests/python_smoke/smoke.py`
- `python tests/python_smoke/evidence_workflow_guide.py`
- `cargo +1.93.0 fmt --all -- --check`
- `git diff --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`
- `cargo +1.93.0 test -p hl7v2-cli --test integration_tests evidence_golden_fixtures`

## Notes
- No TestPyPI or production PyPI upload was run.
- This keeps `hl7v2-python` out of the crates.io publish graph.
