### PR TITLE
policy(clippy): burn down CLI monitor lint debt

### DIFF
--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -4,12 +4,10 @@
     clippy::arithmetic_side_effects,
     clippy::allow_attributes,
     clippy::allow_attributes_without_reason,
-    clippy::cast_precision_loss,
     clippy::indexing_slicing,
     clippy::unchecked_time_subtraction,
     clippy::uninlined_format_args,
     clippy::unnecessary_debug_formatting,
-    clippy::unwrap_used,
     reason = "pre-existing CLI reporting and table-rendering debt is tracked in policy/clippy-debt.toml"
 )]
 #![cfg_attr(

--- a/crates/hl7v2-cli/src/monitor.rs
+++ b/crates/hl7v2-cli/src/monitor.rs
@@ -31,7 +31,10 @@ impl PerformanceMonitor {
     }
 
     /// Get a specific metric
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "retained for report expansion; debt is tracked in policy/clippy-debt.toml"
+    )]
     pub fn get_metric(&self, name: &str) -> Option<std::time::Duration> {
         self.metrics.get(name).copied()
     }
@@ -65,7 +68,14 @@ pub fn get_memory_info() -> MemoryInfo {
     let mut sys = System::new_all();
     sys.refresh_all();
 
-    if let Some(process) = sys.process(sysinfo::get_current_pid().unwrap()) {
+    let Ok(pid) = sysinfo::get_current_pid() else {
+        return MemoryInfo {
+            resident_set_size: None,
+            virtual_memory_size: None,
+        };
+    };
+
+    if let Some(process) = sys.process(pid) {
         MemoryInfo {
             resident_set_size: Some(process.memory()),
             virtual_memory_size: Some(process.virtual_memory()),
@@ -89,8 +99,14 @@ pub fn get_cpu_info() -> CpuInfo {
     let mut sys = System::new_all();
     sys.refresh_all();
 
-    let cpu_usage: f64 = sys.cpus().iter().map(sysinfo::Cpu::cpu_usage).sum::<f32>() as f64
-        / sys.cpus().len() as f64;
+    let cpus = sys.cpus();
+    let Some(cpu_count) = u32::try_from(cpus.len()).ok().filter(|count| *count > 0) else {
+        return CpuInfo {
+            cpu_usage_percent: None,
+        };
+    };
+    let total_usage: f64 = cpus.iter().map(|cpu| f64::from(cpu.cpu_usage())).sum();
+    let cpu_usage = total_usage / f64::from(cpu_count);
 
     CpuInfo {
         cpu_usage_percent: Some(cpu_usage),

--- a/crates/hl7v2-cli/src/serve.rs
+++ b/crates/hl7v2-cli/src/serve.rs
@@ -239,15 +239,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_grpc_invalid_bind_address_fails_before_serving() {
+    async fn test_grpc_invalid_bind_address_fails_before_serving()
+    -> Result<(), Box<dyn std::error::Error>> {
         let result = run_grpc_server("not-a-bind-address", 1024).await;
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Invalid bind address")
-        );
+        let Err(error) = result else {
+            return Err("invalid bind address should fail before serving".into());
+        };
+        if error.to_string().contains("Invalid bind address") {
+            Ok(())
+        } else {
+            Err(format!("expected invalid bind address error, got: {error}").into())
+        }
     }
 
     #[test]

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -48,7 +48,7 @@ expires = "2026-06-30"
 lint = "clippy::unwrap_used"
 path = "crates/hl7v2-cli"
 owner = "EffortlessMetrics"
-reason = "Pre-existing CLI commands and tests use static fixture unwraps; cleanup is split from policy infrastructure."
+reason = "Pre-existing CLI tests use static fixture unwraps; cleanup is split from policy infrastructure."
 expires = "2026-06-30"
 
 [[debt]]
@@ -84,27 +84,6 @@ lint = "clippy::allow_attributes_without_reason"
 path = "crates/hl7v2-cli/src/config.rs"
 owner = "EffortlessMetrics"
 reason = "Pre-existing CLI config module uses legacy allow attributes for staged config wiring; replace with narrower expectations after policy lands."
-expires = "2026-06-30"
-
-[[debt]]
-lint = "clippy::allow_attributes"
-path = "crates/hl7v2-cli/src/monitor.rs"
-owner = "EffortlessMetrics"
-reason = "Pre-existing CLI monitor module uses a legacy allow attribute for a staged reporting helper; replace with a narrower expectation after policy lands."
-expires = "2026-06-30"
-
-[[debt]]
-lint = "clippy::allow_attributes_without_reason"
-path = "crates/hl7v2-cli/src/monitor.rs"
-owner = "EffortlessMetrics"
-reason = "Pre-existing CLI monitor module uses a legacy allow attribute for a staged reporting helper; replace with a narrower expectation after policy lands."
-expires = "2026-06-30"
-
-[[debt]]
-lint = "clippy::cast_precision_loss"
-path = "crates/hl7v2-cli/src/monitor.rs"
-owner = "EffortlessMetrics"
-reason = "Pre-existing CLI monitor CPU averaging casts should be replaced with checked conversion helpers after policy lands."
 expires = "2026-06-30"
 
 [[debt]]


### PR DESCRIPTION
## Summary

- Replace the CLI monitor legacy dead-code allow with a reasoned expectation.
- Remove the monitor get_current_pid().unwrap() path and avoid precision-loss casts in CPU averaging.
- Remove now-stale CLI root expectations for cast_precision_loss and unwrap_used, then fix the exposed gRPC bind-address test unwrap_err().
- Drop the three monitor-specific Clippy debt receipts; policy-report now reports 29 debt receipts.

## Notes

crates/hl7v2-cli/src/monitor.rs was a CRLF file. Touching it caused git diff --check to flag newly-added CRLF lines as trailing whitespace, so this PR leaves that touched file LF-normalized while keeping the functional diff narrow.

No npm package surface exists in this repo today. The future npm identity rule remains @effortlessmetrics/hl7v2 for a user-facing JS/TS package, not hl7v2-rs.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p hl7v2-cli --all-targets --all-features --locked -- -D warnings
- cargo test -p hl7v2-cli --all-features
- cargo run -p xtask -- check-lint-policy
- cargo run -p xtask -- policy-report
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 CARGO_INCREMENTAL=0 cargo run -p xtask -- gate --check --changed
- git diff --check