### PR TITLE
chore(deps): refresh yanked metrics lock entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",


### PR DESCRIPTION
## Summary

- refresh the lockfile from `metrics 0.24.5` to `metrics 0.24.6`
- clear the newly failing `cargo audit --deny warnings` yanked-crate signal without changing manifests

## Root cause

`Security / Dependency Audit` started failing because RustSec/cargo-audit now treats `metrics 0.24.5` as yanked. The workspace already allows `metrics = "0.24"`, so the minimal fix is a lockfile-only update to the non-yanked patch release.

## Validation

- `cargo update -p metrics --precise 0.24.6`
- `cargo tree --workspace -i metrics@0.24.6`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings`
- `cargo check -p hl7v2-server --all-targets --all-features --locked`
- `git diff --check`

## Self-review

- Scope matches PR title: yes, lockfile-only dependency refresh.
- Files touched are expected: yes, `Cargo.lock` only.
- No unrelated cleanup: yes.
- Policy changes are intentional: none.
- No Clippy test carveouts added: yes.
- No bare `#[allow(clippy::...)]` added: yes.
- No-panic baseline handling is scoped: unchanged.
- Non-Rust allowlist changes are narrow: unchanged.
- CI economics: no lane behavior changed.
- ripr mutation-exposure framing preserved: unchanged.
- Release evidence preserved: no release or publish behavior changed.
- Local validation: commands listed above passed.
- CI status: pending hosted checks.
- Bot comments addressed: none yet.
- Follow-ups: re-run package-boundary PR #604 after this lands.