### PR TITLE
chore: ignore npm and yarn debug logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,12 @@ target
 *.key
 *.p12
 
-# Node.js dependencies
+# Node.js dependencies and logs
 node_modules/
 package-lock.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
 # Agent workspace files
 .swarm/


### PR DESCRIPTION
## Summary

- adds npm/yarn transient debug log patterns under the existing Node.js `.gitignore` section
- keeps the existing `node_modules/` and `package-lock.json` ignore behavior intact

Closes #318.

## Validation

- `git check-ignore -v node_modules/example package-lock.json npm-debug.log.123 yarn-debug.log.123 yarn-error.log.123`
- `git diff --check`
- `cargo +1.95.0 run -p xtask -- check-file-policy`

## Release / publish boundary

- No runtime behavior changes.
- No crates.io, TestPyPI, PyPI, npm, tag, or GitHub release action.