### PR TITLE
docs(policy): map Rust 1.95 and 1.5.0 rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- Mapped the Rust 1.95 / `1.5.0` rollout as a minor-release MSRV ratchet with
+  policy tightening, advisory static mutation-exposure analysis, targeted
+  mutation lanes, and release-readiness proof. No MSRV, toolchain, workflow, or
+  runtime behavior changes are part of the planning PR.
+
 ---
 
 ## [1.4.0] - 2026-05-09

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -111,8 +111,25 @@ fn lookup_generated_table(index: usize) -> &'static str {
   selector schema for panic-family exceptions.
 - `policy/non-rust-allowlist.toml` reserves the structured schema for non-Rust
   programming-file exceptions.
+- `policy/clippy-exceptions.toml` is planned for retained suppressions that are
+  not broad cleanup debt.
+- [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) maps current and planned policy
+  ledgers without replacing the TOML sources of truth.
 - `clippy.toml` is only for repo-local disallowed methods, types, macros, or
   fields. It must not weaken the test posture.
+
+## Rust 1.95 rollout
+
+The Rust 1.95 / 1.5.0 rollout is mapped in
+[development/RUST_1_95_ROLLOUT.md](development/RUST_1_95_ROLLOUT.md). The
+current state remains Rust 2024, workspace version `1.4.0`, and MSRV `1.93`
+until the dedicated MSRV PR changes the manifest, toolchain file, CI labels,
+and policy ledger together.
+
+During the rollout, planned Rust 1.94/1.95 lints in
+`policy/clippy-lints.toml` should either become active with clean proof or stay
+planned with an expiring debt receipt. Do not use the MSRV bump as a reason to
+add test carveouts or bare `#[allow(clippy::...)]` suppressions.
 
 ## Gate
 

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -111,3 +111,21 @@ Clippy and the semantic no-panic checker govern the **inside** of Rust
 files. The file policy governs **which other files are allowed to exist**.
 Together, they keep the repository's surface area small, owned, and
 expiring.
