### PR TITLE
docs: align binding backend post-release wording

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -210,7 +210,7 @@ commands = [
   "cargo +1.95.0 run -p xtask -- publish-dry-run --surface bindings --workspace-patches --allow-dirty",
   "cargo +1.95.0 run -p xtask -- check-python-publish-policy",
 ]
-note = "Unpatched cargo publish --dry-run requires hl7v2 1.5.0 to resolve from crates.io; primary v1.5.0 has not been published yet."
+note = "At the time of this metadata PR, unpatched cargo publish --dry-run required hl7v2 1.5.0 to resolve from crates.io. v1.5.0 is now published and receipted in docs/audits/publish-v1.5.0-2026-05-15.md."
 
 [[work_item]]
 id = "npm-wasm-binding-package-model"
@@ -957,8 +957,9 @@ prs = [
 acceptance = [
   "Primary Rust product graph still reports hl7v2, hl7v2-server, and hl7v2-cli.",
   "Binding backend graph reports hl7v2-python separately.",
-  "hl7v2-python remains unpublished unless a later binding-backend release PR records upload proof.",
-  "No crates.io, TestPyPI, or PyPI publish claim is made.",
+  "At closeout time, hl7v2-python remained unpublished unless a later binding-backend release PR recorded upload proof.",
+  "The later v1.5.0 publish receipt records the hl7v2-python crates.io backend upload.",
+  "No TestPyPI or PyPI publish claim is made.",
 ]
 
 [[work_item]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bundle/replay, corpus, ACK, and normalize RPC proof surface.
 - Refreshed the v1.5.0 release-readiness receipt after the Python ACK and
   gRPC parity documentation syncs landed on `main`.
-- Recorded a current package registry state audit showing that v1.5.0 is still
-  unpublished, `hl7v2-python` is not on crates.io, and public Python `hl7v2`
-  is not on PyPI or TestPyPI.
+- Recorded a pre-release package registry state audit showing that v1.5.0 was
+  not yet published at that snapshot and that public Python `hl7v2` was not on
+  PyPI or TestPyPI.
 - Recorded a prompt-to-artifact objective completion audit for the active
   v1.5.0 lane and kept the lane open until publish, Python, and npm receipts
   exist.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -62,12 +62,13 @@ This document provides a transparent view of which features are fully implemente
 Binding backend crates are real language-boundary APIs, but they are not the
 recommended Rust API. `xtask publish-plan --surface bindings` reports this
 separate graph. Current `hl7v2-python` metadata describes it as the PyO3
-extension crate backing the Python `hl7v2` package and is publishable as binding
-infrastructure only. #610-#614 added the binding-backend release-proof spec,
-dry-run surface, publishable metadata, npm/WASM package model, and publish
-surface guard. It still needs refreshed release readiness, language install or
-import smoke receipts, registry resolution proof, and an explicit release
-decision before any crates.io upload claim.
+extension crate backing the Python `hl7v2` package and v1.5.0 published it to
+crates.io as binding infrastructure only. #610-#614 added the binding-backend
+release-proof spec, dry-run surface, publishable metadata, npm/WASM package
+model, and publish surface guard; the v1.5.0 publish receipt owns the
+`hl7v2-python` crates.io upload and registry-resolution proof. That crates.io
+backend receipt is still not a TestPyPI or PyPI proof for the public Python
+package.
 Future TypeScript package work is governed by
 [HL7V2-SPEC-0005](specs/HL7V2-SPEC-0005-npm-wasm-binding-package-model.md):
 the public npm package is `@effortlessmetrics/hl7v2`, while Rust backend crates

--- a/docs/audits/package-registry-state-2026-05-15.md
+++ b/docs/audits/package-registry-state-2026-05-15.md
@@ -8,6 +8,14 @@ and release graph decision.
 This audit records live package index state only. It is not a crates.io,
 TestPyPI, PyPI, npm, tag, or GitHub release receipt.
 
+Post-release note: the crates.io portion of this pre-release snapshot was later
+superseded by
+[`publish-v1.5.0-2026-05-15.md`](publish-v1.5.0-2026-05-15.md), which records
+`hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli` v1.5.0 upload and
+registry resolution. The PyPI and TestPyPI absence recorded here remains the
+current Python registry boundary until a dedicated upload/install-back receipt
+supersedes it.
+
 ## Result
 
 The public registries still match the expected pre-release boundary:

--- a/docs/audits/v1.5.0-release-graph-decision-2026-05-14.md
+++ b/docs/audits/v1.5.0-release-graph-decision-2026-05-14.md
@@ -6,6 +6,12 @@ This decision selects the intended crates.io graph for the v1.5.0 publish
 action. It is not a crates.io publish receipt, tag receipt, GitHub release
 receipt, TestPyPI receipt, PyPI receipt, or npm receipt.
 
+Post-release note: this decision was later fulfilled by
+[`publish-v1.5.0-2026-05-15.md`](publish-v1.5.0-2026-05-15.md), which records
+the crates.io upload, registry resolution, tag, GitHub release, and
+Rust/CLI/server install-back proof. It still does not prove the public Python
+`hl7v2` package on TestPyPI or PyPI.
+
 ## Decision
 
 The v1.5.0 crates.io release graph is:
@@ -83,4 +89,6 @@ The next crates.io release step must record:
 - GitHub release;
 - rollback or yank posture.
 
-Until those receipts exist, v1.5.0 remains unreleased.
+Those crates.io, tag, and GitHub release receipts now exist in
+[`publish-v1.5.0-2026-05-15.md`](publish-v1.5.0-2026-05-15.md). TestPyPI and
+PyPI proof remain separate.

--- a/docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md
+++ b/docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md
@@ -41,9 +41,13 @@ A binding backend crate can be published only when it is:
 - covered by that language package's install/import smoke proof;
 - recorded in a release receipt.
 
-Current `hl7v2-python` metadata may make the crate publishable as binding
-infrastructure. It remains unpublished until a dedicated release PR records the
-required proof and a crates.io upload plus registry resolution succeeds.
+Current `hl7v2-python` metadata makes the crate publishable as binding
+infrastructure. v1.5.0 published it to crates.io after dedicated release proof
+and registry resolution were recorded in
+[`publish-v1.5.0-2026-05-15.md`](../audits/publish-v1.5.0-2026-05-15.md).
+That backend publication remains separate from TestPyPI or PyPI proof for the
+public Python `hl7v2` package. Future binding backend crates must satisfy this
+same proof contract before any publish claim.
 
 ## Package Classes
 


### PR DESCRIPTION
## Summary
- remove stale current-state wording that said hl7v2-python still needed a crates.io upload decision before any backend publish claim
- add post-release notes to pre-release registry and release-graph receipts pointing to the v1.5.0 publish receipt
- keep Python TestPyPI/PyPI proof separate and still blocked/unproven

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- active.toml parsed with Python tomllib
- git diff --check

## CI Economics
- Docs-only truth-alignment PR; no runtime, workflow, package, or publish behavior changes.
- Uses existing doc-link, file-policy, Python publish-policy, and TOML checks.

## Non-claims
- no crates.io publish
- no TestPyPI or PyPI upload
- no npm package
- no tag or GitHub release action
- does not mark the active goal complete