### PR TITLE
release: prepare 1.5.0 for Rust 1.95

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -1,92 +1,129 @@
-id = "hl7v2-1-4-1-source-of-truth-and-python-proof"
-title = "HL7v2 1.4.1 source-of-truth and Python proof"
+id = "hl7v2-1-5-0-rust-1-95-quality-ratchet"
+title = "HL7v2 1.5.0 Rust 1.95 quality ratchet"
 status = "active"
 owner = "codex"
-created = "2026-05-12"
+created = "2026-05-13"
 
 objective = """
-Encode the proposal/spec/ADR/plan/goal source-of-truth model in hl7v2-rs,
-close the TestPyPI Trusted Publisher proof boundary for the public hl7v2 Python
-distribution, and
-prepare a patch release only after evidence receipts are durable.
+Carry hl7v2-rs to a Rust 1.95 / v1.5.0 quality-ratchet release with sharper
+verification rails, no extra default CI weight, and durable receipts before any
+publish claim.
 """
 
 must_not_touch = [
-  "Do not change runtime behavior in this campaign.",
-  "Do not change CI workflows unless a later accepted spec says to.",
+  "Do not combine release prep with crates.io publishing.",
   "Do not publish hl7v2-python to crates.io.",
-  "Do not use token fallback.",
+  "Do not publish the hl7v2 Python distribution to TestPyPI or PyPI without the dedicated proof workflows.",
+  "Do not use TestPyPI or PyPI token fallback.",
   "Do not use skip-existing.",
   "Do not claim TestPyPI or PyPI success until upload and install-back pass.",
+  "Do not make ripr branch-protection blocking yet.",
+  "Do not replace runtime mutation with ripr.",
+  "Do not put broad runtime mutation on ordinary PRs.",
 ]
 
 end_state = [
-  "docs/proposals, docs/specs, docs/adr, plans/1.4.1, and .hl7v2/goals are documented.",
-  "The source-of-truth stack spec is accepted.",
-  "Python distribution proof spec is accepted.",
-  "CI verification economics spec is accepted.",
-  "Evidence artifacts as contracts ADR is accepted.",
-  "Python as separate distribution lane ADR is accepted.",
-  "SUPPORT_TIERS maps product claims to proof commands.",
-  "TestPyPI Trusted Publisher issue #563 is either completed or still explicitly blocked.",
-  "No production PyPI claim exists without upload/install-back receipt.",
-  "Rust publish-plan remains hl7v2, hl7v2-server, hl7v2-cli.",
+  "Rust MSRV is 1.95.",
+  "rust-toolchain.toml pins Rust 1.95.0 with rustfmt and clippy.",
+  "Workspace Rust package graph is prepared as version 1.5.0.",
+  "The Rust publish graph remains hl7v2, hl7v2-server, hl7v2-cli.",
+  "Clippy and rustc lint ratchets are active or explicitly receipted.",
+  "Clippy exceptions are governed separately from broad debt.",
+  "No-panic identity is exact and counted.",
+  "No-panic baseline runs in no-new-debt mode.",
+  "File-policy behavior is split into companion ledgers.",
+  "ripr is advisory static mutation-exposure proof.",
+  "Runtime mutation is targeted by risk instead of default PR tax.",
+  "Release-readiness workflow and v1.5.0 dry-run receipts are present.",
+  "No production release claim exists without publish and install-back receipts.",
 ]
 
 canonical_sources = [
   "docs/STATUS.md",
-  "docs/contracts/evidence-contract-index.md",
-  "schemas/evidence/",
-  "docs/ci/cost-and-verification-policy.md",
-  "policy/ci-lane-whitelist.toml",
-  "policy/ci-risk-packs.toml",
   "docs/status/SUPPORT_TIERS.md",
-  "docs/guides/python-testpypi-release-proof.md",
-  "docs/guides/python-pypi-release.md",
+  "docs/development/RUST_1_95_ROLLOUT.md",
+  "docs/release/1.5.0-readiness.md",
+  "docs/releases/v1.5.0-rust-1.95-quality-ratchet.md",
+  "docs/ci/ripr.md",
+  "docs/ci/test-evidence-lanes.md",
+  "policy/clippy-lints.toml",
+  "policy/clippy-debt.toml",
+  "policy/clippy-exceptions.toml",
+  "policy/no-panic-allowlist.toml",
+  "policy/no-panic-baseline.toml",
+  "policy/non-rust-allowlist.toml",
 ]
 
 proof_commands = [
-  "cargo +1.93.0 run -p xtask -- check-doc-links",
-  "cargo +1.93.0 run -p xtask -- publish-plan",
-  "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed",
+  "cargo +1.95.0 run -p xtask -- publish-plan",
+  "cargo +1.95.0 run -p xtask -- publish-dry-run --workspace-patches --allow-dirty",
+  "cargo +1.95.0 run -p xtask -- evidence-schema-check",
+  "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- gate --check",
+  "cargo +1.95.0 run -p xtask -- policy-report",
 ]
 
 [[work_item]]
