### PR TITLE
plans(1.4.1): add source-of-truth implementation plan

### DIFF
--- a/plans/1.4.1/implementation-plan.md
+++ b/plans/1.4.1/implementation-plan.md
@@ -1,0 +1,69 @@
+# v1.4.1 Source-of-Truth Implementation Plan
+
+Status: Active
+Date: 2026-05-13
+Proposal: [HL7V2-PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Primary spec: [HL7V2-SPEC-0001](../../docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md)
+
+## Goal
+
+Prepare a small release-discipline lane that makes `hl7v2-rs`
+self-describing: durable claims have one home, active work has machine-readable
+state, and release closure is blocked on receipt-backed proof rather than prose
+memory.
+
+## Production Delta
+
+No runtime, workflow, schema, packaging, or publish behavior changes are planned
+in this documentation campaign.
+
+## Work Items
+
+| Item | Status | Linked artifacts | Goal |
+| --- | --- | --- | --- |
+| Finish deployment ADR link fix | Done | PR #565 | Remove stale deployment ADR links. |
+| Source-of-truth scaffold | Done | PR #567 | Add README scaffolding for proposals, specs, plans, and active goals. |
+| Governing proposal | Done | [PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md) | Explain why the source-of-truth stack exists. |
+| Source-of-truth stack spec | Done | [SPEC-0001](../../docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md) | Define claim ownership and traceability rules. |
+| Python distribution proof spec | Done | [SPEC-0002](../../docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md) | Preserve TestPyPI/PyPI proof boundaries. |
+| CI verification economics spec | Done | [SPEC-0003](../../docs/specs/HL7V2-SPEC-0003-ci-verification-economics.md) | Explain deep, cost-aware verification. |
+| Evidence artifacts ADR | Done | [ADR-0001](../../docs/adr/HL7V2-ADR-0001-evidence-artifacts-are-contracts.md) | Record evidence artifacts as product contracts. |
+| Python distribution ADR | Done | [ADR-0002](../../docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md) | Record Python as separate from crates.io. |
+| Support tier map | Done | [SUPPORT_TIERS](../../docs/status/SUPPORT_TIERS.md) | Map product surfaces to proof commands. |
+| TestPyPI Trusted Publisher proof | Blocked | [testpypi-closure.md](testpypi-closure.md), issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563) | Complete upload and install-back after external setup. |
+| Active goal manifest | Ready | `.hl7v2/goals/active.toml` | Record machine-readable current campaign state. |
+| v1.4.1 release readiness | Waiting | [release-readiness.md](release-readiness.md) | Decide patch candidate only after receipts are clean. |
+
+## PR Order
+
+1. Merge the completed source-of-truth documentation PRs.
+2. Add `.hl7v2/goals/active.toml` after this plan exists.
+3. Resolve TestPyPI Trusted Publisher setup outside the repo.
+4. Rerun the Python TestPyPI Proof workflow from `main`.
+5. If upload and install-back pass, add a receipt PR and close #563.
+6. Decide separately whether production PyPI should be attempted.
+7. Prepare v1.4.1 only after the source-of-truth stack and Python proof
+   receipts are durable.
+
+## Non-Goals
+
+- No runtime feature changes.
+- No CI workflow behavior changes.
+- No evidence schema changes.
+- No Python publishing from this plan PR.
+- No production PyPI decision by default.
+
+## Proof Commands
+
+Docs-only plan changes use:
+
+```powershell
+cargo +1.93.0 run -p xtask -- check-doc-links
+cargo +1.93.0 run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
+```
+
+## Rollback
+
+Plans are documentation-only. Revert the plan PR if it misstates sequencing or
+claim ownership. Do not change runtime behavior to make a plan true.

