### PR TITLE
docs: align first-use paths with v1.5.0 publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Modern Rust HL7v2 Processor
 
 A fast, safe, and deterministic HL7 v2 parser, validator, and generator written in Rust.
 
-> **Status**: v1.4.0 is published to crates.io for the primary Rust product graph: `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Current `main` is prepared as the v1.5.0 Rust 1.95 quality-ratchet candidate with readiness and dry-run receipts; v1.5.0 is not published until explicit crates.io publish and tag receipts land. The public Python distribution is `hl7v2`, built from the `hl7v2-python` binding backend lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
+> **Status**: v1.5.0 is published to crates.io for `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`. `hl7v2-python` is binding backend infrastructure for the public Python `hl7v2` package, not the recommended Rust API. Public Python TestPyPI/PyPI proof remains a separate lane. For a detailed breakdown of features, see [docs/STATUS.md](docs/STATUS.md).
 
 ## Feature Status
 
@@ -21,13 +21,13 @@ A fast, safe, and deterministic HL7 v2 parser, validator, and generator written 
 | **Writer / Normalize** | Stable | Writer tests plus HTTP/gRPC normalization contract coverage |
 | **MLLP / Network** | Stable | MLLP parse/framing tests and CI matrix coverage |
 | **REST Server** | Stable | Runtime and OpenAPI agree for parse, validate, redacted validation, bundle/replay, ACK, normalize, inline corpus evidence, readiness, and redacted structured logs |
-| **gRPC Service** | Beta | `hl7v2 serve --mode grpc` starts the Tonic service; contract tests cover Parse, Validate, ProfileLint, ProfileExplain, ProfileTest, ValidateRedacted, CreateEvidenceBundle, ReplayEvidenceBundle, CorpusSummarize, CorpusFingerprint, CorpusDiff, GenerateAck, Normalize, HealthCheck, and ParseStream as one request message into one response message |
+| **gRPC Service** | Beta | `hl7v2-cli serve --mode grpc` starts the Tonic service; contract tests cover Parse, Validate, ProfileLint, ProfileExplain, ProfileTest, ValidateRedacted, CreateEvidenceBundle, ReplayEvidenceBundle, CorpusSummarize, CorpusFingerprint, CorpusDiff, GenerateAck, Normalize, HealthCheck, and ParseStream as one request message into one response message |
 | **Lifecycle** | Beta | Domain tests exist, but lifecycle is not part of the current HTTP/gRPC contract gate |
 | **Guard / Anomaly** | Experimental | Statistical baseline fixtures exist; not a stable runtime contract |
 | **Profile Cache** | L1-only | In-memory verified; Postgres L2 pending |
-| **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; backend crate is publishable only as binding infrastructure and still needs release receipts before any crates.io claim |
-| **Publish Readiness** | Candidate | Primary Rust product crates `hl7v2`, `hl7v2-server`, and `hl7v2-cli` are prepared at v1.5.0; v1.4.0 remains the current published crates.io release until the v1.5.0 release receipt lands |
-| **Evidence Loop** | Stable | v1.4.0 is the published Evidence Contracts and Server Sidecar release; v1.5.0 keeps that surface and adds Rust 1.95, tighter policy rails, advisory ripr, targeted mutation, and release-readiness proof |
+| **Python Bindings** | Experimental | Separate maturin lane with wheel build/install/import smoke coverage; backend crate `hl7v2-python` is published as binding infrastructure, while public Python `hl7v2` still needs TestPyPI/PyPI proof |
+| **Publish Readiness** | Published | v1.5.0 is published to crates.io for `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`; see the publish receipt in `docs/audits/` |
+| **Evidence Loop** | Stable | v1.5.0 is the published Rust 1.95 quality-ratchet release; it keeps the evidence-contract surface and adds tighter policy rails, advisory ripr, targeted mutation, and release-readiness proof |
 
 ## Features
 
@@ -78,7 +78,9 @@ cargo install --path crates/hl7v2-cli
 ### From crates.io
 
 ```bash
+cargo add hl7v2
 cargo install hl7v2-cli
+cargo install hl7v2-server
 ```
 
 ## Quick Start
@@ -101,14 +103,17 @@ The fastest way to get started is with the HTTP API server:
 
 ```bash
 # Start the server
-cargo run --bin hl7v2-server
+hl7v2-server
 
 # Or with custom configuration