-id = "deployment-adr-link-fix"
+id = "rust-1-95-compatibility-probe"
 status = "done"
-pr = "https://github.com/EffortlessMetrics/hl7v2-rs/pull/565"
-goal = "Replace stale deployment ADR references with the current ADR-012 path."
+goal = "Prove the existing repo builds under Rust 1.95 before changing declared MSRV."
 
 [[work_item]]
-id = "source-of-truth-scaffold"
+id = "msrv-toolchain-bump"
 status = "done"
-proposal = "docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md"
-spec = "docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md"
-plan = "plans/1.4.1/source-of-truth-stack.md"
-support_map = "docs/status/SUPPORT_TIERS.md"
+goal = "Declare Rust 1.95, add rust-toolchain.toml, and align CI/tooling pins."
+
+[[work_item]]
+id = "lint-no-panic-file-policy-ratchets"
+status = "done"
+goal = "Activate or receipt Rust 1.95 lint ratchets, Clippy exceptions, exact no-panic identity, no-new-debt baseline, diagnostics, and file-policy companion ledgers."
+
+[[work_item]]
+id = "ripr-advisory-static-exposure"
+status = "done"
+goal = "Add ripr as advisory PR-time static mutation-exposure proof without branch-protection blocking."
+
+[[work_item]]
+id = "targeted-runtime-mutation"
+status = "done"
+goal = "Route runtime mutation by risk, labels, nightly, manual dispatch, or release readiness."
+
+[[work_item]]
+id = "rust-1-95-api-cleanup"
+status = "done"
+goal = "Use Rust 1.95 APIs where they reduce parser, evidence, or tooling complexity."
+
+[[work_item]]
+id = "selected-clippy-debt-cleanup"
+status = "done"
+goal = "Burn down selected CLI monitor and server metrics lint debt without mechanical suppressions."
+
+[[work_item]]
+id = "release-readiness-workflow"
+status = "done"
+goal = "Add the non-publishing Rust 1.95 / v1.5.0 readiness workflow."
+
+[[work_item]]
+id = "v1-5-0-release-prep"
+status = "in_progress"
+goal = "Prepare Cargo versions, current status docs, release notes, changelog, and active goal state for v1.5.0."
 commands = [
-  "cargo +1.93.0 run -p xtask -- check-doc-links",
-  "cargo +1.93.0 run -p xtask -- publish-plan",
-  "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed",
+  "cargo +1.95.0 run -p xtask -- publish-plan",
+  "cargo +1.95.0 run -p xtask -- publish-dry-run --workspace-patches --allow-dirty",
+  "cargo +1.95.0 run -p xtask -- evidence-schema-check",
+  "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- gate --check --changed",
+  "cargo +1.95.0 run -p xtask -- policy-report",
 ]
 
 [[work_item]]
-id = "ci-verification-economics"
-status = "done"
-spec = "docs/specs/HL7V2-SPEC-0003-ci-verification-economics.md"
-policy = "docs/ci/cost-and-verification-policy.md"
-goal = "Explain why deep and efficient verification are the same design goal at industrialized PR volume."
+id = "v1-5-0-dry-run-proof"
+status = "pending"
+goal = "Record v1.5.0 release-readiness and publish-dry-run receipts after release prep lands."
 
 [[work_item]]
 id = "testpypi-trusted-publisher-proof"
 status = "blocked"
 blocked_by = "https://github.com/EffortlessMetrics/hl7v2-rs/issues/563"