--- a/plans/1.4.1/release-readiness.md
+++ b/plans/1.4.1/release-readiness.md
@@ -1,0 +1,61 @@
+# v1.4.1 Release Readiness Plan
+
+Status: Waiting
+Proposal: [HL7V2-PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Support map: [SUPPORT_TIERS](../../docs/status/SUPPORT_TIERS.md)
+
+## Goal
+
+Prepare a patch release candidate only after the source-of-truth stack and
+Python proof receipts are durable.
+
+## Candidate Theme
+
+```text
+v1.4.1 - Evidence Rails and Python Packaging Proof
+```
+
+## Candidate Scope
+
+Likely included after receipts are clean:
+
+- split-train evidence hardening already merged before this lane;
+- final source-tree audit and TestPyPI blocker receipts through #564;
+- #565 deployment ADR link fix;
+- source-of-truth scaffolding, proposal, specs, ADRs, plans, support map, and
+  active goal manifest;
+- TestPyPI success receipt, if issue #563 is completed.
+
+Production PyPI is included only if an explicit production release decision is
+made and upload plus install-back pass from `pypi.org`.
+
+## Required Proof Before Release Decision
+
+```powershell
+cargo +1.93.0 run -p xtask -- check-doc-links
+cargo +1.93.0 run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
+```
+
+Additional proof if TestPyPI closes:
+
+```text
+Python TestPyPI Proof from main with publish_to_testpypi=true
+TestPyPI upload: success
+TestPyPI install-back: success
+smoke.py: success
+production PyPI: not attempted
+```
+
+## Non-Goals
+
+- Do not publish Python to production PyPI by default.
+- Do not publish `hl7v2-python` to crates.io.
+- Do not claim TestPyPI success until upload and install-back pass.
+- Do not include production PyPI unless production upload and install-back pass.
+
+## Rollback
+
+If any proof is missing, stop at "release candidate not ready" and keep the
+blocking issue or receipt open. Do not rewrite release notes to imply proof that
+has not passed.

--- a/plans/1.4.1/source-of-truth-stack.md
+++ b/plans/1.4.1/source-of-truth-stack.md
@@ -1,0 +1,42 @@
+# Source-of-Truth Stack Plan
+
+Status: Active
+Proposal: [HL7V2-PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Spec: [HL7V2-SPEC-0001](../../docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md)
+ADRs: [ADR-0001](../../docs/adr/HL7V2-ADR-0001-evidence-artifacts-are-contracts.md),
+[ADR-0002](../../docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md)
+
+## Goal
+
+Make the documentation operating model explicit so agents and maintainers can
+tell whether a change edits the why, contract, decision, PR sequence, active
+state, or proof receipt.
+
+## Production Delta
+
+Documentation-only.
+
+## Work Items
+
+| Item | Goal | Acceptance | Proof |
+| --- | --- | --- | --- |
+| Scaffolding | Define folder roles. | `docs/README.md` links proposals, specs, plans, and active goals. | `cargo +1.93.0 run -p xtask -- check-doc-links` |
+| Proposal | Explain why governance exists. | PROP-0001 includes problem, users, success criteria, alternatives, evidence plan, risks, and exit criteria. | docs gate |
+| Source stack spec | Define traceability rule. | SPEC-0001 owns proposal/spec/ADR/plan/active-goal/issue/PR/proof/closeout flow. | docs gate |
+| Python proof spec | Preserve packaging boundary. | SPEC-0002 blocks token fallback, skip-existing, and unproven PyPI claims. | docs gate plus `publish-plan` |
+| CI economics spec | Explain cost-aware depth. | SPEC-0003 links to canonical CI policy and the industrialized-AI article appears once. | `rg -n "assisted-native-industrialized" docs` |
+| ADRs | Record durable decisions. | Evidence artifacts are contracts; Python is a separate distribution lane. | docs gate plus `publish-plan` |
+| Support map | Map claims to proof. | Support tiers link proof commands without replacing `docs/STATUS.md`. | docs gate |
+| Active goal manifest | Record current execution state. | `.hl7v2/goals/active.toml` links real proposal, specs, ADRs, and plans. | docs gate |
+
+## Non-Goals
+
+- Do not duplicate `docs/STATUS.md`.
+- Do not duplicate the evidence contract index.
+- Do not change CI workflows or policy TOMLs in this plan.
+- Do not publish packages.
+
+## Rollback
+
+Revert the documentation PR that introduced the incorrect source ownership or
+plan entry. Leave existing receipts intact unless they are factually wrong.

--- a/plans/1.4.1/testpypi-closure.md
+++ b/plans/1.4.1/testpypi-closure.md
@@ -1,0 +1,61 @@
+# TestPyPI Closure Plan
+
+Status: Blocked
+Spec: [HL7V2-SPEC-0002](../../docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md)
+ADR: [HL7V2-ADR-0002](../../docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md)
+Blocker: [issue #563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563)
+
+## Goal
+
+Close the `hl7v2-python` TestPyPI proof boundary only after external Trusted
+Publisher setup exists and a guarded upload plus install-back passes.
+
+## Production Delta
+
+None until an explicit release proof run is requested. This plan does not
+publish anything.
+
+## External Setup
+
+Configure TestPyPI Trusted Publisher for project `hl7v2-python`:
+
+| Field | Value |
+| --- | --- |
+| Owner | `EffortlessMetrics` |
+| Repository name | `hl7v2-rs` |
+| Workflow filename | `python-testpypi.yml` |
+| Environment name | `testpypi` |
+
+Expected subject:
+
+```text
+repo:EffortlessMetrics/hl7v2-rs:environment:testpypi
+```
+
+## Execution
+
+After external setup:
+
+```text
+Workflow: Python TestPyPI Proof
+Branch: main
+publish_to_testpypi: true
+```
+
+## Acceptance
+
+- Build and smoke wheel: success.
+- Publish to TestPyPI: success.
+- Install from TestPyPI and smoke: success.
+- No production PyPI upload.
+- No token fallback.
+- No skip-existing workaround.
+- Receipt PR records run URL, commit SHA, package version, TestPyPI URL,
+  publish job result, install-back result, smoke output, and production-PyPI
+  non-attempt.
+
+## Rollback
+
+If upload fails with `invalid-publisher`, leave #563 open and update the audit
+receipt only if the new run adds useful evidence. Do not switch to token fallback
+or skip-existing.


### PR DESCRIPTION
## Summary

- add the v1.4.1 source-of-truth implementation plan
- add focused plans for source-of-truth stack work, TestPyPI closure, and release readiness
- keep TestPyPI blocked on #563 and avoid any publish or workflow behavior change

## Validation

- `git diff --check`
- `cargo +1.93.0 run -p xtask -- check-doc-links`
- `cargo +1.93.0 run -p xtask -- publish-plan`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed`