### PR TITLE
ci: add targeted mutation lanes behind risk triggers

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,279 @@
+name: Targeted Mutation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "xtask/**"
+      - "api/**"
+      - "fixtures/evidence/**"
+      - "profiles/**"
+      - "schemas/evidence/**"
+      - "test_data/**"
+      - "tests/python_smoke/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "pyproject.toml"
+      - "policy/ci-risk-packs.toml"
+      - "policy/ci-lane-whitelist.toml"
+      - ".github/workflows/mutation.yml"
+  workflow_dispatch:
+    inputs:
+      file_glob:
+        description: "cargo-mutants --file glob for manual targeted runs"
+        required: false
+        default: "crates/hl7v2/src/parser/**/*.rs"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
+jobs:
+  plan:
+    name: Mutation Plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_mutation: ${{ steps.plan.outputs.run_mutation }}
+      reason: ${{ steps.plan.outputs.reason }}
+      risk_packs: ${{ steps.plan.outputs.risk_packs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Plan targeted mutation lane
+        id: plan
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p target/mutation
+          BASE_REF="${BASE_REF:-main}"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth=100
+            git diff --name-only "origin/$BASE_REF"...HEAD > target/mutation/changed-files.txt
+            git diff --unified=0 "origin/$BASE_REF"...HEAD > target/mutation/changed.diff
+          else
+            : > target/mutation/changed-files.txt
+            : > target/mutation/changed.diff
+          fi
+
+          python3 <<'PY'
+          import fnmatch
+          import json
+          import os
+          from pathlib import Path
+
+          event_name = os.environ["EVENT_NAME"]
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+          labels = {
+              label.get("name", "")
+              for label in event.get("pull_request", {}).get("labels", [])
+          }
+          changed = [
+              line.strip().replace("\\", "/")
+              for line in Path("target/mutation/changed-files.txt").read_text().splitlines()
+              if line.strip()
+          ]
+
+          risk_patterns = {
+              "parser-core": [
+                  "crates/hl7v2/src/parser/**",
+                  "crates/hl7v2/src/model/**",
+                  "crates/hl7v2/src/writer/**",
+                  "crates/hl7v2/src/normalize/**",
+              ],
+              "mllp-network": [
+                  "crates/hl7v2/src/transport/**",
+                  "crates/hl7v2/src/stream.rs",
+                  "crates/hl7v2/src/batch.rs",
+              ],
+              "profile-validation": [
+                  "crates/hl7v2/src/conformance/**",
+                  "profiles/**",
+                  "test_data/*profile*",
+              ],
+              "safe-analysis-redaction": [
+                  "crates/hl7v2/src/redact.rs",
+                  "crates/hl7v2-server/src/redaction.rs",
+                  "fixtures/evidence/redaction-*",
+                  "fixtures/evidence/safe-analysis-*",
+              ],
+              "evidence-contracts": [
+                  "crates/hl7v2/src/evidence.rs",
+                  "crates/hl7v2-server/src/evidence.rs",
+                  "fixtures/evidence/**",
+                  "schemas/evidence/**",
+              ],
+              "server-api": [
+                  "crates/hl7v2-server/**",
+                  "api/**",
+                  "schemas/**",
+              ],
+              "python-binding": [
+                  "crates/hl7v2-python/**",
+                  "tests/python_smoke/**",
+                  "pyproject.toml",
+              ],
+          }
+
+          matched = []
+          for pack, patterns in risk_patterns.items():
+              if any(
+                  fnmatch.fnmatch(path, pattern)
+                  for path in changed
+                  for pattern in patterns
+              ):
+                  matched.append(pack)
+
+          forcing_labels = sorted(labels.intersection({"mutation", "full-ci", "release-check"}))
+          manual = event_name == "workflow_dispatch"
+          run_mutation = manual or bool(forcing_labels) or bool(matched)
+
+          if manual:
+              reason = "manual workflow_dispatch"
+          elif forcing_labels:
+              reason = "label:" + ",".join(forcing_labels)
+          elif matched:
+              reason = "risk-pack:" + ",".join(matched)
+          else:
+              reason = "no mutation label or high-risk diff"
+
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as handle:
+              handle.write(f"run_mutation={str(run_mutation).lower()}\n")
+              handle.write(f"reason={reason}\n")
+              handle.write(f"risk_packs={','.join(matched) or 'none'}\n")
+
+          summary = Path("target/mutation/plan.md")
+          summary.write_text(
+              "\n".join(
+                  [
+                      "## Targeted mutation plan",
+                      "",
+                      f"- run mutation: `{str(run_mutation).lower()}`",
+                      f"- reason: `{reason}`",
+                      f"- risk packs: `{','.join(matched) or 'none'}`",
+                      f"- labels: `{','.join(sorted(labels)) or 'none'}`",
+                      f"- changed files considered: `{len(changed)}`",
+                      "",
+                      "Runtime mutation is routed by risk or label. It is not part of the ordinary required PR gate.",
+                  ]
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+          cat target/mutation/plan.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutation plan
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-plan
+          path: |
+            target/mutation/changed-files.txt
+            target/mutation/changed.diff
+            target/mutation/plan.md
+          if-no-files-found: warn
+          retention-days: 14
+
+  targeted-mutation:
+    name: Targeted Mutation
+    runs-on: ubuntu-latest
+    needs: plan
+    if: needs.plan.outputs.run_mutation == 'true'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: mutation-targeted-${{ hashFiles('Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --version 26.1.2 --locked
+
+      - name: Run targeted mutation
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_FILE_GLOB: ${{ github.event.inputs.file_glob }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p target/mutation
+          BASE_REF="${BASE_REF:-main}"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth=100
+            git diff --unified=0 "origin/$BASE_REF"...HEAD > target/mutation/changed.diff
+            mutation_scope=(--in-diff target/mutation/changed.diff)
+          else
+            mutation_scope=(--file "${MANUAL_FILE_GLOB:-crates/hl7v2/src/parser/**/*.rs}")
+          fi
+
+          set +e
+          cargo mutants \
+            --workspace \
+            --all-features \
+            "${mutation_scope[@]}" \
+            --timeout 300 \
+            --jobs 2 \
+            --output target/mutation \
+            --no-shuffle \
+            --test-workspace true
+          mutation_status=$?
+          set -e
+
+          {
+            echo "## Targeted runtime mutation"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| advisory status | $mutation_status |"
+            echo "| trigger reason | ${{ needs.plan.outputs.reason }} |"
+            echo "| risk packs | ${{ needs.plan.outputs.risk_packs }} |"
+            echo
+            echo "This lane is advisory and routed. Mutation findings are review input; broad runtime mutation remains nightly/release proof, not an ordinary PR tax."
+          } > target/mutation/summary.md
+
+          if [ "$mutation_status" -ne 0 ]; then
+            echo "::warning::Targeted mutation completed with findings or a non-zero advisory status: $mutation_status"
+          fi
+
+          cat target/mutation/summary.md >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+
+      - name: Upload mutation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: targeted-mutation
+          path: |
+            target/mutation/summary.md
+            target/mutation/mutants.out/
+            target/mutation/changed.diff
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -19,8 +19,8 @@ nightly, release readiness, and high-risk changes.
 | Coverage | no | main, dispatch, `coverage`, or `full-ci` |
 | Contracts | no | OpenAPI, proto, schema, and evidence validation |
 | Python wheels and publish proof | no | Python-lane workflows and receipts |
-| `ripr` static exposure | planned advisory | JSON, SARIF, and markdown advisory artifacts |
-| Runtime mutation | planned targeted | high-risk labels, nightly, and release readiness |
+| `ripr` static exposure | advisory | JSON, SARIF, and markdown advisory artifacts |
+| Runtime mutation | targeted advisory | high-risk path changes, `mutation`, `full-ci`, `release-check`, nightly, and release readiness |
 
 ## Rust 1.95 Target
 
@@ -28,10 +28,21 @@ The Rust 1.95 / 1.5.0 rollout should keep default PR cost bounded while adding
 better receipts:
 
 - Rust 1.95 MSRV smoke remains a default compatibility proof after the MSRV PR.
-- `ripr` becomes a cheap advisory PR-time static mutation-exposure signal.
+- `ripr` is a cheap advisory PR-time static mutation-exposure signal.
 - Runtime mutation remains targeted by risk pack, label, nightly, or release
   readiness.
 - Release readiness owns the broadest proof bundle before `1.5.0`.
+
+## Runtime Mutation Routing
+
+Runtime mutation is not a default required PR tax. The targeted mutation
+workflow plans against changed files, then runs `cargo-mutants` only when a PR
+touches a high-risk HL7 surface, carries the `mutation`, `full-ci`, or
+`release-check` label, or is invoked manually.
+
+The targeted lane uploads the changed-file plan and mutation artifacts. It is
+review input for PRs; nightly and release-readiness lanes remain the broader
+runtime backstop.
 
 ## High-Risk HL7 Surfaces
 

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -227,6 +227,31 @@ review_after = "2026-06-09"
 expires = "2026-11-09"
 
 # ---------------------------------------------------------------------------
+# targeted_mutation -- Routed runtime mutation lane
+# ---------------------------------------------------------------------------
+[[lane]]
+id = "targeted_mutation"
+workflow = ".github/workflows/mutation.yml"
+job = "targeted-mutation"
+display_name = "Targeted Mutation"
+kind = "mutation"
+tier = "deep"
+default_pr = false
+blocking = false
+runner = "ubuntu_latest"
+base_lem = 45
+owner = "core/test"
+intent = "Run cargo-mutants only for high-risk HL7 surfaces, mutation labels, full-ci, release-check, or manual dispatch."
+failure_mode = "Weak runtime oracle coverage on parser, redaction, evidence, server, or Python boundary changes reaches review without targeted mutation feedback."
+proof_obligation = "Upload mutation plan, changed diff, cargo-mutants output, and job summary."
+evidence = ["mutation-plan artifact", "targeted-mutation artifact", "job summary"]
+allowed_triggers = ["pull_request", "workflow_dispatch"]
+labels = ["mutation", "full-ci", "release-check"]
+duplicate_of = ["ripr_static_exposure", "nightly"]
+review_after = "2026-06-09"
+expires = "2026-11-09"
+
+# ---------------------------------------------------------------------------
 # security — Dependency audit (main/label only)
 # ---------------------------------------------------------------------------
 [[lane]]

--- a/policy/ci-risk-packs.toml
+++ b/policy/ci-risk-packs.toml
@@ -16,8 +16,8 @@ paths = [
   "crates/hl7v2/src/normalize/**",
 ]
 lanes = ["fast_checks", "standard_tests", "ci_success"]
-deep_lanes = ["extended_property_tests"]
-labels = ["property-tests", "full-ci"]
+deep_lanes = ["extended_property_tests", "targeted_mutation"]
+labels = ["property-tests", "mutation", "full-ci"]
 
 [risk_pack.profile_validation]
 description = "Conformance profile loading, inheritance, constraints, validation reports."
@@ -27,8 +27,8 @@ paths = [
   "fixtures/**",
 ]
 lanes = ["fast_checks", "standard_tests", "ci_success"]
-deep_lanes = ["extended_property_tests"]
-labels = ["profile", "property-tests", "full-ci"]
+deep_lanes = ["extended_property_tests", "targeted_mutation"]
+labels = ["profile", "property-tests", "mutation", "full-ci"]
 
 [risk_pack.transport_mllp]
 description = "MLLP/network framing, streaming parser, batch/file transport."
@@ -38,8 +38,8 @@ paths = [
   "crates/hl7v2/src/batch/**",
 ]
 lanes = ["fast_checks", "standard_tests", "ci_success"]
-deep_lanes = ["matrix_tests"]
-labels = ["network", "full-ci"]
+deep_lanes = ["matrix_tests", "targeted_mutation"]
+labels = ["network", "mutation", "full-ci"]
 
 [risk_pack.server_api]
 description = "HTTP/gRPC server, OpenAPI/API schema, auth, metrics, runtime config."
@@ -51,8 +51,33 @@ paths = [
   "buf.gen.yaml",
 ]
 lanes = ["fast_checks", "standard_tests", "ci_success"]
-deep_lanes = ["contracts"]
-labels = ["api-contract", "full-ci"]
+deep_lanes = ["contracts", "targeted_mutation"]
+labels = ["api-contract", "mutation", "full-ci"]
+
+[risk_pack.safe_analysis_redaction]
+description = "PHI redaction, safe support bundle, and redaction receipt behavior."
+paths = [
+  "crates/hl7v2/src/redact.rs",
+  "crates/hl7v2-server/src/redaction.rs",
+  "fixtures/evidence/redaction-*",
+  "fixtures/evidence/safe-analysis-*",
+]
+lanes = ["fast_checks", "standard_tests", "ci_success"]
+deep_lanes = ["contracts", "targeted_mutation"]
+labels = ["evidence", "mutation", "full-ci"]
+
+[risk_pack.evidence_contracts]
+description = "Evidence artifact semantics, bundle/replay hashes, and schema fixtures."
+paths = [
+  "crates/hl7v2/src/evidence.rs",
+  "crates/hl7v2-server/src/evidence.rs",
+  "fixtures/evidence/**",
+  "schemas/evidence/**",
+  "docs/contracts/evidence-contract-index.md",
+]
+lanes = ["fast_checks", "standard_tests", "ci_success"]
+deep_lanes = ["contracts", "targeted_mutation"]
+labels = ["evidence", "mutation", "full-ci"]
 
 [risk_pack.cli]
 description = "Command-line interface, evidence bundle, replay, corpus commands."
@@ -61,8 +86,8 @@ paths = [
   "fixtures/evidence/**",
 ]
 lanes = ["fast_checks", "standard_tests", "ci_success"]
-deep_lanes = []
-labels = ["evidence", "full-ci"]
+deep_lanes = ["targeted_mutation"]
+labels = ["evidence", "mutation", "full-ci"]
 
 [risk_pack.python_binding]
 description = "PyO3/maturin Python binding lane."
@@ -72,8 +97,8 @@ paths = [
   "pyproject.toml",
 ]
 lanes = ["python_wheels"]
-deep_lanes = []
-labels = ["python", "full-ci"]
+deep_lanes = ["targeted_mutation"]
+labels = ["python", "mutation", "full-ci"]
 
 [risk_pack.release]
 description = "Crates publish graph, dependency, release, license, package metadata."

--- a/policy/dependency-surface-allowlist.toml
+++ b/policy/dependency-surface-allowlist.toml
@@ -61,3 +61,14 @@ dependencies = ["ripr 0.5.0"]
 reason = "ripr shifts mutation-exposure signal left without adding runtime mutation to ordinary PRs."
 covered_by = [".github/workflows/ripr.yml"]
 review_after = "2026-06-30"
+
+[[allow]]
+id = "targeted-runtime-mutation"
+owner = "core/test"
+surface = "ci"
+behavior = "The targeted mutation workflow may install cargo-mutants 26.1.2 for routed runtime mutation proof."
+paths = [".github/workflows/mutation.yml", "policy/ci-risk-packs.toml"]
+dependencies = ["cargo-mutants 26.1.2"]
+reason = "cargo-mutants is the slower runtime backstop that complements ripr static exposure analysis."
+covered_by = [".github/workflows/mutation.yml"]
+review_after = "2026-06-30"

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -73,3 +73,18 @@ commands = [
 reason = "Static mutation-exposure analysis should be cheap, advisory, and separate from runtime mutation."
 covered_by = [".github/workflows/ripr.yml"]
 review_after = "2026-06-30"
+
+[[allow]]
+id = "targeted-runtime-mutation"
+owner = "core/test"
+surface = "ci"
+behavior = "The routed mutation lane may install cargo-mutants, compute a changed-file diff, and run cargo-mutants against only that diff or a manual file glob."
+commands = [
+  "cargo install cargo-mutants --version 26.1.2 --locked",
+  "git diff --unified=0 origin/main...HEAD",
+  "cargo mutants --workspace --all-features --in-diff target/mutation/changed.diff",
+  "cargo mutants --workspace --all-features --file crates/hl7v2/src/parser/**/*.rs",
+]
+reason = "Runtime mutation should remain a targeted risk proof without becoming default PR cost."
+covered_by = [".github/workflows/mutation.yml"]
+review_after = "2026-06-30"

--- a/policy/workflow-allowlist.toml
+++ b/policy/workflow-allowlist.toml
@@ -76,3 +76,13 @@ workflows = [".github/workflows/ripr.yml"]
 reason = "ripr provides cheap PR-time mutation-exposure signal while runtime mutation remains targeted."
 covered_by = [".github/workflows/ripr.yml", "cargo run -p xtask -- check-file-policy"]
 review_after = "2026-06-30"
+
+[[allow]]
+id = "targeted-runtime-mutation"
+owner = "core/test"
+surface = "ci"
+behavior = "The mutation workflow may plan changed high-risk surfaces and run advisory cargo-mutants proof only when routed by risk, label, or manual dispatch."
+workflows = [".github/workflows/mutation.yml"]
+reason = "Runtime mutation remains useful proof but should be targeted instead of an ordinary PR tax."
+covered_by = [".github/workflows/mutation.yml", "cargo run -p xtask -- check-ci-lane-whitelist"]
+review_after = "2026-06-30"


### PR DESCRIPTION
## Summary

- add a targeted mutation workflow with a cheap plan job and routed cargo-mutants job
- run runtime mutation only for high-risk paths, mutation/full-ci/release-check labels, or manual dispatch
- wire targeted_mutation into CI lane policy, risk packs, and file-policy companion ledgers
- update test evidence lane docs to distinguish advisory ripr from routed runtime mutation

## Scope fences

- does not make mutation a required branch-protection check
- does not put full runtime mutation on ordinary PRs
- does not replace nightly/release mutation backstops
- no runtime, package, or release behavior changes

## Validation

- cargo run -p xtask -- check-ci-lane-whitelist
- cargo run -p xtask -- check-file-policy
- cargo run -p xtask -- policy-report
- cargo run -p xtask -- check-doc-links
- cargo mutants --workspace --all-features --file crates/hl7v2/src/parser/**/*.rs --list --output target/mutation-smoke --test-workspace true
- git diff --check

## Validation gap

- actionlint .github/workflows/mutation.yml was not run locally because actionlint is not installed on this machine; hosted GitHub Actions validation should cover workflow syntax.