-BIND_ADDRESS=0.0.0.0:8080 cargo run --bin hl7v2-server
+BIND_ADDRESS=0.0.0.0:8080 hl7v2-server
 
 # Inspect sanitized effective configuration and exit
-cargo run --bin hl7v2-server -- --print-config
+hl7v2-server --print-config
 ```
+
+From a source checkout, use `cargo run -q -p hl7v2-server --` before the
+server arguments instead.
 
 **Parse a message via HTTP:**
 ```bash
@@ -194,92 +199,92 @@ policy TOML, and configured filesystem roots are not logged by default.
 
 ```bash
 # Parse an HL7 message and output canonical JSON
-hl7v2 parse <input.hl7> --json > output.json
+hl7v2-cli parse <input.hl7> --json > output.json
 
 # Parse MLLP-framed messages
-hl7v2 parse <input.mllp> --mllp --json > output.json
+hl7v2-cli parse <input.mllp> --mllp --json > output.json
 ```
 
 ### Validate Messages
 
 ```bash
 # Validate against a profile (supports profile inheritance)
-hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml
+hl7v2-cli val <input.hl7> --profile profiles/oru_r01.yaml
 
 # Emit a machine-readable validation report
-hl7v2 val <input.hl7> --profile profiles/oru_r01.yaml --report json
+hl7v2-cli val <input.hl7> --profile profiles/oru_r01.yaml --report json
 
 # Lint a profile before using it as an interface contract
-hl7v2 profile lint profiles/oru_r01.yaml --report json
+hl7v2-cli profile lint profiles/oru_r01.yaml --report json
 
 # Explain the loaded profile contract
-hl7v2 profile explain profiles/oru_r01.yaml --format json
+hl7v2-cli profile explain profiles/oru_r01.yaml --format json
 
 # Test profile fixtures as executable interface contracts
-hl7v2 profile test profiles/oru_r01.yaml fixtures/oru_r01/ --report json
+hl7v2-cli profile test profiles/oru_r01.yaml fixtures/oru_r01/ --report json
 ```
 
 ### Normalize Messages
 
 ```bash
 # Normalize an HL7 message
-hl7v2 norm <input.hl7> > output.hl7
+hl7v2-cli norm <input.hl7> > output.hl7
 ```
 
 ### Redact Messages
 
 ```bash
 # Redact PHI while retaining deterministic analysis evidence
-hl7v2 redact <input.hl7> --policy safe-analysis.toml --format json
+hl7v2-cli redact <input.hl7> --policy safe-analysis.toml --format json
 ```
 
 ### Bundle Evidence
 
 ```bash
 # Create a PHI-safe evidence packet for support or replay
-hl7v2 bundle failing.hl7 --profile profiles/oru_r01.yaml --redact-policy safe-analysis.toml --out issue-bundle/
+hl7v2-cli bundle failing.hl7 --profile profiles/oru_r01.yaml --redact-policy safe-analysis.toml --out issue-bundle/
 
 # Re-run the redacted bundle and verify the stored validation report reproduces
-hl7v2 replay issue-bundle/ --format json
+hl7v2-cli replay issue-bundle/ --format json
 ```
 
 ### Generate Messages
 
 ```bash
 # Generate synthetic HL7 messages with deterministic seeding
-hl7v2 gen --profile profiles/oru_r01.yaml --seed 1337 --count 100 --out corpus/
+hl7v2-cli gen --profile profiles/oru_r01.yaml --seed 1337 --count 100 --out corpus/
 
 # Generate with different template
-hl7v2 gen --template templates/adt_a01.yaml --seed 42 --count 50 --out test_data/
+hl7v2-cli gen --template templates/adt_a01.yaml --seed 42 --count 50 --out test_data/
 ```
 
 ### Summarize Corpora
 
 ```bash
 # Summarize a directory or single-file corpus of HL7 messages
-hl7v2 corpus summarize corpus/
+hl7v2-cli corpus summarize corpus/
 
 # Emit a machine-readable corpus summary
-hl7v2 corpus summarize corpus/ --format json
+hl7v2-cli corpus summarize corpus/ --format json
 
 # Create a deterministic feed fingerprint
-hl7v2 corpus fingerprint corpus/ --format json
+hl7v2-cli corpus fingerprint corpus/ --format json
 
 # Include validation issue-code counts in the fingerprint
-hl7v2 corpus fingerprint corpus/ --profile profiles/oru_r01.yaml --format json
+hl7v2-cli corpus fingerprint corpus/ --profile profiles/oru_r01.yaml --format json
 
 # Compare before/after corpora for feed drift
-hl7v2 corpus diff feeds/before feeds/after --profile profiles/oru_r01.yaml --format json
+hl7v2-cli corpus diff feeds/before feeds/after --profile profiles/oru_r01.yaml --format json
 ```
 
 ### Acknowledgment Generation
 
 ```bash
 # Generate an application ACK (AA - Application Accept)
-hl7v2 ack <input.hl7> --code AA > ack.hl7
+hl7v2-cli ack <input.hl7> --code AA > ack.hl7
 
 # Generate an application error ACK (AE - Application Error)
-hl7v2 ack <input.hl7> --code AE > error_ack.hl7
+hl7v2-cli ack <input.hl7> --code AE > error_ack.hl7
 ```
 
 ## Key Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,7 @@ proposal, spec, plan, or receipt documents.
 | [Final source-tree gap audit](audits/current-source-tree-evidence-objective-gap-audit.md) | Current package-state receipt after the broad local evidence-lane workbench was split and merged. |
 | [v1.4.0 publish dry-run receipt](audits/publish-dry-run-v1.4.0-2026-05-09.md) | Package verification before upload. |
 | [v1.4.0 publish receipt](audits/publish-v1.4.0-2026-05-09.md) | Dependency-ordered crates.io publication proof. |
