### PR TITLE
docs(spec): define npm binding package model

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -47,6 +47,7 @@ canonical_sources = [
   "docs/release/1.5.0-readiness.md",
   "docs/releases/v1.5.0-rust-1.95-quality-ratchet.md",
   "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
+  "docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md",
   "docs/ci/ripr.md",
   "docs/ci/test-evidence-lanes.md",
   "policy/clippy-lints.toml",
@@ -157,6 +158,17 @@ commands = [
   "cargo +1.95.0 run -p xtask -- check-python-publish-policy",
 ]
 note = "Unpatched cargo publish --dry-run requires hl7v2 1.5.0 to resolve from crates.io; primary v1.5.0 has not been published yet."
+
+[[work_item]]
+id = "npm-wasm-binding-package-model"
+status = "done"
+goal = "Define the future TypeScript package as @effortlessmetrics/hl7v2 and keep hl7v2-wasm/hl7v2-node as binding backend infrastructure before any JS implementation."
+spec = "docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface bindings",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable",
+]
 
 [[work_item]]
 id = "binding-backend-package-boundary-closeout"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ The primary Rust product surface is intentionally small:
 Binding backend crates such as `hl7v2-python`, future `hl7v2-wasm`, and future
 `hl7v2-node` may become publishable implementation surfaces for language
 packages. They are not a reason to split parser/model/redaction/MLLP behavior