+
+## Companion ledgers target
+
+The current non-Rust allowlist answers whether a non-Rust file may exist. The
+Rust 1.95 / 1.5.0 rollout should add companion ledgers for behavior that should
+not be hidden inside a broad file-presence exception:
+
+```text
+policy/generated-allowlist.toml
+policy/executable-allowlist.toml
+policy/dependency-surface-allowlist.toml
+policy/workflow-allowlist.toml
+policy/process-allowlist.toml
+policy/network-allowlist.toml
+```
+
+Use [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) for the map of current and
+planned ledgers. The TOML files remain the source of truth.

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -59,6 +59,21 @@ container = "parses_msh"      # enclosing `fn` name (best-effort)
 callee = "unwrap"             # method or macro name
 ```
 
+## Rust 1.95 hardening target
+
+The current identity is acceptable while `policy/no-panic-allowlist.toml` is
+empty, but it is too broad for future exceptions. The Rust 1.95 / 1.5.0 rollout
+should harden identity before adding any baseline:
+
+```text
+identity = path + family + selector_kind + selector_callee + snippet + count
+```
+
+Matching should consume exact allowlist count slots first, then baseline count
+slots in no-new-debt mode. Duplicate allowlist keys should be rejected. This
+prevents one future `unwrap` or `expect` receipt from covering unrelated calls
+in the same file or function.
+
 ## Allowlist schema
 
 `policy/no-panic-allowlist.toml` uses schema `0.3`:
@@ -130,6 +145,10 @@ Failure modes:
 - **allowlist entry not matched** by any finding — fail (stale receipt).
 - **allowlist entry past `expires`** — fail.
 - **drift in `last_seen`** — warn only; rerun `no-panic propose` to refresh.
+
+The planned no-new-debt baseline should be generated only after exact identity
+lands. Baseline refreshes may drop disappeared entries, but should not absorb
+new debt unless an explicit reset is part of the dedicated baseline PR.
 
 `no-panic propose` emits a candidate TOML at
 `target/policy/no-panic-proposed-allowlist.toml`. It **never** mutates

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,56 @@
+# Policy Allowlists
+
+This page explains how the repository policy ledgers fit together. It is a
+map, not a replacement for the TOML files. The TOML ledgers remain the source
+of truth for exceptions and policy state.
+
+## Current Ledgers
+
+| Ledger | Current job |
+| --- | --- |
+| `policy/clippy-lints.toml` | Active Rust and Clippy lint policy, staged packages, and planned Rust 1.94/1.95 lint flips. |
+| `policy/clippy-debt.toml` | Temporary cleanup debt that should expire by 2026-06-30. |
+| `policy/no-panic-allowlist.toml` | Panic-family exception ledger; currently empty with broad identity semantics. |
+| `policy/non-rust-allowlist.toml` | Tracked non-Rust file presence ledger. |
+| `policy/ci-lane-whitelist.toml` | Allowed CI lanes, ownership, trigger class, and LEM estimate. |
+| `policy/ci-risk-packs.toml` | Risk-pack routing for CI lanes. |
+| `policy/ci-budget.toml` | CI budget policy. |
+
+## Planned Ledgers
+
+The Rust 1.95 / 1.5.0 rollout should add companion ledgers only where they
+govern behavior that does not belong in `policy/non-rust-allowlist.toml`.
+
+| Planned ledger | Purpose |
+| --- | --- |
+| `policy/clippy-exceptions.toml` | Retained Clippy suppressions, separate from broad cleanup debt. |
+| `policy/no-panic-baseline.toml` | Exact counted no-panic baseline for no-new-debt mode. |
+| `policy/generated-allowlist.toml` | Generated artifacts and generators. |
+| `policy/executable-allowlist.toml` | Scripts and executable entrypoints. |
+| `policy/dependency-surface-allowlist.toml` | Non-Rust package manager and tool dependencies. |
+| `policy/workflow-allowlist.toml` | Workflow behavior beyond file presence. |
+| `policy/process-allowlist.toml` | Process execution surfaces. |
+| `policy/network-allowlist.toml` | Network access surfaces. |
+| `policy/ripr-suppressions.toml` | Advisory static mutation-exposure suppressions after `ripr` lands. |
+
+## Rules
+
+- Do not duplicate source-of-truth tables from the TOML ledgers.
+- Broad globs need a concrete reason.
+- Production OpenAPI, protobuf, schema, profile, and publishing surfaces need
+  a real `covered_by` command or workflow.
+- Python, Node, Go, Docker, shell, process, and network behavior should move
+  to companion policies when those policies exist.
+- `policy/non-rust-allowlist.toml` answers "may this file exist?" Companion
+  ledgers answer "what behavior may this file perform?"
+- Exceptions must be owned, reviewable, and expiring unless they are permanent
+  platform metadata with a stable proof.
+
+## Local Gates
+
+```bash
+cargo run -p xtask -- check-file-policy
+cargo run -p xtask -- check-lint-policy
+cargo run -p xtask -- check-no-panic-family
+cargo run -p xtask -- policy-report
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ with the current sources below before reading older planning documents.
 | CI and release validation lanes | [CI_PIPELINE.md](CI_PIPELINE.md) |
 | Release process | [../RELEASE_PROCESS.md](../RELEASE_PROCESS.md) |
 | Lint, file, and panic-family policies | [CLIPPY_POLICY.md](CLIPPY_POLICY.md), [FILE_POLICY.md](FILE_POLICY.md), [NO_PANIC_POLICY.md](NO_PANIC_POLICY.md) |
+| Rust 1.95 / 1.5.0 rollout map | [development/RUST_1_95_ROLLOUT.md](development/RUST_1_95_ROLLOUT.md) |
+| Policy allowlist map | [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) |
 
 ## How Docs Fit Together
 
@@ -69,6 +71,8 @@ proposal, spec, plan, or receipt documents.
 ## Current Boundaries
 
 - `docs/STATUS.md` is the current-state source of truth.
