### PR TITLE
python: expose profile evidence helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "pyo3",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
 ]
 
 [[package]]

--- a/crates/hl7v2-python/Cargo.toml
+++ b/crates/hl7v2-python/Cargo.toml
@@ -30,3 +30,4 @@ hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }

--- a/crates/hl7v2-python/README.md
+++ b/crates/hl7v2-python/README.md
@@ -23,6 +23,7 @@ python -m pip install "maturin==1.13.1"
 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin build --release --out dist
 python -m pip install dist/*.whl
 python tests/python_smoke/smoke.py
+python tests/python_smoke/evidence_workflow_guide.py
 ```
 
 On PowerShell:
@@ -33,6 +34,7 @@ $env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY = "1"
 maturin build --release --out dist
 python -m pip install (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
 python tests\python_smoke\smoke.py
+python tests\python_smoke\evidence_workflow_guide.py
 ```
 
 ## Current API
@@ -63,6 +65,47 @@ print(message.to_json())
 
 print(hl7v2.to_json(raw))
 print(hl7v2.normalize(raw))
+print(hl7v2.ack(raw))
+print(hl7v2.ack(raw, code="AE"))
+
+template_yaml = """
+name: ADT_A01_Template
+delims: "^~\\\\&"
+segments:
+  - "MSH|^~\\\\&|TestSystem|TestFacility|ReceivingSystem|ReceivingFacility|20250101000000||ADT^A01^ADT_A01|MSG00001|P|2.5.1"
+  - "PID|1||123456^^^HOSP^MR||Doe^John^A||19800101|M"
+values: {}
+"""
+print(hl7v2.generate(template_yaml, seed=1337, count=2))
+
+lint = hl7v2.profile_lint(profile_yaml)
+lint_v2 = hl7v2.profile_lint(profile_yaml, schema_version=2)
+explain = hl7v2.profile_explain(
+    profile_yaml,
+    profile_name="profiles/adt_a01.yaml",
+)
+explain_v2 = hl7v2.profile_explain(
+    profile_yaml,
+    profile_name="profiles/adt_a01.yaml",
+    schema_version=2,
+)
+profile_test = hl7v2.profile_test(
+    profile_yaml,
+    "fixtures/adt_a01",
+    profile_name="profiles/adt_a01.yaml",
+)
+profile_test_v2 = hl7v2.profile_test(
+    profile_yaml,
+    "fixtures/adt_a01",
+    profile_name="profiles/adt_a01.yaml",
+    schema_version=2,
+)
+print(lint["valid"])
+print(lint_v2["schema_version"])
+print(explain["summary"]["segment_count"])
+print(explain_v2["schema_version"])
+print(profile_test["valid"])
+print(profile_test_v2["schema_version"])
 
 report = hl7v2.validate(raw, profile_yaml)
 print(report.valid)
@@ -134,16 +177,30 @@ print(replay_v2["schema_version"])
 ```
 
 The current Python surface intentionally starts with the minimum evidence loop:
-parse, JSON export, normalize, validate, corpus summary/fingerprint/diff,
+parse, JSON export, normalize, ACK generation, synthetic template generation,
+profile lint/test/explain reports, validate, corpus summary/fingerprint/diff,
 safe-analysis redaction, evidence bundle creation, and replay verification.
 
 ## TestPyPI Proof
 
 Use the manual **Python TestPyPI Proof** GitHub Actions workflow when proving an
 external Python package upload. It defaults to a non-publishing wheel build and
-smoke test. With `publish_to_testpypi=true`, it publishes to TestPyPI through
+smoke tests. With `publish_to_testpypi=true`, it publishes to TestPyPI through
 Trusted Publishing and installs the same version back from TestPyPI before
-running `tests/python_smoke/smoke.py`.
+running `tests/python_smoke/smoke.py` and
+`tests/python_smoke/evidence_workflow_guide.py`.
 
 Setup and stop conditions are documented in
 [`docs/guides/python-testpypi-release-proof.md`](../../docs/guides/python-testpypi-release-proof.md).
+
+## Production PyPI Release
+
+Use the manual **Python PyPI Release Proof** workflow only after the full
+TestPyPI upload/install-back proof has passed for the current workspace version.
+It defaults to a non-publishing production rehearsal. With
+`publish_to_pypi=true`, it publishes to production PyPI through Trusted
+Publishing and installs the same version back from PyPI before rerunning the
+Python smoke and evidence workflow guide.
+
+Setup and stop conditions are documented in
+[`docs/guides/python-pypi-release.md`](../../docs/guides/python-pypi-release.md).

--- a/crates/hl7v2-python/src/lib.rs
+++ b/crates/hl7v2-python/src/lib.rs
@@ -9,10 +9,14 @@ use ::hl7v2::synthetic::corpus::{
     CorpusCount, CorpusFingerprintProfile, compute_sha256, diff_corpus_fingerprints,
     diff_corpus_paths, fingerprint_corpus_path, summarize_corpus_path,
 };
+use ::hl7v2::synthetic::generate::{Template as RustTemplate, generate as rust_generate};
 use ::hl7v2::{
-    Message, ValidationReport, ValidationReportProfileIdentity, is_mllp_framed,
-    load_profile_checked, normalize as rust_normalize, parse as rust_parse,
-    parse_mllp as rust_parse_mllp, to_json as rust_to_json, validate as rust_validate,
+    AckCode as RustAckCode, Message, ProfileTestReport, ValidationReport,
+    ValidationReportProfileIdentity, ack as rust_ack, explain_profile as rust_explain_profile,
+    is_mllp_framed, lint_profile_yaml as rust_lint_profile_yaml, load_profile_checked,
+    normalize as rust_normalize, parse as rust_parse, parse_mllp as rust_parse_mllp,
+    run_profile_fixture_tests as rust_run_profile_fixture_tests, to_json as rust_to_json,
+    validate as rust_validate, write as rust_write,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -218,6 +222,20 @@ fn counts_to_corpus_counts(counts: BTreeMap<String, usize>) -> Vec<CorpusCount> 
         .collect()
 }
 
+fn parse_ack_code(code: &str) -> PyResult<RustAckCode> {
+    match code.to_ascii_uppercase().as_str() {
+        "AA" => Ok(RustAckCode::AA),
+        "AE" => Ok(RustAckCode::AE),
+        "AR" => Ok(RustAckCode::AR),
+        "CA" => Ok(RustAckCode::CA),
+        "CE" => Ok(RustAckCode::CE),
+        "CR" => Ok(RustAckCode::CR),
+        _ => Err(PyValueError::new_err(
+            "ack code must be one of AA, AE, AR, CA, CE, CR",
+        )),
+    }
+}
+
 /// Parse an HL7 message from a string.
 #[pyfunction]
 pub fn parse(content: &str) -> PyResult<PyMessage> {
@@ -239,6 +257,159 @@ pub fn normalize(content: &str, canonical_delims: bool) -> PyResult<String> {
         .map_err(|e| PyValueError::new_err(format!("Normalize error: {e}")))?;
     String::from_utf8(normalized)
         .map_err(|e| PyValueError::new_err(format!("Normalize UTF-8 error: {e}")))
+}
+
+/// Generate an HL7 ACK message for a raw HL7 message.
+#[pyfunction(signature = (content, code = "AA"))]
+pub fn ack(content: &str, code: &str) -> PyResult<String> {
+    let message = rust_parse(content.as_bytes())
+        .map_err(|e| PyValueError::new_err(format!("Parse error: {e}")))?;
+    let ack_code = parse_ack_code(code)?;
+    let ack_message = rust_ack(&message, ack_code)
+        .map_err(|e| PyValueError::new_err(format!("ACK error: {e}")))?;
+    String::from_utf8(rust_write(&ack_message))
+        .map_err(|e| PyValueError::new_err(format!("ACK UTF-8 error: {e}")))
+}
+
+/// Generate deterministic HL7 messages from a template YAML string.
+#[pyfunction(signature = (template_yaml, seed = 42, count = 1))]
+pub fn generate(template_yaml: &str, seed: u64, count: usize) -> PyResult<Vec<String>> {
+    let template: RustTemplate = serde_yaml::from_str(template_yaml)
+        .map_err(|e| PyValueError::new_err(format!("Template parse error: {e}")))?;
+    let messages = rust_generate(&template, seed, count)
+        .map_err(|e| PyValueError::new_err(format!("Generate error: {e}")))?;
+
+    messages
+        .into_iter()
+        .map(|message| {
+            String::from_utf8(rust_write(&message))
+                .map_err(|e| PyValueError::new_err(format!("Generate UTF-8 error: {e}")))
+        })
+        .collect()
+}
+
+/// Lint a profile YAML string and return a Python dict report.
+#[pyfunction(signature = (profile_yaml, schema_version = 1))]
+pub fn profile_lint<'py>(
+    py: Python<'py>,
+    profile_yaml: &str,
+    schema_version: u8,
+) -> PyResult<Bound<'py, PyAny>> {
+    let report = rust_lint_profile_yaml(profile_yaml);
+    match schema_version {
+        1 => report_to_dict(py, &report, "Profile lint serialization error"),
+        2 => report_to_dict(
+            py,
+            &report.to_v2("hl7v2-python", env!("CARGO_PKG_VERSION")),
+            "Profile lint v2 serialization error",
+        ),
+        _ => Err(PyValueError::new_err(
+            "profile lint schema_version must be 1 or 2",
+        )),
+    }
+}
+
+/// Explain a profile YAML string and return a Python dict report.
+#[pyfunction(signature = (profile_yaml, profile_name = "<inline-profile>", schema_version = 1))]
+pub fn profile_explain<'py>(
+    py: Python<'py>,
+    profile_yaml: &str,
+    profile_name: &str,
+    schema_version: u8,
+) -> PyResult<Bound<'py, PyAny>> {
+    let profile = load_profile_checked(profile_yaml)
+        .map_err(|e| PyValueError::new_err(format!("Profile load error: {e}")))?;
+    let lint_report = rust_lint_profile_yaml(profile_yaml);
+    let report = rust_explain_profile(
+        profile_name.to_string(),
+        profile_yaml,
+        &profile,
+        &lint_report,
+    );
+    match schema_version {
+        1 => report_to_dict(py, &report, "Profile explain serialization error"),
+        2 => report_to_dict(
+            py,
+            &report.to_v2("hl7v2-python", env!("CARGO_PKG_VERSION")),
+            "Profile explain v2 serialization error",
+        ),
+        _ => Err(PyValueError::new_err(
+            "profile explain schema_version must be 1 or 2",
+        )),
+    }
+}
+
+/// Test profile fixtures and return a Python dict report.
+#[pyfunction(signature = (profile_yaml, fixture_dir, profile_name = "<inline-profile>", schema_version = 1))]
+pub fn profile_test<'py>(
+    py: Python<'py>,
+    profile_yaml: &str,
+    fixture_dir: &str,
+    profile_name: &str,
+    schema_version: u8,
+) -> PyResult<Bound<'py, PyAny>> {
+    if !matches!(schema_version, 1 | 2) {
+        return Err(PyValueError::new_err(
+            "profile test schema_version must be 1 or 2",
+        ));
+    }
+
+    let profile = load_profile_checked(profile_yaml)
+        .map_err(|e| PyValueError::new_err(format!("Profile load error: {e}")))?;
+    let mut report =
+        rust_run_profile_fixture_tests(Path::new(profile_name), Path::new(fixture_dir), &profile)
+            .map_err(|e| PyValueError::new_err(format!("Profile test error: {e}")))?;
+    sanitize_profile_test_report(&mut report, Path::new(fixture_dir));
+
+    match schema_version {
+        1 => report_to_dict(py, &report, "Profile test serialization error"),
+        2 => report_to_dict(
+            py,
+            &report.to_v2("hl7v2-python", env!("CARGO_PKG_VERSION")),
+            "Profile test v2 serialization error",
+        ),
+        _ => Err(PyValueError::new_err(
+            "profile test schema_version must be 1 or 2",
+        )),
+    }
+}
+
+fn sanitize_profile_test_report(report: &mut ProfileTestReport, fixture_dir: &Path) {
+    report.profile = public_path_label(&report.profile, "profile.yaml");
+    report.fixtures = "fixtures".to_string();
+
+    for case in &mut report.cases {
+        case.path = case.name.clone();
+        if let Some(validation_report) = &mut case.validation_report {
+            validation_report.profile = Some(report.profile.clone());
+        }
+        if let Some(expected_report) = &mut case.expected_report {
+            expected_report.path = relative_or_redacted_path(fixture_dir, &expected_report.path);
+        }
+    }
+}
+
+fn public_path_label(path: &str, fallback: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+fn relative_or_redacted_path(root: &Path, path: &str) -> String {
+    let path = Path::new(path);
+    path.strip_prefix(root).map_or_else(
+        |_| "<expected-report>".to_string(),
+        |relative| {
+            relative
+                .components()
+                .map(|component| component.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/")
+        },
+    )
 }
 
 /// Validate an HL7 message against a profile YAML string.
@@ -450,6 +621,11 @@ fn hl7v2(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     m.add_function(wrap_pyfunction!(to_json, m)?)?;
     m.add_function(wrap_pyfunction!(normalize, m)?)?;
+    m.add_function(wrap_pyfunction!(ack, m)?)?;
+    m.add_function(wrap_pyfunction!(generate, m)?)?;
+    m.add_function(wrap_pyfunction!(profile_lint, m)?)?;
+    m.add_function(wrap_pyfunction!(profile_explain, m)?)?;
+    m.add_function(wrap_pyfunction!(profile_test, m)?)?;
     m.add_function(wrap_pyfunction!(validate, m)?)?;
     m.add_function(wrap_pyfunction!(corpus_summary, m)?)?;
     m.add_function(wrap_pyfunction!(corpus_fingerprint, m)?)?;

--- a/docs/guides/python-evidence-workflow.md
+++ b/docs/guides/python-evidence-workflow.md
@@ -2,8 +2,9 @@
 
 This guide shows the Python binding as an analyst and QA workflow over the same
 evidence contracts used by the Rust crate, CLI, and server. It keeps the Python
-lane focused on deterministic artifacts: validation reports, corpus summaries,
-corpus diffs, redaction receipts, bundles, and replay reports.
+lane focused on deterministic artifacts: generated fixtures, ACKs, profile
+reports, validation reports, corpus summaries, corpus diffs, redaction
+receipts, bundles, and replay reports.
 
 The examples use synthetic messages. They are safe to run from a source checkout
 after installing a locally built `hl7v2` wheel.
@@ -46,6 +47,8 @@ shutil.rmtree(ROOT, ignore_errors=True)
 (ROOT / "before").mkdir(parents=True)
 (ROOT / "after").mkdir(parents=True)
 (ROOT / "reports").mkdir()
+(ROOT / "profile-fixtures" / "valid").mkdir(parents=True)
+(ROOT / "profile-fixtures" / "invalid").mkdir(parents=True)
 
 profile_yaml = """
 message_structure: "GENERIC"
@@ -98,6 +101,15 @@ action = "retain"
 reason = "message control id"
 """
 
+template_yaml = """
+name: "ADT_A01_Template"
+delims: "^~\\\\&"
+segments:
+  - "MSH|^~\\\\&|TestSystem|TestFacility|ReceivingSystem|ReceivingFacility|20250101000000||ADT^A01^ADT_A01|MSG00001|P|2.5.1"
+  - "PID|1||123456^^^HOSP^MR||Doe^Generated^A||19800101|M"
+values: {}
+"""
+
 before_message = (
     "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ADT^A01|CTRL100|P|2.5\r"
     "PID|1||MRN-100^^^HOSP^MR||Example^Valid||19700101|M"
@@ -108,8 +120,37 @@ after_message = (
     "PID|1||MRN-200^^^HOSP^MR||Example^Invalid||19700101|X"
 )
 
+generated_messages = hl7v2.generate(template_yaml, seed=1337, count=2)
+ack_message = hl7v2.ack(after_message, code="AE")
+
 (ROOT / "before" / "site-a-001.hl7").write_text(before_message, encoding="utf-8")
 (ROOT / "after" / "site-a-001.hl7").write_text(after_message, encoding="utf-8")
+(ROOT / "profile-fixtures" / "valid" / "before.hl7").write_text(
+    before_message,
+    encoding="utf-8",
+)
+(ROOT / "profile-fixtures" / "invalid" / "after.hl7").write_text(
+    after_message,
+    encoding="utf-8",
+)
+(ROOT / "reports" / "generated-message-001.hl7").write_text(
+    generated_messages[0],
+    encoding="utf-8",
+)
+(ROOT / "reports" / "ack.hl7").write_text(ack_message, encoding="utf-8")
+
+profile_lint_v2 = hl7v2.profile_lint(profile_yaml, schema_version=2)
+profile_explain_v2 = hl7v2.profile_explain(
+    profile_yaml,
+    profile_name="profiles/generic.yaml",
+    schema_version=2,
+)
+profile_test_v2 = hl7v2.profile_test(
+    profile_yaml,
+    str(ROOT / "profile-fixtures"),
+    profile_name="profiles/generic.yaml",
+    schema_version=2,
+)
 
 report = hl7v2.validate(after_message, profile_yaml)
 report_v2 = report.to_dict(2)
@@ -138,6 +179,9 @@ bundle_v2 = hl7v2.bundle(
 replay_v2 = hl7v2.replay(str(ROOT / "issue-bundle"), schema_version=2)
 
 artifacts = {
+    "profile-lint-v2.json": profile_lint_v2,
+    "profile-explain-v2.json": profile_explain_v2,
+    "profile-test-v2.json": profile_test_v2,
     "validation-report-v2.json": report_v2,
     "corpus-summary-v2.json": summary_v2,
     "corpus-fingerprint-v2.json": fingerprint_v2,
@@ -161,8 +205,13 @@ print(
             "validation_issue_codes": [
                 issue["code"] for issue in report_v2["issues"]
             ],
+            "profile_lint_valid": profile_lint_v2["valid"],
+            "profile_test_valid": profile_test_v2["valid"],
+            "profile_explain_segments": profile_explain_v2["summary"]["segment_count"],
+            "ack_msa": "MSA|AE|CTRL200" in ack_message,
             "after_message_count": summary_v2["message_count"],
             "diff_field_presence_deltas": len(diff_v2["field_presence"]),
+            "generated_message_count": len(generated_messages),
             "redaction_phi_removed": redaction_v2["receipt"]["phi_removed"],
             "bundle_artifacts": len(bundle_v2["artifacts"]),
             "replay_reproduced": replay_v2["reproduced"],
@@ -189,9 +238,14 @@ Expected output has the same evidence semantics as the CLI and server:
 
 ```json
 {
+  "ack_msa": true,
   "after_message_count": 1,
   "bundle_artifacts": 10,
   "diff_field_presence_deltas": 0,
+  "generated_message_count": 2,
+  "profile_explain_segments": 2,
+  "profile_lint_valid": true,
+  "profile_test_valid": true,
   "redaction_phi_removed": true,
   "replay_reproduced": true,
   "validation_issue_codes": [

--- a/schemas/evidence/profile-explain-report-v2.schema.json
+++ b/schemas/evidence/profile-explain-report-v2.schema.json
@@ -32,7 +32,7 @@
     "schema_version": {"const": "2"},
     "tool_name": {
       "type": "string",
-      "enum": ["hl7v2-cli"]
+      "enum": ["hl7v2-cli", "hl7v2-python"]
     },
     "tool_version": {"type": "string"},
     "profile": {"type": "string"},

--- a/schemas/evidence/profile-lint-report-v2.schema.json
+++ b/schemas/evidence/profile-lint-report-v2.schema.json
@@ -19,7 +19,7 @@
     "schema_version": {"const": "2"},
     "tool_name": {
       "type": "string",
-      "enum": ["hl7v2", "hl7v2-cli"]
+      "enum": ["hl7v2", "hl7v2-cli", "hl7v2-python"]
     },
     "tool_version": {"type": "string"},
     "valid": {"type": "boolean"},

--- a/schemas/evidence/profile-test-report-v2.schema.json
+++ b/schemas/evidence/profile-test-report-v2.schema.json
@@ -21,7 +21,7 @@
     "schema_version": {"const": "2"},
     "tool_name": {
       "type": "string",
-      "enum": ["hl7v2-cli"]
+      "enum": ["hl7v2-cli", "hl7v2-python"]
     },
     "tool_version": {"type": "string"},
     "profile": {

--- a/tests/python_smoke/evidence_workflow_guide.py
+++ b/tests/python_smoke/evidence_workflow_guide.py
@@ -19,6 +19,9 @@ SCRIPT_MARKER = 'ROOT = Path("target/hl7v2-python-evidence")'
 SCHEMA_DIR = Path("schemas/evidence")
 ARTIFACT_SCHEMAS = {
     "validation-report-v2.json": "validation-report-v2.schema.json",
+    "profile-lint-v2.json": "profile-lint-report-v2.schema.json",
+    "profile-explain-v2.json": "profile-explain-report-v2.schema.json",
+    "profile-test-v2.json": "profile-test-report-v2.schema.json",
     "corpus-summary-v2.json": "corpus-summary-v2.schema.json",
     "corpus-fingerprint-v2.json": "corpus-fingerprint-v2.schema.json",
     "corpus-diff-v2.json": "corpus-diff-v2.schema.json",
@@ -186,9 +189,14 @@ def main() -> int:
         raise SystemExit(1) from error
 
     expected = {
+        "ack_msa": True,
         "after_message_count": 1,
         "bundle_artifacts": 10,
         "diff_field_presence_deltas": 0,
+        "generated_message_count": 2,
+        "profile_explain_segments": 2,
+        "profile_lint_valid": True,
+        "profile_test_valid": True,
         "redaction_phi_removed": True,
         "replay_reproduced": True,
         "validation_issue_codes": ["value_not_in_set"],
@@ -226,6 +234,11 @@ def main() -> int:
                 f"guide workflow artifact {artifact} failed {schema}: {error}",
                 file=sys.stderr,
             )
+            return 1
+
+    for artifact in ["generated-message-001.hl7", "ack.hl7"]:
+        if not (reports_dir / artifact).is_file():
+            print(f"guide workflow did not write {artifact}", file=sys.stderr)
             return 1
 
     bundle_dir = Path("target/hl7v2-python-evidence/issue-bundle")

--- a/tests/python_smoke/smoke.py
+++ b/tests/python_smoke/smoke.py
@@ -149,6 +149,52 @@ def main() -> int:
         print("normalize did not return expected HL7 content", file=sys.stderr)
         return 1
 
+    ack_message = hl7v2.ack(raw)
+    if "MSA|AA|CTRL123" not in ack_message or "ACK" not in ack_message:
+        print(
+            f"default ACK did not preserve expected status/control id: {ack_message}",
+            file=sys.stderr,
+        )
+        return 1
+    error_ack = hl7v2.ack(raw, code="ae")
+    if "MSA|AE|CTRL123" not in error_ack:
+        print(f"explicit ACK code did not round-trip: {error_ack}", file=sys.stderr)
+        return 1
+    try:
+        hl7v2.ack(raw, code="ZZ")
+    except ValueError as exc:
+        if "ack code must be one of AA, AE, AR, CA, CE, CR" not in str(exc):
+            print(f"unexpected ACK code failure: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print("expected unsupported ACK code to fail", file=sys.stderr)
+        return 1
+
+    template_yaml = """
+name: "ADT_A01_Template"
+delims: "^~\\\\&"
+segments:
+  - "MSH|^~\\\\&|TestSystem|TestFacility|ReceivingSystem|ReceivingFacility|20250101000000||ADT^A01^ADT_A01|MSG00001|P|2.5.1"
+  - "PID|1||123456^^^HOSP^MR||Doe^John^A||19800101|M"
+values: {}
+"""
+    generated = hl7v2.generate(template_yaml, seed=1337, count=2)
+    if len(generated) != 2:
+        print(f"expected two generated messages: {generated}", file=sys.stderr)
+        return 1
+    if not all("MSH|^~\\&" in message and "PID|" in message for message in generated):
+        print(f"generated messages did not look like HL7: {generated}", file=sys.stderr)
+        return 1
+    try:
+        hl7v2.generate("not: [valid", count=1)
+    except ValueError as exc:
+        if "Template parse error" not in str(exc):
+            print(f"unexpected template parse failure: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print("expected invalid template YAML to fail", file=sys.stderr)
+        return 1
+
     profile_yaml = """
 message_structure: ADT_A01
 version: "2.5.1"
@@ -161,6 +207,156 @@ constraints:
   - path: PID.3
     required: true
 """
+    profile_lint = hl7v2.profile_lint(profile_yaml)
+    if profile_lint["valid"] is not True or profile_lint["issue_count"] != 0:
+        print(f"unexpected profile lint report: {profile_lint}", file=sys.stderr)
+        return 1
+    profile_lint_v2 = hl7v2.profile_lint(profile_yaml, schema_version=2)
+    if (
+        profile_lint_v2["schema_version"] != "2"
+        or profile_lint_v2["tool_name"] != "hl7v2-python"
+        or profile_lint_v2["valid"] is not True
+    ):
+        print(f"unexpected profile lint v2 report: {profile_lint_v2}", file=sys.stderr)
+        return 1
+    try:
+        hl7v2.profile_lint(profile_yaml, schema_version=3)
+    except ValueError as exc:
+        if "schema_version must be 1 or 2" not in str(exc):
+            print(f"unexpected profile lint schema failure: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print("expected unsupported profile lint schema version to fail", file=sys.stderr)
+        return 1
+
+    profile_explain = hl7v2.profile_explain(
+        profile_yaml,
+        profile_name="profiles/adt_a01.yaml",
+    )
+    if (
+        profile_explain["profile"] != "profiles/adt_a01.yaml"
+        or profile_explain["message_structure"] != "ADT_A01"
+        or profile_explain["summary"]["segment_count"] != 2
+        or len(profile_explain["profile_sha256"]) != 64
+    ):
+        print(f"unexpected profile explain report: {profile_explain}", file=sys.stderr)
+        return 1
+    profile_explain_v2 = hl7v2.profile_explain(
+        profile_yaml,
+        profile_name="profiles/adt_a01.yaml",
+        schema_version=2,
+    )
+    if (
+        profile_explain_v2["schema_version"] != "2"
+        or profile_explain_v2["tool_name"] != "hl7v2-python"
+        or profile_explain_v2["profile"] != "profiles/adt_a01.yaml"
+    ):
+        print(f"unexpected profile explain v2 report: {profile_explain_v2}", file=sys.stderr)
+        return 1
+    try:
+        hl7v2.profile_explain(profile_yaml, schema_version=3)
+    except ValueError as exc:
+        if "schema_version must be 1 or 2" not in str(exc):
+            print(f"unexpected profile explain schema failure: {exc}", file=sys.stderr)
+            return 1
+    else:
+        print("expected unsupported profile explain schema version to fail", file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory() as tmp:
+        fixture_root = Path(tmp) / "profile-fixtures"
+        (fixture_root / "valid").mkdir(parents=True)
+        (fixture_root / "invalid").mkdir(parents=True)
+        (fixture_root / "expected").mkdir(parents=True)
+        (fixture_root / "valid" / "adt.hl7").write_text(raw, encoding="utf-8")
+        (fixture_root / "invalid" / "missing_pid3.hl7").write_text(
+            (
+                "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605080101||ADT^A01|CTRL999|P|2.5\r"
+                "PID|1||||Doe^John||19700101|M"
+            ),
+            encoding="utf-8",
+        )
+        (fixture_root / "expected" / "missing_pid3.report.json").write_text(
+            json.dumps(
+                {
+                    "valid": False,
+                    "issues": [
+                        {
+                            "code": "missing_required_field",
+                            "severity": "error",
+                            "path": "PID.3",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        profile_test = hl7v2.profile_test(
+            profile_yaml,
+            str(fixture_root),
+            profile_name="profiles/adt_a01.yaml",
+        )
+        if (
+            profile_test["valid"] is not True
+            or profile_test["case_count"] != 2
+            or profile_test["passed_count"] != 2
+        ):
+            print(f"unexpected profile test report: {profile_test}", file=sys.stderr)
+            return 1
+        invalid_cases = [
+            case
+            for case in profile_test["cases"]
+            if case["expectation"] == "invalid"
+        ]
+        if not invalid_cases or not invalid_cases[0]["expected_report"]["matched"]:
+            print(f"profile test did not match expected report: {profile_test}", file=sys.stderr)
+            return 1
+        profile_test_json = json.dumps(profile_test, sort_keys=True)
+        fixture_root_text = str(fixture_root)
+        if fixture_root_text in profile_test_json:
+            print("profile test report leaked local fixture root", file=sys.stderr)
+            return 1
+        if "profiles/adt_a01.yaml" in profile_test_json:
+            print("profile test report leaked caller profile path", file=sys.stderr)
+            return 1
+        if "expected/missing_pid3.report.json" not in profile_test_json:
+            print(
+                f"profile test report did not keep relative expected report path: {profile_test}",
+                file=sys.stderr,
+            )
+            return 1
+
+        profile_test_v2 = hl7v2.profile_test(
+            profile_yaml,
+            str(fixture_root),
+            profile_name="profiles/adt_a01.yaml",
+            schema_version=2,
+        )
+        if (
+            profile_test_v2["schema_version"] != "2"
+            or profile_test_v2["tool_name"] != "hl7v2-python"
+            or profile_test_v2["valid"] is not True
+        ):
+            print(f"unexpected profile test v2 report: {profile_test_v2}", file=sys.stderr)
+            return 1
+        profile_test_v2_json = json.dumps(profile_test_v2, sort_keys=True)
+        if fixture_root_text in profile_test_v2_json:
+            print("profile test v2 report leaked local fixture root", file=sys.stderr)
+            return 1
+        if "profiles/adt_a01.yaml" in profile_test_v2_json:
+            print("profile test v2 report leaked caller profile path", file=sys.stderr)
+            return 1
+        try:
+            hl7v2.profile_test(profile_yaml, str(fixture_root), schema_version=3)
+        except ValueError as exc:
+            if "schema_version must be 1 or 2" not in str(exc):
+                print(f"unexpected profile test schema failure: {exc}", file=sys.stderr)
+                return 1
+        else:
+            print("expected unsupported profile test schema version to fail", file=sys.stderr)
+            return 1
+
     report = hl7v2.validate(raw, profile_yaml)
     if not report.valid:
         print("expected validation report to be valid", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Expose Python helpers for ACK generation, synthetic message generation, and profile lint/explain/test evidence reports.
- Extend the Python smoke and evidence workflow guide so these new helpers are covered by local wheel install-back proof.
- Allow hl7v2-python as the producer for v2 profile lint/explain/test evidence schemas.

## Scope

This is the second salvage slice from the old dirty workbench. The core Rust profile evidence facade landed first in #616; this PR only wires that surface into the Python binding and proof docs.

No registry publish, TestPyPI publish, PyPI publish, tag, or release claim is made here.

## Validation

- cargo +1.95.0 fmt --all -- --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_INCREMENTAL=0 cargo +1.95.0 check -p hl7v2-python --all-targets --all-features --locked
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_INCREMENTAL=0 cargo +1.95.0 clippy -p hl7v2-python --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- evidence-schema-check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 CARGO_INCREMENTAL=0 python -m maturin build --release --out dist
- fresh venv install-back from dist\\hl7v2-1.5.0-cp314-cp314-win_amd64.whl
- python tests/python_smoke/smoke.py
- python tests/python_smoke/evidence_workflow_guide.py
- git diff --check origin/main...HEAD

## Self-review

- Scope matches PR title: yes; Python binding helpers plus their proof docs/smoke coverage.
- Files touched are expected: Python crate, Python smoke scripts, Python evidence guide, and profile evidence schemas.
- No unrelated cleanup: yes.
- Policy changes are intentional: no policy changes.
- No Clippy test carveouts added: yes.
- No bare #[allow(clippy::...)] added: yes.
- No-panic baseline handling is scoped: not touched.
- Non-Rust allowlist changes are narrow: not touched.
- CI economics: default lane weight unchanged.
- ripr mutation-exposure framing preserved: ripr behavior not changed.
- Release evidence preserved: no release or publish claim.
- Bot comments addressed: pending hosted review.
- Follow-ups: remaining dirty-workbench salvage candidates stay separate.