### PR TITLE
docs: align current MSRV references with Rust 1.95

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/EffortlessMetrics/hl7v2-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/hl7v2-rs/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/EffortlessMetrics/hl7v2-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/hl7v2-rs)
-[![MSRV](https://img.shields.io/badge/MSRV-1.93-blue.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![License: AGPL-3.0-or-later](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
 Modern Rust HL7v2 Processor

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -152,7 +152,7 @@ jobs succeeded.
 The local policy rail is:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-python-publish-policy
+cargo run -p xtask -- check-python-publish-policy
 ```
 
 It verifies that `pyproject.toml` names the public Python distribution `hl7v2`,
@@ -169,7 +169,7 @@ grant `id-token: write` only on publish jobs, and keep `hl7v2-python` at
 The local documentation-link rail is:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-doc-links
+cargo run -p xtask -- check-doc-links
 ```
 
 It scans tracked and untracked non-ignored Markdown files outside

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -12,7 +12,8 @@ through explicit package inheritance so lint debt is visible instead of hidden.
 - Make UTF-8, string slicing, indexing, and numeric conversion risks visible in
   review before they can affect healthcare message parsing.
 - Require every suppression to carry a narrow, reviewable reason.
-- Track Rust 1.94 and 1.95 lint flips before the MSRV changes.
+- Resolve Rust 1.94 and 1.95 lint flips after the MSRV ratchet without hiding
+  debt.
 
 ## Workspace baseline
 
@@ -147,6 +148,6 @@ cargo run -p xtask -- policy-report
 
 The gate checks that the workspace MSRV matches the policy ledger, required
 packages inherit workspace lints, staged package rollout is declared, active
-lints match the root manifest, planned 1.94/1.95 lints are still planned until
-the MSRV bump, Clippy test carveouts are absent, and debt entries are complete
-and unexpired. It also validates the retained-exceptions ledger shape.
+lints match the root manifest, deferred 1.94/1.95 lints remain planned with
+receipts, Clippy test carveouts are absent, and debt entries are complete and
+unexpired. It also validates the retained-exceptions ledger shape.

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,8 +71,10 @@ proposal, spec, plan, or receipt documents.
 ## Current Boundaries
 
 - `docs/STATUS.md` is the current-state source of truth.
-- `docs/development/RUST_1_95_ROLLOUT.md` is the current rollout map for the
-  planned Rust 1.95 / 1.5.0 lane; it is not an active MSRV declaration.
+- `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, and
+  `policy/clippy-lints.toml` own the active Rust 1.95 MSRV/toolchain state.
+  `docs/development/RUST_1_95_ROLLOUT.md` remains the current rollout map for
+  the remaining 1.5.0 quality-ratchet lane.
 - The v1.4.0 objective audit is a release-snapshot receipt, not proof that the
   full long-range evidence-layer objective is finished.
 - The public Python distribution is `hl7v2`, built from the internal

--- a/docs/guides/python-pypi-release.md
+++ b/docs/guides/python-pypi-release.md
@@ -66,7 +66,7 @@ to the build/smoke job.
 Before using the production workflow, run the local policy rail:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-python-publish-policy
+cargo run -p xtask -- check-python-publish-policy
 ```
 
 Run the **Python PyPI Release Proof** workflow manually with:

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -41,7 +41,7 @@ you want a second human confirmation before upload.
 Run the policy rail before the manual TestPyPI workflow:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-python-publish-policy
+cargo run -p xtask -- check-python-publish-policy
 ```
 
 Then run the local wheel proof:

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -21,7 +21,7 @@ claim tier or proof expectations.
 | Surface | Tier | Proof |
 | --- | --- | --- |
 | Rust parse, validate, normalize, ACK, MLLP, and evidence models | Stable | `cargo test -p hl7v2 --all-features` |
-| Evidence schemas | Stable | `cargo +1.93.0 run -p xtask -- evidence-schema-check` |
+| Evidence schemas | Stable | `cargo run -p xtask -- evidence-schema-check` |
 | CLI evidence commands | Stable | `cargo test -p hl7v2-cli --test integration_tests` |
 | CLI BDD workflows | Stable | `cargo test -p hl7v2-cli --test bdd_tests` |
 | REST evidence sidecar | Stable | `cargo test -p hl7v2-server --test validate_endpoint_test`; `cargo test -p hl7v2-server --test bundle_endpoint_test`; `cargo test -p hl7v2-server --test replay_endpoint_test` |
@@ -31,7 +31,7 @@ claim tier or proof expectations.
 | Python binding local wheel lane | Experimental | `python tests/python_smoke/smoke.py`; `python tests/python_smoke/evidence_workflow_guide.py` after a local wheel install |
 | Python TestPyPI distribution (`hl7v2`) | Blocked | Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563); requires TestPyPI upload and install-back receipt |
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
-| Rust crates.io release graph | Stable | `cargo +1.93.0 run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli` |
+| Rust crates.io release graph | Stable | `cargo run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli` |
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- update the README MSRV badge from 1.93 to the active 1.95 floor
- clarify that `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, and `policy/clippy-lints.toml` own active Rust 1.95 state
- update current docs commands to use the pinned toolchain instead of stale `cargo +1.93.0` examples
- adjust Clippy policy wording now that the MSRV ratchet has landed

## Boundaries

- Docs only.
- No workflow, Cargo, toolchain, policy TOML, or source changes.
- Historical receipts were left untouched where they record older `+1.93.0` evidence.

## Validation

- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- check-lint-policy`
- `cargo run -p xtask -- check-file-policy`
- `cargo run -p xtask -- publish-plan`
- `git diff --check`