+- `docs/development/RUST_1_95_ROLLOUT.md` is the current rollout map for the
+  planned Rust 1.95 / 1.5.0 lane; it is not an active MSRV declaration.
 - The v1.4.0 objective audit is a release-snapshot receipt, not proof that the
   full long-range evidence-layer objective is finished.
 - `hl7v2-python` remains a separate Python packaging lane until a production

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -90,6 +90,19 @@ They are never default for ordinary PRs unless the diff explicitly touches the s
 | Coverage                      | `coverage`, `full-ci`, main          |
 | ripr soft-gate                | After calibration period             |
 
+## Rust 1.95 / 1.5.0 Rollout
+
+The Rust 1.95 rollout keeps this policy intact: sharper rails, not heavier
+ordinary PRs. The rollout map lives in
+[../development/RUST_1_95_ROLLOUT.md](../development/RUST_1_95_ROLLOUT.md).
+It plans a Rust 1.95 MSRV ratchet, exact no-panic identity, companion policy
+ledgers, advisory `ripr` static mutation-exposure analysis, targeted mutation
+lanes, and release-readiness proof for `1.5.0`.
+
+`ripr` is static mutation-exposure analysis. It shifts mutation signal left at
+PR time; it does not replace runtime mutation testing. Runtime mutation remains
+the slower backstop for high-risk, nightly, and release lanes.
+
 ## Hard Rules
 
 The following are non-negotiable regardless of cost pressure:

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -1,0 +1,53 @@
+# ripr Static Mutation-Exposure Lane
+
+`ripr` is planned as an advisory PR-time static mutation-exposure lane for
+`hl7v2-rs`.
+
+## Doctrine
+
+`ripr` is static mutation-exposure analysis.
+
+It catches much of the same signal mutation testing catches: weak test or
+oracle exposure. It catches that signal earlier and cheaper because it runs
+statically and can run per PR.
+
+Mutation testing remains the slower runtime backstop for what static analysis
+cannot prove. `ripr` shifts mutation signal left; it does not make mutation
+testing unnecessary.
+
+## Planned Role
+
+The initial lane should be advisory:
+
+- run on pull requests touching Rust code, `xtask`, Cargo files, `ripr.toml`,
+  or the `ripr` policy ledger;
+- emit JSON, SARIF, and markdown artifacts;
+- avoid branch-protection blocking until calibration data exists;
+- use suppressions only through a policy ledger;
+- preserve runtime mutation as targeted or release-time proof.
+
+## CI Economics
+
+At industrialized PR volume, broad always-on runtime mutation would become an
+ordinary PR tax. `ripr` is the cheaper PR-time signal for mutation exposure.
+It should identify weak oracle exposure early while targeted runtime mutation
+continues to cover what static analysis cannot prove.
+
+## Non-Goals
+
+- Do not make `ripr` required by branch protection in the first lane.
+- Do not use `ripr` as a reason to remove mutation testing.
+- Do not put full runtime mutation on ordinary PRs.
+- Do not hide skipped mutation lanes as passed.
+- Do not add suppressions without ownership and review.
+
+## Planned Artifacts
+
+```text
+.github/workflows/ripr.yml
+ripr.toml
+policy/ripr-suppressions.toml
+target/ripr/ripr.json
+target/ripr/ripr.sarif
+target/ripr/ripr.md
+```

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -1,0 +1,55 @@
+# Test Evidence Lanes
+
+`hl7v2-rs` keeps verification deep by routing proof to the risk surface that
+needs it. Ordinary PRs should get fast policy, lint, unit, doc, and targeted
+test feedback. Expensive runtime lanes remain available for labels, main,
+nightly, release readiness, and high-risk changes.
+
+## Lane Split
+
+| Lane | Default PR? | Evidence |
+| --- | :---: | --- |
+| Format, lint, no-panic, file policy | yes | `xtask gate`, `check-lint-policy`, `check-no-panic-family`, `check-file-policy` |
+| Unit and doc tests | yes | `cargo test --lib`, `cargo test --doc` |
+| Standard integration and BDD tests | yes | CLI/server integration and BDD job logs |
+| MSRV smoke | yes | Current declared MSRV compile check |
+| Platform matrix | no | main, merge queue, `platform-matrix`, `full-ci`, or `release-check` |
+| Extended property tests | no | main, dispatch, `property-tests`, `full-ci`, or `release-check` |
+| Benchmarks | no | main, dispatch, `benchmarks`, `full-ci`, or `release-check` |
+| Coverage | no | main, dispatch, `coverage`, or `full-ci` |
+| Contracts | no | OpenAPI, proto, schema, and evidence validation |
+| Python wheels and publish proof | no | Python-lane workflows and receipts |
+| `ripr` static exposure | planned advisory | JSON, SARIF, and markdown advisory artifacts |
+| Runtime mutation | planned targeted | high-risk labels, nightly, and release readiness |
+
+## Rust 1.95 Target
+
+The Rust 1.95 / 1.5.0 rollout should keep default PR cost bounded while adding
+better receipts:
+
+- Rust 1.95 MSRV smoke remains a default compatibility proof after the MSRV PR.
+- `ripr` becomes a cheap advisory PR-time static mutation-exposure signal.
+- Runtime mutation remains targeted by risk pack, label, nightly, or release
+  readiness.
+- Release readiness owns the broadest proof bundle before `1.5.0`.
+
+## High-Risk HL7 Surfaces
+
+The following surfaces justify targeted deeper proof:
+
+- message parser and delimiter handling;
+- MLLP framing;
+- profile validation;
+- safe-analysis redaction;
+- evidence bundle and replay hashes;
+- schema and evidence artifact contracts;
+- server auth and rate-limit policy;
+- Python binding parity;
+- release and publish behavior.
+
+## Related Docs
+
+- [Cost and Verification Policy](cost-and-verification-policy.md)
+- [Verification Ladder](verification-ladder.md)
+- [CI Lane Inventory](inventory.md)
+- [ripr](ripr.md)

