### PR TITLE
policy(clippy): remove legacy mock suppressions

### DIFF
--- a/crates/hl7v2-test-utils/src/mocks.rs
+++ b/crates/hl7v2-test-utils/src/mocks.rs
@@ -376,12 +376,13 @@ fn extract_mllp_payload(data: &[u8]) -> &[u8] {
 /// // Use with server
 /// // server.run(handler).await;
 /// ```
+type MockResponseQueue = Arc<RwLock<VecDeque<Result<Option<Message>, Error>>>>;
+type MockResponseFn = Arc<dyn Fn(&Message) -> Result<Option<Message>, Error> + Send + Sync>;
+
 pub struct MockMessageHandler {
-    #[allow(clippy::type_complexity)]
-    responses: Arc<RwLock<VecDeque<Result<Option<Message>, Error>>>>,
+    responses: MockResponseQueue,
     received: Arc<RwLock<Vec<Message>>>,
-    #[allow(clippy::type_complexity)]
-    response_fn: Option<Arc<dyn Fn(&Message) -> Result<Option<Message>, Error> + Send + Sync>>,
+    response_fn: Option<MockResponseFn>,
 }
 
 impl Default for MockMessageHandler {


### PR DESCRIPTION
﻿## Summary

- replace the legacy clippy::type_complexity allow attributes on MockMessageHandler fields with local type aliases
- keep the Clippy exceptions ledger free of retained suppressions for this case
- preserve behavior; this is a type readability and policy cleanup only

## Validation

- cargo fmt --all -- --check
- cargo clippy -p hl7v2-test-utils --all-targets --all-features --locked -- -D warnings
- cargo run -p xtask -- check-lint-policy
- git grep -n for source-level clippy allows under crates and xtask only finds the xtask documentation string
- git diff --check

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes, one mock helper file
- No unrelated cleanup: yes
- Policy changes are intentional: removes legacy bare suppressions instead of adding exceptions
- No Clippy test carveouts added: yes
- No bare clippy allow added: yes
- No-panic baseline handling is scoped: not touched
- Non-Rust allowlist changes are narrow: not touched
- CI economics: lanes are unchanged
- ripr mutation-exposure framing preserved: not touched
- Release evidence preserved: not touched
- Local validation: listed above
- CI status: pending on draft PR
- Bot comments addressed: none yet
- Follow-ups: none
