### PR TITLE
docs(spec): define cross-surface evidence parity

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -49,6 +49,7 @@ canonical_sources = [
   "docs/audits/binding-backend-readiness-2026-05-14.md",
   "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
   "docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md",
+  "docs/specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md",
   "docs/ci/ripr.md",
   "docs/ci/test-evidence-lanes.md",
   "policy/clippy-lints.toml",
@@ -240,6 +241,28 @@ publish_order = [
   "hl7v2-cli",
 ]
 non_claims = [
+  "No crates.io upload.",
+  "No TestPyPI or PyPI upload.",
+  "No npm package.",
+  "No tag or GitHub release.",
+]
+
+[[work_item]]
+id = "cross-surface-evidence-parity-spec"
+status = "done"
+goal = "Define the parity contract for Rust, CLI, REST, gRPC, Python, and future TypeScript evidence semantics without adding runtime behavior."
+spec = "docs/specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md"
+acceptance = [
+  "Parity claims require shared semantics, safe diagnostics, schema-backed artifacts, and proof receipts.",
+  "gRPC, Python, and TypeScript must keep current claims narrower than unimplemented surfaces.",
+  "Python distribution and registry claims remain separate from local binding helper proof.",
+]
+commands = [
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "git diff --check",
+]
+non_claims = [
+  "No runtime implementation.",
   "No crates.io upload.",
   "No TestPyPI or PyPI upload.",
   "No npm package.",

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ proposal, spec, plan, or receipt documents.
 | [v1.5.0 Rust 1.95 release candidate notes](releases/v1.5.0-rust-1.95-quality-ratchet.md) | Candidate scope for the Rust 1.95 quality-ratchet release; not a publish receipt. |
 | [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
 | [v1.5.0 publish dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-13.md) | Non-publishing crates.io dry-run proof for the v1.5.0 Rust graph. |
+| [Cross-surface evidence parity spec](specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Contract map for Rust, CLI, REST/gRPC, Python, and future TypeScript evidence semantics. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the `hl7v2-python` binding backend separate from the primary Rust product graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |
 
@@ -86,8 +87,10 @@ proposal, spec, plan, or receipt documents.
 - gRPC coverage is useful but still narrower than the full HTTP evidence
   surface. It now includes inline corpus summary parity, while corpus
   fingerprint/diff, bundle, and replay remain HTTP-first until focused gRPC
-  parity PRs land. Use `docs/API_GUIDE.md` and `docs/STATUS.md` for current
-  endpoint claims.
+  parity PRs land. Use
+  [`HL7V2-SPEC-0006`](specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md)
+  for the cross-surface parity contract, and use `docs/API_GUIDE.md` and
+  `docs/STATUS.md` for current endpoint claims.
 
 ## Historical Documents
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -70,6 +70,11 @@ Future TypeScript package work is governed by
 [HL7V2-SPEC-0005](specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md):
 the public npm package is `@effortlessmetrics/hl7v2`, while Rust backend crates
 such as `hl7v2-wasm` or `hl7v2-node` remain binding infrastructure.
+Cross-surface evidence parity is governed by
+[HL7V2-SPEC-0006](specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md):
+Rust, CLI, REST, gRPC, Python, and future TypeScript claims must map to shared
+semantics, safe diagnostics, schema-backed artifacts, and receipts before they
+are described as equivalent.
 
 ## Evidence Contracts Release And Current Main
 
@@ -83,8 +88,8 @@ corpus endpoints, redacted structured evidence logs, Docker sidecar smoke
 coverage, broader PHI sentinel tests, Python/TestPyPI proof rails, the server
 bundle replay message-type fix, Rust 1.95 policy ratchets, profile evidence,
 Python profile helpers, gRPC inline corpus summary parity, advisory `ripr`,
-RIPR evidence endpoints, targeted mutation routing, and the v1.5.0
-release-readiness workflow.
+RIPR evidence endpoints, targeted mutation routing, the cross-surface evidence
+parity spec, and the v1.5.0 release-readiness workflow.
 
 For navigation across current docs, historical receipts, and evidence workflow
 guides, start with [the documentation index](README.md). For the current

--- a/docs/specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md
+++ b/docs/specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md
@@ -1,0 +1,126 @@
+# HL7V2-SPEC-0006: Cross-Surface Evidence Parity
+
+Status: Accepted
+Date: 2026-05-14
+Proposal: [HL7V2-PROP-0001](../proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
+Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md)
+Related Python proof spec: [HL7V2-SPEC-0002](HL7V2-SPEC-0002-python-distribution-proof.md)
+Related backend proof spec: [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md)
+Related npm/WASM package model: [HL7V2-SPEC-0005](HL7V2-SPEC-0005-npm-wasm-binding-package-model.md)
+
+## Contract
+
+Evidence parity means the same HL7 message, profile, corpus, redaction policy,
+bundle, or replay input has the same product meaning across supported
+surfaces. It does not require every language package or server transport to
+expose every command immediately, and it does not require byte-for-byte wrapper
+APIs. It requires shared semantics, safe error shape, schema-backed artifacts,
+and proof receipts for every claimed surface.
+
+Current and future surfaces are:
+
+| Surface | Role |
+| --- | --- |
+| Rust crate `hl7v2` | Canonical parser, validator, normalizer, evidence model, and artifact semantics. |
+| CLI `hl7v2-cli` | Operator and CI interface for evidence commands and support receipts. |
+| REST server | HTTP sidecar for validation, redaction, corpus, bundle, replay, and service integration. |
+| gRPC server | Typed service transport; narrower than REST until focused parity PRs land. |
+| Python package `hl7v2` | Python user package backed by `hl7v2-python`; release proof is separate from crates.io backend proof. |
+| TypeScript package `@effortlessmetrics/hl7v2` | Planned package governed by [HL7V2-SPEC-0005](HL7V2-SPEC-0005-npm-wasm-binding-package-model.md). |
+
+## Parity Matrix
+
+| Contract | Rust | CLI | REST | gRPC | Python | TypeScript |
+| --- | --- | --- | --- | --- | --- | --- |
+| parse | Stable | Stable | Stable | Stable | Stable local binding | Planned |
+| write / normalize | Stable | Stable | Stable | Stable | Stable local binding | Planned |
+| validate | Stable | Stable | Stable | Stable | Stable local binding | Planned |
+| ACK | Stable | Stable where exposed | Stable where exposed | Stable | Planned or not claimed | Planned |
+| profile lint / explain / test | Stable | Stable | Stable where exposed | Planned until implemented | Stable local helper | Planned |
+| redaction receipt | Stable | Stable | Stable | Stable via `ValidateRedacted` | Stable local binding | Planned |
+| corpus summary | Stable | Stable | Stable | Stable for inline messages | Stable local helper | Planned |
+| corpus fingerprint / diff | Stable | Stable | Stable | Planned until implemented | Stable local helper where exposed | Planned |
+| bundle / replay | Stable | Stable | Stable | Planned until implemented | Stable local helper where exposed | Planned |
+| safe error shape | Stable | Stable | Stable | Stable for implemented RPCs | Required for every claimed helper | Planned |
+| `schema_version` behavior | Stable | Stable | Stable | Stable for implemented v2 evidence RPCs | Required for every claimed artifact | Planned |
+| PHI sentinel behavior | Stable | Stable | Stable | Required for every evidence RPC | Required for every claimed helper | Planned |
+
+`Stable local binding` means local Python wheel/import smoke and parity tests
+exist for the helper surface. It is not a TestPyPI or production PyPI release
+claim. Python distribution proof remains governed by
+[HL7V2-SPEC-0002](HL7V2-SPEC-0002-python-distribution-proof.md).
+
+`Planned until implemented` means the product claim must stay narrower until a
+focused implementation PR adds the surface, docs, and proof receipts.
+
+## Required Proof
+
+Every parity claim must map to at least one local or hosted receipt:
+
+| Claim | Minimum proof |
+| --- | --- |
+| Rust artifact semantics | `cargo test -p hl7v2 --all-features`; `cargo run -p xtask -- evidence-schema-check` |
+| CLI evidence command | CLI integration or BDD test for the command and artifact shape |
+| REST endpoint | Server endpoint contract test plus schema or PHI sentinel proof where applicable |
+| gRPC RPC | `cargo test -p hl7v2-server --test grpc_contract_tests` and proto lint/packaging proof |
+| Python helper | Local wheel install/import smoke plus helper-specific parity test |
+| Python distribution | TestPyPI or PyPI upload and install-back receipt from the target registry |
+| TypeScript package | npm package review, install/import smoke, and parity fixtures after implementation |
+| Evidence artifact | Schema validation against `schemas/evidence/` and golden fixture coverage |
+| Publish or registry claim | Upload plus registry-resolution or install-back proof |
+
+## Fixture Rules
+
+Parity fixtures should be shared across surfaces where practical. A fixture set
+may be transport-specific only when the transport adds a real concern such as
+MLLP framing, gRPC streaming, HTTP request/response metadata, Python packaging,
+or TypeScript/WASM serialization.
+
+Required fixture families:
+
+- parse and write round trip;
+- validation success, warning, and error shape;
+- normalization with canonical delimiters and optional MLLP framing;
+- ACK code mapping and control ID preservation;
+- profile lint, explain, and fixture test output;
+- redaction receipt with PHI sentinels;
+- corpus summary, fingerprint, and diff;
+- evidence bundle creation and replay;
+- v1 and v2 `schema_version` behavior where an artifact supports both;
+- malformed input that proves safe diagnostics without echoing raw PHI.
+
+## Non-Goals
+
+- No new runtime implementation in this spec.
+- No crates.io, TestPyPI, PyPI, npm, tag, or GitHub release claim.
+- No requirement that gRPC expose every REST endpoint in one PR.
+- No requirement that Python or TypeScript users import binding backend crates.
+- No return to public Rust implementation microcrates for parser, model,
+  redaction, MLLP, batch, stream, or evidence internals.
+
+## Acceptance Examples
+
+### Correct gRPC Parity Claim
+
+`CorpusSummarize` can be described as gRPC corpus summary parity when the RPC
+accepts inline messages, returns the shared corpus summary fields, supports
+opt-in v2 provenance if claimed, rejects unsupported schema versions, avoids
+request filesystem reads, and passes gRPC contract tests.
+
+It must not imply gRPC corpus fingerprint, corpus diff, bundle, or replay
+parity until those RPCs and tests land.
+
+### Correct Python Claim
+
+A local Python helper can be described as locally proven when a wheel install,
+`import hl7v2`, and helper-specific smoke or parity test pass.
+
+It must not be described as TestPyPI-proven or PyPI-released until upload and
+install-back receipts from those registries exist.
+
+### Correct TypeScript Claim
+
+The planned TypeScript user package is `@effortlessmetrics/hl7v2`. Future
+TypeScript parity starts with package review, install/import smoke, and shared
+parse/validate/redaction fixtures. It must not use `hl7v2-rs` as the public SDK
+identity.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -22,3 +22,4 @@ rollback, and use `docs/STATUS.md` for current feature status.
 | [HL7V2-SPEC-0003](HL7V2-SPEC-0003-ci-verification-economics.md) | CI Verification Economics | Accepted |
 | [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md) | Binding Backend Release Proof | Accepted |
 | [HL7V2-SPEC-0005](HL7V2-SPEC-0005-npm-wasm-binding-package-model.md) | npm and WASM Binding Package Model | Accepted |
+| [HL7V2-SPEC-0006](HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Cross-Surface Evidence Parity | Accepted |

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -22,6 +22,7 @@ claim tier or proof expectations.
 | --- | --- | --- |
 | Rust parse, validate, normalize, ACK, MLLP, and evidence models | Stable | `cargo test -p hl7v2 --all-features` |
 | Evidence schemas | Stable | `cargo run -p xtask -- evidence-schema-check` |
+| Cross-surface evidence parity contract | Accepted | [HL7V2-SPEC-0006](../specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md); surface-specific claims still require their own tests, schema checks, language install/import proof, or registry receipts |
 | CLI evidence commands | Stable | `cargo test -p hl7v2-cli --test integration_tests` |
 | CLI BDD workflows | Stable | `cargo test -p hl7v2-cli --test bdd_tests` |
 | REST evidence sidecar | Stable | `cargo test -p hl7v2-server --test validate_endpoint_test`; `cargo test -p hl7v2-server --test bundle_endpoint_test`; `cargo test -p hl7v2-server --test replay_endpoint_test` |


### PR DESCRIPTION
## Summary

- add HL7V2-SPEC-0006 as the cross-surface evidence parity contract
- define current and planned parity for Rust, CLI, REST, gRPC, Python, and future TypeScript
- link the new spec from the docs index, status, support tiers, and active goal manifest

## Boundaries

- docs-only contract map
- no runtime implementation
- no crates.io, TestPyPI, PyPI, npm, tag, or GitHub release claim
- no expansion of gRPC/Python/TypeScript claims beyond current proof

## Validation

- rtk cargo +1.95.0 run -p xtask -- check-doc-links
- rtk cargo +1.95.0 run -p xtask -- check-file-policy
- rtk git diff --check