-| [v1.5.0 Rust 1.95 release candidate notes](releases/v1.5.0-rust-1.95-quality-ratchet.md) | Candidate scope for the Rust 1.95 quality-ratchet release; not a publish receipt. |
+| [v1.5.0 Rust 1.95 release notes](releases/v1.5.0-rust-1.95-quality-ratchet.md) | Published Rust 1.95 quality-ratchet release scope; the dedicated publish receipt owns registry proof. |
 | [v1.5.0 release readiness](release/1.5.0-readiness.md) | Receipt home for Rust 1.95 / 1.5.0 readiness workflow results. |
 | [v1.5.0 publish dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-13.md) | Non-publishing crates.io dry-run proof for the v1.5.0 Rust graph. |
 | [v1.5.0 parity refresh dry-run receipt](audits/publish-dry-run-v1.5.0-2026-05-14-parity-refresh.md) | Current-main non-publishing proof after gRPC corpus summary parity and the cross-surface evidence parity spec. |

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -574,7 +574,8 @@ bundle, quarantine, and replay artifacts when you need deeper evidence.
 - Keep redaction policies fail-closed; a rejected policy is safer than a leaky
   bundle.
 - Replay server-created bundles with `POST /hl7/replay` or
-  `hl7v2 replay <bundle-dir> --format json` before attaching them to tickets.
+  `hl7v2-cli replay <bundle-dir> --format json` before attaching them to
+  tickets.
 
 ## Workflow Summary
 

--- a/docs/guides/first-10-minutes.md
+++ b/docs/guides/first-10-minutes.md
@@ -4,8 +4,15 @@ This guide proves the local CLI can turn HL7 input into evidence artifacts:
 diagnostics, profile checks, validation reports, corpus summaries, fingerprints,
 diffs, a redacted bundle, and replay verification.
 
-The examples use the product command name `hl7v2`. From a source checkout, use
-`cargo run -q -p hl7v2-cli --` before each command instead:
+The examples use the v1.5.0 installed CLI binary name `hl7v2-cli`. Install it
+with:
+
+```bash
+cargo install hl7v2-cli --version 1.5.0
+```
+
+From a source checkout, use `cargo run -q -p hl7v2-cli --` before each command
+instead:
 
 ```bash
 cargo run -q -p hl7v2-cli -- doctor --format json
@@ -42,7 +49,7 @@ Copy-Item test_data/invalid_message.hl7 target/hl7v2-first-10-minutes/fixtures/i
 ## 1. Run Doctor
 
 ```bash
-hl7v2 doctor --format json
+hl7v2-cli doctor --format json
 ```
 
 Expected output includes local diagnostics:
@@ -69,8 +76,8 @@ installed, the Python binding check can warn without blocking the Rust CLI.
 ## 2. Generate and Validate a Built-In Sample
 
 ```bash
