### PR TITLE
docs: record binding-backend package-boundary closeout

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -145,6 +145,24 @@ commands = [
 ]
 
 [[work_item]]
+id = "binding-backend-package-boundary-closeout"
+status = "done"
+goal = "Record the #604-#608 package-boundary closeout without claiming crates.io, TestPyPI, or PyPI publication."
+prs = [
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/604",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/605",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/606",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/607",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/608",
+]
+acceptance = [
+  "Primary Rust product graph still reports hl7v2, hl7v2-server, and hl7v2-cli.",
+  "Binding backend graph reports hl7v2-python separately.",
+  "hl7v2-python remains non-published unless a later binding-backend release PR changes it.",
+  "No crates.io, TestPyPI, or PyPI publish claim is made.",
+]
+
+[[work_item]]
 id = "testpypi-trusted-publisher-proof"
 status = "blocked"
 blocked_by = "https://github.com/EffortlessMetrics/hl7v2-rs/issues/563"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-13
+> **Last Updated**: 2026-05-14
 > **Project Status**: v1.4.0 is published to crates.io for the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate; v1.5.0 is not published until explicit crates.io publish and tag receipts land.
 
 ## Core Components
@@ -43,6 +43,7 @@ This document provides a transparent view of which features are fully implemente
 - ✅ **Dry-run publish**: Workspace-patched dry-run verification and dependency-ordered direct dry-runs were completed before upload. See `docs/audits/publish-dry-run-v1.4.0-2026-05-09.md`.
 - 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and release-readiness and dry-run receipts. It still needs explicit crates.io publish and tag receipts before any release claim.
 - 🟡 **Python binding lane**: `hl7v2-python` is `publish = false` for crates.io. The public Python distribution is `hl7v2`. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the 2026-05-10 TestPyPI upload attempt built and smoke-tested the wheel but failed with `invalid-publisher` because the TestPyPI Trusted Publisher is not configured. Production PyPI release has not been run. A 2026-05-13 package-state check found no visible `hl7v2` package on TestPyPI or production PyPI.
+- ✅ **Binding-backend closeout**: #604 accepted the binding-backend ADR, #605 refreshed the yanked `metrics` lock entry that blocked security checks, #606 added `publish-plan --surface primary|bindings|all-publishable`, #607 framed `hl7v2-python` as the PyO3 backend for the public Python `hl7v2` package, and #608 fixed Python wheel cache behavior. This closeout did not publish `hl7v2-python`, TestPyPI, PyPI, or any v1.5.0 crates.io artifact.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,14 @@ We use the format popularized by Michael Nygard:
 | [HL7V2-ADR-0002](HL7V2-ADR-0002-python-is-separate-distribution-lane.md) | Python Is A Separate Distribution Lane | Accepted, amended by HL7V2-ADR-0003 | 2026-05-12 |
 | [HL7V2-ADR-0003](HL7V2-ADR-0003-publishable-binding-backend-crates.md) | Publishable Binding Backend Crates | Accepted | 2026-05-13 |
 
+## Recent Closeouts
+
+- 2026-05-14: #604-#608 closed the package-boundary policy train. The repo now
+  distinguishes the primary Rust product graph from binding backend crates in
+  ADRs, status docs, Python backend metadata, and `xtask publish-plan`
+  surfaces. The closeout did not publish any crates.io, TestPyPI, or PyPI
+  artifact.
+
 ## Creating a New ADR
 
 ```bash

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -79,6 +79,26 @@ cargo +1.95.0 run -p xtask -- check-python-publish-policy
 | Known non-blockers | TestPyPI Trusted Publisher issue #563 remains external; production PyPI is not released; crates.io publish/tag not run; hosted Actions emitted Node 20 deprecation annotations for existing actions. |
 | Rollback path | Before publish, revert or supersede the v1.5.0 release-prep commits. After crates.io publish, do not yank by default; prefer forward-fix unless a security or legal issue requires yanking. |
 
+## Package-Boundary Closeout
+
+After the readiness receipt above, #604-#608 closed the package-boundary policy
+train without changing any publish claim:
+
+- #604 accepted the binding-backend ADR and separated primary Rust product
+  crates from binding backend crates.
+- #605 refreshed the yanked `metrics` lock entry that blocked security checks.
+- #606 added `publish-plan --surface primary|bindings|all-publishable`.
+- #607 framed `hl7v2-python` as the PyO3 backend for the public Python
+  `hl7v2` package while keeping it non-published on crates.io.
+- #608 fixed Python wheel cache behavior so the backend framing PR could pass
+  the wheel smoke lane.
+
+This closeout does not supersede the v1.5.0 readiness receipt. The primary
+Rust product graph remains `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
+`hl7v2-python` remains in the binding backend graph and still needs a separate
+binding-backend release-proof spec, dry-run tooling, and release decision before
+any crates.io backend publish.
+
 ## Readiness Result
 
 The hosted readiness workflow succeeded on `main` at commit

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -32,7 +32,7 @@ claim tier or proof expectations.
 | Python TestPyPI distribution (`hl7v2`) | Blocked | Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563); requires TestPyPI upload and install-back receipt |
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
 | Primary Rust crates.io product graph | Stable | `cargo run -p xtask -- publish-plan --surface primary`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
-| Binding backend crates | Planned / governed | `cargo run -p xtask -- publish-plan --surface bindings`; ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); future proof must show package metadata, dry-run, and language install/import smoke. |
+| Binding backend crates | Planned / governed | `cargo run -p xtask -- publish-plan --surface bindings`; ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); #604-#608 closeout proved classification and metadata framing only. Future publish proof must show package metadata, dry-run, and language install/import smoke. |
 
 ## Rules
 
@@ -43,5 +43,6 @@ claim tier or proof expectations.
 - Do not add `hl7v2-python` to the primary Rust product graph.
 - If a binding backend crate becomes publishable, record it as binding
   infrastructure, not as the recommended Rust API.
+- Do not treat binding-backend closeout receipts as registry publish receipts.
 - When a surface changes tier, update this map and the relevant proof receipt in
   the same PR.


### PR DESCRIPTION
## Summary

- record the #604-#608 binding-backend package-boundary closeout in status, support tiers, ADR index, release readiness, and the active goal manifest
- keep the release boundary explicit: no crates.io backend publish, no TestPyPI/PyPI publish, and no v1.5.0 release claim
- preserve the primary Rust product graph as `hl7v2`, `hl7v2-server`, and `hl7v2-cli`, with `hl7v2-python` still reported separately as a non-published binding backend

## Validation

- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- publish-plan`
- `cargo run -p xtask -- publish-plan --surface bindings`
- `cargo run -p xtask -- check-python-publish-policy`
- `git diff --check`