### PR TITLE
test: prove normalization parity across surfaces

### DIFF
--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -695,7 +695,7 @@ mod norm_command {
             &dir,
             "custom-delimiters.hl7",
             fixture_content
-                .trim_end_matches(|ch| ch == '\r' || ch == '\n')
+                .trim_end_matches(['\r', '\n'])
                 .as_bytes(),
         );
 

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -684,6 +684,48 @@ mod norm_command {
 
         assert_eq!(original_msg.segments.len(), normalized_msg.segments.len());
     }
+
+    #[test]
+    fn test_norm_canonical_delimiters_matches_shared_fixture() {
+        let dir = create_temp_dir();
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test_data/custom_delimiters.hl7");
+        let fixture_content = std::fs::read_to_string(fixture).unwrap();
+        let custom_file = create_temp_file(
+            &dir,
+            "custom-delimiters.hl7",
+            fixture_content
+                .trim_end_matches(|ch| ch == '\r' || ch == '\n')
+                .as_bytes(),
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args(["norm", custom_file.to_str().unwrap(), "--canonical-delims"])
+            .output()
+            .expect("Failed to execute norm");
+
+        assert!(output.status.success());
+        let canonical = String::from_utf8(output.stdout).unwrap();
+        assert!(canonical.starts_with("MSH|^~\\&|"));
+        assert!(canonical.contains("ADT^A01"));
+        assert!(!canonical.contains("MSH*%$!?*"));
+        assert!(!canonical.contains("ADT%A01"));
+
+        let canonical_file = create_temp_file(&dir, "canonical.hl7", canonical.as_bytes());
+        let mut second_cmd = cli_command();
+        let second_output = second_cmd
+            .args([
+                "norm",
+                canonical_file.to_str().unwrap(),
+                "--canonical-delims",
+            ])
+            .output()
+            .expect("Failed to execute second norm");
+
+        assert!(second_output.status.success());
+        assert_eq!(canonical, String::from_utf8(second_output.stdout).unwrap());
+    }
 }
 
 // =========================================================================

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -694,9 +694,7 @@ mod norm_command {
         let custom_file = create_temp_file(
             &dir,
             "custom-delimiters.hl7",
-            fixture_content
-                .trim_end_matches(['\r', '\n'])
-                .as_bytes(),
+            fixture_content.trim_end_matches(['\r', '\n']).as_bytes(),
         );
 
         let mut cmd = cli_command();

--- a/test_data/custom_delimiters.hl7
+++ b/test_data/custom_delimiters.hl7
@@ -1,0 +1,1 @@
+MSH*%$!?*SendingApp*SendingFac*ReceivingApp*ReceivingFac*20250128152312**ADT%A01*ABC123*P*2.5.1

--- a/tests/python_smoke/smoke.py
+++ b/tests/python_smoke/smoke.py
@@ -138,6 +138,8 @@ def has_count(entries: list[dict[str, object]], value: str, count: int) -> bool:
 
 
 def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+
     raw = (
         "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605080101||ADT^A01|CTRL123|P|2.5\r"
         "PID|1||123456^^^HOSP^MR||Doe^John||19700101|M"
@@ -172,6 +174,32 @@ def main() -> int:
     normalized = hl7v2.normalize(raw)
     if "MSH|^~\\&" not in normalized or "PID|" not in normalized:
         print("normalize did not return expected HL7 content", file=sys.stderr)
+        return 1
+
+    custom_delimiter_raw = (repo_root / "test_data" / "custom_delimiters.hl7").read_text(
+        encoding="utf-8"
+    ).rstrip("\r\n")
+    canonical_custom = hl7v2.normalize(custom_delimiter_raw, canonical_delims=True)
+    if not canonical_custom.startswith("MSH|^~\\&|"):
+        print(
+            f"canonical normalization did not use standard delimiters: {canonical_custom}",
+            file=sys.stderr,
+        )
+        return 1
+    if "ADT^A01" not in canonical_custom or "ADT%A01" in canonical_custom:
+        print(
+            f"canonical normalization did not rewrite component delimiters: {canonical_custom}",
+            file=sys.stderr,
+        )
+        return 1
+    if "MSH*%$!?*" in canonical_custom:
+        print(
+            f"canonical normalization retained custom field delimiters: {canonical_custom}",
+            file=sys.stderr,
+        )
+        return 1
+    if hl7v2.normalize(canonical_custom, canonical_delims=True) != canonical_custom:
+        print("canonical normalization was not idempotent", file=sys.stderr)
         return 1
 
     ack_message = hl7v2.ack(raw)
@@ -580,7 +608,6 @@ constraints:
             print("expected unsupported diff schema version to fail", file=sys.stderr)
             return 1
 
-    repo_root = Path(__file__).resolve().parents[2]
     dirty_fixture_root = repo_root / "test_data" / "dirty-real-world"
     with tempfile.TemporaryDirectory() as tmp:
         dirty_root = Path(tmp)


### PR DESCRIPTION
## Summary

- add a shared custom-delimiter HL7 fixture for cross-surface normalization proof
- prove hl7v2-cli norm --canonical-delims rewrites field/component delimiters and is idempotent
- extend the local Python wheel smoke to prove the same canonical delimiter behavior

## Validation

- cargo +1.95.0 test -p hl7v2-cli --test integration_tests test_norm_canonical_delimiters_matches_shared_fixture --locked
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests norm_command --locked
- RUSTUP_TOOLCHAIN=1.95.0 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 python -m maturin build --release --out F:\cargo-target\hl7v2-rs-normalization-parity-python\dist --target-dir F:\cargo-target\hl7v2-rs-normalization-parity-python\target
- F:\cargo-target\hl7v2-rs-normalization-parity-python\venv\Scripts\python.exe tests\python_smoke\smoke.py
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- git diff --check

## Notes

No registry, release, TestPyPI, PyPI, or npm claim is made here.