### PR TITLE
docs(spec): define binding backend release proof

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -46,6 +46,7 @@ canonical_sources = [
   "docs/development/RUST_1_95_ROLLOUT.md",
   "docs/release/1.5.0-readiness.md",
   "docs/releases/v1.5.0-rust-1.95-quality-ratchet.md",
+  "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
   "docs/ci/ripr.md",
   "docs/ci/test-evidence-lanes.md",
   "policy/clippy-lints.toml",
@@ -160,6 +161,17 @@ acceptance = [
   "Binding backend graph reports hl7v2-python separately.",
   "hl7v2-python remains non-published unless a later binding-backend release PR changes it.",
   "No crates.io, TestPyPI, or PyPI publish claim is made.",
+]
+
+[[work_item]]
+id = "binding-backend-release-proof-spec"
+status = "done"
+goal = "Define the proof contract for publishing binding backend crates without promoting them as the primary Rust API."
+spec = "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md"
+acceptance = [
+  "Binding backend crates require package review, crates.io dry-run, language install/import smoke, and release receipts.",
+  "A crates.io backend publish does not prove PyPI or npm release success.",
+  "A PyPI or npm release does not require users to depend on the backend crate directly.",
 ]
 
 [[work_item]]

--- a/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
+++ b/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
@@ -5,7 +5,8 @@ Date: 2026-05-13
 Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
 Specs:
 [HL7V2-SPEC-0001](../specs/HL7V2-SPEC-0001-source-of-truth-stack.md),
-[HL7V2-SPEC-0002](../specs/HL7V2-SPEC-0002-python-distribution-proof.md)
+[HL7V2-SPEC-0002](../specs/HL7V2-SPEC-0002-python-distribution-proof.md),
+[HL7V2-SPEC-0004](../specs/HL7V2-SPEC-0004-binding-backend-release-proof.md)
 Amends:
 [HL7V2-ADR-0002](HL7V2-ADR-0002-python-is-separate-distribution-lane.md)
 

--- a/docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md
+++ b/docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md
@@ -1,0 +1,174 @@
+# HL7V2-SPEC-0004: Binding Backend Release Proof
+
+Status: Accepted
+Date: 2026-05-14
+Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md)
+Related ADR: [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md)
+Related Python proof spec: [HL7V2-SPEC-0002](HL7V2-SPEC-0002-python-distribution-proof.md)
+
+## Contract
+
+Binding backend crates are publishable implementation surfaces for
+foreign-language APIs. They are honest APIs at the language boundary, but they
+are not the recommended Rust API.
+
+The primary Rust product graph remains:
+
+```text
+hl7v2
+hl7v2-server
+hl7v2-cli
+```
+
+The binding backend graph may include:
+
+```text
+hl7v2-python
+future hl7v2-wasm
+future hl7v2-node
+```
+
+A binding backend crate can be published only when it is:
+
+- thin over `hl7v2`;
+- version-locked to the workspace release;
+- clearly documented as a backend for a language package;
+- not promoted as the Rust API;
+- present in `cargo run -p xtask -- publish-plan --surface bindings`;
+- reviewed with `cargo package --list`;
+- proven with `cargo publish --dry-run`;
+- covered by that language package's install/import smoke proof;
+- recorded in a release receipt.
+
+Current `hl7v2-python` remains non-published until a dedicated release PR
+changes its Cargo metadata and records the required proof.
+
+## Package Classes
+
+| Class | Examples | Audience | Registry |
+| --- | --- | --- | --- |
+| Primary Rust product | `hl7v2`, `hl7v2-server`, `hl7v2-cli` | Rust users and operators | crates.io |
+| Language package | PyPI `hl7v2`, future npm `@effortlessmetrics/hl7v2` | Python and TypeScript users | PyPI, npm |
+| Binding backend crate | `hl7v2-python`, future `hl7v2-wasm`, future `hl7v2-node` | Packagers and binding maintainers | crates.io, if governed |
+| Internal/dev crate | e2e tests, test utilities, examples, `xtask` | Repo maintainers | unpublished |
+
+Do not use binding backend publication to recreate retired implementation
+microcrates such as `hl7v2-parser`, `hl7v2-model`, `hl7v2-redact`, or
+`hl7v2-mllp`.
+
+## Required Proof
+
+### Surface Classification
+
+Before a binding backend crate can publish, release tooling must show the crate
+in the binding backend graph:
+
+```powershell
+cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
+```
+
+The default publish plan must continue to show only the primary Rust product
+graph unless an explicit release decision changes the command or receipt being
+used.
+
+### Package Review
+
+The release PR must record the package file list:
+
+```powershell
+cargo +1.95.0 package -p hl7v2-python --list
+```
+
+The reviewer checks that the package contains only expected binding backend
+sources, metadata, and license/readme files. It must not grow unrelated parser,
+model, redaction, MLLP, batch, or stream implementation crates.
+
+### crates.io Dry-Run
+
+The release PR must record a dry-run:
+
+```powershell
+cargo +1.95.0 publish -p hl7v2-python --dry-run
+```
+
+Dry-run success proves crates.io package shape. It does not prove a PyPI, npm,
+or language-package release.
+
+### Language Install/Import Smoke
+
+The backend release proof must include the relevant language package smoke path.
+For the Python backend, that means a local or hosted wheel proof that installs
+the public Python package artifact and imports `hl7v2`:
+
+```powershell
+python tests/python_smoke/smoke.py
+python tests/python_smoke/evidence_workflow_guide.py
+```
+
+When a future npm package exists, the proof must install the public npm package
+and import `@effortlessmetrics/hl7v2`. It must not use `hl7v2-rs` as the
+user-facing npm package name.
+
+### Release Receipt
+
+A binding backend release receipt records:
+
+- release decision and version;
+- binding backend graph from `xtask publish-plan --surface bindings`;
+- `cargo package --list` review result;
+- `cargo publish --dry-run` result;
+- upload result if publication is approved;
+- crates.io registry resolution if publication happened;
+- language install/import smoke result;
+- confirmation that the crate is not the recommended Rust API;
+- confirmation that PyPI/npm success is not claimed unless the language
+  registry upload and install-back passed.
+
+## Boundary Rules
+
+- A crates.io backend publish does not prove PyPI or npm release success.
+- A PyPI or npm release does not require users to depend on the backend crate
+  directly.
+- `hl7v2-python` may publish as a binding backend crate only after metadata,
+  dry-run tooling, and release receipts are ready.
+- `hl7v2-python` must not be added to the primary Rust product graph.
+- The public Python package and import remain `hl7v2`.
+- The future public TypeScript package should be `@effortlessmetrics/hl7v2`.
+
+## Acceptance Examples
+
+### Primary-Only Rust Release
+
+A Rust release that publishes only:
+
+```text
+hl7v2
+hl7v2-server
+hl7v2-cli
+```
+
+is valid when the receipt says it is primary-only and does not claim binding
+backend publication.
+
+### Binding Backend Ready But Not Published
+
+A PR that adds metadata, `cargo package --list`, and `cargo publish --dry-run`
+proof for `hl7v2-python` may claim the backend is crates.io-ready. It must not
+claim crates.io publication until upload and registry resolution are proven.
+
+### Python Published But Backend Not Published
+
+A successful PyPI `hl7v2` release may claim the public Python package is
+published. It must not imply Rust users should depend on `hl7v2-python`, and it
+must not claim the backend crate was published to crates.io unless that separate
+receipt exists.
+
+## Non-Goals
+
+- No Cargo metadata changes in this spec.
+- No crates.io publish.
+- No TestPyPI, PyPI, or npm publish.
+- No workflow behavior changes.
+- No JS/TS implementation.
+- No new public implementation microcrates.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,3 +12,12 @@ A spec should describe:
 
 Specs do not define PR order. Use implementation plans for sequencing and
 rollback, and use `docs/STATUS.md` for current feature status.
+
+## Index
+
+| Spec | Title | Status |
+| --- | --- | --- |
+| [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md) | Source-of-Truth Stack | Accepted |
+| [HL7V2-SPEC-0002](HL7V2-SPEC-0002-python-distribution-proof.md) | Python Distribution Proof | Accepted |
+| [HL7V2-SPEC-0003](HL7V2-SPEC-0003-ci-verification-economics.md) | CI Verification Economics | Accepted |
+| [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md) | Binding Backend Release Proof | Accepted |


### PR DESCRIPTION
## Summary

- add `HL7V2-SPEC-0004` for binding-backend release proof
- require surface classification, package list review, crates.io dry-run, language install/import smoke, and release receipts before any backend publish claim
- link the new spec from the specs index, the binding-backend ADR, and the active goal manifest

## Boundaries

- no Cargo metadata changes
- no workflow changes
- no crates.io, TestPyPI, PyPI, or npm publish claim
- `hl7v2-python` remains outside the primary Rust product graph

## Validation

- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- publish-plan --surface bindings`
- `cargo run -p xtask -- publish-plan`
- `git diff --check`