-hl7v2 sample --type ADT_A01 --output target/hl7v2-first-10-minutes/sample.hl7
-hl7v2 validate-sample --type ADT_A01 --profile profiles/generic.yaml --report json --schema-version 2
+hl7v2-cli sample --type ADT_A01 --output target/hl7v2-first-10-minutes/sample.hl7
+hl7v2-cli validate-sample --type ADT_A01 --profile profiles/generic.yaml --report json --schema-version 2
 ```
 
 Expected validation output includes:
@@ -90,7 +97,7 @@ sample. Fix that before moving to site-specific messages.
 ## 3. Lint and Explain the Profile
 
 ```bash
-hl7v2 profile lint profiles/generic.yaml --report json
+hl7v2-cli profile lint profiles/generic.yaml --report json
 ```
 
 Expected output:
@@ -107,7 +114,7 @@ Expected output:
 Then inspect what the profile actually enforces:
 
 ```bash
-hl7v2 profile explain profiles/generic.yaml --format json
+hl7v2-cli profile explain profiles/generic.yaml --format json
 ```
 
 Expected fields include:
@@ -133,7 +140,7 @@ trusting validation, corpus fingerprints, or evidence bundles built from it.
 ## 4. Validate One Message
 
 ```bash
-hl7v2 val test_data/valid_message.hl7 --profile profiles/generic.yaml --report json
+hl7v2-cli val test_data/valid_message.hl7 --profile profiles/generic.yaml --report json
 ```
 
 Expected output:
@@ -150,7 +157,7 @@ Expected output:
 Now validate the invalid fixture:
 
 ```bash
-hl7v2 val test_data/invalid_message.hl7 --profile profiles/generic.yaml --report json
+hl7v2-cli val test_data/invalid_message.hl7 --profile profiles/generic.yaml --report json
 ```
 
 Expected behavior:
@@ -166,7 +173,7 @@ still failing the job.
 ## 5. Test the Profile Fixtures
 
 ```bash
-hl7v2 profile test profiles/generic.yaml target/hl7v2-first-10-minutes/fixtures --report json
+hl7v2-cli profile test profiles/generic.yaml target/hl7v2-first-10-minutes/fixtures --report json
 ```
 
 Expected output:
@@ -187,7 +194,7 @@ the case-level failure.
 ## 6. Summarize and Fingerprint the Corpus
 
 ```bash
-hl7v2 corpus summarize target/hl7v2-first-10-minutes/fixtures --format json
+hl7v2-cli corpus summarize target/hl7v2-first-10-minutes/fixtures --format json
 ```
 
 Expected fields:
@@ -209,7 +216,7 @@ Expected fields:
 Create a deterministic feed signature with profile-backed validation counts:
 
 ```bash
-hl7v2 corpus fingerprint target/hl7v2-first-10-minutes/fixtures \
+hl7v2-cli corpus fingerprint target/hl7v2-first-10-minutes/fixtures \
   --profile profiles/generic.yaml \
   --format json
 ```
@@ -239,7 +246,7 @@ LF-only samples can be rejected.
 Use the valid fixture as `before` and the invalid fixture as `after`:
 
 ```bash
-hl7v2 corpus diff \
+hl7v2-cli corpus diff \
   target/hl7v2-first-10-minutes/fixtures/valid \
   target/hl7v2-first-10-minutes/fixtures/invalid \
   --profile profiles/generic.yaml \
@@ -302,7 +309,7 @@ reason = "administrative sex is needed for validation"
 Build the evidence bundle:
 
 ```bash
-hl7v2 bundle test_data/valid_message.hl7 \
+hl7v2-cli bundle test_data/valid_message.hl7 \
   --profile profiles/generic.yaml \
   --redact-policy target/hl7v2-first-10-minutes/safe-analysis.toml \
   --out target/hl7v2-first-10-minutes/issue-bundle
@@ -335,7 +342,7 @@ Expected output:
 Replay the packet:
 
 ```bash
-hl7v2 replay target/hl7v2-first-10-minutes/issue-bundle --format json
+hl7v2-cli replay target/hl7v2-first-10-minutes/issue-bundle --format json
 ```
 
 Expected output:

--- a/docs/guides/first-use-by-surface.md
+++ b/docs/guides/first-use-by-surface.md
@@ -14,15 +14,18 @@ API and they are not the Python package name.
 
 ## Current Release Boundary
 
-`v1.5.0` is prepared and dry-run proven, but it is not a published release until
-the crates.io upload, tag, GitHub release, and registry-resolution receipts
-exist. For current source-checkout proof, use the `cargo run` and local wheel
-commands below. After the release is published, the registry install commands
-become the normal user path.
+`v1.5.0` is published to crates.io for the selected Rust graph:
+`hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`. Normal Rust,
+CLI, and server users should use the registry install commands below.
+
+The public Python package is still separate. Python users will eventually
+install `hl7v2` from TestPyPI/PyPI, but the registry upload and install-back
+proof is not complete yet. Until that proof lands, use the local wheel commands
+below for Python evidence work.
 
 ## Rust Library
 
-Released user path after publication:
+Released user path:
 
 ```bash
 cargo add hl7v2
