### PR TITLE
docs: record user journey acceptance proof

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -65,6 +65,7 @@ canonical_sources = [
   "docs/audits/publish-v1.5.0-2026-05-15.md",
   "docs/audits/ripr-calibration-2026-05-15.md",
   "docs/audits/real-world-corpus-proof-2026-05-14.md",
+  "docs/audits/user-journey-acceptance-2026-05-15.md",
   "docs/guides/first-use-by-surface.md",
   "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
   "docs/specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md",
@@ -1070,6 +1071,27 @@ non_claims = [
   "No TestPyPI or PyPI upload.",
   "No npm package.",
   "No tag or GitHub release.",
+]
+
+[[work_item]]
+id = "first-use-user-journey-acceptance"
+status = "done"
+goal = "Record the Rust, CLI, server, and Python first-use acceptance surfaces that prove users can get from install or local build to shareable evidence receipts."
+receipt = "docs/audits/user-journey-acceptance-2026-05-15.md"
+commands = [
+  "cargo +1.95.0 test -p hl7v2 --test user_journey --all-features --locked",
+  "cargo +1.95.0 test -p hl7v2-cli --test integration_tests journey_cli_validate_redact_bundle_replay_produces_shareable_receipts --locked",
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "cargo +1.95.0 run -p xtask -- badges --check",
+  "cargo +1.95.0 run -p xtask -- impacted-evidence --check",
+  "git diff --check",
+]
+non_claims = [
+  "No TestPyPI upload.",
+  "No PyPI upload.",
+  "No npm package.",
+  "No new crates.io release.",
+  "No Python public-registry install-back proof.",
 ]
 
 [[work_item]]

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ proposal, spec, plan, or receipt documents.
 | [v1.5.0 package registry state audit](audits/package-registry-state-2026-05-15.md) | Live pre-release registry state after the selected v1.5.0 graph and latest readiness refresh. |
 | [v1.5.0 objective completion audit](audits/v1.5.0-objective-completion-audit-2026-05-15.md) | Prompt-to-artifact map for the active lane, including completed evidence and remaining release/Python/npm blockers. |
 | [Dirty real-world corpus proof](audits/real-world-corpus-proof-2026-05-14.md) | Focused proof that core corpus summary, fingerprint, and diff handle Z-segments, odd MSH fields, MLLP bytes, large OBX messages, malformed delimiters, and safe parse-error output. |
+| [User journey acceptance proof](audits/user-journey-acceptance-2026-05-15.md) | First-use acceptance map for Rust, CLI, server, and Python evidence workflows. |
 | [Cross-surface evidence parity spec](specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Contract map for Rust, CLI, REST/gRPC, Python, and future TypeScript evidence semantics. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-09.md) | Python packaging proof that keeps the `hl7v2-python` binding backend separate from the primary Rust product graph. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |

--- a/docs/audits/user-journey-acceptance-2026-05-15.md
+++ b/docs/audits/user-journey-acceptance-2026-05-15.md
@@ -1,0 +1,59 @@
+# User Journey Acceptance Proof
+
+Date: 2026-05-15
+Branch: `docs/user-journey-acceptance-proof`
+Scope: current first-use and evidence-workflow acceptance surface after the
+v1.5.0 crates.io release, CLI/Rust journey tests, and operator guidance landed.
+
+This receipt records the user-facing paths that prove a normal operator can get
+from install or local build to a useful, shareable evidence artifact without
+understanding the repo topology.
+
+## Acceptance Surfaces
+
+| Surface | User job | Proof |
+| --- | --- | --- |
+| Rust library | Embed parse, validation, redaction, bundle, and replay evidence in an application. | `cargo +1.95.0 test -p hl7v2 --test user_journey --all-features --locked` |
+| CLI | Validate, redact, bundle, replay, and inspect shareable support evidence. | `cargo +1.95.0 test -p hl7v2-cli --test integration_tests journey_cli_validate_redact_bundle_replay_produces_shareable_receipts --locked` |
+| Server REST sidecar | Run a validation sidecar and prove redacted validation, bundle, replay, and corpus diff over HTTP. | `tests/server_smoke/smoke.py` against a running sidecar; covered by the server smoke workflow. |
+| Python local wheel | Import `hl7v2`, run evidence helpers, validate schemas, redact, bundle, and replay through the installed wheel. | `tests/python_smoke/smoke.py` and `tests/python_smoke/evidence_workflow_guide.py` after local wheel install. |
+
+## What The Journey Proves
+
+- the Rust and CLI paths produce validation reports, redaction receipts, evidence
+  bundles, and replay reports from one realistic HL7 message;
+- shareable artifacts do not contain the configured PHI leak sentinels;
+- replay detects tampering instead of treating a bundle as trusted by existence;
+- Python and server first-use checks have explicit smoke scripts tied to their
+  install/runtime setup instead of relying only on unit tests;
+- first-use documentation points users to the same product classes recorded in
+  the package-boundary model: Rust product crates, language packages, binding
+  backend crates, and internal/dev crates.
+
+## Current Validation
+
+Run on this branch:
+
+```text
+cargo +1.95.0 test -p hl7v2 --test user_journey --all-features --locked
+cargo +1.95.0 test -p hl7v2-cli --test integration_tests journey_cli_validate_redact_bundle_replay_produces_shareable_receipts --locked
+cargo +1.95.0 run -p xtask -- check-doc-links
+cargo +1.95.0 run -p xtask -- badges --check
+cargo +1.95.0 run -p xtask -- impacted-evidence --check
+git diff --check
+```
+
+## Non-Claims
+
+- This receipt does not upload to TestPyPI or PyPI.
+- This receipt does not prove `pip install hl7v2` from a public Python registry.
+- This receipt does not create or publish an npm package.
+- This receipt does not change the v1.5.0 crates.io release.
+- This receipt does not promote `hl7v2-python` as the recommended Rust API.
+
+## Remaining Gap
+
+The public Python package remains blocked on TestPyPI Trusted Publisher setup
+for project `hl7v2`. After issue #563 is resolved, the Python TestPyPI workflow
+must upload, install back, import `hl7v2`, run `smoke.py`, and run
+`evidence_workflow_guide.py` before any TestPyPI success claim.

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -23,6 +23,7 @@ claim tier or proof expectations.
 | Rust parse, validate, normalize, ACK, MLLP, and evidence models | Stable | `cargo test -p hl7v2 --all-features` |
 | Evidence schemas | Stable | `cargo run -p xtask -- evidence-schema-check` |
 | Cross-surface evidence parity contract | Accepted | [HL7V2-SPEC-0006](../specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md); surface-specific claims still require their own tests, schema checks, language install/import proof, or registry receipts |
+| First-use user journeys | Stable where released; Python registry blocked | Rust: `cargo test -p hl7v2 --test user_journey --all-features`; CLI: `cargo test -p hl7v2-cli --test integration_tests journey_cli_validate_redact_bundle_replay_produces_shareable_receipts`; server: `tests/server_smoke/smoke.py` against a running sidecar; Python: `tests/python_smoke/smoke.py` and `tests/python_smoke/evidence_workflow_guide.py` after local wheel install. See the [user journey acceptance proof](../audits/user-journey-acceptance-2026-05-15.md). |
 | Dirty corpus compatibility proof | Stable core proof | `cargo test -p hl7v2 --lib --all-features dirty_real_world`; [dirty real-world corpus proof](../audits/real-world-corpus-proof-2026-05-14.md) |
 | CLI evidence commands | Stable | `cargo test -p hl7v2-cli --test integration_tests` |
 | CLI BDD workflows | Stable | `cargo test -p hl7v2-cli --test bdd_tests` |


### PR DESCRIPTION
## Summary
- add a user journey acceptance receipt for Rust, CLI, server, and Python evidence workflows
- link the receipt from the docs index and support tier proof map
- record the work item in .hl7v2/goals/active.toml

## Validation
- cargo +1.95.0 test -p hl7v2 --test user_journey --all-features --locked
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests journey_cli_validate_redact_bundle_replay_produces_shareable_receipts --locked
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- badges --check
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- git diff --check

## Non-claims
- no TestPyPI/PyPI upload or install-back proof
- no npm package
- no crates.io release change
- hl7v2-python remains binding backend infrastructure, not the recommended Rust API