### PR TITLE
test(synthetic): cover values and faker generators with inline unit tests

### DIFF
--- a/crates/hl7v2/src/synthetic/faker.rs
+++ b/crates/hl7v2/src/synthetic/faker.rs
@@ -638,3 +638,439 @@ impl std::error::Error for GenerateError {}
 pub use rand::Rng;
 pub use rand::SeedableRng;
 pub use rand::rngs::StdRng;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    fn ensure(condition: bool, message: &'static str) -> TestResult {
+        if condition {
+            Ok(())
+        } else {
+            Err(std::io::Error::other(message).into())
+        }
+    }
+
+    fn seeded_rng() -> StdRng {
+        StdRng::seed_from_u64(42)
+    }
+
+    fn split_assert_two_non_empty(value: &str, sep: char) -> TestResult {
+        let parts: Vec<&str> = value.split(sep).collect();
+        ensure(
+            parts.len() == 2,
+            "value should split into exactly two parts",
+        )?;
+        let first = parts
+            .first()
+            .ok_or_else(|| std::io::Error::other("missing first part"))?;
+        let second = parts
+            .get(1)
+            .ok_or_else(|| std::io::Error::other("missing second part"))?;
+        ensure(!first.is_empty(), "first part should be non-empty")?;
+        ensure(!second.is_empty(), "second part should be non-empty")
+    }
+
+    #[test]
+    fn name_male_returns_caret_delimited_pair() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let name = faker.name(Some("M"));
+        ensure(name.contains('^'), "name should contain '^'")?;
+        split_assert_two_non_empty(&name, '^')
+    }
+
+    #[test]
+    fn name_female_returns_caret_delimited_pair() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let name = faker.name(Some("F"));
+        ensure(name.contains('^'), "name should contain '^'")?;
+        split_assert_two_non_empty(&name, '^')
+    }
+
+    #[test]
+    fn name_any_gender_returns_caret_delimited_pair() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let name = faker.name(None);
+        ensure(name.contains('^'), "name should contain '^'")?;
+        split_assert_two_non_empty(&name, '^')
+    }
+
+    #[test]
+    fn name_unknown_gender_falls_back_to_any() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let name = faker.name(Some("X"));
+        ensure(name.contains('^'), "fallback name should still contain '^'")?;
+        split_assert_two_non_empty(&name, '^')
+    }
+
+    #[test]
+    fn mrn_returns_non_empty_digit_string_within_six_to_ten_chars() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let mrn = faker.mrn();
+        ensure(!mrn.is_empty(), "mrn should be non-empty")?;
+        ensure(
+            mrn.len() >= 6 && mrn.len() <= 10,
+            "mrn length should be 6..=10",
+        )?;
+        ensure(
+            mrn.chars().all(|c| c.is_ascii_digit()),
+            "mrn should be all digits",
+        )
+    }
+
+    #[test]
+    fn ssn_returns_hyphenated_three_two_four_digits() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let ssn = faker.ssn();
+        let parts: Vec<&str> = ssn.split('-').collect();
+        ensure(parts.len() == 3, "ssn should have three parts")?;
+        let first = parts
+            .first()
+            .ok_or_else(|| std::io::Error::other("missing first ssn part"))?;
+        let second = parts
+            .get(1)
+            .ok_or_else(|| std::io::Error::other("missing second ssn part"))?;
+        let third = parts
+            .get(2)
+            .ok_or_else(|| std::io::Error::other("missing third ssn part"))?;
+        ensure(first.len() == 3, "first ssn part should be 3 chars")?;
+        ensure(second.len() == 2, "second ssn part should be 2 chars")?;
+        ensure(third.len() == 4, "third ssn part should be 4 chars")?;
+        ensure(
+            parts
+                .iter()
+                .all(|part| part.chars().all(|c| c.is_ascii_digit())),
+            "all ssn parts should be digits",
+        )
+    }
+
+    #[test]
+    fn phone_returns_parenthesized_format() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let phone = faker.phone();
+        ensure(!phone.is_empty(), "phone should be non-empty")?;
+        ensure(phone.starts_with('('), "phone should start with '('")?;
+        ensure(phone.contains(')'), "phone should contain ')'")?;
+        ensure(phone.contains('-'), "phone should contain '-'")
+    }
+
+    #[test]
+    fn address_returns_hl7_caret_segments() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let address = faker.address();
+        ensure(!address.is_empty(), "address should be non-empty")?;
+        let segments: Vec<&str> = address.split('^').collect();
+        ensure(segments.len() == 6, "address should have 6 caret segments")?;
+        let country = segments
+            .get(5)
+            .ok_or_else(|| std::io::Error::other("missing country segment"))?;
+        ensure(*country == "USA", "address country should be USA")
+    }
+
+    #[test]
+    fn icd10_returns_three_chars_dot_digit() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let code = faker.icd10();
+        ensure(!code.is_empty(), "icd10 should be non-empty")?;
+        ensure(code.contains('.'), "icd10 should contain '.'")?;
+        let parts: Vec<&str> = code.split('.').collect();
+        ensure(parts.len() == 2, "icd10 should have category.subcode")?;
+        let category = parts
+            .first()
+            .ok_or_else(|| std::io::Error::other("missing icd10 category"))?;
+        ensure(category.len() == 3, "icd10 category should be 3 chars")
+    }
+
+    #[test]
+    fn loinc_returns_non_empty_digit_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let code = faker.loinc();
+        ensure(!code.is_empty(), "loinc should be non-empty")?;
+        ensure(
+            code.chars().all(|c| c.is_ascii_digit()),
+            "loinc should be all digits",
+        )
+    }
+
+    #[test]
+    fn medication_returns_non_empty_value() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let med = faker.medication();
+        ensure(!med.is_empty(), "medication should be non-empty")
+    }
+
+    #[test]
+    fn allergen_returns_non_empty_value() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let allergen = faker.allergen();
+        ensure(!allergen.is_empty(), "allergen should be non-empty")
+    }
+
+    #[test]
+    fn blood_type_returns_non_empty_value() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let blood = faker.blood_type();
+        ensure(!blood.is_empty(), "blood type should be non-empty")
+    }
+
+    #[test]
+    fn ethnicity_returns_non_empty_value() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let value = faker.ethnicity();
+        ensure(!value.is_empty(), "ethnicity should be non-empty")
+    }
+
+    #[test]
+    fn race_returns_non_empty_value() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let value = faker.race();
+        ensure(!value.is_empty(), "race should be non-empty")
+    }
+
+    #[test]
+    fn numeric_with_zero_digits_returns_empty_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let value = faker.numeric(0);
+        ensure(value.is_empty(), "numeric(0) should be empty")
+    }
+
+    #[test]
+    fn numeric_with_eight_digits_returns_eight_digit_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let value = faker.numeric(8);
+        ensure(value.len() == 8, "numeric(8) should be 8 chars")?;
+        ensure(
+            value.chars().all(|c| c.is_ascii_digit()),
+            "numeric(8) should be all digits",
+        )
+    }
+
+    #[test]
+    fn same_seed_produces_identical_name_mrn_address() -> TestResult {
+        let mut rng_a = StdRng::seed_from_u64(7);
+        let mut faker_a = Faker::new(&mut rng_a);
+        let name_a = faker_a.name(Some("M"));
+        let mrn_a = faker_a.mrn();
+        let address_a = faker_a.address();
+
+        let mut rng_b = StdRng::seed_from_u64(7);
+        let mut faker_b = Faker::new(&mut rng_b);
+        let name_b = faker_b.name(Some("M"));
+        let mrn_b = faker_b.mrn();
+        let address_b = faker_b.address();
+
+        ensure(name_a == name_b, "same seed should produce same name")?;
+        ensure(mrn_a == mrn_b, "same seed should produce same mrn")?;
+        ensure(
+            address_a == address_b,
+            "same seed should produce same address",
+        )
+    }
+
+    #[test]
+    fn uuid_v4_returns_thirty_six_char_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let faker = Faker::new(&mut rng);
+        let uuid = faker.uuid_v4();
+        ensure(uuid.len() == 36, "uuid should be 36 chars")?;
+        let bytes = uuid.as_bytes();
+        for index in [8usize, 13, 18, 23] {
+            ensure(
+                bytes.get(index).copied() == Some(b'-'),
+                "uuid should have hyphen at expected position",
+            )?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dtm_now_utc_returns_fourteen_digit_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let faker = Faker::new(&mut rng);
+        let dtm = faker.dtm_now_utc();
+        ensure(dtm.len() == 14, "dtm should be 14 chars")?;
+        ensure(
+            dtm.chars().all(|c| c.is_ascii_digit()),
+            "dtm should be all digits",
+        )
+    }
+
+    #[test]
+    fn date_degenerate_range_returns_start() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let date = faker.date("20200101", "20200101")?;
+        ensure(date == "20200101", "degenerate range should return start")
+    }
+
+    #[test]
+    fn date_invalid_format_returns_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let result = faker.date("not-a-date", "20200101");
+        ensure(
+            matches!(result, Err(DateError::InvalidDateFormat(_))),
+            "invalid format should return InvalidDateFormat",
+        )
+    }
+
+    #[test]
+    fn date_inverted_range_returns_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let result = faker.date("20210101", "20200101");
+        ensure(
+            matches!(result, Err(DateError::InvalidDateRange { .. })),
+            "inverted range should return InvalidDateRange",
+        )
+    }
+
+    #[test]
+    fn gaussian_zero_sd_returns_mean_at_precision() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let value = faker.gaussian(50.0, 0.0, 3)?;
+        ensure(
+            value == "50.000",
+            "zero SD should produce mean at precision",
+        )
+    }
+
+    #[test]
+    fn gaussian_nan_sd_returns_invalid_parameters() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let result = faker.gaussian(0.0, f64::NAN, 2);
+        ensure(
+            matches!(result, Err(GaussianError::InvalidParameters)),
+            "NaN SD should return InvalidParameters",
+        )
+    }
+
+    #[test]
+    fn select_from_empty_returns_none() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        ensure(
+            faker.select_from(&[]).is_none(),
+            "empty select_from should return None",
+        )
+    }
+
+    #[test]
+    fn select_from_picks_one_of_options() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let options = vec!["a".to_string(), "b".to_string()];
+        let result = faker
+            .select_from(&options)
+            .ok_or_else(|| std::io::Error::other("select_from should return Some"))?;
+        ensure(
+            options.contains(&result),
+            "select_from should pick from options",
+        )
+    }
+
+    #[test]
+    fn select_from_map_empty_returns_none() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let map = std::collections::HashMap::new();
+        ensure(
+            faker.select_from_map(&map).is_none(),
+            "empty select_from_map should return None",
+        )
+    }
+
+    #[test]
+    fn faker_value_fixed_generates_literal() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let value = FakerValue::Fixed("LIT".to_string()).generate(&mut faker)?;
+        ensure(value == "LIT", "Fixed should yield literal")
+    }
+
+    #[test]
+    fn faker_value_from_empty_returns_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let result = FakerValue::From(Vec::new()).generate(&mut faker);
+        ensure(
+            matches!(result, Err(GenerateError::EmptyOptions)),
+            "empty From should return EmptyOptions",
+        )
+    }
+
+    #[test]
+    fn faker_value_map_empty_returns_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let mut faker = Faker::new(&mut rng);
+        let result = FakerValue::Map(std::collections::HashMap::new()).generate(&mut faker);
+        ensure(
+            matches!(result, Err(GenerateError::EmptyMap)),
+            "empty Map should return EmptyMap",
+        )
+    }
+
+    #[test]
+    fn date_error_display_covers_all_variants() -> TestResult {
+        let invalid_format = format!("{}", DateError::InvalidDateFormat("X".to_string()));
+        let invalid_range = format!(
+            "{}",
+            DateError::InvalidDateRange {
+                start: "B".to_string(),
+                end: "A".to_string(),
+            }
+        );
+        let out_of_range = format!("{}", DateError::DateOutOfRange);
+        ensure(
+            invalid_format.contains('X') && invalid_format.contains("YYYYMMDD"),
+            "InvalidDateFormat display",
+        )?;
+        ensure(
+            invalid_range.contains('A') && invalid_range.contains('B'),
+            "InvalidDateRange display",
+        )?;
+        ensure(!out_of_range.is_empty(), "DateOutOfRange display")
+    }
+
+    #[test]
+    fn gaussian_error_display_covers_invalid_parameters() -> TestResult {
+        let text = format!("{}", GaussianError::InvalidParameters);
+        ensure(text.contains("Gaussian"), "GaussianError display")
+    }
+
+    #[test]
+    fn generate_error_display_covers_all_variants() -> TestResult {
+        let empty_options = format!("{}", GenerateError::EmptyOptions);
+        let empty_map = format!("{}", GenerateError::EmptyMap);
+        let date = format!("{}", GenerateError::Date(DateError::DateOutOfRange));
+        let gaussian = format!(
+            "{}",
+            GenerateError::Gaussian(GaussianError::InvalidParameters)
+        );
+        ensure(!empty_options.is_empty(), "EmptyOptions display")?;
+        ensure(!empty_map.is_empty(), "EmptyMap display")?;
+        ensure(date.contains("Date"), "Date display")?;
+        ensure(gaussian.contains("Gaussian"), "Gaussian display")
+    }
+}

--- a/crates/hl7v2/src/synthetic/values.rs
+++ b/crates/hl7v2/src/synthetic/values.rs
@@ -232,3 +232,260 @@ fn generate_value_from_faker<R: Rng>(
         .generate(&mut faker)
         .map_err(|_err| Error::InvalidEscapeToken)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    fn ensure(condition: bool, message: &'static str) -> TestResult {
+        if condition {
+            Ok(())
+        } else {
+            Err(std::io::Error::other(message).into())
+        }
+    }
+
+    fn seeded_rng() -> StdRng {
+        StdRng::seed_from_u64(42)
+    }
+
+    #[test]
+    fn generate_value_fixed_returns_literal() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::Fixed("HELLO".to_string()), &mut rng)?;
+        ensure(result == "HELLO", "fixed value did not round-trip")
+    }
+
+    #[test]
+    fn generate_value_from_empty_returns_empty_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::From(Vec::new()), &mut rng)?;
+        ensure(result.is_empty(), "empty From should yield empty string")
+    }
+
+    #[test]
+    fn generate_value_from_picks_one_of_options() -> TestResult {
+        let mut rng = seeded_rng();
+        let options = vec!["alpha".to_string(), "beta".to_string()];
+        let result = generate_value(&ValueSource::From(options.clone()), &mut rng)?;
+        ensure(options.contains(&result), "From did not pick an option")
+    }
+
+    #[test]
+    fn generate_value_numeric_returns_string_of_digits_with_expected_length() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::Numeric { digits: 5 }, &mut rng)?;
+        ensure(result.len() == 5, "numeric length should match digits")?;
+        ensure(
+            result.chars().all(|c| c.is_ascii_digit()),
+            "numeric should contain only digits",
+        )
+    }
+
+    #[test]
+    fn generate_value_map_empty_returns_empty_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::Map(HashMap::new()), &mut rng)?;
+        ensure(result.is_empty(), "empty Map should yield empty string")
+    }
+
+    #[test]
+    fn generate_value_uuid_v4_returns_uuid_shaped_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::UuidV4, &mut rng)?;
+        ensure(result.len() == 36, "UUID should be 36 chars")?;
+        let bytes = result.as_bytes();
+        for index in [8usize, 13, 18, 23] {
+            ensure(
+                bytes.get(index).copied() == Some(b'-'),
+                "UUID should have hyphen at expected position",
+            )?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn generate_value_dtm_now_utc_returns_fourteen_digit_string() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::DtmNowUtc, &mut rng)?;
+        ensure(result.len() == 14, "DTM should be 14 chars")?;
+        ensure(
+            result.chars().all(|c| c.is_ascii_digit()),
+            "DTM should contain only digits",
+        )
+    }
+
+    #[test]
+    fn generate_value_date_degenerate_range_returns_only_start() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(
+            &ValueSource::Date {
+                start: "20200101".to_string(),
+                end: "20200101".to_string(),
+            },
+            &mut rng,
+        )?;
+        ensure(result == "20200101", "degenerate range should yield start")
+    }
+
+    #[test]
+    fn generate_value_gaussian_zero_sd_returns_mean_at_precision() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(
+            &ValueSource::Gaussian {
+                mean: 100.0,
+                sd: 0.0,
+                precision: 2,
+            },
+            &mut rng,
+        )?;
+        ensure(
+            result == "100.00",
+            "Gaussian with zero SD should equal mean",
+        )
+    }
+
+    #[test]
+    fn generate_value_invalid_segment_id_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::InvalidSegmentId, &mut rng);
+        ensure(
+            matches!(result, Err(Error::InvalidSegmentId)),
+            "should return InvalidSegmentId",
+        )
+    }
+
+    #[test]
+    fn generate_value_invalid_field_format_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::InvalidFieldFormat, &mut rng);
+        ensure(
+            matches!(result, Err(Error::InvalidFieldFormat { .. })),
+            "should return InvalidFieldFormat",
+        )
+    }
+
+    #[test]
+    fn generate_value_invalid_rep_format_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::InvalidRepFormat, &mut rng);
+        ensure(
+            matches!(result, Err(Error::InvalidRepFormat { .. })),
+            "should return InvalidRepFormat",
+        )
+    }
+
+    #[test]
+    fn generate_value_invalid_comp_format_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::InvalidCompFormat, &mut rng);
+        ensure(
+            matches!(result, Err(Error::InvalidCompFormat { .. })),
+            "should return InvalidCompFormat",
+        )
+    }
+
+    #[test]
+    fn generate_value_invalid_subcomp_format_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::InvalidSubcompFormat, &mut rng);
+        ensure(
+            matches!(result, Err(Error::InvalidSubcompFormat { .. })),
+            "should return InvalidSubcompFormat",
+        )
+    }
+
+    #[test]
+    fn generate_value_duplicate_delims_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::DuplicateDelims, &mut rng);
+        ensure(
+            matches!(result, Err(Error::DuplicateDelims)),
+            "should return DuplicateDelims",
+        )
+    }
+
+    #[test]
+    fn generate_value_bad_delim_length_returns_matching_error() -> TestResult {
+        let mut rng = seeded_rng();
+        let result = generate_value(&ValueSource::BadDelimLength, &mut rng);
+        ensure(
+            matches!(result, Err(Error::BadDelimLength)),
+            "should return BadDelimLength",
+        )
+    }
+
+    #[test]
+    fn to_faker_value_fixed_round_trips() -> TestResult {
+        let source = ValueSource::Fixed("X".to_string());
+        ensure(
+            matches!(source.to_faker_value(), FakerValue::Fixed(ref value) if value == "X"),
+            "Fixed did not round-trip to FakerValue::Fixed",
+        )
+    }
+
+    #[test]
+    fn to_faker_value_from_round_trips() -> TestResult {
+        let source = ValueSource::From(vec!["a".to_string(), "b".to_string()]);
+        ensure(
+            matches!(source.to_faker_value(), FakerValue::From(ref options) if options.len() == 2),
+            "From did not round-trip to FakerValue::From",
+        )
+    }
+
+    #[test]
+    fn to_faker_value_numeric_round_trips() -> TestResult {
+        let source = ValueSource::Numeric { digits: 7 };
+        ensure(
+            matches!(source.to_faker_value(), FakerValue::Numeric { digits: 7 }),
+            "Numeric did not round-trip to FakerValue::Numeric",
+        )
+    }
+
+    #[test]
+    fn to_faker_value_realistic_name_with_gender_round_trips() -> TestResult {
+        let source = ValueSource::RealisticName {
+            gender: Some("M".to_string()),
+        };
+        ensure(
+            matches!(
+                source.to_faker_value(),
+                FakerValue::RealisticName { gender: Some(ref g) } if g == "M"
+            ),
+            "RealisticName did not round-trip to FakerValue::RealisticName",
+        )
+    }
+
+    #[test]
+    fn to_faker_value_uuid_v4_round_trips() -> TestResult {
+        let source = ValueSource::UuidV4;
+        ensure(
+            matches!(source.to_faker_value(), FakerValue::UuidV4),
+            "UuidV4 did not round-trip to FakerValue::UuidV4",
+        )
+    }
+
+    #[test]
+    fn to_faker_value_error_variant_falls_back_to_fixed_empty() -> TestResult {
+        let source = ValueSource::InvalidSegmentId;
+        ensure(
+            matches!(source.to_faker_value(), FakerValue::Fixed(ref value) if value.is_empty()),
+            "error variant should fall back to FakerValue::Fixed(empty)",
+        )
+    }
+
+    #[test]
+    fn value_source_fixed_serde_round_trip() -> TestResult {
+        let source = ValueSource::Fixed("hello".to_string());
+        let encoded = serde_json::to_string(&source)?;
+        let decoded: ValueSource = serde_json::from_str(&encoded)?;
+        ensure(
+            matches!(decoded, ValueSource::Fixed(ref value) if value == "hello"),
+            "serde round-trip should preserve Fixed value",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add 23 inline unit tests in `crates/hl7v2/src/synthetic/values.rs` covering `ValueSource::generate_value`, error-injection variants, `to_faker_value` round-trips, and a serde round-trip.
- Add 34 inline unit tests in `crates/hl7v2/src/synthetic/faker.rs` covering name/address/phone/SSN/MRN/medical-code/numeric/date/gaussian generators, determinism with a fixed seed, and Display/error surfaces for `DateError`, `GaussianError`, and `GenerateError`.
- 57 new tests total. Production code is untouched.
- Tests use seeded `StdRng::seed_from_u64(...)` for determinism and follow the `TestResult` + `ensure(...)` pattern established by recent coverage PRs (`ack.rs`, `batch.rs`, `redaction.rs`). No `.unwrap()`/`.expect()`/`panic!` introduced — keeps `xtask check-no-panic-family` clean.

## Cases covered

### `values.rs`
- `Fixed` returns the literal.
- `From(empty)` yields empty; `From(options)` picks one.
- `Numeric { digits: 5 }` returns 5 ASCII digits.
- `Map(empty)` yields empty.
- `UuidV4` returns a 36-char string with hyphens at indices 8/13/18/23.
- `DtmNowUtc` returns a 14-digit string.
- `Date { start == end }` returns the start date.
- `Gaussian { sd: 0.0 }` returns the mean at the requested precision.
- Each error-injection variant (`InvalidSegmentId`, `InvalidFieldFormat`, `InvalidRepFormat`, `InvalidCompFormat`, `InvalidSubcompFormat`, `DuplicateDelims`, `BadDelimLength`) returns the matching `Error` variant.
- `to_faker_value()` round-trips `Fixed`, `From`, `Numeric`, `RealisticName { gender: Some("M") }`, `UuidV4`, and the error-variant fallback to `FakerValue::Fixed(empty)`.
- `ValueSource::Fixed` serde JSON round-trip.

### `faker.rs`
- `name(Some("M"))`, `name(Some("F"))`, `name(None)`, `name(Some("X"))` all produce non-empty `LAST^FIRST` pairs.
- `mrn()` returns a 6..=10-digit string.
- `ssn()` returns hyphenated 3-2-4 digit groups.
- `phone()` returns a parenthesized formatted string.
- `address()` returns six caret-separated segments ending in `USA`.
- `icd10()` returns a 3-char category with dotted subcode.
- `loinc()`, `medication()`, `allergen()`, `blood_type()`, `ethnicity()`, `race()` return non-empty values.
- `numeric(0)` returns empty; `numeric(8)` returns 8 ASCII digits.
- Same seed reproduces identical `name`, `mrn`, and `address`.
- `uuid_v4()` returns 36-char hyphenated string; `dtm_now_utc()` returns 14 digits.
- `date()` degenerate range returns start; invalid format and inverted range return matching errors.
- `gaussian()` with `sd = 0.0` returns mean at precision; with `sd = NaN` returns `InvalidParameters`.
- `select_from(&[])` and `select_from_map(&empty)` return `None`.
- `FakerValue::Fixed` generates literal; empty `From`/`Map` return `EmptyOptions`/`EmptyMap`.
- `Display` for `DateError`, `GaussianError`, and `GenerateError` variants.

## Test plan

- [x] `cargo build -p hl7v2 --features synthetic`
- [x] `cargo test -p hl7v2 --features synthetic --lib synthetic::values::tests` (23 passed)
- [x] `cargo test -p hl7v2 --features synthetic --lib synthetic::faker::tests` (34 passed)
- [x] `cargo test -p hl7v2 --features synthetic` (545 unit / 4+7+2+2+2 integration / 35 doc passed, 3 pre-existing ignored)
- [x] `cargo clippy -p hl7v2 --features synthetic --all-targets -- -D warnings`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo run -p xtask -- gate --check`
- [x] `cargo fmt --all`

https://claude.ai/code/session_013ACy85E2bcBqiHMjUND1cr

---
_Generated by [Claude Code](https://claude.ai/code/session_013ACy85E2bcBqiHMjUND1cr)_