### PR TITLE
ci(python): avoid caching cargo shims in wheel smoke

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -66,6 +66,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: python-wheels-${{ matrix.os }}-${{ matrix.python-version }}
+          cache-bin: "false"
 
       - name: Install maturin
         run: python -m pip install --upgrade pip "maturin==1.13.1"


### PR DESCRIPTION
## Summary

- set `cache-bin: false` for the Python wheel `Swatinem/rust-cache` step
- prevents restored `$CARGO_HOME/bin` contents from replacing valid cargo/rustup shims on hosted macOS runners
- keeps the Python wheel smoke matrix intact; no checks are skipped or weakened

## Evidence

#607 failed twice on `Wheel smoke (macos-latest, Python 3.13)` during `maturin build --release --out dist` before crate compilation. The failed command reported:

```text
error: unexpected argument 'metadata' found
Usage: rustup-init[EXE] [OPTIONS]
Caused by: `cargo metadata` exited with an error
```

The job log shows the failure occurs after `Swatinem/rust-cache` restores `/Users/runner/.cargo/bin`. Ubuntu and Windows wheel smoke passed.

## Validation

- `cargo run -p xtask -- check-file-policy`
- `git diff --check`

## Self-review

- Scope matches PR title: yes, one Python wheel cache setting.
- Files touched are expected: yes, only `.github/workflows/python-wheels.yml`.
- No unrelated cleanup: yes.
- Policy changes are intentional: no policy change.
- No Clippy test carveouts added: yes.
- No bare `#[allow(clippy::...)]` added: yes.
- No-panic baseline handling is scoped: no baseline changes.
- Non-Rust allowlist changes are narrow: no allowlist changes.
- CI economics: keeps existing wheel lane, avoids bad cache restore.
- ripr mutation-exposure framing preserved: no ripr changes.
- Release evidence preserved: no publish or release claim.
- Local validation: see Validation.
- CI status: pending.
- Bot comments addressed: none yet.
- Follow-ups: rerun/update #607 after this lands.