### PR TITLE
release: add 1.5.0 readiness workflow

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,104 @@
+name: Rust 1.95 / 1.5.0 Release Readiness
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "release/**"
+
+concurrency:
+  group: release-readiness-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+jobs:
+  release-readiness:
+    name: Release Readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust 1.95 toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.95.0"
+          components: rustfmt, clippy
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: hl7v2-release-readiness-1.95-${{ hashFiles('Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check workspace
+        run: cargo check --workspace --all-targets --all-features --locked
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+      - name: Run workspace tests
+        run: cargo test --workspace --all-features --locked
+
+      - name: Run doc tests
+        run: cargo test --doc --workspace --all-features --locked
+
+      - name: Check policy rails
+        run: |
+          cargo run -p xtask -- check-lint-policy
+          cargo run -p xtask -- check-no-panic-family
+          cargo run -p xtask -- check-file-policy
+          cargo run -p xtask -- check-ci-lane-whitelist
+
+      - name: Check evidence schemas
+        run: cargo run -p xtask -- evidence-schema-check
+
+      - name: Check contract workflow coverage
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          text = Path(".github/workflows/contracts.yml").read_text(encoding="utf-8")
+          required = [
+              "spectral lint api/openapi/hl7v2-api-v1.yaml",
+              "@bufbuild/buf lint api/proto",
+              "ajv validate",
+              "cargo run -p xtask -- evidence-schema-check",
+          ]
+          missing = [needle for needle in required if needle not in text]
+          if missing:
+              for needle in missing:
+                  print(f"missing contracts workflow proof: {needle}")
+              raise SystemExit(1)
+          PY
+
+      - name: Check Rust publish graph
+        run: cargo run -p xtask -- publish-plan
+
+      - name: Dry-run Rust publish graph
+        run: cargo run -p xtask -- publish-dry-run --workspace-patches --allow-dirty
+
+      - name: Check Python distribution boundary
+        run: |
+          cargo run -p xtask -- check-python-publish-policy
+          {
+            echo "## Python distribution boundary"
+            echo
+            echo "- Public Python distribution: hl7v2"
+            echo "- Internal Rust binding crate: hl7v2-python"
+            echo "- Rust crates.io publish graph remains hl7v2, hl7v2-server, hl7v2-cli"
+            echo "- No TestPyPI/PyPI success is claimed by this Rust readiness workflow"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ proposal, spec, plan, or receipt documents.
 | [Final source-tree gap audit](audits/current-source-tree-evidence-objective-gap-audit.md) | Current package-state receipt after the broad local evidence-lane workbench was split and merged. |
 | [v1.4.0 publish dry-run receipt](audits/publish-dry-run-v1.4.0-2026-05-09.md) | Package verification before upload. |
 | [v1.4.0 publish receipt](audits/publish-v1.4.0-2026-05-09.md) | Dependency-ordered crates.io publication proof. |
+| [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the internal `hl7v2-python` package outside the Rust crates.io graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |
 

--- a/docs/ci/ci-lane-whitelist.md
+++ b/docs/ci/ci-lane-whitelist.md
@@ -21,8 +21,8 @@ Each `[[lane]]` entry in `ci-lane-whitelist.toml` must provide:
 | `workflow`            | yes      | Relative path to the `.github/workflows/*.yml` file        |
 | `job`                 | yes      | GitHub Actions job id, or `*` for a governed aggregate workflow lane |
 | `display_name`        | yes      | Human-readable name                                        |
-| `kind`                | yes      | One of: `rust-policy`, `rust-integration`, `platform`, `property`, `performance`, `summary`, `coverage`, `security`, `python`, `api-contract`, `release`, `rust-nightly` |
-| `tier`                | yes      | One of: `frontdoor`, `compatibility`, `deep`, `release`    |
+| `kind`                | yes      | One of: `rust-policy`, `rust-integration`, `platform`, `property`, `performance`, `summary`, `coverage`, `security`, `python`, `api-contract`, `release`, `rust-nightly`, `static-analysis`, `mutation` |
+| `tier`                | yes      | One of: `frontdoor`, `compatibility`, `advisory`, `deep`, `release` |
 | `default_pr`          | yes      | Whether this lane runs on every PR by default              |
 | `blocking`            | yes      | Whether failure blocks the PR                              |
 | `runner`              | yes      | Runner type from `ci-budget.toml` `[runner_multipliers]`   |

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -2,7 +2,7 @@
 
 Current lane inventory derived from `policy/ci-lane-whitelist.toml`.
 
-Last updated: 2026-05-09 (PR 07: platform matrix routed off ordinary PRs)
+Last updated: 2026-05-13 (Rust 1.95 / 1.5.0 release-readiness lane)
 
 ## Active Lanes
 
@@ -16,15 +16,18 @@ Last updated: 2026-05-09 (PR 07: platform matrix routed off ordinary PRs)
 | `benchmarks`              | `ci.yml`              | `benchmarks`     | deep          | no          | no        |       15 | performance     |
 | `ci_success`              | `ci.yml`              | `ci-success`     | frontdoor     | yes         | yes       |        1 | release/ci      |
 | `coverage`                | `coverage.yml`        | `coverage`       | deep          | no          | no        |       20 | release/ci      |
+| `ripr_static_exposure`    | `ripr.yml`            | `ripr`           | advisory      | yes         | no        |        5 | release/ci      |
+| `targeted_mutation`       | `mutation.yml`        | `targeted-mutation` | deep       | no          | no        |       45 | core/test       |
 | `security`                | `security.yml`        | `*`              | deep          | no          | no        |        5 | release/ci      |
 | `python_wheels`           | `python-wheels.yml`   | `wheel-smoke`    | deep          | no          | no        |       20 | binding/python  |
 | `nightly`                 | `nightly.yml`         | `*`              | deep          | no          | no        |       25 | core/build      |
 | `contracts`               | `contracts.yml`       | `*`              | deep          | no          | no        |       15 | api/contracts   |
 | `publish`                 | `publish.yml`         | `publish`        | release       | no          | no        |       20 | release/ci      |
+| `release_readiness`       | `release-readiness.yml` | `release-readiness` | release   | no          | no        |      120 | release/ci      |
 
-## Default PR LEM Estimate (after PR 07)
+## Default PR LEM Estimate
 
-Ordinary PRs now run:
+Ordinary PRs now run these blocking lanes:
 
 | Lane             | Base LEM |
 | ---------------- | -------: |
@@ -34,8 +37,12 @@ Ordinary PRs now run:
 | `ci_success`     |        1 |
 | **Total**        |   **40** |
 
+Ordinary Rust-relevant PRs also run advisory `ripr_static_exposure` at roughly
+5 LEM. It is review evidence, not a branch-protection blocker.
+
 Most PRs target 35 LEM. The MSRV smoke check adds a 5 LEM compile-only overage
-for a 40 LEM default path that prevents minimum-supported-Rust regressions.
+for a 40 LEM blocking default path that prevents minimum-supported-Rust
+regressions.
 
 ## LEM Savings from PR 07
 
@@ -54,7 +61,8 @@ now costs approximately $0.32 instead of $0.90.
 | ------------------ | -------------------------------- |
 | `platform-matrix`  | `matrix_tests` (85 LEM)          |
 | `full-ci`          | all deep lanes + `matrix_tests`  |
-| `release-check`    | `matrix_tests`, `security`, `publish` |
+| `release-check`    | `matrix_tests`, `security`, `targeted_mutation`, `publish` |
+| `mutation`         | `targeted_mutation`                 |
 | `property-tests`   | `extended_property_tests`        |
 | `python`           | `python_wheels`                  |
 | `api-contract`     | `contracts`                      |
@@ -73,6 +81,12 @@ On `push` to `main`, the following additional lanes run beyond default PRs:
 ## Scheduled Lanes
 
 - `nightly` (via the `nightly.yml` schedule)
+
+## Manual Release Lanes
+
+- `publish` prints or executes the crates.io publish plan by explicit dispatch.
+- `release_readiness` runs the Rust 1.95 / 1.5.0 readiness proof bundle by
+  explicit dispatch or on `release/**` branches.
 
 ## Exceptions
 

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -39,12 +39,12 @@ self-describing and better receipted.
 | Clippy exceptions ledger | present | `policy/clippy-exceptions.toml` governs retained Clippy suppressions separately from cleanup debt. |
 | No-panic allowlist | present, empty | Exact identity is `path + family + selector_kind + selector_callee + snippet + count`. |
 | No-panic baseline | present | Generated no-new-debt baseline follows exact identity. |
-| Non-Rust allowlist | present | File presence is governed; companion behavior ledgers are still planned. |
+| Non-Rust allowlist | present | File presence is governed; companion behavior ledgers split generated, executable, dependency, workflow, process, and network behavior. |
 | CI | staged and routed | Fast, standard, MSRV, matrix, extended, benchmark, coverage, contract, and security lanes already exist. |
 | Coverage | routed/advisory | Coverage runs on main, dispatch, `coverage`, or `full-ci`. |
 | Contracts workflow | present | OpenAPI, proto, schema, and evidence checks already exist. |
 | Publish workflow | present | `publish.yml` handles crates.io publish execution, but not full 1.5.0 readiness proof. |
-| Release readiness workflow | absent | Add a dedicated readiness workflow before the version bump. |
+| Release readiness workflow | present | `release-readiness.yml` owns the manual Rust 1.95 / 1.5.0 readiness proof bundle. |
 | Python publishing | externally blocked | TestPyPI publish remains blocked by issue #563 until Trusted Publisher is configured. |
 
 ## Target State
@@ -153,5 +153,5 @@ policy changes, no-panic baseline scope, file-policy scope, CI economics,
 
 - Issue #563 remains the external TestPyPI Trusted Publisher blocker for
   `hl7v2-python`.
-- `publish.yml` exists for crates.io publication, but the dedicated 1.5.0
-  readiness workflow and release receipt are still planned.
+- `publish.yml` exists for crates.io publication; `release-readiness.yml` is the
+  non-publishing 1.5.0 readiness proof bundle.

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -1,0 +1,94 @@
+# 1.5.0 Release Readiness
+
+This is the receipt home for the Rust 1.95 / `1.5.0` quality-ratchet release.
+It is not a publish receipt until a workflow run URL, commit SHA, and command
+results are recorded here.
+
+## Current State
+
+| Item | State |
+| --- | --- |
+| Release target | `1.5.0` |
+| MSRV | Rust `1.95` |
+| Toolchain pin | `rust-toolchain.toml` uses `1.95.0` with `rustfmt` and `clippy` |
+| Rust publish graph | `hl7v2`, `hl7v2-server`, `hl7v2-cli` |
+| Python distribution | Separate `hl7v2` PyPI lane from internal `hl7v2-python` crate |
+| TestPyPI status | Externally blocked until Trusted Publisher setup is complete |
+| Production PyPI status | Not released |
+
+## Workflow
+
+Run the manual workflow after release-prep changes land on `main` or on a
+dedicated `release/**` branch:
+
+```text
+Workflow: Rust 1.95 / 1.5.0 Release Readiness
+```
+
+The workflow proves:
+
+- formatting;
+- workspace check;
+- Clippy under `-D warnings`;
+- workspace tests;
+- doc tests;
+- lint policy;
+- no-panic policy;
+- file policy;
+- CI lane whitelist;
+- evidence schema fixtures;
+- contracts workflow coverage for OpenAPI, protobuf, JSON Schema, and evidence
+  schema checks;
+- Rust publish plan;
+- Rust publish dry-run with workspace patches;
+- Python publish-policy boundary.
+
+## Local Equivalent
+
+```powershell
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 check --workspace --all-targets --all-features --locked
+cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo +1.95.0 test --workspace --all-features --locked
+cargo +1.95.0 test --doc --workspace --all-features --locked
+cargo +1.95.0 run -p xtask -- check-lint-policy
+cargo +1.95.0 run -p xtask -- check-no-panic-family
+cargo +1.95.0 run -p xtask -- check-file-policy
+cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
+cargo +1.95.0 run -p xtask -- evidence-schema-check
+cargo +1.95.0 run -p xtask -- publish-plan
+cargo +1.95.0 run -p xtask -- publish-dry-run --workspace-patches --allow-dirty
+cargo +1.95.0 run -p xtask -- check-python-publish-policy
+```
+
+## Receipt Fields
+
+Fill these in only after the workflow has run:
+
+| Field | Value |
+| --- | --- |
+| Workflow run URL | Pending |
+| Commit SHA | Pending |
+| Version | Pending |
+| Rust toolchain | Pending |
+| Publish plan result | Pending |
+| Publish dry-run result | Pending |
+| Evidence schema result | Pending |
+| Policy result | Pending |
+| Contract workflow coverage check | Pending |
+| Python boundary check | Pending |
+| Known non-blockers | Pending |
+| Rollback path | Pending |
+
+## Boundaries
+
+- This workflow does not publish to crates.io.
+- This workflow does not publish to TestPyPI or PyPI.
+- The internal `hl7v2-python` Rust crate must remain outside the Rust crates.io
+  publish graph.
+- `hl7v2` TestPyPI/PyPI success must not be claimed until upload and
+  install-back pass in the Python proof workflows.
+- `ripr` remains advisory static mutation-exposure proof.
+- Runtime mutation remains targeted by risk, labels, manual dispatch, nightly,
+  or release-readiness needs; it is not an ordinary PR tax.

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -59,7 +59,7 @@ expires = "2026-11-09"
 id = "msrv_smoke"
 workflow = ".github/workflows/ci.yml"
 job = "msrv-smoke"
-display_name = "MSRV Smoke (1.93)"
+display_name = "MSRV Smoke (1.95)"
 kind = "platform"
 tier = "compatibility"
 default_pr = true
@@ -67,9 +67,9 @@ blocking = true
 runner = "ubuntu_latest"
 base_lem = 12
 owner = "platform/compat"
-intent = "Verify the workspace compiles on the minimum supported Rust version (1.93)."
+intent = "Verify the workspace compiles on the minimum supported Rust version (1.95)."
 failure_mode = "MSRV regression reaches main undetected."
-proof_obligation = "Run cargo check --workspace --all-features on Rust 1.93."
+proof_obligation = "Run cargo check --workspace --all-features on Rust 1.95."
 evidence = ["job logs"]
 allowed_triggers = ["pull_request", "push", "merge_group"]
 duplicate_of = ["fast_checks"]
@@ -372,5 +372,35 @@ evidence = ["job logs"]
 allowed_triggers = ["push:release/**", "workflow_dispatch", "pull_request:labeled"]
 labels = ["release-check"]
 duplicate_of = []
+review_after = "2026-06-09"
+expires = "2026-11-09"
+
+# ---------------------------------------------------------------------------
+# release_readiness -- Rust 1.95 / 1.5.0 release-readiness proof
+# ---------------------------------------------------------------------------
+[[lane]]
+id = "release_readiness"
+workflow = ".github/workflows/release-readiness.yml"
+job = "release-readiness"
+display_name = "Release Readiness"
+kind = "release"
+tier = "release"
+default_pr = false
+blocking = false
+runner = "ubuntu_latest"
+base_lem = 120
+owner = "release/ci"
+intent = "Run the Rust 1.95 release-readiness proof bundle before preparing or shipping 1.5.0."
+failure_mode = "MSRV, policy, evidence, contract, or publish dry-run failure reaches a release candidate."
+proof_obligation = "Run formatting, check, Clippy, workspace tests, doc tests, policy checks, evidence-schema-check, publish-plan, publish-dry-run, and Python publish-policy boundary checks."
+evidence = ["job logs", "GitHub step summary"]
+allowed_triggers = ["push:release/**", "workflow_dispatch"]
+duplicate_of = [
+  "fast_checks",
+  "standard_tests",
+  "msrv_smoke",
+  "contracts",
+  "publish",
+]
 review_after = "2026-06-09"
 expires = "2026-11-09"

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -17,6 +17,11 @@ commands = [
   "cargo clippy",
   "cargo test",
   "cargo run -p xtask -- gate --check",
+  "cargo run -p xtask -- check-ci-lane-whitelist",
+  "cargo run -p xtask -- evidence-schema-check",
+  "cargo run -p xtask -- publish-plan",
+  "cargo run -p xtask -- publish-dry-run --workspace-patches --allow-dirty",
+  "cargo run -p xtask -- check-python-publish-policy",
   "cargo run -p xtask -- policy-report",
 ]
 reason = "Rust/Cargo and xtask are the primary governed process surface."

--- a/policy/workflow-allowlist.toml
+++ b/policy/workflow-allowlist.toml
@@ -57,6 +57,7 @@ surface = "release"
 behavior = "Release, PR planning, nightly, and agent workflows may produce readiness or coordination receipts without broadening default CI."
 workflows = [
   ".github/workflows/publish.yml",
+  ".github/workflows/release-readiness.yml",
   ".github/workflows/pr-plan.yml",
   ".github/workflows/pr-gate.yml",
   ".github/workflows/nightly.yml",


### PR DESCRIPTION
## Summary

- Add a manual/release-branch Rust 1.95 / 1.5.0 release-readiness workflow.
- Add docs/release/1.5.0-readiness.md as the receipt home without claiming a completed release proof yet.
- Govern the new lane in ci-lane, workflow, and process policy ledgers, and refresh CI inventory docs for ripr, targeted mutation, and release readiness.
- Fix the stale MSRV Smoke policy text from 1.93 to 1.95 while touching the CI lane ledger.

## Boundaries

- No crates.io publish.
- No TestPyPI or PyPI publish.
- No default PR CI expansion; the new workflow runs by manual dispatch or release/** branch push.
- Python remains a separate distribution boundary: public hl7v2 package, internal hl7v2-python crate outside crates.io.

## Validation

- cargo run -p xtask -- check-file-policy
- cargo run -p xtask -- check-ci-lane-whitelist
- cargo run -p xtask -- check-doc-links
- cargo run -p xtask -- check-lint-policy
- cargo run -p xtask -- publish-plan
- cargo run -p xtask -- evidence-schema-check
- cargo run -p xtask -- check-python-publish-policy
- cargo run -p xtask -- publish-dry-run --workspace-patches --allow-dirty
- contracts workflow coverage script from release-readiness.yml
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-rust-195 CARGO_INCREMENTAL=0 cargo run -p xtask -- gate --check --changed
- git diff --check