### PR TITLE
ci: summarize TestPyPI publisher setup

### DIFF
--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -116,6 +116,34 @@ jobs:
           name: python-testpypi-wheel
           path: dist
 
+      - name: Record trusted publisher setup
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.wheel_proof.outputs.package_version }}
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::TestPyPI publishing proof must run from refs/heads/main"
+            exit 1
+          fi
+
+          {
+            echo "## TestPyPI Trusted Publisher"
+            echo
+            echo "This job publishes \`hl7v2-python==${PACKAGE_VERSION}\` to TestPyPI using OIDC Trusted Publishing."
+            echo
+            echo "| Field | Expected value |"
+            echo "| --- | --- |"
+            echo "| Project name | \`hl7v2-python\` |"
+            echo "| Owner | \`EffortlessMetrics\` |"
+            echo "| Repository name | \`hl7v2-rs\` |"
+            echo "| Workflow filename | \`python-testpypi.yml\` |"
+            echo "| Environment name | \`testpypi\` |"
+            echo "| Ref | \`${GITHUB_REF}\` |"
+            echo "| Trusted publisher subject | \`repo:${GITHUB_REPOSITORY}:environment:testpypi\` |"
+            echo
+            echo "If upload fails with \`invalid-publisher\`, configure the pending publisher on TestPyPI with these values and rerun this workflow."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -87,6 +87,12 @@ publish_to_testpypi = true
 Run publishing mode from `main`. The workflow fails early if
 `publish_to_testpypi=true` is selected from any other ref.
 
+Before upload, the publish job writes the expected TestPyPI Trusted Publisher
+fields to the GitHub Actions job summary. If the upload fails with
+`invalid-publisher`, compare the summary fields to the TestPyPI pending
+publisher configuration and fix TestPyPI before rerunning. Do not switch to a
+repository token or `skip-existing` as a shortcut around Trusted Publishing.
+
 This does three things:
 
 1. Builds and smoke-tests the wheel.


### PR DESCRIPTION
## Summary
- add a TestPyPI Trusted Publisher preflight summary before the upload action runs
- fail closed in the publish job if it is not running from `refs/heads/main`
- document that `invalid-publisher` should be resolved by fixing TestPyPI Trusted Publishing, not by switching to tokens or `skip-existing`

## Validation
- `actionlint -version` unavailable locally
- `cargo +1.93.0 run -p xtask -- check-python-publish-policy`
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`

## Security boundary
- No tokens or secrets added.
- `publish_testpypi` still uses OIDC Trusted Publishing with `id-token: write` only in that job.
- Production PyPI is untouched.
