### PR TITLE
policy(clippy): bound server metrics size casts

### DIFF
--- a/crates/hl7v2-server/src/lib.rs
+++ b/crates/hl7v2-server/src/lib.rs
@@ -34,7 +34,6 @@
 #![expect(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
-    clippy::cast_precision_loss,
     clippy::expect_used,
     clippy::indexing_slicing,
     clippy::manual_let_else,

--- a/crates/hl7v2-server/src/metrics.rs
+++ b/crates/hl7v2-server/src/metrics.rs
@@ -239,7 +239,11 @@ pub fn increment_parse_errors() {
 
 /// Record message size in bytes
 pub fn record_message_size(size_bytes: usize) {
-    metrics::histogram!("hl7v2_message_size_bytes").record(size_bytes as f64);
+    metrics::histogram!("hl7v2_message_size_bytes").record(message_size_for_histogram(size_bytes));
+}
+
+fn message_size_for_histogram(size_bytes: usize) -> f64 {
+    f64::from(u32::try_from(size_bytes).unwrap_or(u32::MAX))
 }
 
 /// Axum handler for GET /metrics
@@ -329,6 +333,18 @@ mod tests {
         // Test recording message size
         record_message_size(1024);
         // No panic means success
+    }
+
+    #[test]
+    fn message_size_histogram_value_is_bounded() {
+        assert_eq!(
+            message_size_for_histogram(1024).to_bits(),
+            1024.0f64.to_bits()
+        );
+        assert_eq!(
+            message_size_for_histogram(usize::MAX).to_bits(),
+            f64::from(u32::MAX).to_bits()
+        );
     }
 
     #[test]

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -171,13 +171,6 @@ reason = "Pre-existing gRPC summary and enum conversions need bounded conversion
 expires = "2026-06-30"
 
 [[debt]]
-lint = "clippy::cast_precision_loss"
-path = "crates/hl7v2-server/src/metrics.rs"
-owner = "EffortlessMetrics"
-reason = "Pre-existing metrics size recording casts should use bounded conversion helpers after policy lands."
-expires = "2026-06-30"
-
-[[debt]]
 lint = "clippy::manual_let_else"
 path = "crates/hl7v2-server/src/middleware.rs"
 owner = "EffortlessMetrics"


### PR DESCRIPTION
## Summary

- Replace the server metrics message-size precision-loss cast with a bounded usize-to-u32-to-f64 conversion.
- Add a unit check for ordinary and saturated histogram values without strict float equality.
- Remove the now-stale server root cast_precision_loss expectation and the matching metrics debt receipt.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p hl7v2-server --all-targets --all-features --locked -- -D warnings
- cargo test -p hl7v2-server --all-features message_size_histogram_value_is_bounded
- cargo test -p hl7v2-server --all-features
- cargo run -p xtask -- check-lint-policy
- cargo run -p xtask -- policy-report
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 CARGO_INCREMENTAL=0 cargo run -p xtask -- gate --check --changed
- git diff --check