### PR TITLE
test: prove gRPC ACK parity

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12620",
+  "message": "12614",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -16,12 +16,12 @@ mod tests {
     use hl7v2_server::grpc::proto::hl7_service_server::Hl7Service;
     use hl7v2_server::grpc::proto::{
         CorpusDiffRequest, CorpusFingerprintRequest, CorpusMessageInput, CorpusSummarizeRequest,
-        CreateEvidenceBundleRequest, GenerateAckRequest, HealthCheckRequest, NormalizeOptions,
-        NormalizeRequest, ParseRequest, ParseStreamRequest, ParseStreamResponse,
-        ProfileExplainRequest, ProfileLintRequest, ProfileTestFixture, ProfileTestRequest,
-        ReplayEvidenceBundleRequest, ValidateRedactedRequest, ValidateRequest,
-        evidence_replay_check, generate_ack_request, health_check_response, profile_test_fixture,
-        validation_issue,
+        CreateEvidenceBundleRequest, GenerateAckRequest, HealthCheckRequest,
+        Message as ProtoMessage, NormalizeOptions, NormalizeRequest, ParseRequest,
+        ParseStreamRequest, ParseStreamResponse, ProfileExplainRequest, ProfileLintRequest,
+        ProfileTestFixture, ProfileTestRequest, ReplayEvidenceBundleRequest,
+        ValidateRedactedRequest, ValidateRequest, evidence_replay_check, generate_ack_request,
+        health_check_response, profile_test_fixture, validation_issue,
     };
     use hl7v2_server::server::{AppState, ServerConfig};
     use hl7v2_test_utils::{
@@ -225,6 +225,22 @@ constraints:
             .normalized
     }
 
+    fn assert_ack_message_type(ack: &str) {
+        let message_type = ack
+            .split('\r')
+            .next()
+            .expect("ACK should include an MSH segment")
+            .split('|')
+            .nth(8)
+            .expect("ACK MSH should include MSH-9");
+        assert_eq!(message_type, "ACK^ADT");
+    }
+
+    fn assert_parsed_ack_segments(parsed_ack: &ProtoMessage) {
+        assert_eq!(parsed_ack.segments[0].id, "MSH");
+        assert_eq!(parsed_ack.segments[1].id, "MSA");
+    }
+
     #[tokio::test]
     async fn test_grpc_parse_raw_hl7_success() {
         let service = service();
@@ -315,7 +331,10 @@ constraints:
                 ack_str.contains(&format!("MSA|{}|CTRL123", expected)),
                 "ACK did not preserve code/control id: {ack_str}"
             );
-            assert!(inner.parsed_ack.is_some());
+            assert_ack_message_type(&ack_str);
+
+            let parsed_ack = inner.parsed_ack.expect("parsed ACK should exist");
+            assert_parsed_ack_segments(&parsed_ack);
         }
     }
 


### PR DESCRIPTION
## Summary
- Strengthen gRPC GenerateAck contract tests to assert ACK^ADT in the generated MSH-9 field.
- Assert the parsed ACK returned by gRPC contains the expected MSH and MSA segments.
- Refresh the generated RIPR badge count for the changed test surface.

## Validation
- cargo +1.95.0 test -p hl7v2-server --test grpc_contract_tests test_grpc_generate_ack_maps_codes_and_preserves_control_id --locked
- cargo +1.95.0 test -p hl7v2-server --test grpc_contract_tests --locked
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 run -p xtask -- badges --check
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- git diff --check

## Notes
- Test-only parity hardening. No proto/API expansion, runtime behavior, release, registry, Python, npm, workflow, or package-boundary changes.
- gRPC GenerateAck currently exposes AA/AE/AR in the proto; enhanced ACK code parity is a separate API-contract decision.