### PR TITLE
server: add REST error guidance fields

### DIFF
--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -1830,8 +1830,23 @@ components:
       properties:
         code:
           type: string
+          description: Stable machine-readable error code.
         message:
           type: string
+          description: Human-readable error message. Raw HL7 payloads, raw profile YAML, and server-local roots are not echoed by design.
+        safe_detail:
+          type: string
+          nullable: true
+          description: PHI-safe operator detail describing what failed without echoing raw request payloads.
+        location:
+          type: string
+          nullable: true
+          description: Request field, artifact role, or evidence location when the server can identify one.
+        suggested_next_action:
+          type: string
+          nullable: true
+          description: Suggested next step for the caller or operator.
         details:
           type: object
           nullable: true
+          description: Reserved structured details for future compatible error expansion.

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12869",
+  "message": "12911",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1830,8 +1830,23 @@ components:
       properties:
         code:
           type: string
+          description: Stable machine-readable error code.
         message:
           type: string
+          description: Human-readable error message. Raw HL7 payloads, raw profile YAML, and server-local roots are not echoed by design.
+        safe_detail:
+          type: string
+          nullable: true
+          description: PHI-safe operator detail describing what failed without echoing raw request payloads.
+        location:
+          type: string
+          nullable: true
+          description: Request field, artifact role, or evidence location when the server can identify one.
+        suggested_next_action:
+          type: string
+          nullable: true
+          description: Suggested next step for the caller or operator.
         details:
           type: object
           nullable: true
+          description: Reserved structured details for future compatible error expansion.

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -1237,43 +1237,121 @@ impl AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let (status, code, message) = match self {
-            AppError::Parse(msg) => (StatusCode::BAD_REQUEST, "PARSE_ERROR", msg),
+        let (status, code, message, safe_detail, location, next_action) = match self {
+            AppError::Parse(msg) => (
+                StatusCode::BAD_REQUEST,
+                "PARSE_ERROR",
+                msg,
+                "The request message could not be parsed as HL7 v2. Raw message content is not echoed.",
+                Some("message"),
+                "Check the MSH segment, segment terminators, encoding, and mllp_framed setting.",
+            ),
             // Profile load error is a client error since the profile is provided in the request.
             // Keep the public message stable and avoid echoing parser detail derived from profile YAML.
             AppError::ProfileLoad(_) => (
                 StatusCode::BAD_REQUEST,
                 "PROFILE_LOAD_ERROR",
                 PROFILE_LOAD_SAFE_MESSAGE.to_string(),
+                "The supplied inline profile could not be loaded. Raw profile content is not echoed.",
+                Some("profile"),
+                "Run profile lint on the profile, then retry validation with the corrected profile.",
             ),
-            AppError::Validation(msg) => (StatusCode::BAD_REQUEST, "VALIDATION_ERROR", msg),
-            AppError::Redaction(msg) => (StatusCode::BAD_REQUEST, "REDACTION_ERROR", msg),
+            AppError::Validation(msg) => (
+                StatusCode::BAD_REQUEST,
+                "VALIDATION_ERROR",
+                msg,
+                "The request failed validation before a successful evidence response was produced.",
+                None,
+                "Check request parameters, schema-version fields, and validation issue paths where available.",
+            ),
+            AppError::Redaction(msg) => (
+                StatusCode::BAD_REQUEST,
+                "REDACTION_ERROR",
+                msg,
+                "The redaction policy or redaction run failed before a safe response was produced.",
+                Some("redaction_policy"),
+                "Check safe-analysis policy paths, actions, reasons, and required-field matches before retrying.",
+            ),
             AppError::BundleOutputNotConfigured => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "BUNDLE_OUTPUT_NOT_CONFIGURED",
                 "server bundle output root is not configured".to_string(),
+                "The server cannot create evidence bundles until an operator configures a bundle root.",
+                Some("bundle_output_root"),
+                "Configure the server bundle output root and verify readiness before retrying.",
             ),
             AppError::BundleOutputNotReady(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "BUNDLE_OUTPUT_NOT_READY",
                 msg,
+                "The configured bundle output root is not currently writable or available.",
+                Some("bundle_output_root"),
+                "Check server filesystem permissions and readiness before retrying.",
             ),
-            AppError::Bundle(msg) => (StatusCode::BAD_REQUEST, "BUNDLE_ERROR", msg),
-            AppError::Conflict(msg) => (StatusCode::CONFLICT, "BUNDLE_EXISTS", msg),
-            AppError::BundleNotFound(msg) => (StatusCode::NOT_FOUND, "BUNDLE_NOT_FOUND", msg),
+            AppError::Bundle(msg) => (
+                StatusCode::BAD_REQUEST,
+                "BUNDLE_ERROR",
+                msg,
+                "The bundle request could not be accepted. Server responses use safe bundle identifiers.",
+                Some("bundle_id"),
+                "Use a simple bundle id without path traversal and retry after validating inputs.",
+            ),
+            AppError::Conflict(msg) => (
+                StatusCode::CONFLICT,
+                "BUNDLE_EXISTS",
+                msg,
+                "The requested bundle output already exists under the configured root.",
+                Some("bundle_id"),
+                "Choose a new bundle id or replay the existing bundle instead of overwriting it.",
+            ),
+            AppError::BundleNotFound(msg) => (
+                StatusCode::NOT_FOUND,
+                "BUNDLE_NOT_FOUND",
+                msg,
+                "The requested bundle id was not found under the configured root.",
+                Some("bundle_id"),
+                "Check the bundle id from the bundle creation receipt and retry.",
+            ),
             AppError::QuarantineOutputNotConfigured => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "QUARANTINE_OUTPUT_NOT_CONFIGURED",
                 "server quarantine output is enabled but no path is configured".to_string(),
+                "The server cannot write quarantine artifacts until an operator configures a quarantine root.",
+                Some("quarantine.path"),
+                "Configure the quarantine output path or disable quarantine output before retrying.",
             ),
             AppError::QuarantineOutputNotReady(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "QUARANTINE_OUTPUT_NOT_READY",
                 msg,
+                "The configured quarantine output root is not currently writable or available.",
+                Some("quarantine.path"),
+                "Check server filesystem permissions and readiness before retrying.",
             ),
