### PR TITLE
chore(msrv): raise workspace toolchain to Rust 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
   # Runs on every PR: verifies the minimum supported Rust version compiles.
   # ============================================================================
   msrv-smoke:
-    name: MSRV Smoke (1.93)
+    name: MSRV Smoke (1.95)
     runs-on: ubuntu-latest
     needs: fast
     timeout-minutes: 15
@@ -137,12 +137,12 @@ jobs:
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: '1.93'
+          toolchain: '1.95'
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: hl7v2-msrv-1.93-${{ hashFiles('Cargo.lock') }}
+          shared-key: hl7v2-msrv-1.95-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check workspace compiles on MSRV
@@ -176,7 +176,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable, beta, '1.93']
+        rust: [stable, beta, '1.95']
         exclude:
           # beta and MSRV only on ubuntu to reduce CI load
           - os: windows-latest
@@ -184,9 +184,9 @@ jobs:
           - os: macos-latest
             rust: beta
           - os: windows-latest
-            rust: '1.93'
+            rust: '1.95'
           - os: macos-latest
-            rust: '1.93'
+            rust: '1.95'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: "1.93"
+          toolchain: "1.95"
           components: llvm-tools-preview
 
       - name: Use larger target dir
@@ -70,7 +70,7 @@ jobs:
         with:
           cache-on-failure: true
           cache-directories: ${{ runner.temp }}/target
-          shared-key: coverage-1.93
+          shared-key: coverage-1.95
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install coverage tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raised MSRV from Rust 1.93 to Rust 1.95 and pinned
+  `rust-toolchain.toml` to Rust 1.95.0 for local and CI consistency.
+
 ### Planned
 
 - Mapped the Rust 1.95 / `1.5.0` rollout as a minor-release MSRV ratchet with
@@ -290,7 +295,7 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 ### Rust Version Support
 
-- **MSRV** (Minimum Supported Rust Version): 1.92
+- **MSRV** (Minimum Supported Rust Version): 1.95
 - **Stable**: Latest stable Rust recommended
 
 ### HL7 Versions Supported

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 [workspace.package]
 version = "1.4.0"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.95"
 
 authors = ["EffortlessMetrics <team@effortlessmetrics.com>"]
 homepage = "https://github.com/EffortlessMetrics/hl7v2-rs"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 # Repo-local Clippy configuration for policy-driven disallowed items only.
+msrv = "1.95"
 #
 # Do not add test carveouts such as `allow-unwrap-in-tests`,
 # `allow-expect-in-tests`, `allow-panic-in-tests`,

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -3,8 +3,10 @@
 This document is the rollout map for moving `hl7v2-rs` from Rust 1.93 to
 Rust 1.95 and preparing the next release as `1.5.0`.
 
-This is a planning and operating document. It does not change the active MSRV,
-toolchain, CI behavior, lint policy, package version, or release state.
+This is a planning and operating document. The initial map PR did not change
+the active MSRV, toolchain, CI behavior, lint policy, package version, or
+release state. The dedicated MSRV PR raises the declared Rust floor and
+toolchain pins without activating new lints or changing runtime behavior.
 
 ## Executive Call
 
@@ -28,11 +30,11 @@ self-describing and better receipted.
 | --- | --- | --- |
 | Rust edition | `2024` | No edition migration is planned. |
 | Workspace version | `1.4.0` | The next release target is `1.5.0`. |
-| Workspace MSRV | `1.93` | Declared in the root `Cargo.toml`. |
-| Toolchain file | absent | Add `rust-toolchain.toml` in the MSRV PR, not here. |
+| Workspace MSRV | `1.95` | Declared in the root `Cargo.toml` after the compatibility probe. |
+| Toolchain file | present | `rust-toolchain.toml` pins Rust `1.95.0` with `rustfmt` and `clippy`. |
 | Root lint policy | strict | Rust and Clippy lints are already governed from the workspace root. |
 | Clippy test carveouts | prohibited | `clippy.toml` explicitly rejects test carveouts. |
-| Clippy policy ledger | present | `policy/clippy-lints.toml` records active lints and planned 1.94/1.95 flips. |
+| Clippy policy ledger | present | `policy/clippy-lints.toml` records MSRV `1.95`, active lints, and planned 1.94/1.95 flips. |
 | Clippy debt ledger | present | `policy/clippy-debt.toml` expires current cleanup debt on 2026-06-30. |
 | Clippy exceptions ledger | absent | Add before deeper suppression governance. |
 | No-panic allowlist | present, empty | Current identity is broad: `path + family + selector`. |
@@ -44,11 +46,6 @@ self-describing and better receipted.
 | Publish workflow | present | `publish.yml` handles crates.io publish execution, but not full 1.5.0 readiness proof. |
 | Release readiness workflow | absent | Add a dedicated readiness workflow before the version bump. |
 | Python publishing | externally blocked | TestPyPI publish remains blocked by issue #563 until Trusted Publisher is configured. |
-
-One stale historical compatibility line remains in `CHANGELOG.md`: an older
-section still says MSRV `1.92` even though the workspace is already `1.93`.
-This rollout records the gap here. The MSRV PR should fix it when it raises
-the declared compatibility line to Rust 1.95.
 
 ## Target State
 
@@ -156,7 +153,5 @@ policy changes, no-panic baseline scope, file-policy scope, CI economics,
 
 - Issue #563 remains the external TestPyPI Trusted Publisher blocker for
   `hl7v2-python`.
-- `CHANGELOG.md` still has a historical MSRV `1.92` compatibility line that
-  should be corrected in the MSRV PR.
 - `publish.yml` exists for crates.io publication, but the dedicated 1.5.0
   readiness workflow and release receipt are still planned.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,5 +1,5 @@
 schema = 1
-msrv = "1.93"
+msrv = "1.95"
 
 [policy]
 panic_free_tests = true

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -96,6 +96,18 @@ reason = "Repo-local Clippy configuration paired with policy/clippy-lints.toml."
 covered_by = ["cargo run -p xtask -- check-lint-policy"]
 
 [[allow]]
+path = "rust-toolchain.toml"
+kind = "toolchain_pin"
+owner = "release/ci"
+surface = "developer-tooling"
+classification = "config"
+reason = "Pins the local and CI-compatible Rust toolchain for the Rust 1.95 MSRV lane."
+covered_by = [
+    "cargo check --workspace --all-targets --all-features --locked",
+    "cargo run -p xtask -- gate --check",
+]
+
+[[allow]]
 path = "tokmd.toml"
 kind = "repo_config"
 owner = "EffortlessMetrics"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
﻿## Summary

- raises the workspace rust-version from Rust 1.93 to Rust 1.95
- adds rust-toolchain.toml pinned to Rust 1.95.0 with rustfmt and clippy
- updates Clippy MSRV metadata, CI MSRV/cache pins, coverage toolchain/cache pins, and the changelog compatibility line
- adds a narrow file-policy allowlist entry for rust-toolchain.toml

## Scope

No Rust source changes, no lint activation, no release version bump, and no publish behavior changes.

## Validation

- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo fmt --all -- --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo check --workspace --all-targets --all-features --locked
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- check-lint-policy
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- check-no-panic-family
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- check-file-policy
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- gate --check
- git diff --check
