### PR TITLE
docs: record binding-backend release-readiness audit

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -46,6 +46,7 @@ canonical_sources = [
   "docs/development/RUST_1_95_ROLLOUT.md",
   "docs/release/1.5.0-readiness.md",
   "docs/releases/v1.5.0-rust-1.95-quality-ratchet.md",
+  "docs/audits/binding-backend-readiness-2026-05-14.md",
   "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
   "docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md",
   "docs/ci/ripr.md",
@@ -168,6 +169,33 @@ commands = [
   "cargo +1.95.0 run -p xtask -- check-doc-links",
   "cargo +1.95.0 run -p xtask -- publish-plan --surface bindings",
   "cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable",
+]
+
+[[work_item]]
+id = "binding-backend-readiness-audit"
+status = "done"
+goal = "Record #610-#614 binding-backend release-proof, dry-run tooling, publishable backend metadata, npm/WASM model, and surface guard state without claiming any registry upload."
+receipt = "docs/audits/binding-backend-readiness-2026-05-14.md"
+prs = [
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/610",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/611",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/612",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/613",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/pull/614",
+]
+commands = [
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface primary",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface bindings",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable",
+  "cargo +1.95.0 run -p xtask -- check-python-publish-policy",
+]
+non_claims = [
+  "No crates.io backend upload.",
+  "No v1.5.0 crates.io upload.",
+  "No TestPyPI or PyPI upload.",
+  "No npm package.",
+  "No tag or GitHub release.",
 ]
 
 [[work_item]]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -44,6 +44,7 @@ This document provides a transparent view of which features are fully implemente
 - 🟡 **v1.5.0 candidate**: Current `main` carries the Rust 1.95 MSRV/toolchain ratchet, tighter lint/no-panic/file-policy rails, advisory `ripr`, targeted mutation routing, and release-readiness and dry-run receipts. It still needs explicit crates.io publish and tag receipts before any release claim.
 - 🟡 **Python binding lane**: `hl7v2-python` is publishable as a governed crates.io binding backend, but it is not part of the primary Rust product graph and has not been uploaded. The public Python distribution is `hl7v2`. The v1.4.0 binding is verified through a maturin wheel build/install/import smoke lane; current `main` also has a manual TestPyPI proof workflow before any production PyPI release. The non-publishing workflow mode passed on `main`; the 2026-05-10 TestPyPI upload attempt built and smoke-tested the wheel but failed with `invalid-publisher` because the TestPyPI Trusted Publisher is not configured. Production PyPI release has not been run. A 2026-05-13 package-state check found no visible `hl7v2` package on TestPyPI or production PyPI.
 - ✅ **Binding-backend closeout**: #604 accepted the binding-backend ADR, #605 refreshed the yanked `metrics` lock entry that blocked security checks, #606 added `publish-plan --surface primary|bindings|all-publishable`, #607 framed `hl7v2-python` as the PyO3 backend for the public Python `hl7v2` package, and #608 fixed Python wheel cache behavior. This closeout did not publish `hl7v2-python`, TestPyPI, PyPI, or any v1.5.0 crates.io artifact.
+- ✅ **Binding-backend readiness audit**: #610 added the binding-backend release-proof spec, #611 added the binding backend dry-run surface, #612 prepared `hl7v2-python` as publishable backend metadata, #613 defined the future npm/WASM package model, and #614 added a publish-surface classification guard. See [`docs/audits/binding-backend-readiness-2026-05-14.md`](audits/binding-backend-readiness-2026-05-14.md). This audit does not claim a crates.io backend upload, PyPI/TestPyPI upload, npm package, tag, GitHub release, or v1.5.0 publish.
 - ⚠️ **Registry history**: crates.io already contains historical `1.2.0` artifacts for several old microcrate names. The current release plan does not publish those names again unless a deliberate deprecation-only compatibility release is chosen.
 - ✅ **Tag alignment policy**: the existing `v1.2.0` tag points at an older commit and remains historical. Fresh `v1.2.1`, `v1.3.0`, and `v1.4.0` tags point at their release heads.
 
@@ -60,9 +61,11 @@ Binding backend crates are real language-boundary APIs, but they are not the
 recommended Rust API. `xtask publish-plan --surface bindings` reports this
 separate graph. Current `hl7v2-python` metadata describes it as the PyO3
 extension crate backing the Python `hl7v2` package and is publishable as binding
-infrastructure only. It still needs binding-backend dry-run proof, language
-install/import smoke receipts, and an explicit release decision before any
-crates.io upload claim.
+infrastructure only. #610-#614 added the binding-backend release-proof spec,
+dry-run surface, publishable metadata, npm/WASM package model, and publish
+surface guard. It still needs refreshed release readiness, language install or
+import smoke receipts, registry resolution proof, and an explicit release
+decision before any crates.io upload claim.
 Future TypeScript package work is governed by
 [HL7V2-SPEC-0005](specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md):
 the public npm package is `@effortlessmetrics/hl7v2`, while Rust backend crates

--- a/docs/audits/binding-backend-readiness-2026-05-14.md
+++ b/docs/audits/binding-backend-readiness-2026-05-14.md
@@ -1,0 +1,103 @@
+# Binding Backend Readiness Audit
+
+Date: 2026-05-14
+
+This audit records the binding-backend package-boundary work that landed after
+the initial #604-#608 closeout. It is a readiness receipt only. It is not a
+crates.io publish receipt, a TestPyPI receipt, a PyPI receipt, an npm receipt,
+a tag receipt, or a GitHub release receipt.
+
+## Scope
+
+| Field | Value |
+| --- | --- |
+| Repository commit | `26964ccbc2b01301f590765b6e92c06e24f08333` |
+| Release line | `1.5.0` candidate |
+| Primary Rust product graph | `hl7v2`, `hl7v2-server`, `hl7v2-cli` |
+| Binding backend graph | `hl7v2-python` |
+| Public Python distribution | `hl7v2` |
+| Future public npm package | `@effortlessmetrics/hl7v2` |
+
+## Recorded Work
+
+| PR | Result |
+| --- | --- |
+| #610 | Added the binding-backend release-proof spec, defining package review, dry-run, language smoke, and receipt requirements before backend publish claims. |
+| #611 | Added the binding backend dry-run surface so release tooling can prove binding backend packaging separately from the primary Rust graph. |
+| #612 | Prepared `hl7v2-python` as a publishable PyO3 backend crate while keeping it outside the recommended Rust API. |
+| #613 | Defined the npm/WASM package model: public TypeScript users target `@effortlessmetrics/hl7v2`; Rust backend crates stay binding infrastructure. |
+| #614 | Added a publish-surface classification guard so publishable workspace packages must be classified instead of silently joining the wrong graph. |
+
+## Current Release Meaning
+
+The repo can now express three Rust publish surfaces:
+
+```text
+primary:
+  hl7v2
+  hl7v2-server
+  hl7v2-cli
+
+bindings:
+  hl7v2-python
+
+all-publishable:
+  hl7v2
+  hl7v2-python
+  hl7v2-server
+  hl7v2-cli
+```
+
+`hl7v2-python` is publishable as binding infrastructure, not as the recommended
+Rust API. Rust users should depend on `hl7v2`. Python users should install the
+public `hl7v2` distribution from PyPI after the Python release lane is proven.
+
+## Non-Claims
+
+This audit does not claim:
+
+- `hl7v2-python` was uploaded to crates.io;
+- the primary Rust v1.5.0 graph was uploaded to crates.io;
+- a `v1.5.0` tag or GitHub release was created;
+- the public Python `hl7v2` package was uploaded to TestPyPI or PyPI;
+- an npm package exists or was published.
+
+## Release Decision Boundary
+
+Before any v1.5.x crates.io release, refresh the release-readiness proof against
+the current package surfaces and make the release graph explicit:
+
+- primary-only: `hl7v2`, `hl7v2-server`, `hl7v2-cli`;
+- primary plus binding backend: `hl7v2`, `hl7v2-python`, `hl7v2-server`,
+  `hl7v2-cli`.
+
+A crates.io backend publish does not prove PyPI release success. A PyPI release
+does not require Python users to depend on `hl7v2-python` directly.
+
+## Python Boundary
+
+The public Python lane remains separate:
+
+- TestPyPI project: `hl7v2`;
+- workflow: `python-testpypi.yml`;
+- environment: `testpypi`;
+- external blocker: issue #563 until Trusted Publisher is configured.
+
+No token fallback, `skip-existing`, or production PyPI claim is acceptable
+without upload and install-back receipts.
+
+## Validation
+
+This audit PR verified the current docs and publish-surface model with:
+
+| Command | Result |
+| --- | --- |
+| `cargo +1.95.0 run -p xtask -- check-doc-links` | pass |
+| `cargo +1.95.0 run -p xtask -- publish-plan --surface primary` | pass; primary graph remains `hl7v2`, `hl7v2-server`, `hl7v2-cli` |
+| `cargo +1.95.0 run -p xtask -- publish-plan --surface bindings` | pass; binding graph reports `hl7v2-python` |
+| `cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable` | pass; all-publishable graph reports `hl7v2`, `hl7v2-python`, `hl7v2-server`, `hl7v2-cli` |
+| `cargo +1.95.0 run -p xtask -- check-python-publish-policy` | pass; Python distribution remains `hl7v2`, backend crate remains separately receipted |
+| `git diff --check` | pass |
+
+The later release-readiness refresh should also run the relevant primary and
+binding backend dry-runs before deciding which graph to publish.

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -99,6 +99,35 @@ Rust product graph remains `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
 binding-backend release decision and upload receipt before any crates.io backend
 publish claim.
 
+## Binding-Backend Readiness Audit
+
+After the package-boundary closeout, #610-#614 made the binding-backend release
+path explicit:
+
+- #610 added the binding-backend release-proof spec.
+- #611 added the binding backend dry-run surface.
+- #612 prepared `hl7v2-python` as publishable PyO3 backend metadata.
+- #613 defined the future npm/WASM package model around
+  `@effortlessmetrics/hl7v2`.
+- #614 added a publish-surface classification guard so publishable workspace
+  packages cannot silently join the wrong release graph.
+
+See the dedicated audit:
+[`docs/audits/binding-backend-readiness-2026-05-14.md`](../audits/binding-backend-readiness-2026-05-14.md).
+
+This does not change the hosted readiness receipt above. The recorded v1.5.0
+dry-run remains a primary Rust product graph proof at
+`b0bb5b5392354273946f36f797f39d741d318fc1`. Because current `main` now has a
+publishable binding backend surface, any v1.5.x release decision should refresh
+readiness against the current surfaces before choosing either:
+
+- primary-only: `hl7v2`, `hl7v2-server`, `hl7v2-cli`;
+- primary plus binding backend: `hl7v2`, `hl7v2-python`, `hl7v2-server`,
+  `hl7v2-cli`.
+
+The readiness audit does not claim a crates.io backend upload, PyPI/TestPyPI
+upload, npm package, tag, GitHub release, or v1.5.0 publish.
+
 ## Readiness Result
 
 The hosted readiness workflow succeeded on `main` at commit

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -33,7 +33,7 @@ claim tier or proof expectations.
 | Production PyPI distribution (`hl7v2`) | Not released | Requires same-commit TestPyPI proof, production PyPI upload, install-back from `https://pypi.org/simple/`, smoke proof, and receipt PR |
 | TypeScript/npm package (`@effortlessmetrics/hl7v2`) | Not released | [HL7V2-SPEC-0005](../specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md); requires future npm package review, install/import smoke, registry proof, and receipt |
 | Primary Rust crates.io product graph | Stable | `cargo run -p xtask -- publish-plan --surface primary`; must report `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. v1.5.0 release claims require readiness, dry-run, publish, and tag receipts. |
-| Binding backend crates | Planned / governed | `cargo run -p xtask -- publish-plan --surface bindings`; ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); #604-#608 closeout proved classification and metadata framing only. Future publish proof must show package metadata, dry-run, and language install/import smoke. |
+| Binding backend crates | Planned / governed | `cargo run -p xtask -- publish-plan --surface bindings`; ADR [HL7V2-ADR-0003](../adr/HL7V2-ADR-0003-publishable-binding-backend-crates.md); [binding-backend readiness audit](../audits/binding-backend-readiness-2026-05-14.md). #604-#614 proved classification, release-proof spec, dry-run tooling, publishable `hl7v2-python` metadata, npm/WASM package model, and surface guards only. Future publish proof must show package metadata, dry-run, registry resolution, language install/import smoke, and release receipts. |
 
 ## Rules
 
@@ -45,6 +45,8 @@ claim tier or proof expectations.
 - If a binding backend crate becomes publishable, record it as binding
   infrastructure, not as the recommended Rust API.
 - Do not treat binding-backend closeout receipts as registry publish receipts.
+- Do not treat the binding-backend readiness audit as a crates.io, PyPI,
+  TestPyPI, npm, tag, or GitHub release receipt.
 - Do not use `hl7v2-rs` as the public npm SDK package.
 - When a surface changes tier, update this map and the relevant proof receipt in
   the same PR.


### PR DESCRIPTION
﻿## Summary

- Add a binding-backend readiness audit for #610-#614.
- Link the audit from STATUS, support tiers, v1.5.0 readiness, and the active goal manifest.
- Preserve the release boundary: no crates.io, TestPyPI, PyPI, npm, tag, GitHub release, or v1.5.0 publish claim.

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- publish-plan --surface primary
- cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
- cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- git diff --check

## Self-review

- Scope matches PR title: yes, docs/status audit only.
- Files touched are expected: yes.
- No unrelated cleanup: yes.
- Policy changes are intentional: no policy behavior changes, only documented release state.
- No Clippy test carveouts added: yes.
- No bare #[allow(clippy::...)] added: yes.
- No-panic baseline handling is scoped: no no-panic changes.
- Non-Rust allowlist changes are narrow: no allowlist changes.
- CI economics: no lane behavior changes.
- ripr mutation-exposure framing preserved: no ripr behavior changes.
- Release evidence preserved: yes, this records readiness and non-claims only.
- Local validation: listed above.
- CI status: pending hosted checks.
- Bot comments addressed: none yet.
- Follow-ups: refresh v1.5.x readiness against current primary/binding/all-publishable surfaces before any release decision.
