### PR TITLE
xtask: test publish surface classification guard

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -865,23 +865,7 @@ fn publishable_workspace_packages_for_surface(
     surface: PublishSurface,
 ) -> Result<HashMap<String, Package>> {
     let packages = workspace_member_packages(metadata);
-    let classified: BTreeSet<&str> = PRIMARY_RUST_PRODUCT_CRATES
-        .iter()
-        .chain(BINDING_BACKEND_CRATES.iter())
-        .copied()
-        .collect();
-    let unclassified: Vec<_> = packages
-        .values()
-        .filter(|package| package_is_publishable(package))
-        .map(|package| package.name.as_str())
-        .filter(|package_name| !classified.contains(package_name))
-        .collect();
-    if !unclassified.is_empty() {
-        return Err(anyhow!(
-            "publishable workspace package(s) are missing publish surface classification: {}",
-            unclassified.join(", ")
-        ));
-    }
+    ensure_publishable_workspace_packages_are_classified(&packages)?;
 
     let selected: BTreeSet<&str> = match surface {
         PublishSurface::Primary => PRIMARY_RUST_PRODUCT_CRATES.iter().copied().collect(),
@@ -915,6 +899,30 @@ fn publishable_workspace_packages_for_surface(
     }
 
     Ok(selected_packages)
+}
+
+fn ensure_publishable_workspace_packages_are_classified(
+    packages: &HashMap<String, Package>,
+) -> Result<()> {
+    let classified: BTreeSet<&str> = PRIMARY_RUST_PRODUCT_CRATES
+        .iter()
+        .chain(BINDING_BACKEND_CRATES.iter())
+        .copied()
+        .collect();
+    let unclassified: Vec<_> = packages
+        .values()
+        .filter(|package| package_is_publishable(package))
+        .map(|package| package.name.as_str())
+        .filter(|package_name| !classified.contains(package_name))
+        .collect();
+    if !unclassified.is_empty() {
+        return Err(anyhow!(
+            "publishable workspace package(s) are missing publish surface classification: {}",
+            unclassified.join(", ")
+        ));
+    }
+
+    Ok(())
 }
 
 fn workspace_member_packages(metadata: &Metadata) -> HashMap<String, Package> {
@@ -6344,6 +6352,36 @@ mod tests {
         ensure_not_contains(&primary, "hl7v2-python")?;
         ensure_contains(&bindings, "hl7v2-python")?;
         ensure_contains(&all_publishable, "hl7v2-python")?;
+        Ok(())
+    }
+
+    #[test]
+    fn publish_order_rejects_unclassified_publishable_workspace_package() -> Result<()> {
+        let metadata = MetadataCommand::new().exec()?;
+        let mut packages = workspace_member_packages(&metadata);
+        let mut unclassified = packages
+            .get("hl7v2")
+            .ok_or_else(|| anyhow!("hl7v2 should be present in workspace packages"))?
+            .clone();
+        let unclassified_name = "hl7v2-unclassified-test".to_string();
+        unclassified.name = unclassified_name.clone();
+        packages.insert(unclassified_name.clone(), unclassified);
+
+        let error = match ensure_publishable_workspace_packages_are_classified(&packages) {
+            Ok(()) => {
+                return Err(anyhow!(
+                    "unclassified publishable package should fail surface classification"
+                ));
+            }
+            Err(error) => error.to_string(),
+        };
+
+        if !error
+            .contains("publishable workspace package(s) are missing publish surface classification")
+            || !error.contains(&unclassified_name)
+        {
+            return Err(anyhow!("unexpected surface classification error: {error}"));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Extract the publishable-workspace-package surface classification guard into a testable helper.
- Add a regression test proving publish planning rejects a publishable workspace package that is not classified as primary or binding backend.
- Keep publish-plan output unchanged for primary, bindings, and all-publishable surfaces.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p xtask --locked`
- `cargo test -p xtask publish_order_rejects_unclassified_publishable_workspace_package --locked`
- `cargo test -p xtask publish --locked`
- `cargo run -p xtask -- publish-plan --surface primary`
- `cargo run -p xtask -- publish-plan --surface bindings`
- `cargo run -p xtask -- publish-plan --surface all-publishable`
- `git diff --check`

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes
- No unrelated cleanup: yes
- Policy changes are intentional: yes; test coverage for existing guard
- No Clippy test carveouts added: yes
- No bare `#[allow(clippy::...)]` added: yes
- Release evidence preserved: yes; no publish behavior change
- Local validation: passed as listed
- CI status: pending
- Bot comments addressed: none yet
- Follow-ups: none
