### PR TITLE
xtask: add binding backend dry-run surface

### DIFF
--- a/docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md
+++ b/docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md
@@ -66,11 +66,14 @@ in the binding backend graph:
 
 ```powershell
 cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
+cargo +1.95.0 run -p xtask -- publish-dry-run --surface bindings
 ```
 
 The default publish plan must continue to show only the primary Rust product
 graph unless an explicit release decision changes the command or receipt being
-used.
+used. While a backend crate still has `publish = false`, the binding dry-run
+must list its package files and stop with a policy error that explains the crate
+is not publishable yet.
 
 ### Package Review
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -84,6 +84,9 @@ enum Commands {
         /// Resume from this crate name
         #[arg(long)]
         from: Option<String>,
+        /// Package surface to dry-run
+        #[arg(long, value_enum, default_value = "primary")]
+        surface: PublishSurface,
         /// Patch internal workspace crates to local paths during verification
         #[arg(long)]
         workspace_patches: bool,
@@ -166,9 +169,10 @@ fn main() -> Result<()> {
         } => publish(from, yes, retry_attempts, retry_delay_secs)?,
         Commands::PublishDryRun {
             from,
+            surface,
             workspace_patches,
             allow_dirty,
-        } => publish_dry_run(from, workspace_patches, allow_dirty)?,
+        } => publish_dry_run(from, surface, workspace_patches, allow_dirty)?,
         Commands::Docs { no_open } => docs(no_open)?,
         Commands::HookPreCommit => hook_pre_commit()?,
         Commands::HookPrePush => hook_pre_push()?,
@@ -476,13 +480,22 @@ fn publish(
     Ok(())
 }
 
-fn publish_dry_run(from: Option<String>, workspace_patches: bool, allow_dirty: bool) -> Result<()> {
+fn publish_dry_run(
+    from: Option<String>,
+    surface: PublishSurface,
+    workspace_patches: bool,
+    allow_dirty: bool,
+) -> Result<()> {
+    if surface == PublishSurface::Bindings {
+        return binding_backend_dry_run(from.as_deref(), workspace_patches, allow_dirty);
+    }
+
     let metadata = MetadataCommand::new().exec()?;
-    let packages = publishable_workspace_packages_for_surface(&metadata, PublishSurface::Primary)?;
+    let packages = publishable_workspace_packages_for_surface(&metadata, surface)?;
     let ordered = topological_publish_order(&packages)?;
     let crates = resume_publish_order(&ordered, from.as_deref())?;
 
-    println!("🧪 Dry-running crates.io publish verification");
+    println!("🧪 Dry-running {} verification", surface.dry_run_label());
     if workspace_patches {
         println!("Using local workspace patches for unpublished internal crates.");
     }
@@ -497,6 +510,110 @@ fn publish_dry_run(from: Option<String>, workspace_patches: bool, allow_dirty: b
     }
 
     println!("✅ Publish dry-run checks passed!");
+    Ok(())
+}
+
+fn binding_backend_dry_run(
+    from: Option<&str>,
+    workspace_patches: bool,
+    allow_dirty: bool,
+) -> Result<()> {
+    let metadata = MetadataCommand::new().exec()?;
+    let targets = binding_backend_dry_run_targets(&metadata, from)?;
+    if targets.is_empty() {
+        println!("No binding backend crates are present in this workspace.");
+        return Ok(());
+    }
+
+    let packages =
+        publishable_workspace_packages_for_surface(&metadata, PublishSurface::AllPublishable)?;
+
+    println!("🧪 Dry-running binding backend crates.io package proof");
+    if workspace_patches {
+        println!("Using local workspace patches for unpublished internal crates.");
+    }
+
+    for target in targets {
+        package_list_crate(&target.name, allow_dirty)?;
+        if !target.publishable {
+            return Err(anyhow!(
+                "{} is classified as a binding backend but is not publishable yet (publish = false). Remove publish = false only in a dedicated binding-backend release PR after metadata, dry-run tooling, and release receipts are ready.",
+                target.name
+            ));
+        }
+
+        let config_path = if workspace_patches {
+            workspace_patch_config(&target.name, &packages)?
+        } else {
+            None
+        };
+        publish_dry_run_crate(&target.name, config_path.as_deref(), allow_dirty)?;
+    }
+
+    println!("✅ Binding backend dry-run checks passed!");
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BindingBackendDryRunTarget {
+    name: String,
+    publishable: bool,
+}
+
+fn binding_backend_dry_run_targets(
+    metadata: &Metadata,
+    from: Option<&str>,
+) -> Result<Vec<BindingBackendDryRunTarget>> {
+    publishable_workspace_packages_for_surface(metadata, PublishSurface::Bindings)?;
+
+    let packages = workspace_member_packages(metadata);
+    let mut targets = Vec::new();
+    for crate_name in BINDING_BACKEND_CRATES {
+        if let Some(package) = packages.get(*crate_name) {
+            targets.push(BindingBackendDryRunTarget {
+                name: package.name.to_string(),
+                publishable: package_is_publishable(package),
+            });
+        }
+    }
+
+    match from {
+        Some(start) => {
+            let index = targets
+                .iter()
+                .position(|target| target.name == start)
+                .ok_or_else(|| anyhow!("Unknown binding backend crate '{start}'"))?;
+            let resumed = targets.get(index..).ok_or_else(|| {
+                anyhow!("resume index for {start} is outside binding backend graph")
+            })?;
+            Ok(resumed.to_vec())
+        }
+        None => Ok(targets),
+    }
+}
+
+fn package_list_crate(crate_name: &str, allow_dirty: bool) -> Result<()> {
+    println!("Listing package files for {crate_name}...");
+
+    let mut command = Command::new("cargo");
+    command.args(["package", "--list", "-p", crate_name, "--locked"]);
+    if allow_dirty {
+        command.arg("--allow-dirty");
+    }
+
+    let status = command
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        return Err(anyhow!(
+            "Package file listing failed for {} with exit code: {:?}",
+            crate_name,
+            status.code()
+        ));
+    }
+
     Ok(())
 }
 
@@ -731,6 +848,14 @@ impl PublishSurface {
             Self::Primary => "Primary Rust product crates.io publish order",
             Self::Bindings => "Binding backend crates.io publish order",
             Self::AllPublishable => "All publishable crates.io publish order",
+        }
+    }
+
+    fn dry_run_label(self) -> &'static str {
+        match self {
+            Self::Primary => "primary Rust product crates.io publish",
+            Self::Bindings => "binding backend crates.io package",
+            Self::AllPublishable => "all publishable crates.io package",
         }
     }
 }
