### PR TITLE
fix: reject non-finite numeric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added gRPC inline corpus diff parity, including before/after inline corpus
   deltas and opt-in v2 provenance.
 
+### Fixed
+
+- Rejected non-finite float spellings such as `INF`, `Infinity`, and `NaN`
+  from HL7 numeric validation.
+
 ### Documentation
 
 - Refreshed the v1.5.0 release-readiness receipt after the gRPC inline corpus

--- a/crates/hl7v2/src/conformance/datatype.rs
+++ b/crates/hl7v2/src/conformance/datatype.rs
@@ -343,7 +343,7 @@ pub fn is_timestamp(value: &str) -> bool {
 /// Check if value is numeric
 pub fn is_numeric(value: &str) -> bool {
     // Can be integer or decimal
-    value.parse::<f64>().is_ok()
+    value.parse::<f64>().is_ok_and(f64::is_finite)
 }
 
 /// Check if value is a sequence ID (positive integer)

--- a/crates/hl7v2/src/conformance/validation.rs
+++ b/crates/hl7v2/src/conformance/validation.rs
@@ -458,7 +458,7 @@ pub fn is_timestamp(value: &str) -> bool {
 /// Check if value is numeric
 pub fn is_numeric(value: &str) -> bool {
     // Can be integer or decimal
-    value.parse::<f64>().is_ok()
+    value.parse::<f64>().is_ok_and(f64::is_finite)
 }
 
 /// Check if value is a sequence ID (positive integer)

--- a/crates/hl7v2/src/conformance/validation/tests/unit_tests.rs
+++ b/crates/hl7v2/src/conformance/validation/tests/unit_tests.rs
@@ -317,6 +317,9 @@ fn test_is_numeric_edge_cases() {
     // Invalid
     assert!(!is_numeric("abc"));
     assert!(!is_numeric("12.34.56"));
+    assert!(!is_numeric("INF"));
+    assert!(!is_numeric("Infinity"));
+    assert!(!is_numeric("NaN"));
     assert!(!is_numeric(""));
 }
 


### PR DESCRIPTION
## Summary

- Reject parsed non-finite float spellings such as INF, Infinity, and NaN from HL7 numeric validation.
- Keep datatype and validation numeric helpers aligned.
- Add regression assertions for non-finite values.

## Validation

- cargo +1.95.0 test -p hl7v2 --all-features property_tests::test_non_numeric_rejected -- --nocapture
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features --locked -- -D warnings
- git diff --check