### PR TITLE
policy(rust): enable Rust 1.95 compiler lint floor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ unused_must_use = "deny"
 unexpected_cfgs = "warn"
 const_item_interior_mutations = "deny"
 function_casts_as_integer = "deny"
+unused_visibilities = "warn"
 
 [workspace.lints.clippy]
 # Panic-free production and tests

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -59,6 +59,13 @@ class = "numeric-correctness"
 reason = "Surface numeric conversion, comparison, and arithmetic hazards in protocol code."
 
 [[lint]]
+name = "unused_visibilities"
+level = "warn"
+status = "active"
+class = "api-trait-correctness"
+reason = "Keep public and crate-visible API boundaries intentional after the Rust 1.95 MSRV ratchet."
+
+[[lint]]
 name = "clippy::dbg_macro"
 level = "deny"
 status = "active"


### PR DESCRIPTION
﻿## Summary

- enables the Rust compiler unused_visibilities lint at warn level in the workspace lint floor
- records the lint as active in policy/clippy-lints.toml

## Scope

No Clippy ratchets, no source cleanup, no CI workflow changes, and no release version changes.

## Validation

- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo check --workspace --all-targets --all-features --locked
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- check-lint-policy
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- gate --check --only clippy
- git diff --check
