### PR TITLE
policy(files): add companion behavior ledgers

### DIFF
--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -96,9 +96,11 @@ Failure modes:
 
 1. Add the file or directory to the working tree.
 2. Add an `[[allow]]` entry to `policy/non-rust-allowlist.toml`.
-3. If the surface is generated, set `classification = "generated"` and add
-   `generated_by` to the entry.
-4. Run `cargo run -p xtask -- check-file-policy` — it must pass.
+3. If the surface has executable, generated, dependency, workflow, process, or
+   network behavior, add or update the matching companion ledger.
+4. If a companion ledger uses a broad path glob, include
+   `broad_glob_reason`.
+5. Run `cargo run -p xtask -- check-file-policy` - it must pass.
 
 ## Removing a surface
 
@@ -112,11 +114,10 @@ files. The file policy governs **which other files are allowed to exist**.
 Together, they keep the repository's surface area small, owned, and
 expiring.
 
-## Companion ledgers target
+## Companion ledgers
 
-The current non-Rust allowlist answers whether a non-Rust file may exist. The
-Rust 1.95 / 1.5.0 rollout should add companion ledgers for behavior that should
-not be hidden inside a broad file-presence exception:
+The non-Rust allowlist answers whether a non-Rust file may exist. Companion
+ledgers answer what behavior those files may perform:
 
 ```text
 policy/generated-allowlist.toml
@@ -126,6 +127,15 @@ policy/workflow-allowlist.toml
 policy/process-allowlist.toml
 policy/network-allowlist.toml
 ```
+
+Each companion ledger uses schema `1.0`, requires at least one `[[allow]]`
+entry, and each entry must include `id`, `owner`, `surface`, `behavior`,
+`reason`, and non-empty `covered_by`. Generated entries also require
+non-empty `generated_by`. The required locator depends on the ledger:
+generated entries use `paths`; executable entries use `paths` or `commands`;
+dependency entries use `paths` or `dependencies`; workflow entries use
+`workflows`; process entries use `commands`; network entries use
+`destinations`.
 
 Use [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) for the map of current and
 planned ledgers. The TOML files remain the source of truth.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -14,6 +14,12 @@ of truth for exceptions and policy state.
 | `policy/no-panic-allowlist.toml` | Panic-family exception ledger; currently empty with exact counted identity semantics. |
 | `policy/no-panic-baseline.toml` | Generated exact counted no-new-debt baseline for current panic-family findings. |
 | `policy/non-rust-allowlist.toml` | Tracked non-Rust file presence ledger. |
+| `policy/generated-allowlist.toml` | Generated artifacts and generators. |
+| `policy/executable-allowlist.toml` | Scripts and executable entrypoints. |
+| `policy/dependency-surface-allowlist.toml` | Non-Rust package manager and tool dependencies. |
+| `policy/workflow-allowlist.toml` | Workflow behavior beyond file presence. |
+| `policy/process-allowlist.toml` | Process execution surfaces. |
+| `policy/network-allowlist.toml` | Network access surfaces. |
 | `policy/ci-lane-whitelist.toml` | Allowed CI lanes, ownership, trigger class, and LEM estimate. |
 | `policy/ci-risk-packs.toml` | Risk-pack routing for CI lanes. |
 | `policy/ci-budget.toml` | CI budget policy. |
@@ -25,17 +31,11 @@ checkout. They are not policy ledgers and should not be committed.
 
 ## Planned Ledgers
 
-The Rust 1.95 / 1.5.0 rollout should add companion ledgers only where they
-govern behavior that does not belong in `policy/non-rust-allowlist.toml`.
+The Rust 1.95 / 1.5.0 rollout should add more companion ledgers only where
+they govern behavior that does not belong in `policy/non-rust-allowlist.toml`.
 
 | Planned ledger | Purpose |
 | --- | --- |
-| `policy/generated-allowlist.toml` | Generated artifacts and generators. |
-| `policy/executable-allowlist.toml` | Scripts and executable entrypoints. |
-| `policy/dependency-surface-allowlist.toml` | Non-Rust package manager and tool dependencies. |
-| `policy/workflow-allowlist.toml` | Workflow behavior beyond file presence. |
-| `policy/process-allowlist.toml` | Process execution surfaces. |
-| `policy/network-allowlist.toml` | Network access surfaces. |
 | `policy/ripr-suppressions.toml` | Advisory static mutation-exposure suppressions after `ripr` lands. |
 
 ## Rules
