### PR TITLE
ci(ripr): add advisory static mutation-exposure lane

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -1,0 +1,107 @@
+name: ripr
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "xtask/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "ripr.toml"
+      - "policy/ripr-suppressions.toml"
+      - ".github/workflows/ripr.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ripr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
+jobs:
+  ripr:
+    name: ripr
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install ripr
+        run: cargo install ripr --version 0.5.0 --locked
+
+      - name: Run advisory ripr analysis
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          BASE_REF="${BASE_REF:-main}"
+          mkdir -p target/ripr
+          git fetch origin "$BASE_REF" --depth=50
+
+          set +e
+          ripr doctor --root . > target/ripr/doctor.txt 2>&1
+          doctor_status=$?
+
+          ripr check --root . --base "origin/$BASE_REF" --mode draft --format json \
+            > target/ripr/ripr.json
+          json_status=$?
+
+          ripr check --root . --base "origin/$BASE_REF" --mode draft --format sarif \
+            > target/ripr/ripr.sarif
+          sarif_status=$?
+
+          ripr check --root . --base "origin/$BASE_REF" --mode draft --format github \
+            > target/ripr/ripr.github.txt
+          github_status=$?
+
+          {
+            echo "## ripr advisory static mutation-exposure"
+            echo
+            echo "| Step | Exit status |"
+            echo "| --- | ---: |"
+            echo "| doctor | $doctor_status |"
+            echo "| json | $json_status |"
+            echo "| sarif | $sarif_status |"
+            echo "| github annotation text | $github_status |"
+            echo
+            echo "This lane is advisory. It shifts mutation-exposure signal left but does not replace runtime mutation testing."
+            echo
+            echo "### GitHub annotation output"
+            echo
+            echo '```text'
+            if [ -s target/ripr/ripr.github.txt ]; then
+              sed -n '1,80p' target/ripr/ripr.github.txt
+            else
+              echo "No ripr annotation output was produced."
+            fi
+            echo '```'
+          } > target/ripr/ripr.md
+
+          cat target/ripr/ripr.md >> "$GITHUB_STEP_SUMMARY"
+
+          exit 0
+
+      - name: Upload ripr artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ripr-advisory
+          path: |
+            target/ripr/doctor.txt
+            target/ripr/ripr.json
+            target/ripr/ripr.sarif
+            target/ripr/ripr.md
+            target/ripr/ripr.github.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -20,6 +20,7 @@ of truth for exceptions and policy state.
 | `policy/workflow-allowlist.toml` | Workflow behavior beyond file presence. |
 | `policy/process-allowlist.toml` | Process execution surfaces. |
 | `policy/network-allowlist.toml` | Network access surfaces. |
+| `policy/ripr-suppressions.toml` | Advisory static mutation-exposure suppressions. |
 | `policy/ci-lane-whitelist.toml` | Allowed CI lanes, ownership, trigger class, and LEM estimate. |
 | `policy/ci-risk-packs.toml` | Risk-pack routing for CI lanes. |
 | `policy/ci-budget.toml` | CI budget policy. |
@@ -36,7 +37,7 @@ they govern behavior that does not belong in `policy/non-rust-allowlist.toml`.
 
 | Planned ledger | Purpose |
 | --- | --- |
-| `policy/ripr-suppressions.toml` | Advisory static mutation-exposure suppressions after `ripr` lands. |
+| None currently. | Add only when a behavior cannot be governed by an existing ledger. |
 
 ## Rules
 

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -1,7 +1,6 @@
 # ripr Static Mutation-Exposure Lane
 
-`ripr` is planned as an advisory PR-time static mutation-exposure lane for
-`hl7v2-rs`.
+`ripr` is an advisory PR-time static mutation-exposure lane for `hl7v2-rs`.
 
 ## Doctrine
 
@@ -15,9 +14,9 @@ Mutation testing remains the slower runtime backstop for what static analysis
 cannot prove. `ripr` shifts mutation signal left; it does not make mutation
 testing unnecessary.
 
-## Planned Role
+## Current Role
 
-The initial lane should be advisory:
+The initial lane is advisory:
 
 - run on pull requests touching Rust code, `xtask`, Cargo files, `ripr.toml`,
   or the `ripr` policy ledger;
