### PR TITLE
refactor: use Rust 1.95 APIs in parser and tooling

### DIFF
--- a/crates/hl7v2/src/parser/mod.rs
+++ b/crates/hl7v2/src/parser/mod.rs
@@ -76,11 +76,13 @@ pub fn parse(bytes: &[u8]) -> Result<Message, Error> {
     let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
 
     if lines.is_empty() {
+        std::hint::cold_path();
         return Err(Error::InvalidSegmentId);
     }
 
     // First segment must be MSH
     if !lines[0].starts_with("MSH") {
+        std::hint::cold_path();
         return Err(Error::InvalidSegmentId);
     }
 
@@ -226,6 +228,7 @@ pub fn parse_file_batch(bytes: &[u8]) -> Result<FileBatch, Error> {
 /// Parse a single segment
 fn parse_segment(line: &str, delims: &Delims) -> Result<Segment, Error> {
     if line.len() < 3 {
+        std::hint::cold_path();
         return Err(Error::InvalidSegmentId);
     }
 
@@ -237,6 +240,7 @@ fn parse_segment(line: &str, delims: &Delims) -> Result<Segment, Error> {
     // Ensure segment ID is all uppercase ASCII letters or digits
     for &byte in &id {
         if !(byte.is_ascii_uppercase() || byte.is_ascii_digit()) {
+            std::hint::cold_path();
             return Err(Error::InvalidSegmentId);
         }
     }
@@ -419,15 +423,10 @@ fn extract_charsets(segments: &[Segment]) -> Vec<String> {
 
         let mut charsets = Vec::new();
         for comp in &rep.comps {
-            if !comp.subs.is_empty() {
-                match &comp.subs[0] {
-                    Atom::Text(text) => {
-                        if !text.is_empty() {
-                            charsets.push(text.clone());
-                        }
-                    }
-                    Atom::Null => continue,
-                }
+            if let Some(Atom::Text(text)) = comp.subs.first()
+                && !text.is_empty()
+            {
+                charsets.push(text.clone());
             }
         }
 

--- a/crates/hl7v2/src/transport/network/tests.rs
+++ b/crates/hl7v2/src/transport/network/tests.rs
@@ -814,19 +814,11 @@ mod network_tests {
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
                     + 1;
 
-                // Track max concurrent handlers active
-                let mut max = self.max_active.load(std::sync::atomic::Ordering::SeqCst);
-                while current > max {
-                    match self.max_active.compare_exchange(
-                        max,
-                        current,
-                        std::sync::atomic::Ordering::SeqCst,
-                        std::sync::atomic::Ordering::SeqCst,
-                    ) {
-                        Ok(_) => break,
-                        Err(actual) => max = actual,
-                    }
-                }
+                self.max_active.update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |max| max.max(current),
+                );
 
                 // Sleep to keep the connection/handler active
                 tokio::time::sleep(Duration::from_millis(200)).await;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1407,7 +1407,8 @@ fn git_output(args: &[&str]) -> Result<String> {
 }
 
 fn command_exists(cmd: &str) -> bool {
-    if cfg!(windows) {
+    std::cfg_select! {
+        windows => {
         Command::new("where")
             .arg(cmd)
             .stdout(Stdio::null())
@@ -1415,7 +1416,8 @@ fn command_exists(cmd: &str) -> bool {
             .status()
             .map(|s| s.success())
             .unwrap_or(false)
-    } else {
+        }
+        _ => {
         let safe = cmd.replace('\'', r"'\''");
         Command::new("sh")
             .args(["-lc", &format!("command -v '{safe}' >/dev/null 2>&1")])
@@ -1424,6 +1426,7 @@ fn command_exists(cmd: &str) -> bool {
             .status()
             .map(|s| s.success())
             .unwrap_or(false)
+        }
     }
 }
 
@@ -1625,10 +1628,13 @@ fn run_ajv_validate(schema: &Path, data: &Path) -> Result<()> {
 }
 
 fn command_program(cmd: &str) -> String {
-    if cfg!(windows) {
-        format!("{cmd}.cmd")
-    } else {
-        cmd.to_string()
+    std::cfg_select! {
+        windows => {
+            format!("{cmd}.cmd")
+        }
+        _ => {
+            cmd.to_string()
+        }
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5868,6 +5868,20 @@ mod tests {
     }
 
     #[test]
+    fn command_exists_reports_present_and_missing_commands() {
+        assert!(command_exists("cargo"));
+        assert!(!command_exists("__hl7v2_missing_command__"));
+    }
+
+    #[test]
+    fn command_program_uses_platform_runner_suffix() {
+        #[cfg(windows)]
+        assert_eq!(command_program("cargo"), "cargo.cmd");
+        #[cfg(not(windows))]
+        assert_eq!(command_program("cargo"), "cargo");
+    }
+
+    #[test]
     fn publish_order_uses_workspace_dependency_order() -> Result<()> {
         let ordered = publish_order(None)?;
 


### PR DESCRIPTION
## Summary

- mark malformed parser branches with std::hint::cold_path
- simplify MSH-18 charset extraction with Rust 1.95 let-chain matching over first()
- replace a test compare_exchange loop with AtomicU32::update
- use std::cfg_select! for xtask platform command selection

## Scope fences

- no semantic parser, evidence, server, or release behavior changes
- no broad API cleanup or mechanical rewrites
- no lint, workflow, publish, or policy behavior changes

## Validation

- cargo fmt --all -- --check
- cargo test -p hl7v2 --all-features
- cargo test -p hl7v2 --all-features transport::network
- cargo test -p xtask --locked
- cargo clippy -p hl7v2 -p xtask --all-targets --all-features --locked -- -D warnings
- cargo run -p xtask -- check-no-panic-family
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\\cargo-target\\hl7v2-rs-rust-195 CARGO_INCREMENTAL=0 cargo run -p xtask -- gate --check --changed
- git diff --check