### PR TITLE
xtask: classify publish-plan package surfaces

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -27,6 +27,7 @@ end_state = [
   "rust-toolchain.toml pins Rust 1.95.0 with rustfmt and clippy.",
   "Primary Rust product graph is prepared as version 1.5.0.",
   "The primary Rust product graph remains hl7v2, hl7v2-server, hl7v2-cli.",
+  "Binding backend crates are classified separately from the primary Rust product graph.",
   "Clippy and rustc lint ratchets are active or explicitly receipted.",
   "Clippy exceptions are governed separately from broad debt.",
   "No-panic identity is exact and counted.",
@@ -56,6 +57,8 @@ canonical_sources = [
 
 proof_commands = [
   "cargo +1.95.0 run -p xtask -- publish-plan",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface bindings",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable",
   "cargo +1.95.0 run -p xtask -- publish-dry-run --workspace-patches --allow-dirty",
   "cargo +1.95.0 run -p xtask -- evidence-schema-check",
   "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- gate --check",
@@ -120,6 +123,16 @@ status = "done"
 goal = "Record v1.5.0 release-readiness and publish-dry-run receipts after release prep lands."
 run = "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25810853128"
 receipt = "docs/audits/publish-dry-run-v1.5.0-2026-05-13.md"
+
+[[work_item]]
+id = "publish-plan-surface-classification"
+status = "done"
+goal = "Teach release tooling to report primary Rust product and binding backend publish surfaces separately without changing publish behavior."
+commands = [
+  "cargo +1.95.0 run -p xtask -- publish-plan",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface bindings",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable",
+]
 
 [[work_item]]
 id = "testpypi-trusted-publisher-proof"

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -64,6 +64,11 @@ Use `xtask` to derive the primary Rust product publish order from the workspace 
 # Preview the publish order
 cargo run -p xtask -- publish-plan
 
+# Preview explicit package surfaces
+cargo run -p xtask -- publish-plan --surface primary
+cargo run -p xtask -- publish-plan --surface bindings
+cargo run -p xtask -- publish-plan --surface all-publishable
+
 # Publish the full sequence
 cargo run -p xtask -- publish --yes
 
@@ -82,6 +87,8 @@ Binding backend crates such as `hl7v2-python`, future `hl7v2-wasm`, and future
 `hl7v2-node` are a separate package surface. They may become publishable only
 through a binding-backend release PR with explicit metadata, dry-run proof, and
 language install/import smoke receipts. They are not the recommended Rust API.
+Use `cargo run -p xtask -- publish-plan --surface bindings` to inspect the
+binding backend graph without changing the default primary Rust release plan.
 
 For GitHub Actions based releases, use the manual `Publish to crates.io` workflow. It prints the derived order first and only publishes when `execute=true` is selected and the `CARGO_REGISTRY_TOKEN` secret is configured.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -38,7 +38,7 @@ This document provides a transparent view of which features are fully implemente
 ## Release and Publish Readiness
 
 - ✅ **Main workflows**: required CI success, Security, Python Wheels, and API Contracts are green on the v1.4.0 release head. Coverage is unchanged/skipped for this docs/package release lane. Extended tests and benchmark artifacts remain non-publish performance lanes.
-- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` resolves the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+- ✅ **Publish order**: `cargo run -p xtask -- publish-plan` defaults to the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Use `cargo run -p xtask -- publish-plan --surface bindings` to inspect binding backend crates separately.
 - ✅ **Published Rust graph**: `hl7v2`, `hl7v2-server`, and `hl7v2-cli` v1.4.0 are published and visible in the crates.io index. See `docs/audits/publish-v1.4.0-2026-05-09.md`.
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
 - 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and release-readiness and dry-run receipts. It still needs explicit crates.io publish and tag receipts before any release claim.
@@ -56,8 +56,9 @@ This document provides a transparent view of which features are fully implemente
   `xtask`.
 
 Binding backend crates are real language-boundary APIs, but they are not the
-recommended Rust API. Current `hl7v2-python` metadata remains `publish = false`
-until a separate binding-backend release PR adds the required metadata, tooling,
+recommended Rust API. `xtask publish-plan --surface bindings` reports this
+separate graph. Current `hl7v2-python` metadata remains `publish = false` until
+a separate binding-backend release PR adds the required metadata, tooling,
 dry-run proof, and language install/import smoke receipts.
 
 ## Evidence Contracts Release And Current Main

--- a/docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md
+++ b/docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md
@@ -43,8 +43,10 @@ primary product graph.
 - Default `cargo +1.95.0 run -p xtask -- publish-plan` output continues to
   report the primary Rust product graph: `hl7v2`, `hl7v2-server`, and
   `hl7v2-cli`.
-- Binding backend crates require separate release tooling and receipts before
-  they can be published.
+- `cargo +1.95.0 run -p xtask -- publish-plan --surface bindings` reports the
+  binding backend graph separately. Binding backend crates still require
+  separate metadata, release tooling, and receipts before they can be
+  published.
 - Python TestPyPI and PyPI receipts are separate from Rust crates.io release
   receipts.
 - TestPyPI proof remains blocked until external Trusted Publisher setup for
@@ -69,5 +71,6 @@ Docs-only ADR changes use:
 ```powershell
 cargo +1.95.0 run -p xtask -- check-doc-links
 cargo +1.95.0 run -p xtask -- publish-plan
+cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
 $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.95.0 run -p xtask -- gate --check --changed
 ```

--- a/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
+++ b/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
@@ -73,9 +73,10 @@ binding maintainers rather than ordinary Rust users.
 
 - `hl7v2-python` may become publishable in a later PR, but this ADR does not
   change Cargo metadata.
-- Default Rust release planning may continue to show the primary Rust product
+- Default Rust release planning continues to show the primary Rust product
   graph separately from binding backend graphs.
-- Future release tooling should be able to print surfaces such as:
+- `xtask publish-plan --surface primary|bindings|all-publishable` prints
+  package surfaces such as:
 
 ```text
 Primary Rust product graph:
@@ -107,8 +108,6 @@ Binding backend graph:
 
 ## Follow-Up Work
 
-- Add explicit `xtask publish-plan --surface ...` selectors if a later release
-  needs to print primary and binding backend graphs independently.
 - Decide whether to make `hl7v2-python` publishable as a binding backend.
 - If `hl7v2-python` becomes publishable, update its metadata and README before
   any crates.io dry-run or upload.
@@ -121,6 +120,8 @@ Docs-only ADR changes use:
 ```powershell
 cargo +1.95.0 run -p xtask -- check-doc-links
 cargo +1.95.0 run -p xtask -- publish-plan
+cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
+cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable
 cargo +1.95.0 run -p xtask -- check-file-policy
 git diff --check
 ```

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -8,7 +8,7 @@ surface collapse described by [ADR-015](../adr/0015-collapse-public-crate-surfac
 As of 2026-05-08, the implementation modules have been collapsed into the
 canonical `hl7v2` Rust library crate. Local compatibility shim crate folders
 were retired after the v1.2.1 release. `cargo run -p xtask -- publish-plan`
-resolves the primary Rust product graph:
+defaults to the primary Rust product graph:
 
 1. `hl7v2`
 2. `hl7v2-server`
@@ -19,6 +19,8 @@ crate. Current metadata keeps it at `publish = false`; ADR
 [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md)
 allows binding backend crates to become publishable later when tooling,
 metadata, and receipts make the boundary explicit.
+`cargo run -p xtask -- publish-plan --surface bindings` reports that graph
+separately from the primary Rust release plan.
 
 Historical old microcrate package names may exist on crates.io, but those names
 are compatibility artifacts. New Rust code should depend on `hl7v2` and use

--- a/docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md
+++ b/docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md
@@ -147,8 +147,9 @@ $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.95.0 run -p xtask -- gate
 ```
 
 The default publish plan owns the primary Rust product graph. Binding backend
-crates require separate surface classification and release receipts before they
-can be included in a crates.io publish sequence.
+crates are reported through `publish-plan --surface bindings` and require
+separate metadata, release tooling, and release receipts before they can be
+included in a crates.io publish sequence.
 
 ## Non-Goals
 

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -31,8 +31,8 @@ claim tier or proof expectations.
 | Python binding local wheel lane | Experimental | `python tests/python_smoke/smoke.py`; `python tests/python_smoke/evidence_workflow_guide.py` after a local wheel install |
 | Python TestPyPI distribution (`hl7v2`) | Blocked | Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563); requires TestPyPI upload and install-back receipt |
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
-| Primary Rust crates.io product graph | Stable | `cargo run -p xtask -- publish-plan`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
-| Binding backend crates | Planned / governed | ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); future proof must show surface classification, package metadata, dry-run, and language install/import smoke. |
+| Primary Rust crates.io product graph | Stable | `cargo run -p xtask -- publish-plan --surface primary`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
+| Binding backend crates | Planned / governed | `cargo run -p xtask -- publish-plan --surface bindings`; ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); future proof must show package metadata, dry-run, and language install/import smoke. |
 
 ## Rules
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Result, anyhow};
 use cargo_metadata::{DependencyKind, Metadata, MetadataCommand, Package};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fs;
@@ -17,6 +17,20 @@ use std::time::Duration;
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+const PRIMARY_RUST_PRODUCT_CRATES: &[&str] = &["hl7v2", "hl7v2-server", "hl7v2-cli"];
+const BINDING_BACKEND_CRATES: &[&str] = &["hl7v2-python"];
+const EXCLUDED_PUBLISHABLE_WORKSPACE_PACKAGES: &[&str] = &["xtask", "hl7v2-examples"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum PublishSurface {
+    /// Primary Rust API/operator crates.
+    Primary,
+    /// Binding backend crates for foreign-language packages.
+    Bindings,
+    /// Primary Rust product crates plus publishable binding backend crates.
+    AllPublishable,
 }
 
 #[derive(Subcommand)]
@@ -46,6 +60,9 @@ enum Commands {
         /// Resume from this crate name
         #[arg(long)]
         from: Option<String>,
+        /// Package surface to report
+        #[arg(long, value_enum, default_value = "primary")]
+        surface: PublishSurface,
     },
     /// Publish workspace crates to crates.io in dependency order
     Publish {
@@ -140,7 +157,7 @@ fn main() -> Result<()> {
         Commands::Setup => setup()?,
         Commands::Audit => audit()?,
         Commands::Outdated => outdated()?,
-        Commands::PublishPlan { from } => publish_plan(from)?,
+        Commands::PublishPlan { from, surface } => publish_plan(from, surface)?,
         Commands::Publish {
             from,
             yes,
@@ -387,26 +404,36 @@ fn outdated() -> Result<()> {
     Ok(())
 }
 
-fn publish_plan(from: Option<String>) -> Result<()> {
-    let crates = publish_order(from.as_deref())?;
+fn publish_plan(from: Option<String>, surface: PublishSurface) -> Result<()> {
+    let crates = publish_order_for_surface(surface, from.as_deref())?;
+    let metadata = MetadataCommand::new().exec()?;
 
-    println!("📋 Primary Rust product crates.io publish order");
-    for (index, crate_name) in crates.iter().enumerate() {
-        let display_index = index
-            .checked_add(1)
-            .ok_or_else(|| anyhow!("publish-plan index overflow"))?;
-        println!("{display_index:>2}. {crate_name}");
+    if surface == PublishSurface::Primary {
+        println!("📋 Primary Rust product crates.io publish order");
+    } else {
+        println!("{}", surface.publish_plan_heading());
+    }
+    print_numbered_crates(&crates)?;
+
+    if surface != PublishSurface::Bindings {
+        print_binding_backend_status(&metadata)?;
+    } else if crates.is_empty() {
+        println!("No publishable binding backend crates are currently enabled.");
+        print_binding_backend_status(&metadata)?;
     }
 
     println!();
-    println!("Binding backend crates are a separate surface and are not included in this plan.");
-    println!("Current binding backend graph: hl7v2-python (publish = false)");
-    println!();
-    println!("Execute with:");
-    if let Some(start) = crates.first() {
-        println!("  cargo run -p xtask -- publish --yes --from {start}");
+    if surface == PublishSurface::Primary {
+        println!("Execute with:");
+        if let Some(start) = crates.first() {
+            println!("  cargo run -p xtask -- publish --yes --from {start}");
+        } else {
+            println!("  cargo run -p xtask -- publish --yes");
+        }
     } else {
-        println!("  cargo run -p xtask -- publish --yes");
+        println!(
+            "Publishing non-primary surfaces requires an explicit release decision and dedicated tooling."
+        );
     }
 
     Ok(())
@@ -451,7 +478,7 @@ fn publish(
 
 fn publish_dry_run(from: Option<String>, workspace_patches: bool, allow_dirty: bool) -> Result<()> {
     let metadata = MetadataCommand::new().exec()?;
-    let packages = publishable_workspace_packages(&metadata);
+    let packages = publishable_workspace_packages_for_surface(&metadata, PublishSurface::Primary)?;
     let ordered = topological_publish_order(&packages)?;
     let crates = resume_publish_order(&ordered, from.as_deref())?;
 
@@ -641,11 +668,45 @@ fn docs(no_open: bool) -> Result<()> {
 }
 
 fn publish_order(from: Option<&str>) -> Result<Vec<String>> {
+    publish_order_for_surface(PublishSurface::Primary, from)
+}
+
+fn publish_order_for_surface(surface: PublishSurface, from: Option<&str>) -> Result<Vec<String>> {
     let metadata = MetadataCommand::new().exec()?;
-    let packages = publishable_workspace_packages(&metadata);
+    let packages = publishable_workspace_packages_for_surface(&metadata, surface)?;
     let ordered = topological_publish_order(&packages)?;
 
     resume_publish_order(&ordered, from)
+}
+
+fn print_numbered_crates(crates: &[String]) -> Result<()> {
+    for (index, crate_name) in crates.iter().enumerate() {
+        let display_index = index
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("publish-plan index overflow"))?;
+        println!("{display_index:>2}. {crate_name}");
+    }
+    Ok(())
+}
+
+fn print_binding_backend_status(metadata: &Metadata) -> Result<()> {
+    println!();
+    println!("Binding backend graph:");
+    let packages = workspace_member_packages(metadata);
+    for crate_name in BINDING_BACKEND_CRATES {
+        match packages.get(*crate_name) {
+            Some(package) if package_is_publishable(package) => {
+                println!(" - {crate_name} (publishable binding backend)");
+            }
+            Some(_) => {
+                println!(" - {crate_name} (publish = false)");
+            }
+            None => {
+                println!(" - {crate_name} (not present)");
+            }
+        }
+    }
+    Ok(())
 }
 
 fn resume_publish_order(ordered: &[String], from: Option<&str>) -> Result<Vec<String>> {
@@ -664,7 +725,74 @@ fn resume_publish_order(ordered: &[String], from: Option<&str>) -> Result<Vec<St
     }
 }
 
-fn publishable_workspace_packages(metadata: &Metadata) -> HashMap<String, Package> {
+impl PublishSurface {
+    fn publish_plan_heading(self) -> &'static str {
+        match self {
+            Self::Primary => "Primary Rust product crates.io publish order",
+            Self::Bindings => "Binding backend crates.io publish order",
+            Self::AllPublishable => "All publishable crates.io publish order",
+        }
+    }
+}
+
+fn publishable_workspace_packages_for_surface(
+    metadata: &Metadata,
+    surface: PublishSurface,
+) -> Result<HashMap<String, Package>> {
+    let packages = workspace_member_packages(metadata);
+    let classified: BTreeSet<&str> = PRIMARY_RUST_PRODUCT_CRATES
+        .iter()
+        .chain(BINDING_BACKEND_CRATES.iter())
+        .copied()
+        .collect();
+    let unclassified: Vec<_> = packages
+        .values()
+        .filter(|package| package_is_publishable(package))
+        .map(|package| package.name.as_str())
+        .filter(|package_name| !classified.contains(package_name))
+        .collect();
+    if !unclassified.is_empty() {
+        return Err(anyhow!(
+            "publishable workspace package(s) are missing publish surface classification: {}",
+            unclassified.join(", ")
+        ));
+    }
+
+    let selected: BTreeSet<&str> = match surface {
+        PublishSurface::Primary => PRIMARY_RUST_PRODUCT_CRATES.iter().copied().collect(),
+        PublishSurface::Bindings => BINDING_BACKEND_CRATES
+            .iter()
+            .copied()
+            .filter(|name| packages.get(*name).is_some_and(package_is_publishable))
+            .collect(),
+        PublishSurface::AllPublishable => PRIMARY_RUST_PRODUCT_CRATES
+            .iter()
+            .chain(
+                BINDING_BACKEND_CRATES
+                    .iter()
+                    .filter(|name| packages.get(**name).is_some_and(package_is_publishable)),
+            )
+            .copied()
+            .collect(),
+    };
+
+    let mut selected_packages = HashMap::new();
+    for package_name in selected {
+        let package = packages
+            .get(package_name)
+            .ok_or_else(|| anyhow!("workspace package {package_name} is missing"))?;
+        if !package_is_publishable(package) {
+            return Err(anyhow!(
+                "workspace package {package_name} is selected for {surface:?} but is not publishable"
+            ));
+        }
+        selected_packages.insert(package.name.to_string(), package.clone());
+    }
+
+    Ok(selected_packages)
+}
+
+fn workspace_member_packages(metadata: &Metadata) -> HashMap<String, Package> {
     let workspace_members: HashSet<_> = metadata.workspace_members.iter().cloned().collect();
 
     metadata
@@ -672,14 +800,20 @@ fn publishable_workspace_packages(metadata: &Metadata) -> HashMap<String, Packag
         .iter()
         .filter(|pkg| workspace_members.contains(&pkg.id))
         .filter(|pkg| {
-            pkg.publish
-                .as_ref()
-                .is_none_or(|registries| !registries.is_empty())
+            !EXCLUDED_PUBLISHABLE_WORKSPACE_PACKAGES
+                .iter()
+                .any(|excluded| *excluded == pkg.name)
         })
-        .filter(|pkg| pkg.name != "xtask" && pkg.name != "hl7v2-examples")
         .cloned()
         .map(|pkg| (pkg.name.to_string(), pkg))
         .collect()
+}
+
+fn package_is_publishable(package: &Package) -> bool {
+    package
+        .publish
+        .as_ref()
+        .is_none_or(|registries| !registries.is_empty())
 }
 
 fn topological_publish_order(packages: &HashMap<String, Package>) -> Result<Vec<String>> {
@@ -5932,6 +6066,27 @@ mod tests {
     }
 
     #[test]
+    fn publish_order_surfaces_are_separate() -> Result<()> {
+        let primary = publish_order_for_surface(PublishSurface::Primary, None)?;
+        let bindings = publish_order_for_surface(PublishSurface::Bindings, None)?;
+        let all_publishable = publish_order_for_surface(PublishSurface::AllPublishable, None)?;
+
+        for public_surface in PRIMARY_RUST_PRODUCT_CRATES {
+            ensure_contains(&primary, public_surface)?;
+            ensure_contains(&all_publishable, public_surface)?;
+        }
+
+        ensure_not_contains(&primary, "hl7v2-python")?;
+        ensure_not_contains(&all_publishable, "hl7v2-python")?;
+        if !bindings.is_empty() {
+            return Err(anyhow!(
+                "hl7v2-python is still publish = false and should not be publishable yet"
+            ));
+        }
+        Ok(())
+    }
+
+    #[test]
     fn publish_order_can_resume_from_a_named_crate() -> Result<()> {
         let ordered = publish_order(None)?;
         let resumed = publish_order(Some("hl7v2"))?;
@@ -5955,7 +6110,8 @@ mod tests {
     #[test]
     fn workspace_patch_dependencies_exclude_private_shims() -> Result<()> {
         let metadata = MetadataCommand::new().exec()?;
-        let packages = publishable_workspace_packages(&metadata);
+        let packages =
+            publishable_workspace_packages_for_surface(&metadata, PublishSurface::AllPublishable)?;
         let dependencies = internal_workspace_dependency_closure("hl7v2", &packages)?;
 
         for excluded in [


### PR DESCRIPTION
## Summary

- add `xtask publish-plan --surface primary|bindings|all-publishable`
- keep the default publish and dry-run path on the primary Rust product graph only
- report `hl7v2-python` as the separate binding backend graph while it remains `publish = false`
- update package-boundary docs, ADR/spec/status wording, release process, support tiers, and the active goal manifest
- fail publish-plan if a future publishable workspace package lacks surface classification

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p xtask --locked`
- `cargo test -p xtask publish_order --locked`
- `cargo run -p xtask -- publish-plan`
- `cargo run -p xtask -- publish-plan --surface primary`
- `cargo run -p xtask -- publish-plan --surface bindings`
- `cargo run -p xtask -- publish-plan --surface all-publishable`
- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- check-file-policy`
- `cargo run -p xtask -- check-lint-policy`
- `cargo run -p xtask -- check-python-publish-policy`
- `cargo run -p xtask -- policy-report`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo run -p xtask -- gate --check`
- `git diff --check`

## Self-review

- Scope matches PR title: yes, publish-plan surface classification plus matching docs.
- Files touched are expected: yes, `xtask`, release/package-boundary docs, support/status docs, and active goal state.
- No unrelated cleanup: yes.
- Policy changes are intentional: yes, publishable workspace packages now require surface classification.
- No Clippy test carveouts added: yes.
- No bare `#[allow(clippy::...)]` added: yes.
- No-panic baseline handling is scoped: no baseline changes.
- Non-Rust allowlist changes are narrow: no allowlist changes.
- CI economics: default publish/dry-run behavior stays primary-only.
- ripr mutation-exposure framing preserved: no ripr changes.
- Release evidence preserved: docs keep v1.5.0 as not published.
- Local validation: see Validation.
- CI status: pending.
- Bot comments addressed: none yet.
- Follow-ups: decide separately whether `hl7v2-python` should become publishable as a binding backend.