--- a/docs/ci/verification-ladder.md
+++ b/docs/ci/verification-ladder.md
@@ -71,3 +71,9 @@ for a given diff, not which layers exist.
 | coverage              | `coverage.json`, `lcov.info`, Codecov dashboard                |
 | benchmarks            | `benchmark-results.txt` artifact                               |
 | LEM actuals           | `ci-actuals.json` artifact (after PR 14)                       |
+
+## Related Docs
+
+- [Test Evidence Lanes](test-evidence-lanes.md)
+- [ripr Static Mutation-Exposure Lane](ripr.md)
+- [Cost and Verification Policy](cost-and-verification-policy.md)

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,0 +1,162 @@
+# Rust 1.95 And 1.5.0 Rollout
+
+This document is the rollout map for moving `hl7v2-rs` from Rust 1.93 to
+Rust 1.95 and preparing the next release as `1.5.0`.
+
+This is a planning and operating document. It does not change the active MSRV,
+toolchain, CI behavior, lint policy, package version, or release state.
+
+## Executive Call
+
+The workspace should move from Rust 1.93 to Rust 1.95. Because raising MSRV
+narrows the supported build surface, the release that carries the ratchet is a
+minor release:
+
+```text
+1.4.0 -> 1.5.0
+```
+
+The rollout sharpens existing rails rather than adding a broad default CI tax.
+The current repository already has strict workspace lints, policy ledgers,
+staged CI lanes, coverage routing, contract checks, evidence schemas, and
+Python publishing boundaries. The upgrade should make those rails more
+self-describing and better receipted.
+
+## Current State
+
+| Surface | Current state | Notes |
+| --- | --- | --- |
+| Rust edition | `2024` | No edition migration is planned. |
+| Workspace version | `1.4.0` | The next release target is `1.5.0`. |
+| Workspace MSRV | `1.93` | Declared in the root `Cargo.toml`. |
+| Toolchain file | absent | Add `rust-toolchain.toml` in the MSRV PR, not here. |
+| Root lint policy | strict | Rust and Clippy lints are already governed from the workspace root. |
+| Clippy test carveouts | prohibited | `clippy.toml` explicitly rejects test carveouts. |
+| Clippy policy ledger | present | `policy/clippy-lints.toml` records active lints and planned 1.94/1.95 flips. |
+| Clippy debt ledger | present | `policy/clippy-debt.toml` expires current cleanup debt on 2026-06-30. |
+| Clippy exceptions ledger | absent | Add before deeper suppression governance. |
+| No-panic allowlist | present, empty | Current identity is broad: `path + family + selector`. |
+| No-panic baseline | absent | Add after exact identity hardening. |
+| Non-Rust allowlist | present | File presence is governed; companion behavior ledgers are still planned. |
+| CI | staged and routed | Fast, standard, MSRV, matrix, extended, benchmark, coverage, contract, and security lanes already exist. |
+| Coverage | routed/advisory | Coverage runs on main, dispatch, `coverage`, or `full-ci`. |
+| Contracts workflow | present | OpenAPI, proto, schema, and evidence checks already exist. |
+| Publish workflow | present | `publish.yml` handles crates.io publish execution, but not full 1.5.0 readiness proof. |
+| Release readiness workflow | absent | Add a dedicated readiness workflow before the version bump. |
+| Python publishing | externally blocked | TestPyPI publish remains blocked by issue #563 until Trusted Publisher is configured. |
+
+One stale historical compatibility line remains in `CHANGELOG.md`: an older
+section still says MSRV `1.92` even though the workspace is already `1.93`.
+This rollout records the gap here. The MSRV PR should fix it when it raises
+the declared compatibility line to Rust 1.95.
+
+## Target State
+
+| Surface | Target state |
+| --- | --- |
+| Rust toolchain | Rust `1.95.0` |
+| Workspace version | `1.5.0` |
+| `rust-toolchain.toml` | pinned to `1.95.0` with `rustfmt` and `clippy` |
+| `clippy.toml` | `msrv = "1.95"` and no test carveouts |
+| `policy/clippy-lints.toml` | `msrv = "1.95"` with 1.94/1.95 lint state resolved |
+| Rust compiler lint floor | add the low-risk Rust 1.95 lint floor where clean |
+| Clippy ratchets | activate clean 1.94/1.95 lints or defer with expiring debt |
+| Clippy exceptions | add a retained-suppression ledger separate from debt |
+| No-panic identity | exact counted identity: `path + family + selector_kind + selector_callee + snippet + count` |
+| No-panic baseline | generated no-new-debt baseline after exact identity lands |
+| File policy | companion ledgers for generated, executable, dependency, workflow, process, and network behavior |
+| ripr | advisory PR-time static mutation-exposure analysis |
+| Mutation testing | targeted runtime backstop, not an ordinary PR tax |
+| Release readiness | explicit 1.5.0 readiness workflow and receipt |
+
+## Doctrine
+
+`ripr` is static mutation-exposure analysis.
+
+It catches much of the same signal mutation testing catches: weak test or
+oracle exposure. It catches that signal earlier and cheaper because it runs
+statically and can run per PR.
+
+Mutation testing remains the slower runtime backstop for what static analysis
+cannot prove. `ripr` shifts mutation signal left; it does not make mutation
+testing unnecessary.
+
+This matters because industrialized AI changes verification economics. At high
+PR volume, per-PR verification cost can exceed LLM cost, and small checks
+compound quickly. The answer is not weaker verification. The answer is deep
+verification routed by risk: cheap static, schema, lint, policy, and contract
+checks at PR time; broader runtime mutation, release, and platform proofs
+where the diff and release state justify them.
+
+## PR Ladder
+
+The rollout is split so each PR has one semantic objective.
+
+| PR | Objective | Branch |
+| --- | --- | --- |
+| 1 | Documentation-only rollout map | `docs/rust-1.95-rollout` |
+| 2 | Rust 1.95 compatibility probe | `probe/rust-1.95-compat` |
+| 3 | MSRV and toolchain bump | `chore/msrv-rust-1.95` |
+| 4 | Rust 1.95 compiler lint floor | `policy/rust-1.95-lints` |
+| 5 | Rust 1.94/1.95 Clippy ratchets | `policy/clippy-rust-1.95-ratchets` |
+| 6 | Clippy exceptions ledger | `policy/clippy-exceptions-ledger` |
+| 7 | Exact no-panic identity | `policy/no-panic-exact-identity` |
+| 8 | No-panic baseline and no-new-debt mode | `policy/no-panic-baseline` |
+| 9 | No-panic diagnostics | `policy/no-panic-diagnostics` |
+| 10 | File-policy companion ledgers | `policy/file-companion-ledgers` |
+| 11 | Advisory `ripr` static exposure lane | `ci/ripr-static-exposure` |
+| 12 | Targeted mutation lanes | `ci/targeted-mutation-lanes` |
+| 13 | Rust 1.95 API cleanup | `refactor/rust-1.95-api-cleanups` |
+| 14 | Numeric and protocol lint cleanup | `policy/clippy-protocol-cleanup` |
+| 15 | LEM actuals and risk-pack routing | `ci/lem-and-risk-pack-routing` |
+| 16 | 1.5.0 release-readiness workflow | `release/readiness-workflow` |
+| 17 | Prepare `1.5.0` | `release/1.5.0-prep-rust-1.95` |
+| 18 | Release dry-run proof | `release/1.5.0-dry-run` |
+
+## Acceptance Gates
+
+Documentation-only rollout changes use the narrow policy gates:
+
+```bash
+cargo run -p xtask -- check-doc-links
+cargo run -p xtask -- check-lint-policy
+cargo run -p xtask -- check-file-policy
+cargo run -p xtask -- policy-report
+git diff --check
+```
+
+Implementation PRs should add the smallest gate that directly proves the
+surface they touch. The MSRV and release PRs must include explicit Rust 1.95,
+publish-plan, publish-dry-run, evidence-schema, no-panic, file-policy, and
+lint-policy proof where applicable.
+
+## Operating Rules
+
+- Start each PR from clean `origin/main`.
+- Keep one objective per PR.
+- Open PRs as draft first.
+- Do not push directly to `main`.
+- Do not combine MSRV bump, lint activation, no-panic baseline, file-policy
+  tightening, release prep, and API cleanup.
+- Do not add Clippy test carveouts.
+- Do not add bare `#[allow(clippy::...)]` suppressions.
+- Do not reset the no-panic baseline outside the dedicated baseline PR.
+- Do not make `ripr` branch-protection blocking before calibration.
+- Do not replace mutation testing with `ripr`.
+- Do not put broad runtime mutation on ordinary PRs.
+- Do not hide skipped lanes as passed.
+- Do not weaken coverage, contract, evidence, Python publishing, or crates.io
+  release proofs.
+
+Every PR should include a self-review comment covering scope, files touched,
+policy changes, no-panic baseline scope, file-policy scope, CI economics,
+`ripr` framing, release evidence, validation, bot comments, and follow-ups.
+
+## Current Follow-Ups
+
+- Issue #563 remains the external TestPyPI Trusted Publisher blocker for
+  `hl7v2-python`.
+- `CHANGELOG.md` still has a historical MSRV `1.92` compatibility line that
+  should be corrected in the MSRV PR.
+- `publish.yml` exists for crates.io publication, but the dedicated 1.5.0
+  readiness workflow and release receipt are still planned.


### PR DESCRIPTION
## Summary
- add the Rust 1.95 / 1.5.0 rollout map before changing behavior
- add docs for planned policy allowlist companions, test evidence lanes, and advisory ripr static mutation-exposure analysis
- link the rollout from the docs index, policy docs, CI economics doc, and changelog

## Validation
- cargo run -p xtask -- check-doc-links: local default rustc is 1.92.0, below current MSRV 1.93, so rerun with current MSRV toolchain
- cargo +1.93.0 run -p xtask -- check-doc-links
- cargo +1.93.0 run -p xtask -- check-lint-policy
- cargo +1.93.0 run -p xtask -- check-file-policy
- cargo +1.93.0 run -p xtask -- policy-report
- git diff --check

## Scope
- Docs and changelog only
- No Cargo.toml changes
- No rust-toolchain.toml changes
- No clippy.toml changes
- No workflow changes
- No Rust source changes