### PR TITLE
release: validate 1.5.0 publish readiness

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -104,7 +104,7 @@ goal = "Add the non-publishing Rust 1.95 / v1.5.0 readiness workflow."
 
 [[work_item]]
 id = "v1-5-0-release-prep"
-status = "in_progress"
+status = "done"
 goal = "Prepare Cargo versions, current status docs, release notes, changelog, and active goal state for v1.5.0."
 commands = [
   "cargo +1.95.0 run -p xtask -- publish-plan",
@@ -116,8 +116,10 @@ commands = [
 
 [[work_item]]
 id = "v1-5-0-dry-run-proof"
-status = "pending"
+status = "done"
 goal = "Record v1.5.0 release-readiness and publish-dry-run receipts after release prep lands."
+run = "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128"
+receipt = "docs/audits/publish-dry-run-v1.5.0-2026-05-13.md"
 
 [[work_item]]
 id = "testpypi-trusted-publisher-proof"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.5.0 Rust 1.95 quality-ratchet release; v1.5.0 is not published until the release-readiness and dry-run receipts are complete. The public Python distribution is `hl7v2`, built from the internal `hl7v2-python` maturin lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate with readiness and dry-run receipts; v1.5.0 is not published until explicit crates.io publish and tag receipts land. The public Python distribution is `hl7v2`, built from the internal `hl7v2-python` maturin lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ proposal, spec, plan, or receipt documents.
 | [v1.4.0 publish receipt](audits/publish-v1.4.0-2026-05-09.md) | Dependency-ordered crates.io publication proof. |
 | [v1.5.0 Rust 1.95 release candidate notes](releases/v1.5.0-rust-1.95-quality-ratchet.md) | Candidate scope for the Rust 1.95 quality-ratchet release; not a publish receipt. |
 | [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
+| [v1.5.0 publish dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-13.md) | Non-publishing crates.io dry-run proof for the v1.5.0 Rust graph. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the internal `hl7v2-python` package outside the Rust crates.io graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-13
-> **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is preparing the v1.5.0 Rust 1.95 quality-ratchet release; v1.5.0 is not published until readiness and dry-run receipts land.
+> **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate; v1.5.0 is not published until explicit crates.io publish and tag receipts land.
 
 ## Core Components
 
@@ -41,7 +41,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
-- 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and a release-readiness workflow. It still needs v1.5.0 dry-run and publish receipts before any crates.io release claim.
+- 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and release-readiness and dry-run receipts. It still needs explicit crates.io publish and tag receipts before any release claim.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The public Python distribution is `hl7v2`. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the 2026-05-10 TestPyPI upload attempt built and smoke-tested the wheel but failed with `invalid-publisher` because the TestPyPI Trusted Publisher is not configured. Production PyPI release has not been run. A 2026-05-13 package-state check found no visible `hl7v2` package on TestPyPI or production PyPI.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
@@ -107,13 +107,14 @@ Current source-tree truth audit: [`docs/audits/current-source-tree-evidence-obje
 ## v1.5.0 Readiness Checklist
 
 Release notes: [`docs/releases/v1.5.0-rust-1.95-quality-ratchet.md`](releases/v1.5.0-rust-1.95-quality-ratchet.md).
-Readiness receipt home: [`docs/release/1.5.0-readiness.md`](release/1.5.0-readiness.md).
+Readiness receipt: [`docs/release/1.5.0-readiness.md`](release/1.5.0-readiness.md).
+Dry-run receipt: [`docs/audits/publish-dry-run-v1.5.0-2026-05-13.md`](audits/publish-dry-run-v1.5.0-2026-05-13.md).
 
 - 🟡 **Release candidate**: workspace package versions are prepared as `1.5.0` for the Rust package graph.
 - ✅ **Rust floor**: MSRV is Rust 1.95 and `rust-toolchain.toml` pins Rust 1.95.0 with `rustfmt` and `clippy`.
 - ✅ **Verification rails**: lint policy, Clippy exceptions, no-panic exact identity and no-new-debt baseline, file-policy companion ledgers, advisory `ripr`, and targeted mutation routing are present.
 - ✅ **Release readiness workflow**: `.github/workflows/release-readiness.yml` records the non-publishing readiness proof bundle.
-- 🟡 **Dry-run receipt**: v1.5.0 publish dry-run receipt is pending and must land before a release claim.
+- ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `38043c62b6684c3bd074661ae6e6089250593132`.
 - 🟡 **Publish receipt**: crates.io upload has not been run for v1.5.0.
 - 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains outside the Rust crates.io graph, and still requires Trusted Publisher upload/install-back proof before any TestPyPI or PyPI success claim.
 
@@ -124,6 +125,6 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 
 **Current published release**: v1.4.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
 
-**Current main**: prepares the v1.5.0 Rust 1.95 quality-ratchet candidate.
-v1.4.0 remains the current published crates.io release until v1.5.0 readiness,
-dry-run, publish, and tag receipts land.
+**Current main**: is prepared as the v1.5.0 Rust 1.95 quality-ratchet
+candidate. v1.4.0 remains the current published crates.io release until v1.5.0
+publish and tag receipts land.

--- a/docs/audits/publish-dry-run-v1.5.0-2026-05-13.md
+++ b/docs/audits/publish-dry-run-v1.5.0-2026-05-13.md
@@ -1,0 +1,79 @@
+# v1.5.0 Publish Dry-Run Receipt
+
+This receipt records non-publishing release-readiness proof for the
+`hl7v2-rs` Rust 1.95 / v1.5.0 quality-ratchet candidate.
+
+It is not a crates.io publish receipt. It is not a TestPyPI or PyPI receipt.
+
+## Candidate
+
+| Field | Value |
+| --- | --- |
+| Version | `1.5.0` |
+| Commit SHA | `38043c62b6684c3bd074661ae6e6089250593132` |
+| Workflow | Rust 1.95 / 1.5.0 Release Readiness |
+| Run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128> |
+| Job URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128/job/75826420754> |
+| Result | Success |
+
+## Rust Publish Graph
+
+The publish plan remained:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+The internal `hl7v2-python` Rust crate remained outside the crates.io graph.
+
+## Hosted Proof
+
+The release-readiness workflow passed on `main` with Rust `1.95.0` and
+`PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`.
+
+Passed steps:
+
+- `cargo fmt --all -- --check`
+- `cargo check --workspace --all-targets --all-features --locked`
+- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+- `cargo test --workspace --all-features --locked`
+- `cargo test --doc --workspace --all-features --locked`
+- `cargo run -p xtask -- check-lint-policy`
+- `cargo run -p xtask -- check-no-panic-family`
+- `cargo run -p xtask -- check-file-policy`
+- `cargo run -p xtask -- check-ci-lane-whitelist`
+- `cargo run -p xtask -- evidence-schema-check`
+- contract workflow coverage check for OpenAPI, protobuf, JSON Schema, and
+  evidence schema rails
+- `cargo run -p xtask -- publish-plan`
+- `cargo run -p xtask -- publish-dry-run --workspace-patches --allow-dirty`
+- `cargo run -p xtask -- check-python-publish-policy`
+
+The dry-run packaged and verified `hl7v2`, `hl7v2-server`, and `hl7v2-cli` as
+`1.5.0`, then aborted uploads because the run was a dry-run.
+
+## Python Boundary
+
+The workflow confirmed:
+
+- public Python distribution: `hl7v2`;
+- internal Rust binding crate: `hl7v2-python`;
+- Rust crates.io publish graph: `hl7v2`, `hl7v2-server`, `hl7v2-cli`;
+- no TestPyPI or PyPI success claim was made.
+
+Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563)
+remains the external TestPyPI Trusted Publisher blocker.
+
+## Known Non-Blockers
+
+- Hosted Actions emitted Node 20 deprecation annotations for existing actions.
+- Production PyPI has not been released.
+- crates.io publish, tag, and GitHub release have not been run.
+
+## Rollback Path
+
+Before crates.io publish, supersede this candidate with another release-prep
+commit or revert the v1.5.0 candidate commits.
+
+After crates.io publish, prefer a forward-fix patch unless a security, legal, or
+metadata integrity issue requires yanking.

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -1,8 +1,8 @@
 # 1.5.0 Release Readiness
 
 This is the receipt home for the Rust 1.95 / `1.5.0` quality-ratchet release.
-It is not a publish receipt until a workflow run URL, commit SHA, and command
-results are recorded here.
+It records readiness and dry-run proof only. It is not a crates.io publish,
+tag, GitHub release, TestPyPI, or PyPI receipt.
 
 ## Current State
 
@@ -64,22 +64,49 @@ cargo +1.95.0 run -p xtask -- check-python-publish-policy
 
 ## Receipt Fields
 
-Fill these in only after the workflow has run:
-
 | Field | Value |
 | --- | --- |
-| Workflow run URL | Pending |
-| Commit SHA | Pending |
+| Workflow run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128> |
+| Commit SHA | `38043c62b6684c3bd074661ae6e6089250593132` |
 | Version | `1.5.0` candidate |
 | Rust toolchain | Rust `1.95.0` |
-| Publish plan result | Pending |
-| Publish dry-run result | Pending |
-| Evidence schema result | Pending |
-| Policy result | Pending |
-| Contract workflow coverage check | Pending |
-| Python boundary check | Pending |
-| Known non-blockers | Pending |
-| Rollback path | Pending |
+| Publish plan result | Passed. Publish order remains `hl7v2`, `hl7v2-server`, `hl7v2-cli`. |
+| Publish dry-run result | Passed with workspace patches and dry-run upload aborts only. |
+| Evidence schema result | Passed. Evidence fixtures validated against schema contracts. |
+| Policy result | Passed. Lint, no-panic, file, and CI lane policy checks completed. |
+| Contract workflow coverage check | Passed. Workflow still covers OpenAPI, protobuf, JSON Schema, and evidence schema checks. |
+| Python boundary check | Passed. Public Python distribution is `hl7v2`; internal Rust crate `hl7v2-python` remains outside crates.io. |
+| Known non-blockers | TestPyPI Trusted Publisher issue #563 remains external; production PyPI is not released; crates.io publish/tag not run; hosted Actions emitted Node 20 deprecation annotations for existing actions. |
+| Rollback path | Before publish, revert or supersede the v1.5.0 release-prep commits. After crates.io publish, do not yank by default; prefer forward-fix unless a security or legal issue requires yanking. |
+
+## Readiness Result
+
+The hosted readiness workflow succeeded on `main` at commit
+`38043c62b6684c3bd074661ae6e6089250593132`.
+
+The release-readiness job passed these steps:
+
+- formatting;
+- workspace check;
+- Clippy under `-D warnings`;
+- workspace tests;
+- doc tests;
+- lint, no-panic, file, and CI lane policy rails;
+- evidence schema fixtures;
+- contract workflow coverage check;
+- Rust publish graph check;
+- Rust publish dry-run with workspace patches;
+- Python distribution boundary check.
+
+The dry-run packaged and verified the Rust crates.io graph as `1.5.0` without
+uploading:
+
+1. `hl7v2`
+2. `hl7v2-server`
+3. `hl7v2-cli`
+
+See the dedicated dry-run receipt:
+[`docs/audits/publish-dry-run-v1.5.0-2026-05-13.md`](../audits/publish-dry-run-v1.5.0-2026-05-13.md).
 
 ## Boundaries
 

--- a/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
+++ b/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
@@ -43,14 +43,16 @@ and PyPI success require separate upload and install-back receipts.
 - Production PyPI remains a separate explicit release decision after
   same-commit TestPyPI proof.
 
-## Receipts Required Before Publish
+## Readiness Receipts
 
-- Release-readiness workflow run URL.
-- Commit SHA for the release candidate.
-- `cargo +1.95.0 run -p xtask -- publish-plan`.
-- `cargo +1.95.0 run -p xtask -- publish-dry-run --workspace-patches --allow-dirty`.
-- `cargo +1.95.0 run -p xtask -- evidence-schema-check`.
-- `cargo +1.95.0 run -p xtask -- gate --check`.
-- `cargo +1.95.0 run -p xtask -- policy-report`.
+- Release-readiness workflow:
+  <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128>.
+- Candidate commit SHA:
+  `38043c62b6684c3bd074661ae6e6089250593132`.
+- Publish dry-run receipt:
+  [`docs/audits/publish-dry-run-v1.5.0-2026-05-13.md`](../audits/publish-dry-run-v1.5.0-2026-05-13.md).
+
+## Receipts Still Required For A Release Claim
+
 - Publish receipt after crates.io upload.
 - Tag and GitHub release receipt.


### PR DESCRIPTION
## Summary

- record the successful hosted Rust 1.95 / v1.5.0 Release Readiness run on main
- add the v1.5.0 publish dry-run receipt and link it from status/release docs
- mark release-prep and dry-run proof work items done while leaving publish pending explicit approval

## Receipt

- Workflow run: https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128
- Commit: 38043c62b6684c3bd074661ae6e6089250593132
- Result: success
- Publish graph: hl7v2 -> hl7v2-server -> hl7v2-cli

## Boundaries

- no crates.io publish
- no tag or GitHub release
- no TestPyPI or PyPI publish
- Python distribution remains hl7v2 and internal hl7v2-python remains outside crates.io

## Validation

- hosted release-readiness workflow passed on main
- cargo run -p xtask -- check-doc-links
- cargo run -p xtask -- check-file-policy
- cargo run -p xtask -- publish-plan
- cargo run -p xtask -- policy-report
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo run -p xtask -- gate --check --changed
- git diff --check