@@ -41,7 +40,7 @@ continues to cover what static analysis cannot prove.
 - Do not hide skipped mutation lanes as passed.
 - Do not add suppressions without ownership and review.
 
-## Planned Artifacts
+## Artifacts
 
 ```text
 .github/workflows/ripr.yml
@@ -51,3 +50,8 @@ target/ripr/ripr.json
 target/ripr/ripr.sarif
 target/ripr/ripr.md
 ```
+
+The workflow installs `ripr` 0.5.0 with Cargo, runs `ripr doctor`, renders
+`ripr check` in `json`, `sarif`, and `github` formats, and wraps the advisory
+status in `target/ripr/ripr.md`. It uploads the artifacts as `ripr-advisory`
+and exits successfully even when the advisory analysis returns findings.

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -178,6 +178,30 @@ review_after = "2026-06-09"
 expires = "2026-11-09"
 
 # ---------------------------------------------------------------------------
+# ripr_static_exposure -- advisory static mutation-exposure lane
+# ---------------------------------------------------------------------------
+[[lane]]
+id = "ripr_static_exposure"
+workflow = ".github/workflows/ripr.yml"
+job = "ripr"
+display_name = "ripr"
+kind = "static-analysis"
+tier = "advisory"
+default_pr = true
+blocking = false
+runner = "ubuntu_latest"
+base_lem = 5
+owner = "release/ci"
+intent = "Run advisory static mutation-exposure analysis for Rust-relevant PR changes."
+failure_mode = "Weak test-oracle exposure reaches review without a cheap static signal."
+proof_obligation = "Upload ripr doctor, JSON, SARIF, and markdown artifacts."
+evidence = ["ripr-advisory artifact", "job summary"]
+allowed_triggers = ["pull_request", "workflow_dispatch"]
+duplicate_of = []
+review_after = "2026-06-09"
+expires = "2026-11-09"
+
+# ---------------------------------------------------------------------------
 # coverage — Execution surface evidence (main/label only)
 # ---------------------------------------------------------------------------
 [[lane]]

--- a/policy/dependency-surface-allowlist.toml
+++ b/policy/dependency-surface-allowlist.toml
@@ -50,3 +50,14 @@ dependencies = ["cargo-deny", "RustSec advisory database"]
 reason = "Dependency and license gates require an explicit audit tool surface."
 covered_by = ["cargo run -p xtask -- audit"]
 review_after = "2026-06-30"
+
+[[allow]]
+id = "ripr-static-exposure"
+owner = "release/ci"
+surface = "ci"
+behavior = "The advisory ripr workflow may install ripr 0.5.0 as the PR-time static mutation-exposure tool."
+paths = [".github/workflows/ripr.yml", "ripr.toml", "policy/ripr-suppressions.toml"]
+dependencies = ["ripr 0.5.0"]
+reason = "ripr shifts mutation-exposure signal left without adding runtime mutation to ordinary PRs."
+covered_by = [".github/workflows/ripr.yml"]
+review_after = "2026-06-30"

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -108,6 +108,15 @@ covered_by = [
 ]
 
 [[allow]]
+path = "ripr.toml"
+kind = "static_analysis_config"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "Configuration for the advisory ripr static mutation-exposure lane."
+covered_by = [".github/workflows/ripr.yml", "cargo run -p xtask -- check-file-policy"]
+
+[[allow]]
 path = "tokmd.toml"
 kind = "repo_config"
 owner = "EffortlessMetrics"

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -57,3 +57,19 @@ commands = ["docker compose -f infrastructure/docker/docker-compose.yml config"]
 reason = "Deployment proof needs container configuration validation without making Docker a default PR tax."
 covered_by = ["docker compose -f infrastructure/docker/docker-compose.yml config"]
 review_after = "2026-06-30"
+
+[[allow]]
+id = "ripr-static-exposure"
+owner = "release/ci"
+surface = "ci"
+behavior = "The advisory ripr lane may install ripr and render doctor, JSON, SARIF, and markdown mutation-exposure artifacts."
+commands = [
+  "cargo install ripr --version 0.5.0 --locked",
+  "ripr doctor --root .",
+  "ripr check --root . --base origin/main --mode draft --format json",
+  "ripr check --root . --base origin/main --mode draft --format sarif",
+  "ripr check --root . --base origin/main --mode draft --format github",
+]
+reason = "Static mutation-exposure analysis should be cheap, advisory, and separate from runtime mutation."
+covered_by = [".github/workflows/ripr.yml"]
+review_after = "2026-06-30"

