### PR TITLE
test(corpus): add dirty real-world corpus proof

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -48,6 +48,7 @@ canonical_sources = [
   "docs/releases/v1.5.0-rust-1.95-quality-ratchet.md",
   "docs/audits/binding-backend-readiness-2026-05-14.md",
   "docs/audits/publish-dry-run-v1.5.0-2026-05-14-parity-refresh.md",
+  "docs/audits/real-world-corpus-proof-2026-05-14.md",
   "docs/guides/first-use-by-surface.md",
   "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
   "docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md",
@@ -362,6 +363,28 @@ commands = [
   "git diff --check",
 ]
 non_claims = [
+  "No crates.io upload.",
+  "No TestPyPI or PyPI upload.",
+  "No npm package.",
+  "No tag or GitHub release.",
+]
+
+[[work_item]]
+id = "dirty-real-world-corpus-proof"
+status = "done"
+goal = "Add a focused core proof that corpus summary, fingerprint, and diff handle dirty real-world interface data safely."
+receipt = "docs/audits/real-world-corpus-proof-2026-05-14.md"
+commands = [
+  "CARGO_TARGET_DIR=F:\\cargo-target\\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 test -p hl7v2 --lib --all-features dirty_real_world",
+  "CARGO_TARGET_DIR=F:\\cargo-target\\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 test -p hl7v2 --lib --all-features summary_tests",
+  "cargo +1.95.0 fmt --all -- --check",
+  "CARGO_TARGET_DIR=F:\\cargo-target\\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 clippy -p hl7v2 --lib --all-features -- -D warnings",
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "git diff --check",
+]
+non_claims = [
+  "No public compatibility corpus.",
+  "No cross-surface corpus parity claim.",
   "No crates.io upload.",
   "No TestPyPI or PyPI upload.",
   "No npm package.",

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12008",
+  "message": "12010",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/synthetic/corpus.rs
+++ b/crates/hl7v2/src/synthetic/corpus.rs
@@ -1604,6 +1604,21 @@ mod summary_tests {
         assert!(result.is_ok(), "test message should be written: {result:?}");
     }
 
+    fn write_message_bytes(path: &Path, contents: &[u8]) {
+        let result = fs::write(path, contents);
+        assert!(result.is_ok(), "test message should be written: {result:?}");
+    }
+
+    fn large_obx_message(control_id: &str, obx_count: usize) -> String {
+        let mut message = format!(
+            "MSH|^~\\&|LAB|LEGACY|EHR|HOSP|202605140101||ORU^R01|{control_id}|P|2.3\rPID|1||MRN-LARGE^^^HOSP^MR||Example^Large||19700101|U\rOBR|1|ORD-LARGE|FILL-LARGE|CBC^Complete Blood Count"
+        );
+        for index in 1..=obx_count {
+            message.push_str(&format!("\rOBX|{index}|NM|718-7^Hemoglobin||{index}|g/dL"));
+        }
+        message
+    }
+
     #[test]
     fn summarize_corpus_path_counts_messages_segments_and_fields() {
         let Ok(dir) = tempfile::tempdir() else {
@@ -1699,6 +1714,115 @@ mod summary_tests {
             panic!("parse failure should be recorded");
         };
         assert!(!parse_failure.error.contains("not an hl7 message"));
+    }
+
+    #[test]
+    fn dirty_real_world_corpus_produces_safe_summary_fingerprint_and_diff() {
+        let Ok(before) = tempfile::tempdir() else {
+            panic!("before temp dir should be created");
+        };
+        let Ok(after) = tempfile::tempdir() else {
+            panic!("after temp dir should be created");
+        };
+
+        let z_segment_message = "MSH|^~\\&|INTF|SITE|EHR|HOSP|202605140101||ADT^A01|CTRL-Z|P|2.5\rPID|1||MRN-Z^^^HOSP^MR||Example^Zed||19700101|U\rZPV|legacy-room|dirty interface note";
+        let odd_msh_message = "MSH|^~\\&|LEGACY||EHR||202605140102||ADT^A08|CTRL-ODD|P|2.3\rPID|1||MRN-ODD^^^HOSP^MR||Example^Odd||19600101|";
+        let large_before = large_obx_message("CTRL-LARGE-BEFORE", 5);
+        let large_after = large_obx_message("CTRL-LARGE-AFTER", 20);
+        let malformed_delimiters =
+            b"MSH|^^^^|BROKEN|SITE|EHR|HOSP|202605140103||ADT^A01|MRN-DIRTY|P|2.5\rPID|1";
+        let mllp_after = crate::wrap_mllp(odd_msh_message.as_bytes());
+
+        write_message(&before.path().join("z-segment.hl7"), z_segment_message);
+        write_message(&before.path().join("large-obx.hl7"), &large_before);
+
+        write_message(&after.path().join("z-segment.hl7"), z_segment_message);
+        write_message(&after.path().join("large-obx.hl7"), &large_after);
+        write_message_bytes(&after.path().join("mllp-framed.hl7"), &mllp_after);
+        write_message_bytes(
+            &after.path().join("malformed-delimiters.hl7"),
+            malformed_delimiters,
+        );
+
+        let Ok(summary) = summarize_corpus_path(after.path()) else {
+            panic!("dirty corpus should summarize");
+        };
+        let Ok(fingerprint) = fingerprint_corpus_path(after.path()) else {
+            panic!("dirty corpus should fingerprint");
+        };
+        let Ok(diff) = diff_corpus_paths(before.path(), after.path()) else {
+            panic!("dirty corpus should diff");
+        };
+
+        assert_eq!(summary.file_count, 4);
+        assert_eq!(summary.message_count, 3);
+        assert_eq!(summary.parse_error_count, 1);
+        assert!(summary.total_bytes > large_after.len());
+        assert!(
+            summary
+                .message_types
+                .iter()
+                .any(|count| count.value == "ADT^A01" && count.count == 1)
+        );
+        assert!(
+            summary
+                .message_types
+                .iter()
+                .any(|count| count.value == "ADT^A08" && count.count == 1)
+        );
+        assert!(
+            summary
+                .message_types
+                .iter()
+                .any(|count| count.value == "ORU^R01" && count.count == 1)
+        );
+        assert!(
+            summary
+                .segments
+                .iter()
+                .any(|count| count.value == "ZPV" && count.count == 1)
+        );
+        assert!(
+            summary
+                .segments
+                .iter()
+                .any(|count| count.value == "OBX" && count.count == 20)
+        );
+        let Some(parse_failure) = summary.parse_errors.first() else {
+            panic!("malformed delimiter failure should be recorded");
+        };
+        assert_eq!(parse_failure.path, "malformed-delimiters.hl7");
+        assert!(!parse_failure.error.contains("MRN-DIRTY"));
+
+        assert_eq!(fingerprint.file_count, 4);
+        assert_eq!(fingerprint.message_count, 3);
+        assert_eq!(fingerprint.parse_error_count, 1);
+        assert!(
+            fingerprint
+                .field_cardinality
+                .iter()
+                .any(|field| field.path == "OBX.5"
+                    && field.max_per_message == 20
+                    && field.total_occurrences == 20)
+        );
+        assert!(
+            fingerprint
+                .field_cardinality
+                .iter()
+                .any(|field| field.path == "ZPV.1" && field.total_occurrences == 1)
+        );
+
+        assert_eq!(diff.file_count.before, 2);
+        assert_eq!(diff.file_count.after, 4);
+        assert_eq!(diff.message_count.delta, 1);
+        assert_eq!(diff.parse_error_count.delta, 1);
+        assert!(
+            diff.field_cardinality
+                .iter()
+                .any(|field| field.path == "OBX.5"
+                    && field.max_per_message_delta == 15
+                    && field.total_occurrences_delta == 15)
+        );
     }
 
     #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ proposal, spec, plan, or receipt documents.
 | [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
 | [v1.5.0 publish dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-13.md) | Non-publishing crates.io dry-run proof for the v1.5.0 Rust graph. |
 | [v1.5.0 parity refresh dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-14-parity-refresh.md) | Current-main non-publishing proof after gRPC corpus summary parity and the cross-surface evidence parity spec. |
+| [Dirty real-world corpus proof](audits/real-world-corpus-proof-2026-05-14.md) | Focused proof that core corpus summary, fingerprint, and diff handle Z-segments, odd MSH fields, MLLP bytes, large OBX messages, malformed delimiters, and safe parse-error output. |
 | [Cross-surface evidence parity spec](specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Contract map for Rust, CLI, REST/gRPC, Python, and future TypeScript evidence semantics. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the `hl7v2-python` binding backend separate from the primary Rust product graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -89,7 +89,8 @@ coverage, broader PHI sentinel tests, Python/TestPyPI proof rails, the server
 bundle replay message-type fix, Rust 1.95 policy ratchets, profile evidence,
 Python profile helpers, gRPC inline corpus summary parity, advisory `ripr`,
 RIPR evidence endpoints, targeted mutation routing, the cross-surface evidence
-parity spec, and the v1.5.0 release-readiness workflow.
+parity spec, dirty real-world corpus proof, and the v1.5.0 release-readiness
+workflow.
 
 For navigation across current docs, historical receipts, and evidence workflow
 guides, start with [the documentation index](README.md). For the current
@@ -101,7 +102,7 @@ final source-tree gap audit after the local workbench split, see
 | First-run diagnostics | ✅ Stable | `hl7v2 doctor` verifies CLI version, sample parse, profile loading, JSON output, optional server reachability, and optional Python binding presence. |
 | Typed validation evidence | ✅ Stable | `ValidationReport` is shared by library, CLI, server validation, and Python bindings. |
 | Profiles as code | ✅ Stable | `profile lint`, `profile test`, and `profile explain` produce machine-readable profile evidence. |
-| Corpus observability | ✅ Stable | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. |
+| Corpus observability | ✅ Stable | `corpus summarize`, `corpus fingerprint`, and `corpus diff` produce feed-level evidence for regression and migration review. Current proof includes dirty-corpus coverage for Z-segments, odd MSH fields, MLLP bytes, large OBX messages, malformed delimiters, and safe parse-error output. |
 | Safe support packets | ✅ Stable | `redact`, `bundle`, and `replay` produce redacted evidence bundles with manifest checks and replay verification. |
 | Evidence contracts | ✅ Stable | v1.4.0 ships opt-in v2 provenance schemas/producers and an `xtask evidence-schema-check` gate. |
 | CLI automation contract | ✅ Stable | Evidence commands use stable exit codes, primary stdout, diagnostic stderr, and output-file/quiet/no-color flags. |

--- a/docs/audits/real-world-corpus-proof-2026-05-14.md
+++ b/docs/audits/real-world-corpus-proof-2026-05-14.md
@@ -1,0 +1,60 @@
+# Dirty Real-World Corpus Proof
+
+Date: 2026-05-14
+Branch: `test/real-world-corpus-proof`
+Result: Passed
+
+This receipt records the first focused dirty-corpus compatibility proof for the
+core corpus summary, fingerprint, and diff surfaces. It is a local test receipt,
+not a registry, release, TestPyPI, PyPI, npm, tag, or GitHub release receipt.
+
+## Scope
+
+The proof adds a core library regression test that builds before/after corpus
+directories with deliberately ugly but common interface data:
+
+- Z-segments;
+- blank and odd legacy MSH fields;
+- MLLP-framed message bytes;
+- a larger OBX-heavy message;
+- malformed delimiter input that must be counted as a parse error without
+  echoing the raw payload.
+
+The test then verifies:
+
+- corpus summary file, message, segment, message-type, byte, and parse-error
+  counts;
+- corpus fingerprint file, message, parse-error, and field-cardinality counts;
+- corpus diff before/after deltas for file count, message count, parse errors,
+  and OBX field cardinality;
+- safe parse-error output that does not include the synthetic `MRN-DIRTY`
+  payload marker.
+
+## Validation
+
+The local H: target directory hit disk pressure during broad test compilation,
+so the passing Rust checks used an F: target directory and disabled incremental
+compilation for the cargo-heavy commands.
+
+| Command | Result |
+| --- | --- |
+| `CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 test -p hl7v2 --lib --all-features dirty_real_world` | pass; 1 targeted dirty-corpus test passed |
+| `CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 test -p hl7v2 --lib --all-features summary_tests` | pass; 7 corpus summary/fingerprint/diff tests passed |
+| `cargo +1.95.0 fmt --all -- --check` | pass |
+| `CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 clippy -p hl7v2 --lib --all-features -- -D warnings` | pass |
+| `git diff --check` | pass |
+
+## Non-Claims
+
+This proof does not claim:
+
+- a public compatibility corpus exists;
+- all real-world HL7 variants are covered;
+- server, Python, or TypeScript corpus parity;
+- any crates.io upload;
+- any TestPyPI or PyPI upload;
+- any npm package;
+- any tag or GitHub release.
+
+Future corpus work should expand this into named fixture categories and
+cross-surface parity receipts after the stable Rust proof remains useful.

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -23,6 +23,7 @@ claim tier or proof expectations.
 | Rust parse, validate, normalize, ACK, MLLP, and evidence models | Stable | `cargo test -p hl7v2 --all-features` |
 | Evidence schemas | Stable | `cargo run -p xtask -- evidence-schema-check` |
 | Cross-surface evidence parity contract | Accepted | [HL7V2-SPEC-0006](../specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md); surface-specific claims still require their own tests, schema checks, language install/import proof, or registry receipts |
+| Dirty corpus compatibility proof | Stable core proof | `cargo test -p hl7v2 --lib --all-features dirty_real_world`; [dirty real-world corpus proof](../audits/real-world-corpus-proof-2026-05-14.md) |
 | CLI evidence commands | Stable | `cargo test -p hl7v2-cli --test integration_tests` |
 | CLI BDD workflows | Stable | `cargo test -p hl7v2-cli --test bdd_tests` |
 | REST evidence sidecar | Stable | `cargo test -p hl7v2-server --test validate_endpoint_test`; `cargo test -p hl7v2-server --test bundle_endpoint_test`; `cargo test -p hl7v2-server --test replay_endpoint_test` |


### PR DESCRIPTION
## Summary

- add a focused dirty-corpus regression proof for corpus summary, fingerprint, and diff
- cover Z-segments, odd MSH fields, MLLP-framed bytes, large OBX-heavy messages, malformed delimiters, and safe parse-error output
- record the proof in docs/audits and wire it into status, support tiers, and the active goal manifest

## Validation

- cargo +1.95.0 fmt --all -- --check
- CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 test -p hl7v2 --lib --all-features dirty_real_world
- CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 test -p hl7v2 --lib --all-features summary_tests
- CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-real-world-corpus CARGO_INCREMENTAL=0 cargo +1.95.0 clippy -p hl7v2 --lib --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Notes

- H: target compilation hit local disk pressure during a broad test run, so the passing cargo-heavy checks used the F: target directory.
- This does not claim a public compatibility corpus, cross-surface corpus parity, crates.io, TestPyPI, PyPI, npm, tag, or GitHub release success.