-spec = "docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md"
-adr = "docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md"
-plan = "plans/1.4.1/testpypi-closure.md"
-commands = [
-  "gh workflow run python-testpypi.yml --ref main -f publish_to_testpypi=true",
-]
+goal = "Configure TestPyPI Trusted Publisher for the public hl7v2 Python distribution, then prove upload and install-back."
 acceptance = [
   "Build and smoke wheel succeeds.",
   "Publish to TestPyPI succeeds.",
@@ -97,19 +134,6 @@ acceptance = [
 ]
 
 [[work_item]]
-id = "active-goal-manifest"
-status = "ready"
-plan = "plans/1.4.1/implementation-plan.md"
-goal = "Land this active manifest after all referenced proposal, spec, ADR, and plan files exist."
-commands = [
-  "cargo +1.93.0 run -p xtask -- check-doc-links",
-  "cargo +1.93.0 run -p xtask -- publish-plan",
-  "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.93.0 run -p xtask -- gate --check --changed",
-]
-
-[[work_item]]
-id = "v1-4-1-release-readiness"
-status = "waiting"
-plan = "plans/1.4.1/release-readiness.md"
-goal = "Prepare a patch release candidate only after source-of-truth and Python proof receipts are clean."
-blocked_by = "testpypi-trusted-publisher-proof"
+id = "v1-5-0-publish"
+status = "pending-explicit-approval"
+goal = "Publish the Rust crates.io graph only after readiness and dry-run receipts are clean and explicit release approval is given."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No entries yet.
+
+---
+
+## [1.5.0] - 2026-05-13
+
+### Added
+
+- Added an advisory `ripr` static mutation-exposure workflow and suppression
+  policy, keeping runtime mutation as a targeted backstop rather than a default
+  PR tax.
+- Added targeted mutation lane routing for high-risk parser, MLLP, profile,
+  redaction, bundle/replay, evidence-schema, server, Python, and release
+  surfaces.
+- Added a Rust 1.95 / v1.5.0 release-readiness workflow and receipt home for
+  non-publishing proof before crates.io release.
+
 ### Changed
 
 - Raised MSRV from Rust 1.93 to Rust 1.95 and pinned
   `rust-toolchain.toml` to Rust 1.95.0 for local and CI consistency.
+- Prepared the Rust package graph as version `1.5.0` for `hl7v2`,
+  `hl7v2-server`, and `hl7v2-cli`.
+- Tightened the compiler, Clippy, no-panic, and file-policy rails for
+  high-throughput maintenance without increasing default CI weight.
+- Retargeted the public Python distribution metadata and proof workflows to
+  `hl7v2` while keeping the internal `hl7v2-python` Rust crate unpublished to
+  crates.io.
 
-### Planned
+### Fixed
 
-- Mapped the Rust 1.95 / `1.5.0` rollout as a minor-release MSRV ratchet with
-  policy tightening, advisory static mutation-exposure analysis, targeted
-  mutation lanes, and release-readiness proof. No MSRV, toolchain, workflow, or
-  runtime behavior changes are part of the planning PR.
+- Burned down selected CLI monitor and server metrics Clippy debt with bounded
+  conversions and narrower test assertions.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "async-lock",
  "bytes",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-bench"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "criterion",
  "futures",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-e2e-tests"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-examples"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "hl7v2",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-python"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "hl7v2",
  "pyo3",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-server"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "assert_cmd",
  "axum 0.8.9",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "hl7v2-test-utils"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "hl7v2",
  "insta",
@@ -5557,7 +5557,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 rust-version = "1.95"
 
@@ -203,7 +203,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-hl7v2 = { version = "1.4.0", path = "crates/hl7v2", features = [
+hl7v2 = { version = "1.5.0", path = "crates/hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Some historical implementation microcrate artifacts already exist on crates.io; they are compatibility artifacts, not the product surface for new code. The public Python distribution is `hl7v2`, built from the internal `hl7v2-python` maturin lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.5.0 Rust 1.95 quality-ratchet release; v1.5.0 is not published until the release-readiness and dry-run receipts are complete. The public Python distribution is `hl7v2`, built from the internal `hl7v2-python` maturin lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -19,13 +19,13 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Writer / Normalize** | Stable | Writer tests plus HTTP/gRPC normalization contract coverage |
 | **MLLP / Network** | Stable | MLLP parse/framing tests and CI matrix coverage |
 | **REST Server** | Stable | Runtime and OpenAPI agree for parse, validate, redacted validation, bundle/replay, ACK, normalize, inline corpus evidence, readiness, and redacted structured logs |
-| **gRPC Service** | Beta | v1.4.0 contract tests cover Parse, Validate, GenerateAck, Normalize, and HealthCheck; current main also covers ParseStream as one request message into one response message and ValidateRedacted with opt-in v2 evidence |
+| **gRPC Service** | Beta | Contract tests cover Parse, Validate, GenerateAck, Normalize, HealthCheck, ParseStream as one request message into one response message, and ValidateRedacted with opt-in v2 evidence |
 | **Lifecycle** | Beta | Domain tests exist, but lifecycle is not part of the current HTTP/gRPC contract gate |
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
 | **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
-| **Publish Readiness** | Published | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published to crates.io; Python remains a separate binding lane |
-| **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release with opt-in v2 provenance, schema gates, server sidecar hardening, non-publishing Python/TestPyPI proof, PHI sentinels, and replay fixes |
+| **Publish Readiness** | Candidate | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` are prepared at v1.5.0; v1.4.0 remains the current published crates.io release until the v1.5.0 release receipt lands |
+| **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release; v1.5.0 keeps that surface and adds Rust 1.95, tighter policy rails, advisory ripr, targeted mutation, and release-readiness proof |
 
 ## Features
 

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.4.0
+  version: 1.5.0
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-bench/Cargo.toml
+++ b/crates/hl7v2-bench/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "parsing"]
 
 [dependencies]
 # Library surface under benchmark
-hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-cli/Cargo.toml
+++ b/crates/hl7v2-cli/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml.workspace = true
 sha2.workspace = true
-hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
@@ -27,7 +27,7 @@ hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
     "network",
     "synthetic",
 ] }
-hl7v2-server = { version = "1.4.0", path = "../hl7v2-server" }
+hl7v2-server = { version = "1.5.0", path = "../hl7v2-server" }
 sysinfo = "0.38.2"
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -3252,9 +3252,9 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut report_v2, "/tool_version", "1.4.0");
-        set(&mut report_v2, "/version", "1.4.0");
-        set(&mut report_v2, "/checks/0/message", "hl7v2-cli 1.4.0");
+        set(&mut report_v2, "/tool_version", "1.5.0");
+        set(&mut report_v2, "/version", "1.5.0");
+        set(&mut report_v2, "/checks/0/message", "hl7v2-cli 1.5.0");
         set(&mut report_v2, "/checks/5/status", "warn");
         set(
             &mut report_v2,
@@ -3315,7 +3315,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut lint_report_v2, "/tool_version", "1.4.0");
+        set(&mut lint_report_v2, "/tool_version", "1.5.0");
         assert_fixture("profile-lint-report-v2", lint_report_v2);
 
         let mut explain_report = command_json(
@@ -3343,7 +3343,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut explain_report_v2, "/tool_version", "1.4.0");
+        set(&mut explain_report_v2, "/tool_version", "1.5.0");
         set(&mut explain_report_v2, "/profile", "profile.yaml");
         assert_fixture("profile-explain-report-v2", explain_report_v2);
 
@@ -3409,7 +3409,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut test_report_v2, "/tool_version", "1.4.0");
+        set(&mut test_report_v2, "/tool_version", "1.5.0");
         set(&mut test_report_v2, "/profile", "profile.yaml");
         set(&mut test_report_v2, "/fixtures", "fixtures");
         set(
@@ -3473,7 +3473,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut summary_v2, "/tool_version", "1.4.0");
+        set(&mut summary_v2, "/tool_version", "1.5.0");
         set(&mut summary_v2, "/root", "site-a");
         assert_fixture("corpus-summary-v2", summary_v2);
 
@@ -3541,7 +3541,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             ],
             true,
         );
-        set(&mut redact_v2_output, "/receipt/tool_version", "1.4.0");
+        set(&mut redact_v2_output, "/receipt/tool_version", "1.5.0");
         assert_fixture("redaction-receipt-v2", redact_v2_output["receipt"].clone());
 
         let bundle = dir.path().join("issue-bundle");
@@ -3584,7 +3584,7 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
                 .expect("bundle v2 redaction receipt should be readable"),
         )
         .expect("bundle v2 redaction receipt should be JSON");
-        set(&mut receipt_v2, "/tool_version", "1.4.0");
+        set(&mut receipt_v2, "/tool_version", "1.5.0");
         assert_fixture("redaction-receipt-v2", receipt_v2);
 
         let mut field_paths_v2: Value = serde_json::from_slice(

--- a/crates/hl7v2-e2e-tests/Cargo.toml
+++ b/crates/hl7v2-e2e-tests/Cargo.toml
@@ -12,15 +12,15 @@ repository.workspace = true
 
 [dependencies]
 # Local crates - full system integration
-hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",
     "stream",
     "network",
 ] }
-hl7v2-test-utils = { version = "1.4.0", path = "../hl7v2-test-utils" }
-hl7v2-server = { version = "1.4.0", path = "../hl7v2-server" }
+hl7v2-test-utils = { version = "1.5.0", path = "../hl7v2-test-utils" }
+hl7v2-server = { version = "1.5.0", path = "../hl7v2-server" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/Cargo.toml
+++ b/crates/hl7v2-server/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 
 [dependencies]
 # Local crates
-hl7v2 = { version = "1.4.0", path = "../hl7v2", features = [
+hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
     "profile",
     "ack",
     "normalize",

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HL7v2-rs HTTP API
-  version: 1.4.0
+  version: 1.5.0
   description: |
     RESTful API for HL7 v2 message parsing, validation, and processing.
 

--- a/crates/hl7v2-test-utils/Cargo.toml
+++ b/crates/hl7v2-test-utils/Cargo.toml
@@ -11,7 +11,7 @@ publish = false  # Dev-only crate
 repository.workspace = true
 
 [dependencies]
-hl7v2 = { version = "1.4.0", path = "../hl7v2", default-features = false }
+hl7v2 = { version = "1.5.0", path = "../hl7v2", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/hl7v2/src/conformance/validation.rs
+++ b/crates/hl7v2/src/conformance/validation.rs
@@ -1275,7 +1275,7 @@ mod legacy_tests {
         let v1_json = serde_json::to_value(&report).unwrap_or_default();
         let v2 = report.to_v2(
             "hl7v2",
-            "1.4.0",
+            "1.5.0",
             Some(ValidationReportProfileIdentity {
                 label: "adt_a01.yaml".to_string(),
                 message_structure: Some("ADT_A01".to_string()),
@@ -1290,7 +1290,7 @@ mod legacy_tests {
         assert!(v1_json.get("schema_version").is_none());
         assert_eq!(v2.schema_version, "2");
         assert_eq!(v2.tool_name, "hl7v2");
-        assert_eq!(v2.tool_version, "1.4.0");
+        assert_eq!(v2.tool_version, "1.5.0");
         assert_eq!(v2_json["profile_identity"]["message_structure"], "ADT_A01");
         assert_eq!(v2.issue_count, report.issue_count);
         assert_eq!(v2.issues, report.issues);

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -125,7 +125,7 @@ fn lookup_generated_table(index: usize) -> &'static str {
 
 The Rust 1.95 / 1.5.0 rollout is mapped in
 [development/RUST_1_95_ROLLOUT.md](development/RUST_1_95_ROLLOUT.md). The
-current state is Rust 2024, workspace version `1.4.0`, and MSRV `1.95`.
+current state is Rust 2024, workspace version `1.5.0`, and MSRV `1.95`.
 
 During the rollout, planned Rust 1.94/1.95 lints in
 `policy/clippy-lints.toml` should either become active with clean proof or stay

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ proposal, spec, plan, or receipt documents.
 | [Final source-tree gap audit](audits/current-source-tree-evidence-objective-gap-audit.md) | Current package-state receipt after the broad local evidence-lane workbench was split and merged. |
 | [v1.4.0 publish dry-run receipt](audits/publish-dry-run-v1.4.0-2026-05-09.md) | Package verification before upload. |
 | [v1.4.0 publish receipt](audits/publish-v1.4.0-2026-05-09.md) | Dependency-ordered crates.io publication proof. |
+| [v1.5.0 Rust 1.95 release candidate notes](releases/v1.5.0-rust-1.95-quality-ratchet.md) | Candidate scope for the Rust 1.95 quality-ratchet release; not a publish receipt. |
 | [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the internal `hl7v2-python` package outside the Rust crates.io graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,8 +2,8 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-10
-> **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+> **Last Updated**: 2026-05-13
+> **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.5.0 Rust 1.95 quality-ratchet release; v1.5.0 is not published until readiness and dry-run receipts land.
 
 ## Core Components
 
@@ -41,6 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
+- 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and a release-readiness workflow. It still needs v1.5.0 dry-run and publish receipts before any crates.io release claim.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The public Python distribution is `hl7v2`. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the 2026-05-10 TestPyPI upload attempt built and smoke-tested the wheel but failed with `invalid-publisher` because the TestPyPI Trusted Publisher is not configured. Production PyPI release has not been run. A 2026-05-13 package-state check found no visible `hl7v2` package on TestPyPI or production PyPI.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
@@ -54,8 +55,9 @@ uploaded to crates.io for the final Rust package graph.
 Current `main` contains opt-in v2 provenance producers, maintained schema
 validation through `xtask evidence-schema-check`, server replay and inline
 corpus endpoints, redacted structured evidence logs, Docker sidecar smoke
-coverage, broader PHI sentinel tests, Python/TestPyPI proof, and the server
-bundle replay message-type fix.
+coverage, broader PHI sentinel tests, Python/TestPyPI proof rails, the server
+bundle replay message-type fix, Rust 1.95 policy ratchets, advisory `ripr`,
+targeted mutation routing, and the v1.5.0 release-readiness workflow.
 
 For navigation across current docs, historical receipts, and evidence workflow
 guides, start with [the documentation index](README.md). For the current
@@ -102,6 +104,19 @@ Current source-tree truth audit: [`docs/audits/current-source-tree-evidence-obje
 - ✅ **Python proof**: the maturin wheel build/install/import smoke proof passes for the v1.4.0 Python lane package without publishing `hl7v2-python` to crates.io.
 - ✅ **Release notes and tag**: `v1.4.0` is tagged and the GitHub release is published.
 
+## v1.5.0 Readiness Checklist
+
+Release notes: [`docs/releases/v1.5.0-rust-1.95-quality-ratchet.md`](releases/v1.5.0-rust-1.95-quality-ratchet.md).
+Readiness receipt home: [`docs/release/1.5.0-readiness.md`](release/1.5.0-readiness.md).
+
+- 🟡 **Release candidate**: workspace package versions are prepared as `1.5.0` for the Rust package graph.
+- ✅ **Rust floor**: MSRV is Rust 1.95 and `rust-toolchain.toml` pins Rust 1.95.0 with `rustfmt` and `clippy`.
+- ✅ **Verification rails**: lint policy, Clippy exceptions, no-panic exact identity and no-new-debt baseline, file-policy companion ledgers, advisory `ripr`, and targeted mutation routing are present.
+- ✅ **Release readiness workflow**: `.github/workflows/release-readiness.yml` records the non-publishing readiness proof bundle.
+- 🟡 **Dry-run receipt**: v1.5.0 publish dry-run receipt is pending and must land before a release claim.
+- 🟡 **Publish receipt**: crates.io upload has not been run for v1.5.0.
+- 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains outside the Rust crates.io graph, and still requires Trusted Publisher upload/install-back proof before any TestPyPI or PyPI success claim.
+
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
@@ -109,5 +124,6 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 
 **Current published release**: v1.4.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
-**Current main**: tracks the v1.4.0 Evidence Contracts and Server Sidecar
-release line.
+**Current main**: prepares the v1.5.0 Rust 1.95 quality-ratchet candidate.
+v1.4.0 remains the current published crates.io release until v1.5.0 readiness,
+dry-run, publish, and tag receipts land.

--- a/docs/architecture/evidence-provenance-versioning.md
+++ b/docs/architecture/evidence-provenance-versioning.md
@@ -45,7 +45,7 @@ exception:
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0"
+  "tool_version": "1.5.0"
 }
 ```
 

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -29,7 +29,7 @@ self-describing and better receipted.
 | Surface | Current state | Notes |
 | --- | --- | --- |
 | Rust edition | `2024` | No edition migration is planned. |
-| Workspace version | `1.4.0` | The next release target is `1.5.0`. |
+| Workspace version | `1.5.0` candidate | v1.4.0 remains the current published crates.io release until v1.5.0 receipts land. |
 | Workspace MSRV | `1.95` | Declared in the root `Cargo.toml` after the compatibility probe. |
 | Toolchain file | present | `rust-toolchain.toml` pins Rust `1.95.0` with `rustfmt` and `clippy`. |
 | Root lint policy | strict | Rust and Clippy lints are already governed from the workspace root. |
@@ -151,7 +151,7 @@ policy changes, no-panic baseline scope, file-policy scope, CI economics,
 
 ## Current Follow-Ups
 
-- Issue #563 remains the external TestPyPI Trusted Publisher blocker for
-  `hl7v2-python`.
+- Issue #563 remains the external TestPyPI Trusted Publisher blocker for the
+  public `hl7v2` Python distribution.
 - `publish.yml` exists for crates.io publication; `release-readiness.yml` is the
   non-publishing 1.5.0 readiness proof bundle.

--- a/docs/guides/first-10-minutes.md
+++ b/docs/guides/first-10-minutes.md
@@ -49,7 +49,7 @@ Expected output includes local diagnostics:
 
 ```json
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "checks": [
     {
       "name": "sample-parse",

--- a/docs/guides/python-evidence-workflow.md
+++ b/docs/guides/python-evidence-workflow.md
@@ -198,7 +198,7 @@ Expected output has the same evidence semantics as the CLI and server:
     "value_not_in_set"
   ],
   "validation_valid": false,
-  "version": "1.4.0"
+  "version": "1.5.0"
 }
 ```
 

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -70,8 +70,8 @@ Fill these in only after the workflow has run:
 | --- | --- |
 | Workflow run URL | Pending |
 | Commit SHA | Pending |
-| Version | Pending |
-| Rust toolchain | Pending |
+| Version | `1.5.0` candidate |
+| Rust toolchain | Rust `1.95.0` |
 | Publish plan result | Pending |
 | Publish dry-run result | Pending |
 | Evidence schema result | Pending |

--- a/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
+++ b/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
@@ -1,0 +1,56 @@
+# v1.5.0 Rust 1.95 Quality Ratchet
+
+Status: release candidate. This document describes the intended v1.5.0 Rust
+release scope. It is not a publish receipt.
+
+## Release Graph
+
+The Rust crates.io graph remains:
+
+- `hl7v2`
+- `hl7v2-server`
+- `hl7v2-cli`
+
+The internal `hl7v2-python` Rust crate remains `publish = false` and outside the
+Rust crates.io graph. The public Python distribution is `hl7v2`, but TestPyPI
+and PyPI success require separate upload and install-back receipts.
+
+## Highlights
+
+- Raises the workspace MSRV to Rust 1.95 and pins `rust-toolchain.toml` to
+  Rust 1.95.0 with `rustfmt` and `clippy`.
+- Prepares the Rust package graph as version `1.5.0`.
+- Tightens compiler, Clippy, no-panic, and file-policy rails without adding
+  broad default CI weight.
+- Keeps retained Clippy suppressions in a dedicated exceptions ledger separate
+  from temporary lint cleanup debt.
+- Uses exact counted no-panic identity with a no-new-debt baseline.
+- Splits file existence policy from generated, executable, dependency,
+  workflow, process, and network behavior ledgers.
+- Adds advisory `ripr` static mutation-exposure analysis as a PR-time signal.
+- Routes runtime mutation by risk, labels, nightly, manual dispatch, or release
+  readiness instead of making full mutation an ordinary PR tax.
+- Applies Rust 1.95 API cleanup where it reduces parser, evidence, or tooling
+  complexity.
+- Adds a non-publishing release-readiness workflow for v1.5.0 proof.
+
+## Boundaries
+
+- This release candidate does not publish to crates.io.
+- This release candidate does not publish to TestPyPI or PyPI.
+- `ripr` remains advisory and is not branch-protection blocking.
+- Runtime mutation remains the slower backstop and is not replaced by `ripr`.
+- Production PyPI remains a separate explicit release decision after
+  same-commit TestPyPI proof.
+
+## Receipts Required Before Publish
+
+- Release-readiness workflow run URL.
+- Commit SHA for the release candidate.
+- `cargo +1.95.0 run -p xtask -- publish-plan`.
+- `cargo +1.95.0 run -p xtask -- publish-dry-run --workspace-patches --allow-dirty`.
+- `cargo +1.95.0 run -p xtask -- evidence-schema-check`.
+- `cargo +1.95.0 run -p xtask -- gate --check`.
+- `cargo +1.95.0 run -p xtask -- policy-report`.
+- Publish receipt after crates.io upload.
+- Tag and GitHub release receipt.

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -31,7 +31,7 @@ claim tier or proof expectations.
 | Python binding local wheel lane | Experimental | `python tests/python_smoke/smoke.py`; `python tests/python_smoke/evidence_workflow_guide.py` after a local wheel install |
 | Python TestPyPI distribution (`hl7v2`) | Blocked | Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563); requires TestPyPI upload and install-back receipt |
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
-| Rust crates.io release graph | Stable | `cargo run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli` |
+| Rust crates.io release graph | Stable | `cargo run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
 
 ## Rules
 

--- a/fixtures/evidence/corpus-diff-v2.json
+++ b/fixtures/evidence/corpus-diff-v2.json
@@ -2,7 +2,7 @@
   "schema_version": "2",
   "diff_version": "1",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "before_root": "before",
   "after_root": "after",
   "profile": null,

--- a/fixtures/evidence/corpus-fingerprint-v2.json
+++ b/fixtures/evidence/corpus-fingerprint-v2.json
@@ -2,7 +2,7 @@
   "schema_version": "2",
   "fingerprint_version": "1",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "root": "site-a",
   "profile": null,
   "file_count": 1,

--- a/fixtures/evidence/corpus-summary-v2.json
+++ b/fixtures/evidence/corpus-summary-v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "root": "site-a",
   "file_count": 1,
   "message_count": 1,

--- a/fixtures/evidence/doctor-report-v2.json
+++ b/fixtures/evidence/doctor-report-v2.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
-  "version": "1.4.0",
+  "tool_version": "1.5.0",
+  "version": "1.5.0",
   "checks": [
     {
       "name": "cli-version",
       "status": "ok",
-      "message": "hl7v2-cli 1.4.0"
+      "message": "hl7v2-cli 1.5.0"
     },
     {
       "name": "sample-parse",

--- a/fixtures/evidence/profile-explain-report-v2.json
+++ b/fixtures/evidence/profile-explain-report-v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "profile": "profile.yaml",
   "profile_sha256": "3fb926fc70cb562412775c4f91f0ee9e9c4405e120057d7c8ab21f6a6d2526bc",
   "message_structure": "ADT_A01",

--- a/fixtures/evidence/profile-lint-report-v2.json
+++ b/fixtures/evidence/profile-lint-report-v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "valid": true,
   "error_count": 0,
   "warning_count": 1,

--- a/fixtures/evidence/profile-test-report-v2.json
+++ b/fixtures/evidence/profile-test-report-v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "profile": "profile.yaml",
   "fixtures": "fixtures",
   "valid": true,

--- a/fixtures/evidence/redaction-receipt-v2.json
+++ b/fixtures/evidence/redaction-receipt-v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "phi_removed": true,
   "hash_algorithm": "sha256",
   "actions": [

--- a/fixtures/evidence/validation-report-v2.json
+++ b/fixtures/evidence/validation-report-v2.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2",
   "tool_name": "hl7v2-cli",
-  "tool_version": "1.4.0",
+  "tool_version": "1.5.0",
   "valid": false,
   "message_type": "ADT^A01",
   "profile": "profile.yaml",


### PR DESCRIPTION
## Summary

- prepare the Rust crates.io graph as v1.5.0 for the Rust 1.95 quality-ratchet release
- update current status, changelog, release-candidate notes, readiness docs, and active goal state
- align OpenAPI/examples/evidence golden fixture tool versions with the v1.5.0 package graph

## Boundaries

- no crates.io publishing
- no TestPyPI or PyPI publishing
- hl7v2-python remains outside the Rust crates.io publish graph
- v1.5.0 remains a candidate until readiness, dry-run, publish, and tag receipts land

## Validation

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features --locked
- cargo test -p hl7v2 --all-features
- cargo test -p hl7v2-cli --all-features
- cargo run -p xtask -- check-doc-links
- cargo run -p xtask -- check-lint-policy
- cargo run -p xtask -- check-no-panic-family
- cargo run -p xtask -- check-file-policy
- cargo run -p xtask -- check-ci-lane-whitelist
- cargo run -p xtask -- publish-plan
- cargo run -p xtask -- evidence-schema-check
- cargo run -p xtask -- check-python-publish-policy
- cargo run -p xtask -- policy-report
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo run -p xtask -- gate --check --changed
- cargo run -p xtask -- publish-dry-run --workspace-patches --allow-dirty
- git diff --check