--- a/policy/ripr-suppressions.toml
+++ b/policy/ripr-suppressions.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+
+# No suppressions are active for the initial advisory lane.
+#
+# This file intentionally uses ripr's native suppressions schema so
+# `ripr check` can validate it directly. Future entries must be owned,
+# reviewed, and linked to proof. Keep this ledger separate from the runtime
+# mutation backstop; ripr suppressions only affect static mutation-exposure
+# reporting.
+#
+# [[suppressions]]
+# kind = "exposure_gap"
+# finding_id = "finding-id"
+# owner = "core/parser"
+# reason = "Specific reviewed invariant."
+# expires = "2026-06-30"

--- a/policy/workflow-allowlist.toml
+++ b/policy/workflow-allowlist.toml
@@ -66,3 +66,13 @@ workflows = [
 reason = "Release and agent coordination need explicit workflows but should remain routed by intent and policy."
 covered_by = ["cargo run -p xtask -- check-ci-lane-whitelist", "cargo run -p xtask -- policy-report"]
 review_after = "2026-06-30"
+
+[[allow]]
+id = "ripr-advisory"
+owner = "release/ci"
+surface = "ci"
+behavior = "The ripr workflow may run advisory static mutation-exposure analysis on Rust-relevant PR changes and upload review artifacts."
+workflows = [".github/workflows/ripr.yml"]
+reason = "ripr provides cheap PR-time mutation-exposure signal while runtime mutation remains targeted."
+covered_by = [".github/workflows/ripr.yml", "cargo run -p xtask -- check-file-policy"]
+review_after = "2026-06-30"

--- a/ripr.toml
+++ b/ripr.toml
@@ -1,0 +1,41 @@
+[analysis]
+# Keep the first hl7v2-rs ripr lane cheap and review-facing. Runtime mutation
+# remains a targeted/nightly/release backstop, not an ordinary PR tax.
+mode = "draft"
+include_unchanged_tests = true
+
+[oracles]
+snapshot_strength = "medium"
+mock_expectation_strength = "medium"
+broad_error_strength = "weak"
+
+[severity.findings]
+exposed = "info"
+weakly_exposed = "warning"
+reachable_unrevealed = "warning"
+no_static_path = "warning"
+infection_unknown = "warning"
+propagation_unknown = "note"
+static_unknown = "note"
+
+[severity.seams]
+strongly_gripped = "off"
+weakly_gripped = "warning"
+ungripped = "warning"
+reachable_unrevealed = "warning"
+activation_unknown = "info"
+propagation_unknown = "info"
+observation_unknown = "info"
+discrimination_unknown = "info"
+opaque = "info"
+intentional = "off"
+suppressed = "off"
+
+[lsp]
+seam_diagnostics = true
+
+[reports]
+max_related_tests = 5
+
+[suppressions]
+path = "policy/ripr-suppressions.toml"


### PR DESCRIPTION
## Summary

- add an advisory ripr workflow for PR-time static mutation-exposure analysis
- pin ripr 0.5.0 and emit doctor, JSON, SARIF, GitHub annotation text, and Markdown artifacts
- add ripr.toml plus a native policy/ripr-suppressions.toml ledger
- receipt the new workflow through the CI lane whitelist and file-policy companion ledgers

## Scope fences

- advisory only; not branch-protection blocking
- does not replace runtime mutation testing
- no README badge endpoints or badge refresh workflow
- no runtime, package, or release behavior changes

## Validation

- ripr doctor --root .
- local ripr check --root . --base origin/main --mode draft artifact smoke for JSON, SARIF, GitHub, and Markdown outputs
- cargo run -p xtask -- check-file-policy
- cargo run -p xtask -- check-ci-lane-whitelist
- cargo run -p xtask -- policy-report
- cargo run -p xtask -- check-doc-links
- git diff --check

## Validation gap

- actionlint .github/workflows/ripr.yml was not run locally because actionlint is not installed on this machine; hosted GitHub Actions validation should cover workflow syntax.