-            AppError::Quarantine(msg) => (StatusCode::BAD_REQUEST, "QUARANTINE_ERROR", msg),
-            AppError::QuarantineConflict(msg) => (StatusCode::CONFLICT, "QUARANTINE_EXISTS", msg),
-            AppError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", msg),
+            AppError::Quarantine(msg) => (
+                StatusCode::BAD_REQUEST,
+                "QUARANTINE_ERROR",
+                msg,
+                "The quarantine request could not be written as configured.",
+                Some("quarantine"),
+                "Check quarantine artifact settings and retry with reviewed redaction inputs.",
+            ),
+            AppError::QuarantineConflict(msg) => (
+                StatusCode::CONFLICT,
+                "QUARANTINE_EXISTS",
+                msg,
+                "The generated quarantine output collided with existing output.",
+                Some("quarantine"),
+                "Retry the request or inspect the existing quarantine output before sharing evidence.",
+            ),
+            AppError::Internal(msg) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                msg,
+                "The server hit an internal failure. Raw request payloads are not included in this response.",
+                None,
+                "Check server logs and readiness, then retry with the same request only if disclosure policy allows.",
+            ),
         };
 
         tracing::warn!(
@@ -1284,7 +1362,12 @@ impl IntoResponse for AppError {
             "request failed"
         );
 
-        let error = ErrorResponse::new(code, message);
+        let mut error = ErrorResponse::new(code, message)
+            .with_safe_detail(safe_detail)
+            .with_suggested_next_action(next_action);
+        if let Some(location) = location {
+            error = error.with_location(location);
+        }
         (status, Json(error)).into_response()
     }
 }
@@ -1343,6 +1426,9 @@ mod tests {
         let err = ErrorResponse::new("TEST_ERROR", "Test error message");
         assert_eq!(err.code, "TEST_ERROR");
         assert_eq!(err.message, "Test error message");
+        assert!(err.safe_detail.is_none());
+        assert!(err.location.is_none());
+        assert!(err.suggested_next_action.is_none());
         assert!(err.details.is_none());
     }
 

