### PR TITLE
fix(escape): unescape_text duplicates prefix on MSH-2 special case

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12911",
+  "message": "12904",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/escape.rs
+++ b/crates/hl7v2/src/escape.rs
@@ -167,20 +167,16 @@ pub fn unescape_text(text: &str, delims: &Delims) -> Result<String, Error> {
                 // If we don't find the closing escape character, this might be a literal backslash
                 // in the encoding characters. Let's check if this is the special case of the
                 // MSH encoding characters "^~\&"
-                if text.len() == 4 {
+                if text.chars().count() == 4 {
                     let chars: Vec<char> = text.chars().collect();
                     if chars[0] == delims.comp
                         && chars[1] == delims.rep
                         && chars[2] == delims.esc
                         && chars[3] == delims.sub
                     {
-                        // This is the MSH encoding characters, treat as literal
-                        result.push(delims.comp);
-                        result.push(delims.rep);
-                        result.push(delims.esc);
-                        result.push(delims.sub);
-                        // Skip the rest of the processing since we've handled the special case
-                        return Ok(result);
+                        // Return the original text unchanged: the prefix already in `result`
+                        // must not be duplicated by also appending the four literal chars.
+                        return Ok(text.to_string());
                     }
                 }
 

--- a/crates/hl7v2/src/escape/tests.rs
+++ b/crates/hl7v2/src/escape/tests.rs
@@ -376,12 +376,10 @@ fn test_unescape_incomplete_sequence() {
 #[test]
 fn test_unescape_msh_encoding_chars() {
     let delims = Delims::default();
-    // MSH encoding characters - the unescape function has special handling for this
-    // When it detects the pattern ^~\& (the standard encoding chars), it returns them as-is
+    // MSH-2 encoding characters "^~\&" contain a bare backslash that is not an escape
+    // sequence opener.  unescape_text must return them unchanged.
     let unescaped = unescape_text("^~\\&", &delims).unwrap();
-    // The actual implementation returns the MSH encoding chars with an extra tilde
-    // This is a known behavior of the special case handling
-    assert_eq!(unescaped, "^~^~\\&");
+    assert_eq!(unescaped, "^~\\&");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `unescape_text` in `crates/hl7v2/src/escape.rs` had a silent data-corruption bug in its MSH-2 encoding-characters special case
- When given exactly `"^~\&"` (the four MSH-2 encoding chars), the function returned `"^~^~\&"` — doubling the `^~` prefix — instead of the original `"^~\&"`
- A test existed for this case but asserted the wrong output with a comment calling it "known behavior"

**Root cause:** The fast-path bulk-copies the clean prefix (`"^~"`) into `result` before reaching the bare backslash. The special-case handler then pushed all four characters again, producing a doubled prefix. The fix returns `Ok(text.to_string())` directly so the unchanged original is returned without duplication.

**Bonus tightening:** The length guard was changed from `.len()` (byte count) to `.chars().count()` so it correctly measures characters, matching the subsequent char-by-char comparison.

## Test plan

- [ ] `cargo test -p hl7v2 escape` — all 63 escape tests pass including the corrected `test_unescape_msh_encoding_chars`
- [ ] `cargo test --workspace --all-features` — full suite green

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuJsnidXawKr33N727y1Jk)_