-back into public Rust microcrates.
+back into public Rust microcrates. Future TypeScript users should install
+`@effortlessmetrics/hl7v2`, not `hl7v2-rs`; see
+[`HL7V2-SPEC-0005`](docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md).
 
 Implementation boundaries live as modules under `hl7v2`, including
 `hl7v2::model`, `hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -63,6 +63,10 @@ extension crate backing the Python `hl7v2` package and is publishable as binding
 infrastructure only. It still needs binding-backend dry-run proof, language
 install/import smoke receipts, and an explicit release decision before any
 crates.io upload claim.
+Future TypeScript package work is governed by
+[HL7V2-SPEC-0005](specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md):
+the public npm package is `@effortlessmetrics/hl7v2`, while Rust backend crates
+such as `hl7v2-wasm` or `hl7v2-node` remain binding infrastructure.
 
 ## Evidence Contracts Release And Current Main
 

--- a/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
+++ b/docs/adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md
@@ -6,7 +6,8 @@ Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-rel
 Specs:
 [HL7V2-SPEC-0001](../specs/HL7V2-SPEC-0001-source-of-truth-stack.md),
 [HL7V2-SPEC-0002](../specs/HL7V2-SPEC-0002-python-distribution-proof.md),
-[HL7V2-SPEC-0004](../specs/HL7V2-SPEC-0004-binding-backend-release-proof.md)
+[HL7V2-SPEC-0004](../specs/HL7V2-SPEC-0004-binding-backend-release-proof.md),
+[HL7V2-SPEC-0005](../specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md)
 Amends:
 [HL7V2-ADR-0002](HL7V2-ADR-0002-python-is-separate-distribution-lane.md)
 
@@ -93,9 +94,11 @@ Binding backend graph:
   crates.io backend publish does not prove Python upload or install-back.
 - Rust users should still be routed to `hl7v2` unless they are working on the
   binding backend itself.
-- Future JS/TS package work should prefer `@effortlessmetrics/hl7v2` as the
-  public npm package and use backend crate names such as `hl7v2-wasm` or
-  `hl7v2-node` only for implementation packaging.
+- Future JS/TS package work must follow
+  [HL7V2-SPEC-0005](../specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md):
+  use `@effortlessmetrics/hl7v2` as the public npm package and use backend
+  crate names such as `hl7v2-wasm` or `hl7v2-node` only for implementation
+  packaging.
 
 ## Non-Goals
 
@@ -113,7 +116,9 @@ Binding backend graph:
   upload claim.
 - Keep `hl7v2-python` out of the primary Rust product graph even when it is
   publishable as binding infrastructure.
-- Define a future npm binding backend spec before adding JS/TS packages.
+- Do not add JS/TS packages until
+  [HL7V2-SPEC-0005](../specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md)
+  is satisfied by the proposed package shape and proof plan.
 
 ## Proof Expectations
 

--- a/docs/architecture/module-map.md
+++ b/docs/architecture/module-map.md
@@ -42,7 +42,9 @@ service, or foreign-language binding boundary.
 | Internal/dev crate | `hl7v2-e2e-tests`, `hl7v2-test-utils`, `hl7v2-bench`, `xtask`, root examples | Repository implementation | No |
 
 Binding backend crates are real language-boundary APIs. They are not the
-recommended Rust API for normal users.
+recommended Rust API for normal users. Future TypeScript package shape is
+defined by
+[HL7V2-SPEC-0005](../specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md).
 
 ## Workspace Crates
 

--- a/docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md
+++ b/docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md
@@ -1,0 +1,134 @@
+# HL7V2-SPEC-0005: npm and WASM Binding Package Model
+
+Status: Accepted
+Date: 2026-05-14
+Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md)
+Related ADR: [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md)
+Related backend proof spec: [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md)
+
+## Contract
+
+The future TypeScript user package is:
+
+```text
+npm package: @effortlessmetrics/hl7v2
+import:      @effortlessmetrics/hl7v2
+```
+
+Do not use `hl7v2-rs` as the public npm package name. The `-rs` suffix is
+appropriate for the repository identity and Rust implementation context, but it
+is the wrong primary identity for JavaScript and TypeScript users.
+
+Future Rust backend crates may exist only as binding infrastructure:
+
+```text
+hl7v2-wasm
+hl7v2-node
+```
+
+Those crates are language-boundary APIs for packaging, ABI, lifecycle,
+runtime-specific conversion, and release provenance. They are not the
+recommended Rust API, and they must not become new homes for parser, model,
+redaction, MLLP, batch, stream, or evidence implementation.
+
+## Package Classes
+
+| Class | Examples | Audience | Registry |
+| --- | --- | --- | --- |
+| Primary Rust product | `hl7v2`, `hl7v2-server`, `hl7v2-cli` | Rust users and operators | crates.io |
+| Language package | PyPI `hl7v2`, npm `@effortlessmetrics/hl7v2` | Python and TypeScript users | PyPI, npm |
+| Binding backend crate | `hl7v2-python`, future `hl7v2-wasm`, future `hl7v2-node` | Packagers and binding maintainers | crates.io, if governed |
+| Internal/dev crate | e2e tests, test utilities, examples, `xtask` | Repo maintainers | unpublished |
+
+The TypeScript package is the user-facing API. The Rust backend crate is an
+implementation package boundary.
+
+## Expected TypeScript Shape
+
+The eventual public API should optimize for the language package identity:
+
+```ts
+import { parse, validate, normalize, redact } from "@effortlessmetrics/hl7v2";
+```
+
+The public API may internally select a WASM backend, a Node-native backend, or a
+pure TypeScript fallback if one is later accepted. That selection is an
+implementation concern and must not require users to import `hl7v2-wasm`,
+`hl7v2-node`, or `hl7v2-rs` for normal usage.
+
+## Backend Crate Rules
+
+Future backend crates must:
+
+- stay thin over the canonical `hl7v2` Rust crate;
+- remain version-locked to the workspace release;
+- appear in `cargo run -p xtask -- publish-plan --surface bindings` when they
+  become publishable;
+- follow [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md)
+  for package list, dry-run, upload, and receipt proof;
+- route Rust users to `hl7v2`;
+- route TypeScript users to `@effortlessmetrics/hl7v2`;
+- avoid owning parser, model, redaction, MLLP, batch, stream, or evidence
+  implementation logic.
+
+## npm Proof Requirements
+
+A future npm release proof must record:
+
+- package name `@effortlessmetrics/hl7v2`;
+- package version;
+- commit SHA;
+- `npm pack --dry-run` output or equivalent package file review;
+- install proof from the intended registry or tarball;
+- import smoke that imports `@effortlessmetrics/hl7v2`;
+- parse, validate, normalize, and redaction smoke coverage when those APIs are
+  claimed;
+- confirmation that no package named `hl7v2-rs` is claimed as the public SDK;
+- confirmation that any Rust backend crate proof is separate from npm registry
+  proof.
+
+A crates.io backend publish does not prove npm release success. An npm release
+does not prove crates.io backend publication.
+
+## Acceptance Examples
+
+### Correct Public npm Identity
+
+```bash
+npm install @effortlessmetrics/hl7v2
+```
+
+```ts
+import { parse } from "@effortlessmetrics/hl7v2";
+```
+
+### Correct Backend Identity
+
+```text
+crates.io backend: hl7v2-wasm
+npm package:       @effortlessmetrics/hl7v2
+```
+
+The backend crate can be published for provenance without becoming the public
+TypeScript package name.
+
+### Rejected Public npm Identity
+
+```bash
+npm install hl7v2-rs
+```
+
+This may be valid only for an explicitly low-level implementation package that
+is not the public SDK. It must not be the default TypeScript user path.
+
+## Non-Goals
+
+- No JavaScript or TypeScript implementation.
+- No WASM or Node backend crate.
+- No npm package metadata.
+- No npm publish.
+- No crates.io publish.
+- No workflow behavior changes.
+- No new public Rust implementation microcrates.
+

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -21,3 +21,4 @@ rollback, and use `docs/STATUS.md` for current feature status.
 | [HL7V2-SPEC-0002](HL7V2-SPEC-0002-python-distribution-proof.md) | Python Distribution Proof | Accepted |
 | [HL7V2-SPEC-0003](HL7V2-SPEC-0003-ci-verification-economics.md) | CI Verification Economics | Accepted |
 | [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md) | Binding Backend Release Proof | Accepted |
+| [HL7V2-SPEC-0005](HL7V2-SPEC-0005-npm-wasm-binding-package-model.md) | npm and WASM Binding Package Model | Accepted |

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -31,6 +31,7 @@ claim tier or proof expectations.
 | Python binding local wheel lane | Experimental | `python tests/python_smoke/smoke.py`; `python tests/python_smoke/evidence_workflow_guide.py` after a local wheel install |
 | Python TestPyPI distribution (`hl7v2`) | Blocked | Issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563); requires TestPyPI upload and install-back receipt |
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
+| TypeScript/npm package (`@effortlessmetrics/hl7v2`) | Not released | [HL7V2-SPEC-0005](../specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md); requires future npm package review, install/import smoke, registry proof, and receipt |
 | Primary Rust crates.io product graph | Stable | `cargo run -p xtask -- publish-plan --surface primary`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
 | Binding backend crates | Planned / governed | `cargo run -p xtask -- publish-plan --surface bindings`; ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); #604-#608 closeout proved classification and metadata framing only. Future publish proof must show package metadata, dry-run, and language install/import smoke. |
 
@@ -44,5 +45,6 @@ claim tier or proof expectations.
 - If a binding backend crate becomes publishable, record it as binding
   infrastructure, not as the recommended Rust API.
 - Do not treat binding-backend closeout receipts as registry publish receipts.
+- Do not use `hl7v2-rs` as the public npm SDK package.
 - When a surface changes tier, update this map and the relevant proof receipt in
   the same PR.


### PR DESCRIPTION
## Summary

- Add `HL7V2-SPEC-0005` for the future npm/WASM binding package model.
- Define the TypeScript user package as `@effortlessmetrics/hl7v2`, not `hl7v2-rs`.
- Keep future `hl7v2-wasm` / `hl7v2-node` crates as binding backend infrastructure, not primary Rust APIs or implementation microcrates.
- Link the spec from ADR/status/support/module-map/README and active goal state.

## Boundary

Docs only. No JS/TS implementation, no WASM/Node crate, no npm metadata, no workflow change, no crates.io publish, and no npm publish.

## Validation

- `cargo run -p xtask -- check-doc-links`
- `cargo run -p xtask -- check-file-policy`
- `cargo run -p xtask -- publish-plan --surface primary`
- `cargo run -p xtask -- publish-plan --surface bindings`
- `cargo run -p xtask -- publish-plan --surface all-publishable`
- `git diff --check`

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes
- No unrelated cleanup: yes
- Policy changes are intentional: yes
- No Clippy test carveouts added: yes
- No bare `#[allow(clippy::...)]` added: yes
- No-panic baseline handling is scoped: no no-panic changes
- Non-Rust allowlist changes are narrow: no allowlist changes
- CI economics: no lane changes
- ripr mutation-exposure framing preserved: no ripr changes
- Release evidence preserved: yes; no publish claim added
- Local validation: passed as listed
- CI status: pending
- Bot comments addressed: none yet
- Follow-ups: JS/TS implementation and npm release proof remain future work