@@ -44,8 +44,8 @@ govern behavior that does not belong in `policy/non-rust-allowlist.toml`.
 - Broad globs need a concrete reason.
 - Production OpenAPI, protobuf, schema, profile, and publishing surfaces need
   a real `covered_by` command or workflow.
-- Python, Node, Go, Docker, shell, process, and network behavior should move
-  to companion policies when those policies exist.
+- Python, Node, Go, Docker, shell, process, and network behavior belongs in
+  companion policies instead of broad file-presence entries.
 - `policy/non-rust-allowlist.toml` answers "may this file exist?" Companion
   ledgers answer "what behavior may this file perform?"
 - Exceptions must be owned, reviewable, and expiring unless they are permanent

--- a/policy/dependency-surface-allowlist.toml
+++ b/policy/dependency-surface-allowlist.toml
@@ -1,0 +1,52 @@
+schema_version = "1.0"
+policy = "dependency-surface-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-13"
+
+# Dependency surfaces are governed separately from file presence so package
+# managers and external toolchains remain reviewable.
+
+[[allow]]
+id = "rust-toolchain"
+owner = "release/ci"
+surface = "rust-msrv"
+behavior = "The repository may pin Rust 1.95.0 with rustfmt and clippy components."
+paths = ["rust-toolchain.toml", "Cargo.toml", "Cargo.lock"]
+dependencies = ["rustc 1.95.0", "rustfmt", "clippy"]
+reason = "Rust 1.95 is the declared MSRV and release support boundary."
+covered_by = ["cargo run -p xtask -- gate --check"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "python-maturin"
+owner = "hl7v2-python"
+surface = "python-binding"
+behavior = "The Python distribution may use maturin/PyO3 build metadata while keeping the Rust binding crate unpublished to crates.io."
+paths = ["pyproject.toml", "crates/hl7v2-python/Cargo.toml"]
+dependencies = ["maturin", "pyo3"]
+reason = "Python wheels are built from the internal PyO3 crate and published only through Python workflows."
+covered_by = [".github/workflows/python-wheels.yml", ".github/workflows/python-testpypi.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "contract-toolchain"
+owner = "api"
+surface = "contracts"
+behavior = "The contracts workflow may install OpenAPI, schema, and protobuf validation tools."
+paths = [".github/workflows/contracts.yml", ".spectral.yml"]
+dependencies = ["@stoplight/spectral-cli", "@redocly/cli", "ajv-cli", "ajv-formats", "buf"]
+reason = "Contract validation needs external linters for OpenAPI, JSON Schema, and protobuf compatibility."
+covered_by = [".github/workflows/contracts.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "security-audit-tooling"
+owner = "release/ci"
+surface = "security"
+behavior = "Security policy may depend on cargo-deny advisory and license checks."
+paths = ["deny.toml"]
+dependencies = ["cargo-deny", "RustSec advisory database"]
+reason = "Dependency and license gates require an explicit audit tool surface."
+covered_by = ["cargo run -p xtask -- audit"]
+review_after = "2026-06-30"

--- a/policy/executable-allowlist.toml
+++ b/policy/executable-allowlist.toml
@@ -1,0 +1,58 @@
+schema_version = "1.0"
+policy = "executable-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-13"
+
+# Executable entrypoints must be owned and covered by a proof command. This
+# ledger describes what may execute; non-rust-allowlist describes file presence.
+
+[[allow]]
+id = "git-hooks"
+owner = "release/ci"
+surface = "developer-tooling"
+behavior = "Repository git hooks may delegate pre-commit and pre-push checks to xtask."
+paths = [".githooks/*"]
+commands = ["cargo run -p xtask -- hook-pre-commit", "cargo run -p xtask -- hook-pre-push"]
+broad_glob_reason = "The directory contains the versioned hook entrypoints installed by `just setup`."
+reason = "Hooks keep local policy checks aligned with CI without adding a new language runtime."
+covered_by = ["cargo run -p xtask -- hook-pre-commit", "cargo run -p xtask -- hook-pre-push"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "just-and-cargo-make"
+owner = "EffortlessMetrics"
+surface = "developer-tooling"
+behavior = "Task-runner files may invoke repository setup and validation commands."
+paths = ["justfile", "Makefile.toml"]
+commands = ["just setup", "cargo make"]
+reason = "These are local convenience entrypoints around governed xtask and Cargo commands."
+covered_by = ["cargo run -p xtask -- check-file-policy"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "python-smoke-scripts"
+owner = "hl7v2-python"
+surface = "python-binding"
+behavior = "Python smoke scripts may import the built `hl7v2` module and verify evidence workflow behavior."
+paths = ["tests/python_smoke/*.py"]
+commands = [
+  "python tests/python_smoke/smoke.py",
+  "python tests/python_smoke/evidence_workflow_guide.py",
+]
+broad_glob_reason = "The smoke directory is intentionally limited to Python proof scripts for the separate Python distribution lane."
+reason = "The Python binding lane needs install-back and workflow smoke scripts outside Rust source."
+covered_by = [".github/workflows/python-wheels.yml", ".github/workflows/python-testpypi.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "script-tree"
+owner = "release/ci"
+surface = "developer-tooling"
+behavior = "Repository scripts may run local CI and test helper commands when routed through reviewed script directories."
+paths = ["scripts/**"]
+commands = ["cargo run -p xtask -- check-file-policy"]
+broad_glob_reason = "The scripts tree is split by reviewed subdirectories and remains covered by file-policy presence checks."
+reason = "Some CI and test helper entrypoints live outside Cargo for platform interoperability."
+covered_by = ["cargo run -p xtask -- check-file-policy"]
+review_after = "2026-06-30"

--- a/policy/generated-allowlist.toml
+++ b/policy/generated-allowlist.toml
@@ -1,0 +1,31 @@
+schema_version = "1.0"
+policy = "generated-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-13"
+
+# Generated artifacts are allowed only when the generator and proof command are
+# explicit. This ledger governs generated behavior; non-rust-allowlist governs
+# whether the file may exist.
+
+[[allow]]
+id = "no-panic-baseline"
+owner = "release/ci"
+surface = "panic-policy"
+behavior = "The no-panic no-new-debt baseline is generated from current panic-family findings and refreshed only by the dedicated baseline command."
+paths = ["policy/no-panic-baseline.toml"]
+generated_by = ["cargo run -p xtask -- no-panic baseline --reset"]
+reason = "The baseline is a generated policy receipt, not hand-written source."
+covered_by = ["cargo run -p xtask -- check-no-panic-family"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "cargo-metadata-snapshot"
+owner = "EffortlessMetrics"
+surface = "review-tooling"
+behavior = "Cargo metadata snapshots may be checked in when used as review evidence or tooling input."
+paths = ["metadata.json"]
+generated_by = ["cargo metadata --format-version=1 --all-features"]
+reason = "The snapshot records workspace package metadata for review tooling."
+covered_by = ["cargo metadata --format-version=1 --all-features"]
+review_after = "2026-06-30"

--- a/policy/network-allowlist.toml
+++ b/policy/network-allowlist.toml
@@ -1,0 +1,63 @@
+schema_version = "1.0"
+policy = "network-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-13"
+
+# Network access is explicit because publish, package-manager, coverage, and
+# contract tooling boundaries are release-sensitive.
+
+[[allow]]
+id = "github-actions-and-api"
+owner = "release/ci"
+surface = "ci"
+behavior = "GitHub Actions jobs may call GitHub APIs and download workflow dependencies for repository-owned checks."
+destinations = ["github.com", "api.github.com", "objects.githubusercontent.com"]
+reason = "CI orchestration, workflow status, and action downloads depend on GitHub network endpoints."
+covered_by = ["cargo run -p xtask -- check-ci-lane-whitelist"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "rust-registry-and-advisories"
+owner = "release/ci"
+surface = "rust-workspace"
+behavior = "Cargo and security checks may access the Rust registry index, crate downloads, and advisory data."
+destinations = ["crates.io", "index.crates.io", "static.crates.io", "github.com/RustSec/advisory-db"]
+reason = "Build, lockfile, and advisory proof need the Rust package ecosystem."
+covered_by = ["cargo run -p xtask -- audit", "cargo run -p xtask -- gate --check"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "python-package-indexes"
+owner = "hl7v2-python"
+surface = "python-binding"
+behavior = "Python proof workflows may publish to and install back from TestPyPI/PyPI using Trusted Publishing only."
+destinations = [
+  "test.pypi.org",
+  "upload.pypi.org",
+  "pypi.org",
+  "files.pythonhosted.org",
+]
+reason = "Python release proof requires upload and install-back receipts for the public `hl7v2` distribution."
+covered_by = ["cargo run -p xtask -- check-python-publish-policy"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "coverage-upload"
+owner = "release/ci"
+surface = "ci"
+behavior = "Coverage workflows may upload bounded coverage receipts to Codecov."
+destinations = ["codecov.io", "uploader.codecov.io"]
+reason = "Coverage evidence is advisory/routed and needs an external dashboard upload."
+covered_by = [".github/workflows/coverage.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "contract-tool-downloads"
+owner = "api"
+surface = "contracts"
+behavior = "Contract validation workflows may download Node, Go, npm, and buf tooling."
+destinations = ["registry.npmjs.org", "proxy.golang.org", "buf.build", "github.com"]
+reason = "OpenAPI, protobuf, and schema validation use external contract tooling."
+covered_by = [".github/workflows/contracts.yml"]
+review_after = "2026-06-30"

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -194,7 +194,7 @@ kind = "policy_data"
 owner = "EffortlessMetrics"
 surface = "ci"
 classification = "config"
-reason = "Lint policy, debt receipts, panic-family and file-policy allowlists."
+reason = "Lint policy, debt receipts, panic-family ledgers, file-presence allowlists, and companion behavior ledgers."
 covered_by = [
   "cargo run -p xtask -- check-lint-policy",
   "cargo run -p xtask -- check-no-panic-family",

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -1,0 +1,59 @@
+schema_version = "1.0"
+policy = "process-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-13"
+
+# Process execution is governed separately from script/config file presence.
+
+[[allow]]
+id = "cargo-and-xtask"
+owner = "release/ci"
+surface = "rust-workspace"
+behavior = "Cargo and xtask may run formatting, lint, test, policy, schema, publish-plan, and publish-dry-run checks."
+commands = [
+  "cargo fmt",
+  "cargo check",
+  "cargo clippy",
+  "cargo test",
+  "cargo run -p xtask -- gate --check",
+  "cargo run -p xtask -- policy-report",
+]
+reason = "Rust/Cargo and xtask are the primary governed process surface."
+covered_by = ["cargo run -p xtask -- gate --check"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "python-wheel-proof"
+owner = "hl7v2-python"
+surface = "python-binding"
+behavior = "Python and maturin may build, install, and smoke-test the `hl7v2` distribution."
+commands = [
+  "python -m pip install",
+  "maturin build",
+  "python tests/python_smoke/smoke.py",
+  "python tests/python_smoke/evidence_workflow_guide.py",
+]
+reason = "Python release proof requires wheel build/install/import validation."
+covered_by = [".github/workflows/python-wheels.yml", ".github/workflows/python-testpypi.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "contract-tool-processes"
+owner = "api"
+surface = "contracts"
+behavior = "Node, AJV, Redocly, Spectral, and buf may run contract validation inside the contracts workflow."
+commands = ["npm install -g", "npx", "ajv", "redocly", "spectral", "buf"]
+reason = "OpenAPI, protobuf, and schema contracts need ecosystem-native validators."
+covered_by = [".github/workflows/contracts.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "container-smoke"
+owner = "platform"
+surface = "deployment"
+behavior = "Docker compose may render and smoke-check deployment sidecar configuration."
+commands = ["docker compose -f infrastructure/docker/docker-compose.yml config"]
+reason = "Deployment proof needs container configuration validation without making Docker a default PR tax."
+covered_by = ["docker compose -f infrastructure/docker/docker-compose.yml config"]
+review_after = "2026-06-30"

--- a/policy/workflow-allowlist.toml
+++ b/policy/workflow-allowlist.toml
@@ -1,0 +1,68 @@
+schema_version = "1.0"
+policy = "workflow-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-13"
+
+# Workflow behavior is governed separately from YAML file presence.
+
+[[allow]]
+id = "default-ci"
+owner = "release/ci"
+surface = "ci"
+behavior = "Default CI may run fast checks, standard checks, MSRV smoke, routed matrix/extended lanes, and the aggregate CI success job."
+workflows = [".github/workflows/ci.yml"]
+reason = "The staged CI layout keeps default PR proof useful without making expensive lanes an unconditional tax."
+covered_by = ["cargo run -p xtask -- check-ci-lane-whitelist", "cargo run -p xtask -- gate --check"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "coverage-and-security"
+owner = "release/ci"
+surface = "ci"
+behavior = "Coverage and security workflows may run routed advisory proof and upload bounded receipts."
+workflows = [".github/workflows/coverage.yml", ".github/workflows/security.yml"]
+reason = "Coverage and security evidence are routed separately from default CI cost."
+covered_by = ["cargo run -p xtask -- check-ci-lane-whitelist", "cargo run -p xtask -- policy-report"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "contract-validation"
+owner = "api"
+surface = "contracts"
+behavior = "Contract workflows may validate OpenAPI, protobuf, JSON Schema, and evidence fixture compatibility."
+workflows = [".github/workflows/contracts.yml"]
+reason = "Server, CLI, Python, and evidence surfaces rely on stable contract artifacts."
+covered_by = [".github/workflows/contracts.yml", "cargo run -p xtask -- evidence-schema-check"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "python-distribution"
+owner = "hl7v2-python"
+surface = "python-binding"
+behavior = "Python workflows may build wheels, run smoke checks, and publish only through guarded TestPyPI/PyPI proof workflows."
+workflows = [
+  ".github/workflows/python-wheels.yml",
+  ".github/workflows/python-testpypi.yml",
+  ".github/workflows/python-pypi.yml",
+]
+reason = "The public Python distribution is separate from the Rust crates.io publish graph."
+covered_by = ["cargo run -p xtask -- check-python-publish-policy"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "release-and-agent-planning"
+owner = "release/ci"
+surface = "release"
+behavior = "Release, PR planning, nightly, and agent workflows may produce readiness or coordination receipts without broadening default CI."
+workflows = [
+  ".github/workflows/publish.yml",
+  ".github/workflows/pr-plan.yml",
+  ".github/workflows/pr-gate.yml",
+  ".github/workflows/nightly.yml",
+  ".github/workflows/droid.yml",
+  ".github/workflows/server-smoke.yml",
+]
+reason = "Release and agent coordination need explicit workflows but should remain routed by intent and policy."
+covered_by = ["cargo run -p xtask -- check-ci-lane-whitelist", "cargo run -p xtask -- policy-report"]
+review_after = "2026-06-30"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -893,6 +893,7 @@ fn policy_report() -> Result<()> {
     );
     let file_policy_text = fs::read_to_string(root.join("policy/non-rust-allowlist.toml"))?;
     let file_policy_entries = parse_file_policy_allowlist(&file_policy_text)?;
+    let companion_policy_summary = check_companion_policy_ledgers(&root)?;
 
     let metadata = MetadataCommand::new().current_dir(&root).exec()?;
     let strict_units = collect_rust_files_for(&root, &metadata, &required_packages)?;
@@ -970,6 +971,10 @@ fn policy_report() -> Result<()> {
     println!(
         "  Non-Rust allowlist entries: {}",
         file_policy_entries.len()
+    );
+    println!(
+        "  Companion ledgers: {} ledger(s), {} allow entr(ies)",
+        companion_policy_summary.ledgers, companion_policy_summary.entries
     );
     Ok(())
 }
@@ -3650,6 +3655,32 @@ struct FilePolicyEntry {
     retired: bool,
 }
 
+#[derive(Debug)]
+#[expect(
+    dead_code,
+    reason = "companion entries are parsed for schema validation and policy-report counts"
+)]
+struct CompanionPolicyEntry {
+    id: String,
+    owner: String,
+    surface: String,
+    behavior: String,
+    reason: String,
+    covered_by: Vec<String>,
+}
+
+struct CompanionPolicySpec {
+    path: &'static str,
+    policy: &'static str,
+    required_locator: &'static [&'static str],
+}
+
+#[derive(Clone, Copy)]
+struct CompanionPolicyLedgerSummary {
+    ledgers: usize,
+    entries: usize,
+}
+
 const FILE_POLICY_CLASSIFICATIONS: &[&str] = &[
     "production",
     "test",
@@ -3659,12 +3690,46 @@ const FILE_POLICY_CLASSIFICATIONS: &[&str] = &[
     "docs",
 ];
 
+const COMPANION_POLICY_SPECS: &[CompanionPolicySpec] = &[
+    CompanionPolicySpec {
+        path: "policy/generated-allowlist.toml",
+        policy: "generated-allowlist",
+        required_locator: &["paths"],
+    },
+    CompanionPolicySpec {
+        path: "policy/executable-allowlist.toml",
+        policy: "executable-allowlist",
+        required_locator: &["paths", "commands"],
+    },
+    CompanionPolicySpec {
+        path: "policy/dependency-surface-allowlist.toml",
+        policy: "dependency-surface-allowlist",
+        required_locator: &["paths", "dependencies"],
+    },
+    CompanionPolicySpec {
+        path: "policy/workflow-allowlist.toml",
+        policy: "workflow-allowlist",
+        required_locator: &["workflows"],
+    },
+    CompanionPolicySpec {
+        path: "policy/process-allowlist.toml",
+        policy: "process-allowlist",
+        required_locator: &["commands"],
+    },
+    CompanionPolicySpec {
+        path: "policy/network-allowlist.toml",
+        policy: "network-allowlist",
+        required_locator: &["destinations"],
+    },
+];
+
 fn check_file_policy() -> Result<()> {
     println!("🔎 Checking non-Rust file policy...");
     let root = env::current_dir()?;
     let allowlist_text = fs::read_to_string(root.join("policy/non-rust-allowlist.toml"))?;
     let entries = parse_file_policy_allowlist(&allowlist_text)?;
     enforce_file_policy_expirations(&entries)?;
+    let companion_summary = check_companion_policy_ledgers(&root)?;
 
     let tracked = git_output(&["ls-files", "--cached", "--others", "--exclude-standard"])?;
     let files = file_policy_inventory_from_git_listing(&tracked);
@@ -3729,9 +3794,10 @@ fn check_file_policy() -> Result<()> {
     }
 
     println!(
-        "✅ file policy: {} tracked/untracked non-ignored file(s) checked, {} allowlist entr(ies)",
+        "✅ file policy: {} tracked/untracked non-ignored file(s) checked, {} allowlist entr(ies), {} companion ledger entr(ies)",
         files.len(),
-        entries.len()
+        entries.len(),
+        companion_summary.entries
     );
     Ok(())
 }
@@ -4254,6 +4320,148 @@ fn parse_file_policy_allowlist(text: &str) -> Result<Vec<FilePolicyEntry>> {
         });
     }
     Ok(parsed)
+}
+
+fn check_companion_policy_ledgers(root: &Path) -> Result<CompanionPolicyLedgerSummary> {
+    let mut entries = 0usize;
+    for spec in COMPANION_POLICY_SPECS {
+        let text = fs::read_to_string(root.join(spec.path))?;
+        let parsed = parse_companion_policy_ledger(spec, &text)?;
+        entries = entries.saturating_add(parsed.len());
+    }
+    Ok(CompanionPolicyLedgerSummary {
+        ledgers: COMPANION_POLICY_SPECS.len(),
+        entries,
+    })
+}
+
+fn parse_companion_policy_ledger(
+    spec: &CompanionPolicySpec,
+    text: &str,
+) -> Result<Vec<CompanionPolicyEntry>> {
+    let schema_version = top_level_quoted_value(text, "schema_version")
+        .ok_or_else(|| anyhow!("{} is missing `schema_version`", spec.path))?;
+    if schema_version != "1.0" {
+        return Err(anyhow!(
+            "{} schema_version must be `1.0`, found `{schema_version}`",
+            spec.path
+        ));
+    }
+
+    let policy = top_level_quoted_value(text, "policy")
+        .ok_or_else(|| anyhow!("{} is missing `policy`", spec.path))?;
+    if policy != spec.policy {
+        return Err(anyhow!(
+            "{} policy must be `{}`, found `{policy}`",
+            spec.path,
+            spec.policy
+        ));
+    }
+
+    for key in ["owner", "status"] {
+        if top_level_quoted_value(text, key).is_none() {
+            return Err(anyhow!("{} is missing `{key}`", spec.path));
+        }
+    }
+
+    let entries = table_array_entries(text, "[[allow]]");
+    if entries.is_empty() {
+        return Err(anyhow!(
+            "{} must contain at least one [[allow]] entry",
+            spec.path
+        ));
+    }
+
+    let mut parsed = Vec::with_capacity(entries.len());
+    let mut ids = BTreeSet::new();
+    for (index, raw) in entries.iter().enumerate() {
+        let entry_no = index
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("{} entry index overflow", spec.path))?;
+        let field = |key: &str| -> Result<String> {
+            top_level_quoted_value(raw, key).ok_or_else(|| {
+                anyhow!(
+                    "{} entry {entry_no} is missing required field `{key}`",
+                    spec.path
+                )
+            })
+        };
+        let id = field("id")?;
+        if !ids.insert(id.clone()) {
+            return Err(anyhow!("{} duplicates allow entry id `{id}`", spec.path));
+        }
+        let owner = field("owner")?;
+        let surface = field("surface")?;
+        let behavior = field("behavior")?;
+        let reason = field("reason")?;
+        let covered_by = string_array_after_root(raw, "covered_by").unwrap_or_default();
+        if covered_by.is_empty() {
+            return Err(anyhow!(
+                "{} entry {id} must set non-empty `covered_by`",
+                spec.path
+            ));
+        }
+
+        let mut has_locator = false;
+        for key in spec.required_locator {
+            if !string_array_after_root(raw, key)
+                .unwrap_or_default()
+                .is_empty()
+            {
+                has_locator = true;
+            }
+        }
+        if !has_locator {
+            return Err(anyhow!(
+                "{} entry {id} must set at least one of: {}",
+                spec.path,
+                spec.required_locator.join(", ")
+            ));
+        }
+        if spec.policy == "generated-allowlist"
+            && string_array_after_root(raw, "generated_by")
+                .unwrap_or_default()
+                .is_empty()
+        {
+            return Err(anyhow!(
+                "{} entry {id} must set non-empty `generated_by`",
+                spec.path
+            ));
+        }
+
+        if companion_entry_has_broad_path_glob(raw)
+            && top_level_quoted_value(raw, "broad_glob_reason").is_none()
+        {
+            return Err(anyhow!(
+                "{} entry {id} uses a broad path glob and must set `broad_glob_reason`",
+                spec.path
+            ));
+        }
+
+        for key in ["review_after", "expires"] {
+            if let Some(value) = top_level_quoted_value(raw, key) {
+                parse_ci_date(&value, &format!("{} entry {id} {key}", spec.path))?;
+            }
+        }
+
+        parsed.push(CompanionPolicyEntry {
+            id,
+            owner,
+            surface,
+            behavior,
+            reason,
+            covered_by,
+        });
+    }
+
+    Ok(parsed)
+}
+
+fn companion_entry_has_broad_path_glob(raw: &str) -> bool {
+    string_array_after_root(raw, "paths")
+        .unwrap_or_default()
+        .iter()
+        .any(|path| path.contains('*'))
 }
 
 fn enforce_file_policy_expirations(entries: &[FilePolicyEntry]) -> Result<()> {
@@ -6479,6 +6687,120 @@ docs\\README.md
                 "{path} must require a non-rust-allowlist entry"
             );
         }
+    }
+
+    #[test]
+    fn companion_policy_validates_common_schema() -> Result<()> {
+        let spec = CompanionPolicySpec {
+            path: "policy/generated-allowlist.toml",
+            policy: "generated-allowlist",
+            required_locator: &["paths"],
+        };
+        let text = r#"
+schema_version = "1.0"
+policy = "generated-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+
+[[allow]]
+id = "generated-baseline"
+owner = "release/ci"
+surface = "panic-policy"
+behavior = "Generated no-new-debt baseline may be refreshed only by the dedicated baseline command."
+paths = ["policy/no-panic-baseline.toml"]
+generated_by = ["cargo run -p xtask -- no-panic baseline --reset"]
+reason = "The baseline is a generated policy receipt, not hand-written prose."
+covered_by = ["cargo run -p xtask -- check-no-panic-family"]
+review_after = "2026-06-30"
+"#;
+
+        let entries = parse_companion_policy_ledger(&spec, text)?;
+        if entries.len() != 1 {
+            return Err(anyhow!("expected one companion entry"));
+        }
+        let first = entries
+            .first()
+            .ok_or_else(|| anyhow!("expected first companion entry"))?;
+        if first.id != "generated-baseline" {
+            return Err(anyhow!(
+                "expected generated-baseline entry id, found {}",
+                first.id
+            ));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn companion_policy_rejects_duplicate_ids() -> Result<()> {
+        let spec = CompanionPolicySpec {
+            path: "policy/process-allowlist.toml",
+            policy: "process-allowlist",
+            required_locator: &["commands"],
+        };
+        let text = r#"
+schema_version = "1.0"
+policy = "process-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+
+[[allow]]
+id = "cargo"
+owner = "release/ci"
+surface = "build"
+behavior = "Cargo may run repository checks."
+commands = ["cargo check"]
+reason = "Rust build system."
+covered_by = ["cargo check --workspace"]
+
+[[allow]]
+id = "cargo"
+owner = "release/ci"
+surface = "build"
+behavior = "Cargo may run repository tests."
+commands = ["cargo test"]
+reason = "Rust test system."
+covered_by = ["cargo test --workspace"]
+"#;
+
+        let Err(err) = parse_companion_policy_ledger(&spec, text) else {
+            return Err(anyhow!("duplicate companion policy id should fail"));
+        };
+        if !err.to_string().contains("duplicates allow entry id") {
+            return Err(anyhow!("unexpected duplicate-id error: {err}"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn companion_policy_requires_broad_glob_reason() -> Result<()> {
+        let spec = CompanionPolicySpec {
+            path: "policy/executable-allowlist.toml",
+            policy: "executable-allowlist",
+            required_locator: &["paths"],
+        };
+        let text = r#"
+schema_version = "1.0"
+policy = "executable-allowlist"
+owner = "EffortlessMetrics"
+status = "active"
+
+[[allow]]
+id = "scripts"
+owner = "release/ci"
+surface = "developer-tooling"
+behavior = "Scripts may execute local validation helpers."
+paths = ["scripts/**"]
+reason = "Scripts are owned tooling entrypoints."
+covered_by = ["cargo run -p xtask -- check-file-policy"]
+"#;
+
+        let Err(err) = parse_companion_policy_ledger(&spec, text) else {
+            return Err(anyhow!("broad path glob should require a reason"));
+        };
+        if !err.to_string().contains("broad path glob") {
+            return Err(anyhow!("unexpected broad-glob error: {err}"));
+        }
+        Ok(())
     }
 
     // ---- panic-family scanning ------------------------------------------


### PR DESCRIPTION
## Summary

- Adds generated, executable, dependency-surface, workflow, process, and network companion policy ledgers.
- Extends `xtask check-file-policy` and `policy-report` to validate companion ledger schema, required proof, locators, duplicate IDs, dates, generated_by, and broad path glob reasons.
- Updates file-policy docs so `non-rust-allowlist` owns file presence while companion ledgers own behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p xtask --all-targets --locked -- -D warnings`
- `cargo test -p xtask --locked`
- `cargo run -p xtask -- check-file-policy`
- `cargo run -p xtask -- policy-report`
- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- check-lint-policy`
- `git diff --check`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 CARGO_INCREMENTAL=0 cargo run -p xtask -- gate --check --changed`