### PR TITLE
release: confirm v1.5.0 graph after readiness refresh

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -271,6 +271,8 @@ status = "done"
 goal = "Select the v1.5.0 crates.io graph after primary and binding backend dry-runs passed."
 decision = "primary plus binding backend"
 receipt = "docs/audits/v1.5.0-release-graph-decision-2026-05-14.md"
+confirmed_after = "docs/audits/publish-dry-run-v1.5.0-2026-05-15-grpc-bundle-refresh.md"
+confirmed_commit = "ff812d190647ff521a3d3665b9aee4255cdef923"
 publish_order = [
   "hl7v2",
   "hl7v2-python",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parity landed on `main`.
 - Refreshed the v1.5.0 release-readiness receipt after gRPC evidence bundle
   creation parity landed on `main`.
+- Confirmed the v1.5.0 release graph decision still selects the primary Rust
+  graph plus `hl7v2-python` as binding backend after the latest readiness
+  refresh.
 - Refreshed the v1.5.0 release-readiness receipt after the gRPC inline corpus
   fingerprint and diff parity work landed on `main`.
 - Refreshed the v1.5.0 release-readiness receipt after the nightly property

--- a/docs/audits/v1.5.0-release-graph-decision-2026-05-14.md
+++ b/docs/audits/v1.5.0-release-graph-decision-2026-05-14.md
@@ -36,6 +36,33 @@ The current-main refresh passed at
 `b4b7962e6f3f9d7ae5d91adf603e6328e3d13297` and is recorded in
 [`publish-dry-run-v1.5.0-2026-05-14.md`](publish-dry-run-v1.5.0-2026-05-14.md).
 
+## Current-Main Confirmation
+
+The decision remains current after the 2026-05-15 gRPC bundle creation
+readiness refresh on `main` at
+`ff812d190647ff521a3d3665b9aee4255cdef923`.
+
+That refresh records the same selected crates.io graph:
+
+1. `hl7v2`
+2. `hl7v2-python`
+3. `hl7v2-server`
+4. `hl7v2-cli`
+
+It also re-proved:
+
+- `publish-plan --surface primary`;
+- `publish-plan --surface bindings`;
+- `publish-plan --surface all-publishable`;
+- primary publish dry-run;
+- binding backend publish dry-run;
+- Python publish-policy boundary;
+- RIPR badge and impacted-evidence receipts;
+- evidence schema, doc-link, and file-policy checks.
+
+See
+[`publish-dry-run-v1.5.0-2026-05-15-grpc-bundle-refresh.md`](publish-dry-run-v1.5.0-2026-05-15-grpc-bundle-refresh.md).
+
 ## Boundaries
 
 - This decision does not upload any crate to crates.io.


### PR DESCRIPTION
﻿## Summary

- Confirms the v1.5.0 crates.io graph decision remains current after the latest gRPC bundle readiness receipt on main.
- Keeps the selected graph as hl7v2, hl7v2-python, hl7v2-server, and hl7v2-cli, with hl7v2-python documented only as binding backend infrastructure.
- Updates the active goal manifest and changelog with the confirmation.

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- active.toml parsed with Python tomllib
- git diff --check
- git diff --cached --check

## Non-claims

- No crates.io upload.
- No TestPyPI or PyPI upload.
- No npm package.
- No tag or GitHub release.
- No production install-back proof.
