### PR TITLE
test: prove Python enhanced ACK parity

### DIFF
--- a/tests/python_smoke/smoke.py
+++ b/tests/python_smoke/smoke.py
@@ -209,10 +209,20 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    error_ack = hl7v2.ack(raw, code="ae")
-    if "MSA|AE|CTRL123" not in error_ack:
-        print(f"explicit ACK code did not round-trip: {error_ack}", file=sys.stderr)
-        return 1
+    for requested_code, expected_code in [
+        ("ae", "AE"),
+        ("AR", "AR"),
+        ("CA", "CA"),
+        ("CE", "CE"),
+        ("CR", "CR"),
+    ]:
+        explicit_ack = hl7v2.ack(raw, code=requested_code)
+        if f"MSA|{expected_code}|CTRL123" not in explicit_ack:
+            print(
+                f"explicit ACK code {requested_code} did not round-trip: {explicit_ack}",
+                file=sys.stderr,
+            )
+            return 1
     try:
         hl7v2.ack(raw, code="ZZ")
     except ValueError as exc:


### PR DESCRIPTION
## Summary

- expands the Python smoke ACK receipt from default AA and explicit AE to all enhanced ACK codes exposed by the binding: AE, AR, CA, CE, and CR
- keeps this test-only and preserves the existing invalid ZZ failure proof

## Validation

- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 RUSTUP_TOOLCHAIN=1.95.0 CARGO_TARGET_DIR=F:\cargo-target\hl7v2-rs-python-ack-parity python -m maturin build --manifest-path crates/hl7v2-python/Cargo.toml --out F:\cargo-target\hl7v2-rs-python-ack-parity\wheels
- python -m pip install --force-reinstall F:\cargo-target\hl7v2-rs-python-ack-parity\wheels\hl7v2-1.5.0-cp314-cp314-win_amd64.whl
- python tests\python_smoke\smoke.py
- cargo +1.95.0 test -p hl7v2 --features ack --test ack_facade ack_facade_supports_application_and_commit_codes -- --exact
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 run -p xtask -- badges --check
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- git diff --check

## Self-review

- Scope matches PR title: yes, Python smoke ACK parity only.
- Files touched are expected: yes, 	ests/python_smoke/smoke.py only.
- No unrelated cleanup: yes.
- Policy changes are intentional: no policy changes.
- No Clippy test carveouts added: yes.
- No bare #[allow(clippy::...)] added: yes.
- No-panic baseline handling is scoped: no no-panic changes.
- Non-Rust allowlist changes are narrow: no allowlist changes.
- CI economics: no lane changes.
- ripr mutation-exposure framing preserved: no RIPR behavior changes.
- Release evidence preserved: no publish or release claim.
- Local validation: listed above.
- CI status: pending.
- Bot comments addressed: pending.
- Follow-ups: gRPC enhanced ACK code parity still requires proto/API/runtime work, not a test-only PR.