@@ -6221,6 +6346,40 @@ mod tests {
         if !bindings.is_empty() {
             return Err(anyhow!(
                 "hl7v2-python is still publish = false and should not be publishable yet"
+            ));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn binding_backend_dry_run_targets_include_nonpublishable_backend() -> Result<()> {
+        let metadata = MetadataCommand::new().exec()?;
+        let targets = binding_backend_dry_run_targets(&metadata, None)?;
+
+        let expected = vec![BindingBackendDryRunTarget {
+            name: "hl7v2-python".to_string(),
+            publishable: false,
+        }];
+        if targets != expected {
+            return Err(anyhow!(
+                "binding backend dry-run targets were {targets:?}, expected {expected:?}"
+            ));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn binding_backend_dry_run_can_resume_from_backend_crate() -> Result<()> {
+        let metadata = MetadataCommand::new().exec()?;
+        let targets = binding_backend_dry_run_targets(&metadata, Some("hl7v2-python"))?;
+
+        let expected = vec![BindingBackendDryRunTarget {
+            name: "hl7v2-python".to_string(),
+            publishable: false,
+        }];
+        if targets != expected {
+            return Err(anyhow!(
+                "resumed binding backend dry-run targets were {targets:?}, expected {expected:?}"
             ));
         }
         Ok(())


### PR DESCRIPTION
## Summary

- add `--surface` to `xtask publish-dry-run`, preserving `primary` as the default
- add a binding-backend dry-run path that runs `cargo package --list -p hl7v2-python` and then stops with a policy error while `publish = false` remains set
- add xtask tests for binding backend target selection/resume and update the binding-backend release-proof spec

## Current behavior

`cargo run -p xtask -- publish-dry-run --surface bindings` now lists the `hl7v2-python` package contents, then fails intentionally with:

```text
hl7v2-python is classified as a binding backend but is not publishable yet (publish = false)
```

No Cargo metadata was changed and `hl7v2-python` remains non-published.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p xtask --locked`
- `cargo test -p xtask binding_backend --locked`
- `cargo test -p xtask --locked`
- `cargo run -p xtask -- publish-dry-run --surface bindings` expected failure after package listing
- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- publish-plan --surface bindings`
- `cargo run -p xtask -- publish-dry-run --workspace-patches --allow-dirty`
- `cargo run -p xtask -- check-python-publish-policy`
- `git diff --check`