### PR TITLE
docs: define source-of-truth model

### DIFF
--- a/.hl7v2/goals/README.md
+++ b/.hl7v2/goals/README.md
@@ -1,0 +1,16 @@
+# Active Goals
+
+This directory holds machine-readable current execution state for hl7v2-rs
+campaigns.
+
+`active.toml` should tell an agent:
+
+- the active campaign and objective;
+- accepted proposal, spec, ADR, and plan links;
+- the next PR-sized work item;
+- proof commands;
+- blockers and explicit non-goals;
+- what must not be touched.
+
+Do not use active goals as historical receipts. Move completed campaign state to
+`archive/` or a closeout audit when the proof trail is durable.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,28 @@ with the current sources below before reading older planning documents.
 | Release process | [../RELEASE_PROCESS.md](../RELEASE_PROCESS.md) |
 | Lint, file, and panic-family policies | [CLIPPY_POLICY.md](CLIPPY_POLICY.md), [FILE_POLICY.md](FILE_POLICY.md), [NO_PANIC_POLICY.md](NO_PANIC_POLICY.md) |
 
+## How Docs Fit Together
+
+Use the smallest document type that owns the claim:
+
+| Document type | Job |
+| --- | --- |
+| Proposal / PRD | Explain why a campaign exists, who it serves, and what success means. |
+| Spec | Define required behavior, contracts, acceptance criteria, and proof. |
+| ADR | Record a durable architecture decision and its consequences. |
+| Implementation plan | Sequence PR-sized work, rollback, and validation commands. |
+| Active goal | Record current agent execution state, blockers, and next work. |
+| Status / support | State current product claims and the proof behind them. |
+| Policy TOML | Hold exception, CI, lint, file, and package ledgers. |
+| Audit / handoff | Preserve what happened, what was validated, and what remains open. |
+
+Start new governance work in [proposals/](proposals/), define durable
+requirements in [specs/](specs/), use [adr/](adr/) only for architecture
+decisions, sequence execution in [../plans/1.4.1/](../plans/1.4.1/), and keep
+the current active state in [../.hl7v2/goals/](../.hl7v2/goals/). Current
+feature status still lives in [STATUS.md](STATUS.md); do not duplicate it in
+proposal, spec, plan, or receipt documents.
+
 ## Evidence Guides
 
 | Guide | Workflow |

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,15 @@
+# Proposals
+
+Proposals explain why a campaign exists before the repo commits to detailed
+behavior or a PR sequence.
+
+A proposal should describe:
+
+- the problem and users or maintainers affected;
+- success criteria and non-goals;
+- the source-of-truth surfaces that the work will change;
+- specs or ADRs expected before implementation;
+- the evidence plan and exit criteria.
+
+Proposals do not own current feature status, artifact contracts, CI policy, or
+release receipts. Link to the current source instead of copying those tables.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,14 @@
+# Specs
+
+Specs define what behavior, contracts, and proof requirements must be true.
+
+A spec should describe:
+
+- the accepted behavior or repo contract;
+- acceptance criteria and examples;
+- required proof commands or receipts;
+- links to proposals, ADRs, plans, schemas, and policy ledgers;
+- explicit non-goals.
+
+Specs do not define PR order. Use implementation plans for sequencing and
+rollback, and use `docs/STATUS.md` for current feature status.

--- a/plans/1.4.1/README.md
+++ b/plans/1.4.1/README.md
@@ -1,0 +1,16 @@
+# v1.4.1 Plans
+
+This directory sequences PR-sized work for the v1.4.1 source-of-truth and
+Python proof lane.
+
+Plans should describe:
+
+- linked proposals, specs, and ADRs;
+- PR-sized work items;
+- production delta and non-goals;
+- proof commands;
+- rollback or closeout steps.
+
+Plans do not define the product contract. Link to specs for behavior, ADRs for
+durable decisions, `.hl7v2/goals/active.toml` for current execution state, and
+audits or handoffs for completed proof.


### PR DESCRIPTION
## Summary

- add README scaffolding for proposals, specs, v1.4.1 plans, and active goals
- document how proposal/spec/ADR/plan/active-goal/status/policy/audit docs divide ownership
- preserve `docs/STATUS.md` as the current feature/status source of truth

## Validation

- `git diff --check`
- `cargo +1.93.0 run -p xtask -- check-doc-links`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed`