### PR TITLE
docs(adr): allow publishable binding backend crates

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -12,7 +12,7 @@ publish claim.
 
 must_not_touch = [
   "Do not combine release prep with crates.io publishing.",
-  "Do not publish hl7v2-python to crates.io.",
+  "Do not publish hl7v2-python to crates.io until a binding-backend release PR explicitly approves metadata, tooling, and receipts.",
   "Do not publish the hl7v2 Python distribution to TestPyPI or PyPI without the dedicated proof workflows.",
   "Do not use TestPyPI or PyPI token fallback.",
   "Do not use skip-existing.",
@@ -25,8 +25,8 @@ must_not_touch = [
 end_state = [
   "Rust MSRV is 1.95.",
   "rust-toolchain.toml pins Rust 1.95.0 with rustfmt and clippy.",
-  "Workspace Rust package graph is prepared as version 1.5.0.",
-  "The Rust publish graph remains hl7v2, hl7v2-server, hl7v2-cli.",
+  "Primary Rust product graph is prepared as version 1.5.0.",
+  "The primary Rust product graph remains hl7v2, hl7v2-server, hl7v2-cli.",
   "Clippy and rustc lint ratchets are active or explicitly receipted.",
   "Clippy exceptions are governed separately from broad debt.",
   "No-panic identity is exact and counted.",
@@ -138,4 +138,4 @@ acceptance = [
 [[work_item]]
 id = "v1-5-0-publish"
 status = "pending-explicit-approval"
-goal = "Publish the Rust crates.io graph only after readiness and dry-run receipts are clean and explicit release approval is given."
+goal = "Publish the primary Rust product graph only after readiness and dry-run receipts are clean and explicit release approval is given."

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate with readiness and dry-run receipts; v1.5.0 is not published until explicit crates.io publish and tag receipts land. The public Python distribution is `hl7v2`, built from the internal `hl7v2-python` maturin lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.4.0 is published to crates.io for the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate with readiness and dry-run receipts; v1.5.0 is not published until explicit crates.io publish and tag receipts land. The public Python distribution is `hl7v2`, built from the `hl7v2-python` binding backend lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -23,8 +23,8 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Lifecycle** | Beta | Domain tests exist, but lifecycle is not part of the current HTTP/gRPC contract gate |
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
-| **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; not published to crates.io |
-| **Publish Readiness** | Candidate | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` are prepared at v1.5.0; v1.4.0 remains the current published crates.io release until the v1.5.0 release receipt lands |
+| **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; backend crate remains unpublished until binding-backend release guardrails land |
+| **Publish Readiness** | Candidate | Primary Rust product crates `hl7v2`, `hl7v2-server`, and `hl7v2-cli` are prepared at v1.5.0; v1.4.0 remains the current published crates.io release until the v1.5.0 release receipt lands |
 | **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release; v1.5.0 keeps that surface and adds Rust 1.95, tighter policy rails, advisory ripr, targeted mutation, and release-readiness proof |
 
 ## Features
@@ -38,14 +38,19 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 
 ## Crates
 
-The public Rust package surface is intentionally small:
+The primary Rust product surface is intentionally small:
 
 | Crate | Role |
 | --- | --- |
 | `hl7v2` | Canonical Rust library crate. Normal Rust users should depend on this crate. |
 | `hl7v2-server` | HTTP/gRPC runtime service with Axum, Tonic, metrics, auth, and deployment behavior. |
 | `hl7v2-cli` | Command-line binary distribution. |
-| `hl7v2-python` | Internal PyO3/Python binding package for the public `hl7v2` Python distribution; held out of the crates.io Rust publish graph. |
+| `hl7v2-python` | PyO3 binding backend for the public `hl7v2` Python distribution. It is not the recommended Rust API and is not included in the primary Rust product graph. |
+
+Binding backend crates such as `hl7v2-python`, future `hl7v2-wasm`, and future
+`hl7v2-node` may become publishable implementation surfaces for language
+packages. They are not a reason to split parser/model/redaction/MLLP behavior
+back into public Rust microcrates.
 
 Implementation boundaries live as modules under `hl7v2`, including
 `hl7v2::model`, `hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`,
@@ -348,7 +353,7 @@ hl7v2-cli
   command-line binary
 
 hl7v2-python
-  Internal PyO3 binding package; builds the public hl7v2 Python distribution
+  PyO3 binding backend; builds the public hl7v2 Python distribution
 ```
 
 Retired compatibility crate names should not gain new behavior. See
@@ -358,8 +363,9 @@ Retired compatibility crate names should not gain new behavior. See
 ## Python Binding Lane
 
 The public Python distribution is `hl7v2` and imports as `hl7v2`. It is built
-from the internal `hl7v2-python` maturin package, which is not part of the Rust
-crates.io publish graph.
+from the `hl7v2-python` maturin backend crate. Rust users should depend on
+`hl7v2`; Python users should install `hl7v2` from PyPI once the Python release
+lane is proven.
 
 ```bash
 python -m pip install "maturin==1.13.1"
@@ -376,7 +382,7 @@ bundle, and replay APIs also support the same opt-in v2 evidence shapes used by
 the CLI/server contracts where those surfaces expose v2 output.
 
 TestPyPI proof is manual-first through the `Python TestPyPI Proof` workflow and
-does not change the Rust publish graph. See
+does not change the primary Rust product graph. See
 [`docs/guides/python-testpypi-release-proof.md`](docs/guides/python-testpypi-release-proof.md).
 
 ## Performance Characteristics

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -58,7 +58,7 @@ git push origin v<version>
 
 ### 5. Publish to Crates.io
 
-Use `xtask` to derive the publish order from the workspace dependency graph so the sequence stays correct as crates are added or dependencies change.
+Use `xtask` to derive the primary Rust product publish order from the workspace dependency graph so the sequence stays correct as crates are added or dependencies change.
 
 ```bash
 # Preview the publish order
@@ -71,19 +71,24 @@ cargo run -p xtask -- publish --yes
 cargo run -p xtask -- publish --yes --from hl7v2-server
 ```
 
-The publish sequence is the Rust product graph: `hl7v2`, then `hl7v2-server`,
+The publish sequence is the primary Rust product graph: `hl7v2`, then `hl7v2-server`,
 then `hl7v2-cli`. It excludes non-published workspace members such as
 `hl7v2-python`, `hl7v2-bench`, `hl7v2-test-utils`, `hl7v2-e2e-tests`, `xtask`,
 and the root `hl7v2-examples` package. Historical old microcrate package names
 are not published again unless a deliberate deprecation-only compatibility
 release is approved.
 
+Binding backend crates such as `hl7v2-python`, future `hl7v2-wasm`, and future
+`hl7v2-node` are a separate package surface. They may become publishable only
+through a binding-backend release PR with explicit metadata, dry-run proof, and
+language install/import smoke receipts. They are not the recommended Rust API.
+
 For GitHub Actions based releases, use the manual `Publish to crates.io` workflow. It prints the derived order first and only publishes when `execute=true` is selected and the `CARGO_REGISTRY_TOKEN` secret is configured.
 
 ### Python TestPyPI Proof
 
-`hl7v2-python` is not part of the Rust crates.io publish graph. Prove the
-Python package separately before any PyPI release:
+`hl7v2-python` is not part of the primary Rust product graph. Prove the Python
+package separately before any PyPI release:
 
 ```powershell
 python -m pip install --upgrade pip "maturin==1.13.1"

--- a/crates/hl7v2-python/README.md
+++ b/crates/hl7v2-python/README.md
@@ -2,13 +2,17 @@
 
 Python bindings for the Rust `hl7v2` toolkit.
 
-This package is intentionally outside the crates.io Rust publish graph. Build
-and validate it through the Python/maturin lane before any PyPI or TestPyPI
-release.
+This crate backs the Python `hl7v2` package. Rust users should depend on
+`hl7v2`; Python users should install `hl7v2` from PyPI after the Python release
+lane is proven.
+
+Current metadata keeps this binding backend crate unpublished on crates.io.
+Build and validate it through the Python/maturin lane before any PyPI or
+TestPyPI release. A future binding-backend release may publish this crate as
+packaging infrastructure, but it is not the primary Rust API.
 
 The Python distribution name is `hl7v2`; the import module is also `hl7v2`.
-The internal Rust/PyO3 package remains `hl7v2-python` and is not published to
-crates.io.
+The Rust/PyO3 backend crate remains `hl7v2-python`.
 
 ## Build
 

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -105,8 +105,8 @@ pass because they can create branches and need broader write permissions.
 
 ### `.github/workflows/python-wheels.yml` - Python Wheel Smoke
 
-Builds the public `hl7v2` Python distribution from the internal
-`hl7v2-python` maturin package and proves the wheel can be installed and
+Builds the public `hl7v2` Python distribution from the `hl7v2-python`
+binding backend crate and proves the wheel can be installed and
 imported. This workflow does not publish to PyPI.
 
 #### Jobs:
@@ -161,8 +161,9 @@ name `hl7v2`, the
 TestPyPI/PyPI workflows remain manual, default to non-publishing mode, publish
 only from `main`, run both Python smoke scripts before upload and during
 install-back, reject `skip-existing`, avoid secret-backed upload credentials,
-grant `id-token: write` only on publish jobs, and keep `hl7v2-python` at
-`publish = false` for crates.io.
+grant `id-token: write` only on publish jobs, and keep the `hl7v2-python`
+binding backend crate at `publish = false` for crates.io until a separate
+binding-backend release PR changes that policy.
 
 ### Markdown Local-Link Policy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ proposal, spec, plan, or receipt documents.
 | [Safe Support Bundle](guides/safe-support-bundle.md) | Redact and package replayable support evidence. |
 | [Deploy Validation Sidecar](guides/deploy-validation-sidecar.md) | Run `hl7v2-server` as an edge guard. |
 | [Python Evidence Workflow](guides/python-evidence-workflow.md) | Use the Python binding for validation reports, corpus diffs, redaction, bundles, and replay. |
-| [Python TestPyPI Release Proof](guides/python-testpypi-release-proof.md) | Prove the separate Python packaging lane without changing the Rust crates.io graph. |
+| [Python TestPyPI Release Proof](guides/python-testpypi-release-proof.md) | Prove the separate Python packaging lane without changing the primary Rust product graph. |
 
 ## Release And Proof Receipts
 
@@ -68,7 +68,7 @@ proposal, spec, plan, or receipt documents.
 | [v1.5.0 Rust 1.95 release candidate notes](releases/v1.5.0-rust-1.95-quality-ratchet.md) | Candidate scope for the Rust 1.95 quality-ratchet release; not a publish receipt. |
 | [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
 | [v1.5.0 publish dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-13.md) | Non-publishing crates.io dry-run proof for the v1.5.0 Rust graph. |
-| [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the internal `hl7v2-python` package outside the Rust crates.io graph. |
+| [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the `hl7v2-python` binding backend separate from the primary Rust product graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |
 
 ## Current Boundaries
@@ -80,9 +80,9 @@ proposal, spec, plan, or receipt documents.
   the remaining 1.5.0 quality-ratchet lane.
 - The v1.4.0 objective audit is a release-snapshot receipt, not proof that the
   full long-range evidence-layer objective is finished.
-- The public Python distribution is `hl7v2`, built from the internal
-  `hl7v2-python` maturin lane, until a production PyPI release is intentionally
-  proven and executed.
+- The public Python distribution is `hl7v2`, built from the `hl7v2-python`
+  binding backend lane, until a production PyPI release is intentionally proven
+  and executed.
 - gRPC coverage is useful but still narrower than the full HTTP evidence
   surface; use `docs/API_GUIDE.md` and `docs/STATUS.md` for current endpoint
   claims.
@@ -109,13 +109,13 @@ for live navigation.
 
 ## Package Surface
 
-The current Rust product surface is:
+The current primary Rust product surface is:
 
 - `hl7v2`
 - `hl7v2-server`
 - `hl7v2-cli`
 
-The public Python distribution is `hl7v2`, built from the internal
-`hl7v2-python` maturin lane. `hl7v2-python` is not part of the Rust crates.io
-publish graph. Historical old microcrate names may exist on crates.io, but they
-are not the product surface for new code.
+The public Python distribution is `hl7v2`, built from the
+`hl7v2-python` maturin backend lane. `hl7v2-python` is a binding backend crate, not the
+recommended Rust API. Historical old microcrate names may exist on crates.io,
+but they are not the product surface for new code.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
 > **Last Updated**: 2026-05-13
-> **Project Status**: v1.4.0 is published to crates.io for the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate; v1.5.0 is not published until explicit crates.io publish and tag receipts land.
+> **Project Status**: v1.4.0 is published to crates.io for the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate; v1.5.0 is not published until explicit crates.io publish and tag receipts land.
 
 ## Core Components
 
@@ -12,7 +12,7 @@ This document provides a transparent view of which features are fully implemente
 | `hl7v2` | ✅ 100% | 92% | Canonical Rust library crate for parsing, writing, validation, transport framing, ACK, normalization, and generation. Foundation model, escape, and MLLP implementations now live here. |
 | `hl7v2-server` | ✅ 100% | 80% | HTTP REST API with metrics, auth, ACK, normalization, redacted validation, configured-root bundle/replay, inline corpus evidence, readiness, quarantine, and redacted structured logs. |
 | `hl7v2-cli` | ✅ 100% | 75% | Full-featured CLI with streaming support. |
-| Python binding (`hl7v2` distribution) | 🟡 Experimental | Smoke | Public Python distribution built from the internal `hl7v2-python` PyO3 package; held out of the crates.io Rust publish graph and validated through the Python/maturin wheel smoke lane before any PyPI release. |
+| Python binding (`hl7v2` distribution) | 🟡 Experimental | Smoke | Public Python distribution built from the `hl7v2-python` PyO3 binding backend; not part of the primary Rust product graph and validated through the Python/maturin wheel smoke lane before any PyPI release. |
 | retired old package names | ✅ Retired locally | N/A | Old microcrate package names, including `hl7v2-model`, `hl7v2-escape`, and `hl7v2-mllp`, are no longer local workspace crates. Some historical old-name `1.2.0` artifacts already exist on crates.io and should not be treated as the current product surface. |
 
 ## Published Feature Set (v1.4.0)
@@ -38,7 +38,7 @@ This document provides a transparent view of which features are fully implemente
 ## Release and Publish Readiness
 
 - ✅ **Main workflows**: required CI success, Security, Python Wheels, and API Contracts are green on the v1.4.0 release head. Coverage is unchanged/skipped for this docs/package release lane. Extended tests and benchmark artifacts remain non-publish performance lanes.
-- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the final Rust package graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
 - 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and release-readiness and dry-run receipts. It still needs explicit crates.io publish and tag receipts before any release claim.
@@ -46,11 +46,25 @@ This document provides a transparent view of which features are fully implemente
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
 
+## Package Boundary Model
+
+- Primary Rust product crates: `hl7v2`, `hl7v2-server`, `hl7v2-cli`.
+- Language packages: PyPI `hl7v2`, future npm `@effortlessmetrics/hl7v2`.
+- Binding backend crates: `hl7v2-python`, future `hl7v2-wasm`, future
+  `hl7v2-node`.
+- Internal/dev crates: benches, e2e tests, test utilities, examples, and
+  `xtask`.
+
+Binding backend crates are real language-boundary APIs, but they are not the
+recommended Rust API. Current `hl7v2-python` metadata remains `publish = false`
+until a separate binding-backend release PR adds the required metadata, tooling,
+dry-run proof, and language install/import smoke receipts.
+
 ## Evidence Contracts Release And Current Main
 
 v1.4.0 is the Evidence Contracts and Server Sidecar release line around
 deterministic HL7 interface evidence. It is tagged, released on GitHub, and
-uploaded to crates.io for the final Rust package graph.
+uploaded to crates.io for the primary Rust product graph.
 
 Current `main` contains opt-in v2 provenance producers, maintained schema
 validation through `xtask evidence-schema-check`, server replay and inline
@@ -74,7 +88,7 @@ final source-tree gap audit after the local workbench split, see
 | Evidence contracts | ✅ Stable | v1.4.0 ships opt-in v2 provenance schemas/producers and an `xtask evidence-schema-check` gate. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |
 | Server edge guard | ✅ Stable | v1.4.0 ships `/hl7/replay`, inline-message corpus endpoints that do not read request filesystem paths, bundle artifact schema opt-in, redacted structured evidence logs with hashed message-control and bundle identifiers, evidence metrics, Docker smoke coverage, and the bundle replay message-type fix. |
-| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. v1.4.0 adds v2 parity, PHI sentinel coverage, Python evidence docs, and a manual TestPyPI proof workflow. Python remains outside the crates.io Rust publish graph. |
+| Python evidence lane | 🟡 Separate lane | Python wheel proof and minimum API parity cover parse, JSON export, normalize, validation, corpus, redaction, bundle, and replay. v1.4.0 adds v2 parity, PHI sentinel coverage, Python evidence docs, and a manual TestPyPI proof workflow. Python package proof remains separate from the primary Rust product graph. |
 
 ## v1.3.0 Readiness Checklist
 
@@ -110,20 +124,20 @@ Release notes: [`docs/releases/v1.5.0-rust-1.95-quality-ratchet.md`](releases/v1
 Readiness receipt: [`docs/release/1.5.0-readiness.md`](release/1.5.0-readiness.md).
 Dry-run receipt: [`docs/audits/publish-dry-run-v1.5.0-2026-05-13.md`](audits/publish-dry-run-v1.5.0-2026-05-13.md).
 
-- 🟡 **Release candidate**: workspace package versions are prepared as `1.5.0` for the Rust package graph.
+- 🟡 **Release candidate**: workspace package versions are prepared as `1.5.0` for the primary Rust product graph.
 - ✅ **Rust floor**: MSRV is Rust 1.95 and `rust-toolchain.toml` pins Rust 1.95.0 with `rustfmt` and `clippy`.
 - ✅ **Verification rails**: lint policy, Clippy exceptions, no-panic exact identity and no-new-debt baseline, file-policy companion ledgers, advisory `ripr`, and targeted mutation routing are present.
 - ✅ **Release readiness workflow**: `.github/workflows/release-readiness.yml` records the non-publishing readiness proof bundle.
 - ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `b0bb5b5392354273946f36f797f39d741d318fc1`.
 - 🟡 **Publish receipt**: crates.io upload has not been run for v1.5.0.
-- 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains outside the Rust crates.io graph, and still requires Trusted Publisher upload/install-back proof before any TestPyPI or PyPI success claim.
+- 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains separate from the primary Rust product graph, and still requires Trusted Publisher upload/install-back proof before any TestPyPI or PyPI success claim.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
 
 ---
 
-**Current published release**: v1.4.0 is tested, package-verified, tagged, and published to crates.io for the final Rust package graph.
+**Current published release**: v1.4.0 is tested, package-verified, tagged, and published to crates.io for the primary Rust product graph.
 
 **Current main**: is prepared as the v1.5.0 Rust 1.95 quality-ratchet
 candidate. v1.4.0 remains the current published crates.io release until v1.5.0

--- a/docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md
+++ b/docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md
@@ -4,15 +4,17 @@ Status: Accepted
 Date: 2026-05-12
 Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
 Spec: [HL7V2-SPEC-0002](../specs/HL7V2-SPEC-0002-python-distribution-proof.md)
+Amended by:
+[HL7V2-ADR-0003](HL7V2-ADR-0003-publishable-binding-backend-crates.md)
 
 ## Context
 
 The public Python package is `hl7v2` and is built with maturin from the
-internal `hl7v2-python` Rust/PyO3 package. It shares Rust implementation code
+`hl7v2-python` Rust/PyO3 binding backend crate. It shares Rust implementation code
 with the workspace, but its release proof, package index, Trusted Publishing
 configuration, and install-back receipts are Python packaging concerns.
 
-The Rust crates.io product surface is:
+The primary Rust crates.io product surface is:
 
 ```text
 hl7v2
@@ -20,23 +22,29 @@ hl7v2-server
 hl7v2-cli
 ```
 
-Publishing `hl7v2-python` as a Rust crate would blur package manager boundaries
-and create false release evidence.
+Publishing `hl7v2-python` as a primary Rust product crate would blur package
+manager boundaries and create false release evidence. A later ADR allows
+binding backend crates to be published as implementation packaging artifacts
+when they are clearly separated from the primary Rust product graph.
 
 ## Decision
 
-`hl7v2-python` is not a crates.io product crate. It is the internal
-Rust/PyO3 package for the public `hl7v2` Python distribution lane.
+`hl7v2-python` is not a primary crates.io product crate. It is the Rust/PyO3
+package for the public `hl7v2` Python distribution lane.
 
-`publish = false` remains required for `crates/hl7v2-python`.
+Current metadata keeps `crates/hl7v2-python` at `publish = false` until a
+separate binding-backend tooling and metadata PR deliberately changes it.
 
 Python release proof uses TestPyPI and PyPI workflows, not the Rust crates.io
-publish graph.
+primary product graph.
 
 ## Consequences
 
-- `cargo +1.93.0 run -p xtask -- publish-plan` must continue to report only
-  `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- Default `cargo +1.95.0 run -p xtask -- publish-plan` output continues to
+  report the primary Rust product graph: `hl7v2`, `hl7v2-server`, and
+  `hl7v2-cli`.
+- Binding backend crates require separate release tooling and receipts before
+  they can be published.
 - Python TestPyPI and PyPI receipts are separate from Rust crates.io release
   receipts.
 - TestPyPI proof remains blocked until external Trusted Publisher setup for
@@ -59,7 +67,7 @@ publish graph.
 Docs-only ADR changes use:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-doc-links
-cargo +1.93.0 run -p xtask -- publish-plan
-$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
+cargo +1.95.0 run -p xtask -- check-doc-links
+cargo +1.95.0 run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.95.0 run -p xtask -- gate --check --changed
 ```

--- a/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
+++ b/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
@@ -1,0 +1,126 @@
+# HL7V2-ADR-0003: Publishable Binding Backend Crates
+
+Status: Accepted
+Date: 2026-05-13
+Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Specs:
+[HL7V2-SPEC-0001](../specs/HL7V2-SPEC-0001-source-of-truth-stack.md),
+[HL7V2-SPEC-0002](../specs/HL7V2-SPEC-0002-python-distribution-proof.md)
+Amends:
+[HL7V2-ADR-0002](HL7V2-ADR-0002-python-is-separate-distribution-lane.md)
+
+## Context
+
+The demicrocrating work collapsed ordinary SRP implementation boundaries into
+the canonical `hl7v2` Rust library crate. That decision remains correct:
+parser, model, redaction, profile, transport, and evidence implementation units
+are modules, not independent product crates.
+
+Language bindings are a different kind of boundary. A binding crate can be a
+thin packaging backend that gives external package managers reproducible source
+availability, version anchoring, and build provenance without becoming the main
+Rust API.
+
+The current Python surface already has this shape:
+
+| Layer | Name | Registry | User-facing |
+| --- | --- | --- | --- |
+| Core Rust API | `hl7v2` | crates.io | yes |
+| Rust service and CLI wrappers | `hl7v2-server`, `hl7v2-cli` | crates.io | yes |
+| Python public package | `hl7v2` | PyPI | yes |
+| Python Rust backend crate | `hl7v2-python` | crates.io, if promoted by policy and tooling | no |
+
+The public Python package and import remain `hl7v2`. The Rust/PyO3 binding
+backend crate remains `hl7v2-python`.
+
+## Decision
+
+The repo distinguishes primary Rust product crates from binding backend crates.
+
+Primary Rust product crates are the crates users should choose when they want a
+Rust API, service, or CLI:
+
+```text
+hl7v2
+hl7v2-server
+hl7v2-cli
+```
+
+Binding backend crates may be publishable to crates.io when they support an
+external language package:
+
+```text
+hl7v2-python
+future hl7v2-wasm
+future hl7v2-node
+```
+
+A binding backend crate may be published only when it is:
+
+- thin;
+- version-locked to the workspace release;
+- clearly described as a binding backend;
+- not documented as the main user-facing Rust API;
+- covered by release proof for its own package boundary;
+- prevented from becoming a broad implementation microcrate.
+
+Publishing a binding backend is allowed for packaging provenance. It is not a
+signal that the crate is a primary Rust product API. These crates are honest
+APIs at the foreign-language boundary, but their audience is packagers and
+binding maintainers rather than ordinary Rust users.
+
+## Consequences
+
+- `hl7v2-python` may become publishable in a later PR, but this ADR does not
+  change Cargo metadata.
+- Default Rust release planning may continue to show the primary Rust product
+  graph separately from binding backend graphs.
+- Future release tooling should be able to print surfaces such as:
+
+```text
+Primary Rust product graph:
+1. hl7v2
+2. hl7v2-server
+3. hl7v2-cli
+
+Binding backend graph:
+1. hl7v2-python
+```
+
+- Python TestPyPI and PyPI proof remain separate from crates.io proof. A
+  crates.io backend publish does not prove Python upload or install-back.
+- Rust users should still be routed to `hl7v2` unless they are working on the
+  binding backend itself.
+- Future JS/TS package work should prefer `@effortlessmetrics/hl7v2` as the
+  public npm package and use backend crate names such as `hl7v2-wasm` or
+  `hl7v2-node` only for implementation packaging.
+
+## Non-Goals
+
+- This ADR does not publish any crate.
+- This ADR does not change `crates/hl7v2-python/Cargo.toml`.
+- This ADR does not rename the Python PyPI package or import module.
+- This ADR does not reopen retired implementation microcrates such as
+  `hl7v2-parser`, `hl7v2-model`, or `hl7v2-redact`.
+- This ADR does not make TestPyPI or PyPI claims.
+- This ADR does not change CI workflow behavior.
+
+## Follow-Up Work
+
+- Add explicit `xtask publish-plan --surface ...` selectors if a later release
+  needs to print primary and binding backend graphs independently.
+- Decide whether to make `hl7v2-python` publishable as a binding backend.
+- If `hl7v2-python` becomes publishable, update its metadata and README before
+  any crates.io dry-run or upload.
+- Define a future npm binding backend spec before adding JS/TS packages.
+
+## Proof Expectations
+
+Docs-only ADR changes use:
+
+```powershell
+cargo +1.95.0 run -p xtask -- check-doc-links
+cargo +1.95.0 run -p xtask -- publish-plan
+cargo +1.95.0 run -p xtask -- check-file-policy
+git diff --check
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,14 @@ We use the format popularized by Michael Nygard:
 | [0014](0014-observability-architecture.md) | Observability Architecture | Accepted | 2026-03-04 |
 | [0015](0015-collapse-public-crate-surface.md) | Collapse Public Crate Surface | Accepted | 2026-05-06 |
 
+## HL7V2 Governance ADRs
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [HL7V2-ADR-0001](HL7V2-ADR-0001-evidence-artifacts-are-contracts.md) | Evidence Artifacts Are Contracts | Accepted | 2026-05-12 |
+| [HL7V2-ADR-0002](HL7V2-ADR-0002-python-is-separate-distribution-lane.md) | Python Is A Separate Distribution Lane | Accepted, amended by HL7V2-ADR-0003 | 2026-05-12 |
+| [HL7V2-ADR-0003](HL7V2-ADR-0003-publishable-binding-backend-crates.md) | Publishable Binding Backend Crates | Accepted | 2026-05-13 |
+
 ## Creating a New ADR
 
 ```bash

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -8,14 +8,17 @@ surface collapse described by [ADR-015](../adr/0015-collapse-public-crate-surfac
 As of 2026-05-08, the implementation modules have been collapsed into the
 canonical `hl7v2` Rust library crate. Local compatibility shim crate folders
 were retired after the v1.2.1 release. `cargo run -p xtask -- publish-plan`
-resolves the Rust product graph:
+resolves the primary Rust product graph:
 
 1. `hl7v2`
 2. `hl7v2-server`
 3. `hl7v2-cli`
 
-`hl7v2-python` remains in the workspace as a separate PyO3 binding lane with
-`publish = false` for crates.io.
+`hl7v2-python` remains in the workspace as a separate PyO3 binding backend
+crate. Current metadata keeps it at `publish = false`; ADR
+[HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md)
+allows binding backend crates to become publishable later when tooling,
+metadata, and receipts make the boundary explicit.
 
 Historical old microcrate package names may exist on crates.io, but those names
 are compatibility artifacts. New Rust code should depend on `hl7v2` and use
@@ -27,14 +30,26 @@ Crates are product and distribution surfaces. SRP implementation units are
 modules unless they require a separate release, package, binary, runtime
 service, or foreign-language binding boundary.
 
-## Public And Internal Crates
+## Crate Classes
+
+| Class | Examples | Audience | Publishable |
+| --- | --- | --- | --- |
+| Primary Rust product | `hl7v2`, `hl7v2-server`, `hl7v2-cli` | Rust users and operators | Yes |
+| Language package | PyPI `hl7v2`, future npm `@effortlessmetrics/hl7v2` | Python and TypeScript users | Yes, through that language registry |
+| Binding backend crate | `hl7v2-python`, future `hl7v2-wasm`, future `hl7v2-node` | Packagers and binding maintainers | Yes, when governed by binding-backend release policy |
+| Internal/dev crate | `hl7v2-e2e-tests`, `hl7v2-test-utils`, `hl7v2-bench`, `xtask`, root examples | Repository implementation | No |
+
+Binding backend crates are real language-boundary APIs. They are not the
+recommended Rust API for normal users.
+
+## Workspace Crates
 
 | Crate | Role | Publish policy |
 | --- | --- | --- |
 | `hl7v2` | Canonical Rust library crate and implementation home. | Public crates.io package. |
 | `hl7v2-server` | HTTP/gRPC runtime service with Axum, Tonic, metrics, auth, CORS, and deployment config. | Public crates.io package. |
 | `hl7v2-cli` | Command-line binary distribution. | Public crates.io package. |
-| `hl7v2-python` | Python binding package that depends on `hl7v2`. | `publish = false`; Python/maturin lane. |
+| `hl7v2-python` | PyO3 binding backend for the public Python `hl7v2` package. Rust users should depend on `hl7v2`. | Currently `publish = false`; may become a governed binding backend crate. |
 | `hl7v2-e2e-tests` | End-to-end tests. | `publish = false`. |
 | `hl7v2-test-utils` | Shared test utilities. | `publish = false`; later candidate for `tests/support`. |
 | `hl7v2-bench` | Benchmark harness. | `publish = false`; later candidate for root `benches/`. |
@@ -119,5 +134,8 @@ describes the active repository shape.
 - Do not reintroduce implementation microcrates for ordinary SRP boundaries.
 - Do not collapse `hl7v2-server`, `hl7v2-cli`, or `hl7v2-python` into `hl7v2`.
 - Do not keep `hl7v2-core` as a second facade.
-- Add new workspace crates only for product, runtime, binary, binding, test,
-  benchmark, or tool boundaries.
+- Add new workspace crates only for product, runtime, binary, language binding,
+  test, benchmark, or tool boundaries.
+- Binding backend crates must stay thin over `hl7v2`; do not use them to split
+  parser, model, redaction, transport, or evidence implementation back into
+  public Rust microcrates.

--- a/docs/audits/current-source-tree-evidence-objective-gap-audit.md
+++ b/docs/audits/current-source-tree-evidence-objective-gap-audit.md
@@ -38,15 +38,15 @@ narrow PRs.
 
 These package-state checks recorded the public distribution name that existed
 in the repository on 2026-05-10. The current public Python distribution target
-is `hl7v2`; the internal Rust/PyO3 package remains `hl7v2-python`.
+is `hl7v2`; the Rust/PyO3 binding backend crate remains `hl7v2-python`.
 
 ## Current Product Boundary
 
-- The Rust crates.io product graph remains `hl7v2`, `hl7v2-server`, and
+- The primary Rust product graph remains `hl7v2`, `hl7v2-server`, and
   `hl7v2-cli`.
-- The public Python distribution target is `hl7v2`, built from the internal
-  `hl7v2-python` maturin lane. `hl7v2-python` is not part of the Rust crates.io
-  graph.
+- The public Python distribution target is `hl7v2`, built from the
+  `hl7v2-python` maturin backend lane. `hl7v2-python` is not part of the
+  primary Rust product graph.
 - The repository now has policy rails for Python publishing, including manual
   TestPyPI proof controls and production PyPI guardrails.
 - A 2026-05-10 TestPyPI upload/install-back attempt was run from current

--- a/docs/audits/publish-dry-run-v1.5.0-2026-05-13.md
+++ b/docs/audits/publish-dry-run-v1.5.0-2026-05-13.md
@@ -16,7 +16,7 @@ It is not a crates.io publish receipt. It is not a TestPyPI or PyPI receipt.
 | Job URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25814999531/job/75841051085> |
 | Result | Success |
 
-## Rust Publish Graph
+## Primary Rust Product Graph
 
 The publish plan remained:
 
@@ -24,7 +24,9 @@ The publish plan remained:
 2. `hl7v2-server`
 3. `hl7v2-cli`
 
-The internal `hl7v2-python` Rust crate remained outside the crates.io graph.
+The `hl7v2-python` Rust crate remained outside the primary Rust product graph.
+It is a binding backend crate and needs separate binding-backend release
+receipts before any crates.io publish.
 
 ## Hosted Proof
 
@@ -57,8 +59,8 @@ The dry-run packaged and verified `hl7v2`, `hl7v2-server`, and `hl7v2-cli` as
 The workflow confirmed:
 
 - public Python distribution: `hl7v2`;
-- internal Rust binding crate: `hl7v2-python`;
-- Rust crates.io publish graph: `hl7v2`, `hl7v2-server`, `hl7v2-cli`;
+- Rust binding backend crate: `hl7v2-python`;
+- primary Rust crates.io product graph: `hl7v2`, `hl7v2-server`, `hl7v2-cli`;
 - no TestPyPI or PyPI success claim was made.
 
 Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563)

--- a/docs/contracts/evidence-contract-index.md
+++ b/docs/contracts/evidence-contract-index.md
@@ -79,9 +79,11 @@ message control IDs.
 
 ### Python
 
-The Python binding is outside the crates.io Rust publish graph. It mirrors the
-same evidence shapes for validation, corpus, redaction, bundle, and replay APIs
-with opt-in v2 `schema_version` arguments where the contract exists.
+The Python binding is a separate language package surface backed by the
+`hl7v2-python` binding backend crate. It mirrors the same evidence shapes for
+validation, corpus, redaction, bundle, and replay APIs with opt-in v2
+`schema_version` arguments where the contract exists. Rust users should depend
+on `hl7v2` for the primary Rust API.
 
 ## Related References
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,5 +13,5 @@ For the broader documentation map and historical receipt boundaries, see
 | [Safe Support Bundle](safe-support-bundle.md) | You need to redact one failing message, bundle the evidence, and prove someone else can replay it safely. |
 | [Deploy Validation Sidecar](deploy-validation-sidecar.md) | You need to run `hl7v2-server` as a small edge guard with readiness, redacted validation, ACK policy, quarantine, bundles, and metrics. |
 | [Python Evidence Workflow](python-evidence-workflow.md) | You want to use the Python binding for validation reports, corpus diffs, redaction, bundles, and replay in notebooks or QA scripts. |
-| [Python TestPyPI Release Proof](python-testpypi-release-proof.md) | You need to prove the separate `hl7v2` Python distribution through TestPyPI without changing the Rust crates.io graph. |
+| [Python TestPyPI Release Proof](python-testpypi-release-proof.md) | You need to prove the separate `hl7v2` Python distribution through TestPyPI without changing the primary Rust product graph. |
 | [Python PyPI Release](python-pypi-release.md) | You have completed TestPyPI proof and need the guarded production PyPI release path for the separate Python package. |

--- a/docs/guides/python-pypi-release.md
+++ b/docs/guides/python-pypi-release.md
@@ -3,7 +3,7 @@
 Use this guide only after the separate `hl7v2` Python distribution has passed the
 local wheel proof and the full TestPyPI upload/install-back proof. This is a
 production package release path for Python users. It does not change the Rust
-crates.io graph.
+primary product graph.
 
 ## Package Identity
 
@@ -11,13 +11,13 @@ crates.io graph.
 | --- | --- |
 | Python distribution | `hl7v2` |
 | Python import module | `hl7v2` |
-| Rust package | `hl7v2-python` |
-| crates.io publish policy | `publish = false` |
+| Rust backend crate | `hl7v2-python` |
+| crates.io publish policy | currently `publish = false`; binding-backend publication requires a separate release PR |
 | Production PyPI workflow | `.github/workflows/python-pypi.yml` |
 | GitHub environment | `pypi` |
 
-Do not publish `hl7v2-python` to crates.io. The Rust release graph remains
-`hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+Do not publish `hl7v2-python` as part of PyPI proof. The primary Rust product
+graph remains `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 
 ## Preconditions
 

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -2,7 +2,7 @@
 
 Use this guide when you need to prove the `hl7v2` distribution as a Python
 package before any production PyPI release. This lane is separate from the Rust
-crates.io release graph.
+primary product graph.
 
 ## Package Identity
 
@@ -10,13 +10,13 @@ crates.io release graph.
 | --- | --- |
 | Python distribution | `hl7v2` |
 | Python import module | `hl7v2` |
-| Rust package | `hl7v2-python` |
-| crates.io publish policy | `publish = false` |
+| Rust backend crate | `hl7v2-python` |
+| crates.io publish policy | currently `publish = false`; binding-backend publication requires a separate release PR |
 | TestPyPI workflow | `.github/workflows/python-testpypi.yml` |
 | GitHub environment | `testpypi` |
 
-Do not publish `hl7v2-python` to crates.io. The Rust release graph remains
-`hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+Do not publish `hl7v2-python` as part of TestPyPI proof. The primary Rust
+product graph remains `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 
 ## One-Time TestPyPI Setup
 
@@ -119,7 +119,8 @@ A TestPyPI proof is complete only when all of these are true:
   `tests/python_smoke/evidence_workflow_guide.py` successfully.
 
 This is still not a production PyPI release. Treat it as packaging evidence for
-the separate Python lane.
+the separate Python lane. A crates.io binding-backend publish, if later
+approved, does not replace TestPyPI upload and install-back proof.
 
 After the upload/install-back proof passes, use
 [Python PyPI Release](python-pypi-release.md) for the guarded production PyPI

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -11,8 +11,8 @@ tag, GitHub release, TestPyPI, or PyPI receipt.
 | Release target | `1.5.0` |
 | MSRV | Rust `1.95` |
 | Toolchain pin | `rust-toolchain.toml` uses `1.95.0` with `rustfmt` and `clippy` |
-| Rust publish graph | `hl7v2`, `hl7v2-server`, `hl7v2-cli` |
-| Python distribution | Separate `hl7v2` PyPI lane from internal `hl7v2-python` crate |
+| Primary Rust product graph | `hl7v2`, `hl7v2-server`, `hl7v2-cli` |
+| Python distribution | Separate `hl7v2` PyPI lane from `hl7v2-python` binding backend crate |
 | TestPyPI status | Externally blocked until Trusted Publisher setup is complete |
 | Production PyPI status | Not released |
 
@@ -70,12 +70,12 @@ cargo +1.95.0 run -p xtask -- check-python-publish-policy
 | Commit SHA | `b0bb5b5392354273946f36f797f39d741d318fc1` |
 | Version | `1.5.0` candidate |
 | Rust toolchain | Rust `1.95.0` |
-| Publish plan result | Passed. Publish order remains `hl7v2`, `hl7v2-server`, `hl7v2-cli`. |
+| Publish plan result | Passed. Primary Rust product order remains `hl7v2`, `hl7v2-server`, `hl7v2-cli`. |
 | Publish dry-run result | Passed with workspace patches and dry-run upload aborts only. |
 | Evidence schema result | Passed. Evidence fixtures validated against schema contracts. |
 | Policy result | Passed. Lint, no-panic, file, and CI lane policy checks completed. |
 | Contract workflow coverage check | Passed. Workflow still covers OpenAPI, protobuf, JSON Schema, and evidence schema checks. |
-| Python boundary check | Passed. Public Python distribution is `hl7v2`; internal Rust crate `hl7v2-python` remains outside crates.io. |
+| Python boundary check | Passed. Public Python distribution is `hl7v2`; Rust crate `hl7v2-python` remains a separate binding backend and is not included in the primary Rust product graph. |
 | Known non-blockers | TestPyPI Trusted Publisher issue #563 remains external; production PyPI is not released; crates.io publish/tag not run; hosted Actions emitted Node 20 deprecation annotations for existing actions. |
 | Rollback path | Before publish, revert or supersede the v1.5.0 release-prep commits. After crates.io publish, do not yank by default; prefer forward-fix unless a security or legal issue requires yanking. |
 
@@ -94,12 +94,12 @@ The release-readiness job passed these steps:
 - lint, no-panic, file, and CI lane policy rails;
 - evidence schema fixtures;
 - contract workflow coverage check;
-- Rust publish graph check;
+- primary Rust product graph check;
 - Rust publish dry-run with workspace patches;
 - Python distribution boundary check.
 
-The dry-run packaged and verified the Rust crates.io graph as `1.5.0` without
-uploading:
+The dry-run packaged and verified the primary Rust crates.io product graph as
+`1.5.0` without uploading:
 
 1. `hl7v2`
 2. `hl7v2-server`
@@ -112,8 +112,9 @@ See the dedicated dry-run receipt:
 
 - This workflow does not publish to crates.io.
 - This workflow does not publish to TestPyPI or PyPI.
-- The internal `hl7v2-python` Rust crate must remain outside the Rust crates.io
-  publish graph.
+- The `hl7v2-python` Rust crate must remain outside the primary Rust product
+  graph unless a binding-backend release PR deliberately includes it with
+  separate receipts.
 - `hl7v2` TestPyPI/PyPI success must not be claimed until upload and
   install-back pass in the Python proof workflows.
 - `ripr` remains advisory static mutation-exposure proof.

--- a/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
+++ b/docs/releases/v1.5.0-rust-1.95-quality-ratchet.md
@@ -5,21 +5,22 @@ release scope. It is not a publish receipt.
 
 ## Release Graph
 
-The Rust crates.io graph remains:
+The primary Rust crates.io product graph remains:
 
 - `hl7v2`
 - `hl7v2-server`
 - `hl7v2-cli`
 
-The internal `hl7v2-python` Rust crate remains `publish = false` and outside the
-Rust crates.io graph. The public Python distribution is `hl7v2`, but TestPyPI
-and PyPI success require separate upload and install-back receipts.
+The `hl7v2-python` Rust crate is a binding backend for the public Python
+`hl7v2` package. Current metadata keeps it at `publish = false`, and this
+release candidate does not include it in the primary Rust product graph.
+TestPyPI and PyPI success require separate upload and install-back receipts.
 
 ## Highlights
 
 - Raises the workspace MSRV to Rust 1.95 and pins `rust-toolchain.toml` to
   Rust 1.95.0 with `rustfmt` and `clippy`.
-- Prepares the Rust package graph as version `1.5.0`.
+- Prepares the primary Rust product graph as version `1.5.0`.
 - Tightens compiler, Clippy, no-panic, and file-policy rails without adding
   broad default CI weight.
 - Keeps retained Clippy suppressions in a dedicated exceptions ledger separate
@@ -38,6 +39,7 @@ and PyPI success require separate upload and install-back receipts.
 
 - This release candidate does not publish to crates.io.
 - This release candidate does not publish to TestPyPI or PyPI.
+- Binding backend crates are not promoted as the recommended Rust API.
 - `ripr` remains advisory and is not branch-protection blocking.
 - Runtime mutation remains the slower backstop and is not replaced by `ripr`.
 - Production PyPI remains a separate explicit release decision after

--- a/docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md
+++ b/docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md
@@ -141,12 +141,14 @@ cargo +1.93.0 run -p xtask -- check-doc-links
 Docs-only source-of-truth PRs should run:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-doc-links
-cargo +1.93.0 run -p xtask -- publish-plan
-$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
+cargo +1.95.0 run -p xtask -- check-doc-links
+cargo +1.95.0 run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.95.0 run -p xtask -- gate --check --changed
 ```
 
-The publish plan must keep `hl7v2-python` outside the Rust crates.io graph.
+The default publish plan owns the primary Rust product graph. Binding backend
+crates require separate surface classification and release receipts before they
+can be included in a crates.io publish sequence.
 
 ## Non-Goals
 

--- a/docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md
+++ b/docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md
@@ -7,9 +7,9 @@ Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.m
 
 ## Contract
 
-`hl7v2` is the public Python/maturin distribution. The internal Rust/PyO3
-package remains `hl7v2-python`; it is not a Rust crates.io product crate and
-must not be treated as part of the Rust publish graph.
+`hl7v2` is the public Python/maturin distribution. The Rust/PyO3 backend crate
+remains `hl7v2-python`; it is not the primary Rust API and must not be treated
+as part of the primary Rust product graph.
 
 Python distribution proof requires:
 
@@ -102,7 +102,9 @@ Production proof must show:
 
 ## Hard Rules
 
-- Do not publish `hl7v2-python` to crates.io.
+- Do not publish `hl7v2-python` as part of Python TestPyPI or PyPI proof.
+- Do not publish `hl7v2-python` to crates.io until binding-backend metadata,
+  tooling, and receipts deliberately promote it.
 - Do not use token fallback.
 - Do not use skip-existing.
 - Do not claim TestPyPI success until upload and install-back pass.
@@ -142,7 +144,7 @@ separate production proof passes.
 
 ### Rust Release Candidate
 
-A Rust release candidate may use the Rust publish graph:
+A Rust release candidate may use the primary Rust product graph:
 
 ```text
 hl7v2
@@ -150,7 +152,9 @@ hl7v2-server
 hl7v2-cli
 ```
 
-It must not include `hl7v2-python` as a crates.io publish target.
+It must not include `hl7v2-python` as a primary Rust product publish target.
+If a future release includes binding backend crates, it must list that graph
+separately and keep Python package proof separate.
 
 ## Non-Goals
 

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -31,7 +31,8 @@ claim tier or proof expectations.
 | Python binding local wheel lane | Experimental | `python tests/python_smoke/smoke.py`; `python tests/python_smoke/evidence_workflow_guide.py` after a local wheel install |
 | Python TestPyPI distribution (`hl7v2`) | Blocked | Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563); requires TestPyPI upload and install-back receipt |
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
-| Rust crates.io release graph | Stable | `cargo run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
+| Primary Rust crates.io product graph | Stable | `cargo run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
+| Binding backend crates | Planned / governed | ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); future proof must show surface classification, package metadata, dry-run, and language install/import smoke. |
 
 ## Rules
 
@@ -39,6 +40,8 @@ claim tier or proof expectations.
 - Do not copy current release status here. Link to `docs/STATUS.md`.
 - Do not claim TestPyPI or production PyPI success without upload and
   install-back receipts.
-- Do not add `hl7v2-python` to the Rust crates.io publish graph.
+- Do not add `hl7v2-python` to the primary Rust product graph.
+- If a binding backend crate becomes publishable, record it as binding
+  infrastructure, not as the recommended Rust API.
 - When a surface changes tier, update this map and the relevant proof receipt in
   the same PR.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,7 +41,7 @@ enum Commands {
     Audit,
     /// Check for outdated dependencies
     Outdated,
-    /// Print the crates.io publish order for workspace crates
+    /// Print the primary Rust product crates.io publish order
     PublishPlan {
         /// Resume from this crate name
         #[arg(long)]
@@ -390,7 +390,7 @@ fn outdated() -> Result<()> {
 fn publish_plan(from: Option<String>) -> Result<()> {
     let crates = publish_order(from.as_deref())?;
 
-    println!("📋 crates.io publish order");
+    println!("📋 Primary Rust product crates.io publish order");
     for (index, crate_name) in crates.iter().enumerate() {
         let display_index = index
             .checked_add(1)
@@ -398,6 +398,9 @@ fn publish_plan(from: Option<String>) -> Result<()> {
         println!("{display_index:>2}. {crate_name}");
     }
 
+    println!();
+    println!("Binding backend crates are a separate surface and are not included in this plan.");
+    println!("Current binding backend graph: hl7v2-python (publish = false)");
     println!();
     println!("Execute with:");
     if let Some(start) = crates.first() {
@@ -4683,7 +4686,7 @@ fn check_python_publish_policy() -> Result<()> {
     }
 
     println!(
-        "✅ python publish policy: pyproject.toml and {} workflow(s) checked; Python distribution is hl7v2 and hl7v2-python remains outside crates.io",
+        "✅ python publish policy: pyproject.toml and {} workflow(s) checked; Python distribution is hl7v2 and hl7v2-python remains a non-published binding backend crate",
         PYTHON_PUBLISH_WORKFLOWS.len()
     );
     Ok(())
@@ -4701,7 +4704,7 @@ fn ensure_hl7v2_python_not_crates_io_published(root: &Path) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!(
-            "crates/hl7v2-python/Cargo.toml must keep publish = false so Python stays outside the Rust crates.io graph"
+            "crates/hl7v2-python/Cargo.toml must keep publish = false until a binding-backend release PR updates the Python publish policy"
         ))
     }
 }


### PR DESCRIPTION
## Summary

- add HL7V2-ADR-0003 to allow governed publishable binding backend crates without reopening implementation microcrates
- clarify primary Rust product graph vs language packages vs binding backend crates across status, specs, release docs, guides, and package-boundary docs
- update `xtask publish-plan` and Python publish-policy wording so `hl7v2-python` is shown as a separate currently non-published binding backend surface

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- publish-plan`
- `cargo run -p xtask -- check-file-policy`
- `cargo run -p xtask -- check-lint-policy`
- `cargo run -p xtask -- check-python-publish-policy`
- `cargo run -p xtask -- policy-report`
- `cargo test -p xtask publish_order --locked`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo run -p xtask -- gate --check --changed`
- `git diff --check`

## Self-review

- Scope matches PR title: yes, package-boundary ADR/docs/tooling wording only.
- Files touched are expected: yes, source-of-truth/status/release docs plus `xtask` diagnostics for publish-plan and Python publish policy.
- No unrelated cleanup: yes.
- Policy changes are intentional: yes, binding backend crates are governed separately from the primary Rust product graph.
- No Clippy test carveouts added: yes.
- No bare `#[allow(clippy::...)]` added: yes.
- No-panic baseline handling is scoped: unchanged.
- Non-Rust allowlist changes are narrow: unchanged.
- CI economics: no lane behavior changed.
- ripr mutation-exposure framing preserved: unchanged.
- Release evidence preserved: yes, v1.5.0 remains a non-published candidate in docs.
- Local validation: commands listed above passed.
- CI status: pending hosted checks.
- Bot comments addressed: none yet.
- Follow-ups: a later PR can add explicit `publish-plan --surface ...` selectors and decide whether to make `hl7v2-python` publishable.