### PR TITLE
docs: mark readiness snapshots as post-release

### DIFF
--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,7 +1,7 @@
 # Rust 1.95 And 1.5.0 Rollout
 
-This document is the rollout map for moving `hl7v2-rs` from Rust 1.93 to
-Rust 1.95 and preparing the next release as `1.5.0`.
+This document is the rollout map that moved `hl7v2-rs` from Rust 1.93 to
+Rust 1.95 and prepared the `1.5.0` release.
 
 This is a planning and operating document. The initial map PR did not change
 the active MSRV, toolchain, CI behavior, lint policy, package version, or
@@ -29,7 +29,7 @@ self-describing and better receipted.
 | Surface | Current state | Notes |
 | --- | --- | --- |
 | Rust edition | `2024` | No edition migration is planned. |
-| Workspace version | `1.5.0` candidate | v1.4.0 remains the current published crates.io release until v1.5.0 receipts land. |
+| Workspace version | `1.5.0` | v1.5.0 is published on crates.io; see [`docs/audits/publish-v1.5.0-2026-05-15.md`](../audits/publish-v1.5.0-2026-05-15.md). |
 | Workspace MSRV | `1.95` | Declared in the root `Cargo.toml` after the compatibility probe. |
 | Toolchain file | present | `rust-toolchain.toml` pins Rust `1.95.0` with `rustfmt` and `clippy`. |
 | Root lint policy | strict | Rust and Clippy lints are already governed from the workspace root. |

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -104,11 +104,13 @@ train without changing any publish claim:
 - #608 fixed Python wheel cache behavior so the backend framing PR could pass
   the wheel smoke lane.
 
-This closeout does not supersede the v1.5.0 readiness receipt. The primary
-Rust product graph remains `hl7v2`, `hl7v2-server`, and `hl7v2-cli`.
-`hl7v2-python` remains in the binding backend graph and still needs a separate
-binding-backend release decision and upload receipt before any crates.io backend
-publish claim.
+At closeout time, this did not supersede the v1.5.0 readiness receipt. The
+primary Rust product graph remained `hl7v2`, `hl7v2-server`, and `hl7v2-cli`,
+while `hl7v2-python` remained in the binding backend graph pending a separate
+binding-backend release decision and upload receipt. The later
+[v1.5.0 publish receipt](../audits/publish-v1.5.0-2026-05-15.md) satisfied that
+crates.io backend proof for `hl7v2-python`; it did not prove TestPyPI or PyPI
+for the public Python `hl7v2` package.
 
 ## Binding-Backend Readiness Audit
 
@@ -126,18 +128,21 @@ path explicit:
 See the dedicated audit:
 [`docs/audits/binding-backend-readiness-2026-05-14.md`](../audits/binding-backend-readiness-2026-05-14.md).
 
-This does not change the hosted readiness receipt above. The recorded v1.5.0
-dry-run remains a primary Rust product graph proof at
-`b0bb5b5392354273946f36f797f39d741d318fc1`. Because current `main` now has a
-publishable binding backend surface, any v1.5.x release decision should refresh
-readiness against the current surfaces before choosing either:
+At audit time, this did not change the hosted readiness receipt above. The
+recorded v1.5.0 dry-run remained a primary Rust product graph proof at
+`b0bb5b5392354273946f36f797f39d741d318fc1`. Because `main` had gained a
+publishable binding backend surface, the later release decision needed to
+refresh readiness against the current surfaces before choosing either:
 
 - primary-only: `hl7v2`, `hl7v2-server`, `hl7v2-cli`;
 - primary plus binding backend: `hl7v2`, `hl7v2-python`, `hl7v2-server`,
   `hl7v2-cli`.
 
-The readiness audit does not claim a crates.io backend upload, PyPI/TestPyPI
-upload, npm package, tag, GitHub release, or v1.5.0 publish.
+The readiness audit itself did not claim a crates.io backend upload,
+PyPI/TestPyPI upload, npm package, tag, GitHub release, or v1.5.0 publish. The
+later [v1.5.0 publish receipt](../audits/publish-v1.5.0-2026-05-15.md)
+supersedes only the crates.io upload, tag, and GitHub release portions of that
+pre-publish state.
 
 ## Current-Main Refresh After Evidence Updates
 


### PR DESCRIPTION
## Summary
- update the Rust 1.95 rollout map so the workspace version row reflects the published v1.5.0 crates.io receipt
- qualify older package-boundary and binding-backend readiness text as pre-publish snapshots superseded by the v1.5.0 publish receipt
- preserve the TestPyPI/PyPI non-claim for public Python hl7v2

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check