### PR TITLE
fix(escape): preserve MSH-2 encoding characters

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12911",
+  "message": "12904",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/escape.rs
+++ b/crates/hl7v2/src/escape.rs
@@ -167,20 +167,16 @@ pub fn unescape_text(text: &str, delims: &Delims) -> Result<String, Error> {
                 // If we don't find the closing escape character, this might be a literal backslash
                 // in the encoding characters. Let's check if this is the special case of the
                 // MSH encoding characters "^~\&"
-                if text.len() == 4 {
+                if text.chars().count() == 4 {
                     let chars: Vec<char> = text.chars().collect();
                     if chars[0] == delims.comp
                         && chars[1] == delims.rep
                         && chars[2] == delims.esc
                         && chars[3] == delims.sub
                     {
-                        // This is the MSH encoding characters, treat as literal
-                        result.push(delims.comp);
-                        result.push(delims.rep);
-                        result.push(delims.esc);
-                        result.push(delims.sub);
-                        // Skip the rest of the processing since we've handled the special case
-                        return Ok(result);
+                        // Return the original text unchanged: the prefix already in `result`
+                        // must not be duplicated by also appending the four literal chars.
+                        return Ok(text.to_string());
                     }
                 }
 

--- a/crates/hl7v2/src/escape/tests.rs
+++ b/crates/hl7v2/src/escape/tests.rs
@@ -376,12 +376,10 @@ fn test_unescape_incomplete_sequence() {
 #[test]
 fn test_unescape_msh_encoding_chars() {
     let delims = Delims::default();
-    // MSH encoding characters - the unescape function has special handling for this
-    // When it detects the pattern ^~\& (the standard encoding chars), it returns them as-is
+    // MSH-2 encoding characters "^~\&" contain a bare backslash that is not an escape
+    // sequence opener.  unescape_text must return them unchanged.
     let unescaped = unescape_text("^~\\&", &delims).unwrap();
-    // The actual implementation returns the MSH encoding chars with an extra tilde
-    // This is a known behavior of the special case handling
-    assert_eq!(unescaped, "^~^~\\&");
+    assert_eq!(unescaped, "^~\\&");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fix `unescape_text("^~\\&")` so the MSH-2 encoding characters are returned unchanged instead of duplicating the prefix.
- Update the regression test to assert the correct MSH-2 behavior.
- Refresh the generated RIPR badge artifact after the code change.

## Validation
- `cargo +1.95.0 test -p hl7v2 escape --all-features --locked`
- `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `cargo +1.95.0 run -p xtask -- impacted-evidence --check`
- `git diff --check`

Supersedes draft PR #658; this replacement exists because GitHub GraphQL quota is exhausted and #658 could not be marked ready through REST.