### PR TITLE
ci: fix nightly property test command

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -170,9 +170,8 @@ jobs:
       - name: Run extended property tests
         env:
           PROPTEST_CASES: 10000
-          PROPTEST_MAX_DEFAULT_SIZE: 1000
         run: |
-          cargo test --workspace --test property_tests \
+          cargo test -p hl7v2 --all-features property_tests \
             -- --nocapture
         timeout-minutes: 25
 


### PR DESCRIPTION
## Summary

- fix the nightly extended property-test command so it targets the existing `hl7v2` property-test filter
- remove the ignored `PROPTEST_MAX_DEFAULT_SIZE` env var from that job

## Validation

- `PROPTEST_CASES=32 cargo +1.95.0 test -p hl7v2 --all-features property_tests -- --nocapture`
- `cargo +1.95.0 run -p xtask -- check-file-policy`
- `git diff --check`

## Context

Post-merge main Nightly Tests failed because `cargo test --workspace --test property_tests` refers to a nonexistent workspace integration test target. The matching CI lane already uses `cargo test -p hl7v2 --all-features property_tests`.