@@ -77,10 +80,11 @@ validation report JSON + normalized byte count + ACK output
 
 ## CLI
 
-Released user path after publication:
+Released user path:
 
 ```bash
-cargo install hl7v2-cli
+cargo install hl7v2-cli --version 1.5.0
+hl7v2-cli doctor --format json
 ```
 
 Source-checkout command shape:
@@ -92,9 +96,9 @@ cargo run -q -p hl7v2-cli -- doctor --format json
 Then run the full CLI evidence loop:
 
 ```bash
-cargo run -q -p hl7v2-cli -- profile lint profiles/generic.yaml --report json
-cargo run -q -p hl7v2-cli -- val test_data/valid_message.hl7 --profile profiles/generic.yaml --report json
-cargo run -q -p hl7v2-cli -- corpus summarize test_data --format json
+hl7v2-cli profile lint profiles/generic.yaml --report json
+hl7v2-cli val test_data/valid_message.hl7 --profile profiles/generic.yaml --report json
+hl7v2-cli corpus summarize test_data --format json
 ```
 
 For the copy/paste ten-minute flow that adds corpus fingerprint, corpus diff,
@@ -109,10 +113,11 @@ doctor JSON + profile lint JSON + validation report JSON + corpus summary JSON
 
 ## Server
 
-Released user path after publication:
+Released user path:
 
 ```bash
-cargo install hl7v2-server
+cargo install hl7v2-server --version 1.5.0
+hl7v2-server --print-config
 ```
 
 Source-checkout command shape:

--- a/docs/guides/safe-support-bundle.md
+++ b/docs/guides/safe-support-bundle.md
@@ -5,8 +5,9 @@ replayable support packet. The goal is to give a vendor, support engineer,
 data team, or agent enough evidence to reproduce the failure without sending
 raw message PHI in reports, receipts, traces, manifests, or replay output.
 
-The examples use the product command name `hl7v2`. From a source checkout, use
-`cargo run -q -p hl7v2-cli --` before each command instead:
+The examples use the v1.5.0 installed CLI binary name `hl7v2-cli`. From a
+source checkout, use `cargo run -q -p hl7v2-cli --` before each command
+instead:
 
 ```bash
 cargo run -q -p hl7v2-cli -- bundle failing.hl7 --profile profile.yaml --redact-policy safe-analysis.toml --out issue-bundle/
@@ -97,7 +98,7 @@ That makes policy mistakes visible before an evidence packet is created.
 Run redaction first and write the JSON preview to a file:
 
 ```bash
-hl7v2 redact test_data/invalid_message.hl7 \
+hl7v2-cli redact test_data/invalid_message.hl7 \
   --policy target/hl7v2-safe-support-bundle/safe-analysis.toml \
   --format json \
   --output target/hl7v2-safe-support-bundle/reports/redaction-preview.json
@@ -147,7 +148,7 @@ why `PID.8 = X` violates the profile value set.
 Create the bundle. The output directory must not already exist:
 
 ```bash
-hl7v2 bundle test_data/invalid_message.hl7 \
+hl7v2-cli bundle test_data/invalid_message.hl7 \
   --profile profiles/generic.yaml \
   --redact-policy target/hl7v2-safe-support-bundle/safe-analysis.toml \
   --out target/hl7v2-safe-support-bundle/issue-bundle \
@@ -222,7 +223,7 @@ validation report.
 Run replay and keep the report:
 
 ```bash
-hl7v2 replay target/hl7v2-safe-support-bundle/issue-bundle \
+hl7v2-cli replay target/hl7v2-safe-support-bundle/issue-bundle \
   --format json \
   --output target/hl7v2-safe-support-bundle/reports/replay-report.json
 ```

--- a/docs/guides/vendor-upgrade-diff.md
+++ b/docs/guides/vendor-upgrade-diff.md
@@ -5,8 +5,9 @@ migration, acquisition cleanup, or feed regression. The goal is not to inspect
 one message by hand. The goal is to produce deterministic evidence of what
 changed across two corpora.
 
-The examples use the product command name `hl7v2`. From a source checkout, use
-`cargo run -q -p hl7v2-cli --` before each command instead:
+The examples use the v1.5.0 installed CLI binary name `hl7v2-cli`. From a
+source checkout, use `cargo run -q -p hl7v2-cli --` before each command
+instead:
 
 ```bash
 cargo run -q -p hl7v2-cli -- corpus diff before/ after/ --format json
