### PR TITLE
docs: link TestPyPI blocker issue

### DIFF
--- a/docs/audits/python-testpypi-publish-attempt-2026-05-10.md
+++ b/docs/audits/python-testpypi-publish-attempt-2026-05-10.md
@@ -103,7 +103,9 @@ Publisher configuration for project `hl7v2-python`.
 
 ## Next Step
 
-Configure the TestPyPI Trusted Publisher for project `hl7v2-python` with:
+Configure the TestPyPI Trusted Publisher for project `hl7v2-python` with the
+fields below. The external setup work is tracked in
+[#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563).
 
 | TestPyPI field | Value |
 | --- | --- |

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -130,4 +130,5 @@ publishing-mode run from `main` built and smoke-tested the wheel, then failed
 during Trusted Publishing token exchange with `invalid-publisher`; see
 [docs/audits/python-testpypi-publish-attempt-2026-05-10.md](../audits/python-testpypi-publish-attempt-2026-05-10.md).
 The TestPyPI upload/install-back proof remains incomplete until the TestPyPI
-Trusted Publisher is configured and a rerun passes.
+Trusted Publisher is configured and a rerun passes. Track the external setup
+blocker in [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563).


### PR DESCRIPTION
## Summary
- link the TestPyPI release proof guide to the tracked external publisher setup issue
- link the publishing-attempt audit receipt to the same blocker issue
- keep the documented boundary clear: no token fallback, no `skip-existing`, and no production PyPI attempt

## Validation
- `git diff --check`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed`