### PR TITLE
policy(clippy): add exception ledger for retained suppressions

### DIFF
--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -105,14 +105,16 @@ fn lookup_generated_table(index: usize) -> &'static str {
 
 - `policy/clippy-lints.toml` is the machine-readable source of truth for active
   lints and planned Rust 1.94/1.95 flips.
-- `policy/clippy-debt.toml` records temporary exceptions with `lint`, `path`,
-  `owner`, `reason`, and `expires`.
+- `policy/clippy-debt.toml` records temporary cleanup debt with `lint`,
+  `path`, `owner`, `reason`, and `expires`.
+- `policy/clippy-exceptions.toml` records retained suppressions that are
+  intentional exceptions rather than broad cleanup debt. Entries must carry an
+  `id`, `lint`, `path`, `selector`, `owner`, `reason`, `covered_by`, and
+  `expires`.
 - `policy/no-panic-allowlist.toml` reserves the semantic path + family +
   selector schema for panic-family exceptions.
 - `policy/non-rust-allowlist.toml` reserves the structured schema for non-Rust
   programming-file exceptions.
-- `policy/clippy-exceptions.toml` is planned for retained suppressions that are
-  not broad cleanup debt.
 - [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) maps current and planned policy
   ledgers without replacing the TOML sources of truth.
 - `clippy.toml` is only for repo-local disallowed methods, types, macros, or
@@ -122,14 +124,12 @@ fn lookup_generated_table(index: usize) -> &'static str {
 
 The Rust 1.95 / 1.5.0 rollout is mapped in
 [development/RUST_1_95_ROLLOUT.md](development/RUST_1_95_ROLLOUT.md). The
-current state remains Rust 2024, workspace version `1.4.0`, and MSRV `1.93`
-until the dedicated MSRV PR changes the manifest, toolchain file, CI labels,
-and policy ledger together.
+current state is Rust 2024, workspace version `1.4.0`, and MSRV `1.95`.
 
 During the rollout, planned Rust 1.94/1.95 lints in
 `policy/clippy-lints.toml` should either become active with clean proof or stay
-planned with an expiring debt receipt. Do not use the MSRV bump as a reason to
-add test carveouts or bare `#[allow(clippy::...)]` suppressions.
+planned with an expiring receipt. Do not use the MSRV bump as a reason to add
+test carveouts or bare `#[allow(clippy::...)]` suppressions.
 
 ## Gate
 
@@ -149,4 +149,4 @@ The gate checks that the workspace MSRV matches the policy ledger, required
 packages inherit workspace lints, staged package rollout is declared, active
 lints match the root manifest, planned 1.94/1.95 lints are still planned until
 the MSRV bump, Clippy test carveouts are absent, and debt entries are complete
-and unexpired.
+and unexpired. It also validates the retained-exceptions ledger shape.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -10,6 +10,7 @@ of truth for exceptions and policy state.
 | --- | --- |
 | `policy/clippy-lints.toml` | Active Rust and Clippy lint policy, staged packages, and planned Rust 1.94/1.95 lint flips. |
 | `policy/clippy-debt.toml` | Temporary cleanup debt that should expire by 2026-06-30. |
+| `policy/clippy-exceptions.toml` | Retained Clippy suppressions, separate from broad cleanup debt. |
 | `policy/no-panic-allowlist.toml` | Panic-family exception ledger; currently empty with broad identity semantics. |
 | `policy/non-rust-allowlist.toml` | Tracked non-Rust file presence ledger. |
 | `policy/ci-lane-whitelist.toml` | Allowed CI lanes, ownership, trigger class, and LEM estimate. |
@@ -23,7 +24,6 @@ govern behavior that does not belong in `policy/non-rust-allowlist.toml`.
 
 | Planned ledger | Purpose |
 | --- | --- |
-| `policy/clippy-exceptions.toml` | Retained Clippy suppressions, separate from broad cleanup debt. |
 | `policy/no-panic-baseline.toml` | Exact counted no-panic baseline for no-new-debt mode. |
 | `policy/generated-allowlist.toml` | Generated artifacts and generators. |
 | `policy/executable-allowlist.toml` | Scripts and executable entrypoints. |

--- a/policy/clippy-exceptions.toml
+++ b/policy/clippy-exceptions.toml
@@ -1,0 +1,17 @@
+schema_version = "1.0"
+policy = "clippy-exceptions"
+owner = "EffortlessMetrics"
+status = "active"
+
+# Retained Clippy suppressions live here when they are intentional exceptions,
+# not broad cleanup debt. Temporary cleanup belongs in policy/clippy-debt.toml.
+#
+# [[exception]]
+# id = "clippy-exception-0001"
+# lint = "clippy::some_lint"
+# path = "crates/hl7v2-cli/src/main.rs"
+# selector = "fn main"
+# owner = "hl7v2-cli"
+# reason = "Specific retained invariant."
+# covered_by = "cargo test -p hl7v2-cli --all-features"
+# expires = "2026-06-30"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -789,6 +789,7 @@ fn check_lint_policy() -> Result<()> {
     let cargo_toml = root.join("Cargo.toml");
     let policy_lints = root.join("policy/clippy-lints.toml");
     let policy_debt = root.join("policy/clippy-debt.toml");
+    let policy_exceptions = root.join("policy/clippy-exceptions.toml");
     let clippy_toml = root.join("clippy.toml");
 
     let cargo_text = fs::read_to_string(&cargo_toml)?;
@@ -844,6 +845,7 @@ fn check_lint_policy() -> Result<()> {
     ensure_no_test_carveouts(&clippy_toml)?;
     ensure_workspace_lint_inheritance(&root, &policy_text)?;
     ensure_debt_receipts(&policy_debt)?;
+    ensure_clippy_exceptions(&policy_exceptions)?;
 
     println!("✅ Lint policy checks passed!");
     Ok(())
@@ -854,6 +856,7 @@ fn policy_report() -> Result<()> {
     let cargo_text = fs::read_to_string(root.join("Cargo.toml"))?;
     let policy_text = fs::read_to_string(root.join("policy/clippy-lints.toml"))?;
     let debt_text = fs::read_to_string(root.join("policy/clippy-debt.toml"))?;
+    let exceptions_text = fs::read_to_string(root.join("policy/clippy-exceptions.toml"))?;
 
     let workspace_msrv = quoted_value_after(&cargo_text, "[workspace.package]", "rust-version")
         .ok_or_else(|| anyhow!("Cargo.toml is missing workspace.package.rust-version"))?;
@@ -870,6 +873,7 @@ fn policy_report() -> Result<()> {
             || anyhow!("policy/clippy-lints.toml is missing rollout.staged_inheriting_packages"),
         )?;
     let debt_count = table_array_entries(&debt_text, "[[debt]]").len();
+    let exception_count = parse_clippy_exceptions(&exceptions_text)?.len();
 
     let no_panic_text = fs::read_to_string(root.join("policy/no-panic-allowlist.toml"))?;
     let no_panic_entries = parse_no_panic_allowlist(&no_panic_text)?;
@@ -893,6 +897,7 @@ fn policy_report() -> Result<()> {
     );
     println!("  Staged packages: {}", staged_packages.join(", "));
     println!("  Debt receipts: {debt_count}");
+    println!("  Retained exceptions: {exception_count}");
     println!();
     println!("No-panic policy");
     println!("  Allowlist entries: {}", no_panic_entries.len());
@@ -1050,6 +1055,78 @@ fn ensure_debt_receipts(policy_debt: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn ensure_clippy_exceptions(policy_exceptions: &Path) -> Result<()> {
+    let text = fs::read_to_string(policy_exceptions)?;
+    for (key, expected) in [
+        ("schema_version", "1.0"),
+        ("policy", "clippy-exceptions"),
+        ("owner", "EffortlessMetrics"),
+        ("status", "active"),
+    ] {
+        let actual = top_level_quoted_value(&text, key)
+            .ok_or_else(|| anyhow!("policy/clippy-exceptions.toml is missing {key}"))?;
+        if actual != expected {
+            return Err(anyhow!(
+                "policy/clippy-exceptions.toml {key} must be {expected}, found {actual}"
+            ));
+        }
+    }
+    parse_clippy_exceptions(&text)?;
+    Ok(())
+}
+
+fn parse_clippy_exceptions(text: &str) -> Result<Vec<String>> {
+    let mut ids = BTreeSet::new();
+    let mut parsed = Vec::new();
+    for (index, entry) in table_array_entries(text, "[[exception]]")
+        .iter()
+        .enumerate()
+    {
+        let entry_number = index
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("clippy exception entry index overflow"))?;
+        for key in [
+            "id",
+            "lint",
+            "path",
+            "selector",
+            "owner",
+            "reason",
+            "covered_by",
+            "expires",
+        ] {
+            if top_level_quoted_value(entry, key).is_none() {
+                return Err(anyhow!(
+                    "policy/clippy-exceptions.toml exception entry {entry_number} is missing required field `{key}`"
+                ));
+            }
+        }
+
+        let id = top_level_quoted_value(entry, "id").ok_or_else(|| {
+            anyhow!("policy/clippy-exceptions.toml exception entry {entry_number} is missing id")
+        })?;
+        if !ids.insert(id.clone()) {
+            return Err(anyhow!(
+                "policy/clippy-exceptions.toml duplicate exception id `{id}`"
+            ));
+        }
+
+        let expires = top_level_quoted_value(entry, "expires").ok_or_else(|| {
+            anyhow!(
+                "policy/clippy-exceptions.toml exception entry {entry_number} is missing expires"
+            )
+        })?;
+        if expires.as_str() < "2026-05-06" {
+            return Err(anyhow!(
+                "policy/clippy-exceptions.toml exception entry {entry_number} expired on {expires}"
+            ));
+        }
+
+        parsed.push(id);
+    }
+    Ok(parsed)
 }
 
 fn parse_workspace_lints(cargo_text: &str) -> BTreeMap<String, String> {


### PR DESCRIPTION
﻿## Summary

- adds policy/clippy-exceptions.toml as the retained Clippy suppression ledger
- validates the exceptions ledger from xtask check-lint-policy
- reports retained exception count from xtask policy-report
- updates Clippy policy docs and the policy ledger map

## Scope

The new ledger starts empty. This PR does not approve any source suppressions, add lint debt, or change runtime behavior.

## Validation

- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo fmt --all -- --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- check-lint-policy
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- policy-report
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo test -p xtask --locked
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 cargo run -p xtask -- check-doc-links
- git diff --check