@@ -61,7 +62,7 @@ Copy-Item test_data/invalid_message.hl7 target/hl7v2-vendor-upgrade-diff/after/s
 Lint the profile before treating it as the comparison contract:
 
 ```bash
-hl7v2 profile lint profiles/generic.yaml \
+hl7v2-cli profile lint profiles/generic.yaml \
   --report json \
   --output target/hl7v2-vendor-upgrade-diff/reports/profile-lint.json
 ```
@@ -85,11 +86,11 @@ sides are compared against a contract that actually loads.
 Run summaries first. They tell you whether the corpus can be parsed at all.
 
 ```bash
-hl7v2 corpus summarize target/hl7v2-vendor-upgrade-diff/before \
+hl7v2-cli corpus summarize target/hl7v2-vendor-upgrade-diff/before \
   --format json \
   --output target/hl7v2-vendor-upgrade-diff/reports/before-summary.json
 
-hl7v2 corpus summarize target/hl7v2-vendor-upgrade-diff/after \
+hl7v2-cli corpus summarize target/hl7v2-vendor-upgrade-diff/after \
   --format json \
   --output target/hl7v2-vendor-upgrade-diff/reports/after-summary.json
 ```
@@ -121,12 +122,12 @@ counts, segment counts, field presence, field cardinality, value-shape stats,
 parse error count, profile metadata, and validation issue-code counts.
 
 ```bash
-hl7v2 corpus fingerprint target/hl7v2-vendor-upgrade-diff/before \
+hl7v2-cli corpus fingerprint target/hl7v2-vendor-upgrade-diff/before \
   --profile profiles/generic.yaml \
   --format json \
   --output target/hl7v2-vendor-upgrade-diff/reports/before-fingerprint.json
 
-hl7v2 corpus fingerprint target/hl7v2-vendor-upgrade-diff/after \
+hl7v2-cli corpus fingerprint target/hl7v2-vendor-upgrade-diff/after \
   --profile profiles/generic.yaml \
   --format json \
   --output target/hl7v2-vendor-upgrade-diff/reports/after-fingerprint.json
@@ -168,7 +169,7 @@ upgrade event.
 Run the actual before/after comparison:
 
 ```bash
-hl7v2 corpus diff \
+hl7v2-cli corpus diff \
   target/hl7v2-vendor-upgrade-diff/before \
   target/hl7v2-vendor-upgrade-diff/after \
   --profile profiles/generic.yaml \
@@ -216,7 +217,7 @@ outside the agreed value set?"
 
 ## 5. Decide What Fails CI
 
-`hl7v2 corpus diff` reports drift; it does not decide your policy for you. A
+`hl7v2-cli corpus diff` reports drift; it does not decide your policy for you. A
 useful CI gate usually fails on any of these conditions:
 
 | Field | Typical gate |
@@ -263,7 +264,7 @@ If a specific failing message needs to travel with the ticket, create a redacted
 bundle:
 
 ```bash
-hl7v2 bundle failing.hl7 \
+hl7v2-cli bundle failing.hl7 \
   --profile profiles/generic.yaml \
   --redact-policy safe-analysis.toml \
   --out issue-bundle/
@@ -272,7 +273,7 @@ hl7v2 bundle failing.hl7 \
 Then verify it:
 
 ```bash
-hl7v2 replay issue-bundle/ --format json
+hl7v2-cli replay issue-bundle/ --format json
 ```
 
 Only share the bundle when replay reports `"reproduced": true` and your


### PR DESCRIPTION
## Summary
- Update the README and first-use guides from v1.5.0 candidate wording to the published Rust release state.
- Point Rust/CLI/server users at the registry paths now proven by the v1.5.0 publish receipt.
- Use the actual installed CLI binary name, hl7v2-cli, in copy/paste command examples while keeping Python TestPyPI/PyPI proof separate.

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims
- No TestPyPI upload
- No production PyPI upload
- No npm package
- No runtime behavior change