--- a/crates/hl7v2-server/src/models.rs
+++ b/crates/hl7v2-server/src/models.rs
@@ -1082,6 +1082,15 @@ pub struct ErrorResponse {
     pub code: String,
     /// Human-readable error message
     pub message: String,
+    /// PHI-safe detail for operators.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safe_detail: Option<String>,
+    /// Request field, artifact role, or evidence location when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    /// Suggested next action for the caller.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_next_action: Option<String>,
     /// Additional error details
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<serde_json::Value>,
@@ -1093,11 +1102,36 @@ impl ErrorResponse {
         Self {
             code: code.into(),
             message: message.into(),
+            safe_detail: None,
+            location: None,
+            suggested_next_action: None,
             details: None,
         }
     }
 
+    /// Add PHI-safe operator detail to the error response.
+    #[must_use]
+    pub fn with_safe_detail(mut self, safe_detail: impl Into<String>) -> Self {
+        self.safe_detail = Some(safe_detail.into());
+        self
+    }
+
+    /// Add an operator-facing location to the error response.
+    #[must_use]
+    pub fn with_location(mut self, location: impl Into<String>) -> Self {
+        self.location = Some(location.into());
+        self
+    }
+
+    /// Add a suggested next action to the error response.
+    #[must_use]
+    pub fn with_suggested_next_action(mut self, action: impl Into<String>) -> Self {
+        self.suggested_next_action = Some(action.into());
+        self
+    }
+
     /// Add details to the error response
+    #[must_use]
     pub fn with_details(mut self, details: serde_json::Value) -> Self {
         self.details = Some(details);
         self

--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -306,6 +306,16 @@ async fn test_bundle_endpoint_rejects_unsupported_artifact_schema_version() {
             .as_str()
             .is_some_and(|message| message.contains("bundle artifact schema version"))
     );
+    assert!(
+        body["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("successful evidence response"))
+    );
+    assert!(
+        body["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("schema-version fields"))
+    );
     assert_no_phi(&body_text);
     assert!(fs::read_dir(root.path()).unwrap().next().is_none());
 }
@@ -316,6 +326,17 @@ async fn test_bundle_endpoint_fails_closed_without_configured_output_root() {
 
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     assert_eq!(body["code"], "BUNDLE_OUTPUT_NOT_CONFIGURED");
+    assert_eq!(body["location"], "bundle_output_root");
+    assert!(
+        body["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("bundle root"))
+    );
+    assert!(
+        body["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("Configure the server bundle output root"))
+    );
     assert_no_phi(&body_text);
 }
 
@@ -338,6 +359,17 @@ async fn test_bundle_endpoint_rejects_unsafe_bundle_id_without_writing() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(body["code"], "BUNDLE_ERROR");
+    assert_eq!(body["location"], "bundle_id");
+    assert!(
+        body["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("safe bundle identifiers"))
+    );
+    assert!(
+        body["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("without path traversal"))
+    );
     assert_no_phi(&body_text);
     assert!(fs::read_dir(root.path()).unwrap().next().is_none());
 }

--- a/crates/hl7v2-server/tests/parse_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/parse_endpoint_test.rs
@@ -10,7 +10,7 @@ use axum::{
     http::{Request, StatusCode},
 };
 use http_body_util::BodyExt;
-use serde_json::json;
+use serde_json::{Value, json};
 use tower::ServiceExt;
 
 mod common;
@@ -181,6 +181,31 @@ async fn test_parse_malformed_message_returns_error() {
         response.status().is_client_error() || response.status().is_server_error(),
         "Should return 4xx or 5xx status code"
     );
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let body_json: Value = serde_json::from_str(&body_text).unwrap();
+    assert_eq!(
+        body_json.get("code").and_then(Value::as_str),
+        Some("PARSE_ERROR")
+    );
+    assert_eq!(
+        body_json.get("location").and_then(Value::as_str),
+        Some("message")
+    );
+    assert!(
+        body_json
+            .get("safe_detail")
+            .and_then(Value::as_str)
+            .is_some_and(|detail| detail.contains("Raw message content is not echoed"))
+    );
+    assert!(
+        body_json
+            .get("suggested_next_action")
+            .and_then(Value::as_str)
+            .is_some_and(|action| action.contains("MSH segment"))
+    );
+    assert!(!body_text.contains(common::fixtures::INVALID_MALFORMED));
 }
 
 #[tokio::test]

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -103,6 +103,17 @@ async fn test_validate_malformed_message_returns_error() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(body_json["code"], "PARSE_ERROR");
+    assert_eq!(body_json["location"], "message");
+    assert!(
+        body_json["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("Raw message content is not echoed"))
+    );
+    assert!(
+        body_json["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("MSH segment"))
+    );
 }
 
 #[tokio::test]
@@ -128,6 +139,17 @@ async fn test_validate_invalid_profile_yaml_returns_error() {
     assert_eq!(
         body_json["message"],
         "profile could not be loaded; run profile lint for details"
+    );
+    assert_eq!(body_json["location"], "profile");
+    assert!(
+        body_json["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("Raw profile content is not echoed"))
+    );
+    assert!(
+        body_json["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("Run profile lint"))
     );
     assert!(!body_text.contains("Jane Secret"));
     assert!(!body_text.contains("MRN-SECRET-123"));
@@ -159,6 +181,17 @@ segments:
     assert_eq!(
         body_json["message"],
         "profile could not be loaded; run profile lint for details"
+    );
+    assert_eq!(body_json["location"], "profile");
+    assert!(
+        body_json["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("Raw profile content is not echoed"))
+    );
+    assert!(
+        body_json["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("Run profile lint"))
     );
     assert!(!body_text.contains("missing field"));
     assert!(!body_text.contains("segments"));
@@ -279,6 +312,16 @@ async fn test_validate_report_schema_version_rejects_unknown_version() {
     let body_json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(body_json["code"], "VALIDATION_ERROR");
     assert!(body_json["message"].as_str().unwrap().contains("1 or 2"));
+    assert!(
+        body_json["safe_detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("successful evidence response"))
+    );
+    assert!(
+        body_json["suggested_next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("schema-version fields"))
+    );
 }
 
 #[tokio::test]

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -489,10 +489,31 @@ The API uses standard HTTP status codes and returns a JSON error body:
 ```json
 {
   "code": "PROFILE_LOAD_ERROR",
-  "message": "Failed to load profile: missing required field `version`",
+  "message": "profile could not be loaded; run profile lint for details",
+  "safe_detail": "The supplied inline profile could not be loaded. Raw profile content is not echoed.",
+  "location": "profile",
+  "suggested_next_action": "Run profile lint on the profile, then retry validation with the corrected profile.",
   "details": null
 }
 ```
+
+`code` and `message` are the compatibility fields. Newer clients should prefer
+`code`, `safe_detail`, `location`, and `suggested_next_action` for operator
+workflows. Error responses do not echo raw HL7 payloads, raw profile YAML,
+redaction policies, configured filesystem roots, API keys, or raw bundle IDs by
+default.
+
+Common operator actions:
+
+| Code | First action |
+| --- | --- |
+| `PARSE_ERROR` | Check the `MSH` segment, segment terminators, encoding, and `mllp_framed` setting. |
+| `PROFILE_LOAD_ERROR` | Run profile lint and retry with the corrected profile. |
+| `VALIDATION_ERROR` | Check request parameters, schema-version fields, and validation issue paths where available. |
+| `REDACTION_ERROR` | Check safe-analysis policy paths, actions, reasons, and required-field matches. |
+| `BUNDLE_OUTPUT_NOT_CONFIGURED` | Configure the server bundle output root and verify readiness. |
+| `BUNDLE_ERROR` | Use a simple bundle id without path traversal and retry after validating inputs. |
+| `QUARANTINE_OUTPUT_NOT_CONFIGURED` | Configure the quarantine output path or disable quarantine output before retrying. |
 
 ### Common Status Codes:
 - `200 OK`: Success.


### PR DESCRIPTION
## Summary

- Add optional REST ErrorResponse operator fields: safe_detail, location, and suggested_next_action while preserving existing code and message compatibility fields.
- Populate PHI-safe next-action guidance for parse, profile, validation, redaction, bundle, quarantine, and internal server failures.
- Update OpenAPI and API guide docs, and add endpoint assertions for parse/profile/schema/bundle failures without echoing raw payloads or profile content.

## Validation

- cargo +1.95.0 test -p hl7v2-server --test parse_endpoint_test --test validate_endpoint_test --test bundle_endpoint_test --locked
- cargo +1.95.0 clippy -p hl7v2-server --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- 
px --yes @stoplight/spectral-cli lint api/openapi/hl7v2-api-v1.yaml --ruleset .spectral.yml
- 
px --yes @redocly/cli build-docs api/openapi/hl7v2-api-v1.yaml -o F:\cargo-target\hl7v2-rs-rest-error-guidance\api-reference.html
- git diff --check

## Compatibility

Additive REST response fields only. Existing code, message, and details fields remain present/compatible.

## Security

Error responses continue to avoid raw HL7 payloads, raw profile YAML, redaction policy TOML, configured roots, API keys, and raw bundle IDs by default.