### PR TITLE
docs(release): refresh 1.5.0 readiness receipt

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -114,7 +114,7 @@ Dry-run receipt: [`docs/audits/publish-dry-run-v1.5.0-2026-05-13.md`](audits/pub
 - ✅ **Rust floor**: MSRV is Rust 1.95 and `rust-toolchain.toml` pins Rust 1.95.0 with `rustfmt` and `clippy`.
 - ✅ **Verification rails**: lint policy, Clippy exceptions, no-panic exact identity and no-new-debt baseline, file-policy companion ledgers, advisory `ripr`, and targeted mutation routing are present.
 - ✅ **Release readiness workflow**: `.github/workflows/release-readiness.yml` records the non-publishing readiness proof bundle.
-- ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `38043c62b6684c3bd074661ae6e6089250593132`.
+- ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `b0bb5b5392354273946f36f797f39d741d318fc1`.
 - 🟡 **Publish receipt**: crates.io upload has not been run for v1.5.0.
 - 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains outside the Rust crates.io graph, and still requires Trusted Publisher upload/install-back proof before any TestPyPI or PyPI success claim.
 

--- a/docs/audits/publish-dry-run-v1.5.0-2026-05-13.md
+++ b/docs/audits/publish-dry-run-v1.5.0-2026-05-13.md
@@ -10,10 +10,10 @@ It is not a crates.io publish receipt. It is not a TestPyPI or PyPI receipt.
 | Field | Value |
 | --- | --- |
 | Version | `1.5.0` |
-| Commit SHA | `38043c62b6684c3bd074661ae6e6089250593132` |
+| Commit SHA | `b0bb5b5392354273946f36f797f39d741d318fc1` |
 | Workflow | Rust 1.95 / 1.5.0 Release Readiness |
-| Run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128> |
-| Job URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128/job/75826420754> |
+| Run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25814999531> |
+| Job URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25814999531/job/75841051085> |
 | Result | Success |
 
 ## Rust Publish Graph

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -66,8 +66,8 @@ cargo +1.95.0 run -p xtask -- check-python-publish-policy
 
 | Field | Value |
 | --- | --- |
-| Workflow run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128> |
-| Commit SHA | `38043c62b6684c3bd074661ae6e6089250593132` |
+| Workflow run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25814999531> |
+| Commit SHA | `b0bb5b5392354273946f36f797f39d741d318fc1` |
 | Version | `1.5.0` candidate |
 | Rust toolchain | Rust `1.95.0` |
 | Publish plan result | Passed. Publish order remains `hl7v2`, `hl7v2-server`, `hl7v2-cli`. |
@@ -82,7 +82,7 @@ cargo +1.95.0 run -p xtask -- check-python-publish-policy
 ## Readiness Result
 
 The hosted readiness workflow succeeded on `main` at commit
-`38043c62b6684c3bd074661ae6e6089250593132`.
+`b0bb5b5392354273946f36f797f39d741d318fc1`.
 
 The release-readiness job passed these steps:
 

--- a/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
+++ b/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
@@ -46,9 +46,9 @@ and PyPI success require separate upload and install-back receipts.
 ## Readiness Receipts
 
 - Release-readiness workflow:
-  <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128>.
+  <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25814999531>.
 - Candidate commit SHA:
-  `38043c62b6684c3bd074661ae6e6089250593132`.
+  `b0bb5b5392354273946f36f797f39d741d318fc1`.
 - Publish dry-run receipt:
   [`docs/audits/publish-dry-run-v1.5.0-2026-05-13.md`](../audits/publish-dry-run-v1.5.0-2026-05-13.md).
 


### PR DESCRIPTION
﻿## Summary

- update the v1.5.0 readiness and dry-run receipts to the fresh post-#602 release-readiness workflow
- record current main commit b0bb5b5392354273946f36f797f39d741d318fc1 and run 25814999531
- keep the receipt explicit that this is not a crates.io, TestPyPI, or PyPI publish

## Validation

- cargo run -p xtask -- check-doc-links
- cargo run -p xtask -- check-file-policy
- git diff --check

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes, release/status docs only
- No unrelated cleanup: yes
- Policy changes are intentional: no policy behavior changes
- No Clippy test carveouts added: yes
- No bare clippy allow added: yes
- No-panic baseline handling is scoped: not touched
- Non-Rust allowlist changes are narrow: not touched
- CI economics: lanes are unchanged
- ripr mutation-exposure framing preserved: not touched
- Release evidence preserved: yes, refreshed to latest readiness run
- Local validation: listed above
- CI status: pending on draft PR
- Bot comments addressed: none yet
- Follow-ups: none
