### PR TITLE
docs: record TestPyPI publisher blocker refresh

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -79,6 +79,7 @@ canonical_sources = [
   "docs/audits/python-local-wheel-proof-2026-05-15.md",
   "docs/audits/python-testpypi-nonpublish-proof-2026-05-15.md",
   "docs/audits/python-testpypi-nonpublish-proof-2026-05-16.md",
+  "docs/audits/python-testpypi-publish-attempt-2026-05-16.md",
   "docs/audits/publish-dry-run-v1.5.0-2026-05-16-post-srp-refresh.md",
   "docs/guides/first-use-by-surface.md",
   "docs/specs/HL7V2-SPEC-0004-binding-backend-release-proof.md",
@@ -105,6 +106,37 @@ proof_commands = [
   "cargo +1.95.0 run -p xtask -- impacted-evidence --check",
   "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- gate --check",
   "cargo +1.95.0 run -p xtask -- policy-report",
+]
+
+[[work_item]]
+id = "python-testpypi-publish-attempt-refresh"
+status = "blocked"
+goal = "Rerun the guarded Python TestPyPI proof in publishing mode from current main and record the external Trusted Publisher boundary."
+blocked_by = "https://github.com/EffortlessMetrics/hl7v2-rs/issues/563"
+commit = "bbb10eae8b351753f8741905fa28d64e521fed03"
+receipt = "docs/audits/python-testpypi-publish-attempt-2026-05-16.md"
+workflow_run = "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25972812666"
+commands = [
+  "gh workflow run python-testpypi.yml --ref main -f publish_to_testpypi=true",
+  "gh run view 25972812666 --json headSha,event,status,conclusion,url,jobs",
+  "gh run view 25972812666 --log-failed",
+  "gh api repos/EffortlessMetrics/hl7v2-rs/actions/runs/25972812666/artifacts",
+  "curl -I https://test.pypi.org/pypi/hl7v2/json",
+  "curl -I https://pypi.org/pypi/hl7v2/json",
+]
+result = [
+  "Build and smoke wheel succeeded.",
+  "Publish to TestPyPI failed with invalid-publisher.",
+  "Install from TestPyPI and smoke was skipped.",
+  "TestPyPI and PyPI hl7v2 JSON endpoints still returned 404.",
+]
+non_claims = [
+  "No TestPyPI upload.",
+  "No TestPyPI install-back.",
+  "No PyPI upload.",
+  "No PyPI install-back.",
+  "No token fallback.",
+  "No skip-existing.",
 ]
 
 [[work_item]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Recorded a post-release current-main readiness refresh after gRPC enhanced ACK
   parity landed through #705.
+- Recorded a current-main TestPyPI publishing-mode proof attempt for public
+  Python package `hl7v2`; wheel smoke passed, while upload remains blocked by
+  TestPyPI Trusted Publisher setup.
 - Added a repeatable public crates.io install-back smoke script and receipt for
   the v1.5.0 Rust library, CLI, and server first-use paths.
 - Recorded a post-release current-main readiness refresh after normalization

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@ proposal, spec, plan, or receipt documents.
 | [Cross-surface evidence parity spec](specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Contract map for Rust, CLI, REST/gRPC, Python, and future TypeScript evidence semantics. |
 | [Python local wheel proof](audits/python-local-wheel-proof-2026-05-15.md) | Current-main non-publishing wheel build, fresh-venv install, import smoke, and Python evidence workflow proof for `hl7v2`. |
 | [Python TestPyPI non-publish proof](audits/python-testpypi-nonpublish-proof-2026-05-16.md) | Current hosted non-publishing Python wheel, import, smoke, and evidence workflow proof for public package `hl7v2`. |
+| [Python TestPyPI publish attempt refresh](audits/python-testpypi-publish-attempt-2026-05-16.md) | Publishing-mode proof attempt on current `main`; wheel smoke passed, upload is still blocked by TestPyPI Trusted Publishing setup. |
 | [Python TestPyPI publish attempt](audits/python-testpypi-publish-attempt-2026-05-10.md) | Publishing-mode proof attempt; wheel smoke passed, upload is blocked by TestPyPI Trusted Publishing setup. |
 
 ## Current Boundaries

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -188,7 +188,7 @@ RIPR calibration: [`docs/audits/ripr-calibration-2026-05-15.md`](audits/ripr-cal
 - ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `b0bb5b5392354273946f36f797f39d741d318fc1`; current-main primary and binding surface dry-runs passed locally at `b4b7962e6f3f9d7ae5d91adf603e6328e3d13297` after #616-#618, at `cc1e3046e2496ea0c10a25239b9d077641d01c36` after #621-#622, at `425ff79b959ef5ceff1bdd072cbe074ff2a7ab04` after #624-#625, at `eb518e948d57bc07e96512ced306fe0db2dc2990` after #627, at `acfeacec0eda6d632d52e61440f2c85fda93d95f` after #629-#630, at `b0018c8760f07d738b3a6b7a11eeeda300786ef2` after #632-#633, at `fe8680c551bc3ce9248063906cbbe90ffe732a70` after #635-#636, at `483fb572a42006c07bd2e857fb7638ec91615b7d` after #638, at `915578b5cab5ab3abde7f806e5ad39c063d9cc82` after #640, at `47ba93201aaa15c95157d341bb5ec4f5f3871741` after #642, at `addbbe3e6962dc7f1629053c8a9c6810c7e37cc1` after #645, at `a12c6fdf61396de74f971c27f4887dd7c451543b` after #647, at `686dbff26afbbdcb97e4cc1915d1e33bd1404d14` after #649-#650, at `9fc95604d8950b565b6b6b7941ad275fd5624178` after #653, at `4cf501ddc0f7fc3d027b3ce2459e899fe4aa7092` after #684-#691, at `1564a1ac6a028146471e53c80fe3dbca22a32497` after #693-#695, at `c888405000384f391b24864e3e572dd0e9b6ba6a` after #696-#698, at `65c3c30ec52c9c5d65b58dae245b62f0bee9d198` after #699-#702, and at `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04` after #705.
 - ✅ **Release graph decision**: v1.5.0 selects `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`, with `hl7v2-python` included only as binding backend infrastructure.
 - ✅ **Publish receipt**: crates.io upload, registry resolution, `v1.5.0` tag, GitHub release, and public Rust/CLI/server install-back smoke are recorded in [`docs/audits/publish-v1.5.0-2026-05-15.md`](audits/publish-v1.5.0-2026-05-15.md). The repeatable install-back harness is recorded in [`docs/audits/public-crates-install-first-use-2026-05-16.md`](audits/public-crates-install-first-use-2026-05-16.md).
-- 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains separate from the primary Rust product graph, has current-main local wheel/import/evidence smoke proof, and still requires Trusted Publisher upload/install-back proof before any TestPyPI or PyPI success claim.
+- 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains separate from the primary Rust product graph, has current-main local wheel/import/evidence smoke proof, and the 2026-05-16 publishing-mode TestPyPI run again passed wheel smoke before failing at `invalid-publisher`; Trusted Publisher upload/install-back proof is still required before any TestPyPI or PyPI success claim.
 
 ## Historical Plans
 Old planning documents have been moved to `docs/plans/` for archival reference.
@@ -201,4 +201,6 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 and the post-release gRPC enhanced ACK refresh at
 `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04`.
 The public Python `hl7v2` TestPyPI/PyPI lane remains separate and still needs
-upload and install-back proof before any Python release claim.
+upload and install-back proof before any Python release claim. The latest
+publishing-mode TestPyPI attempt is
+[`docs/audits/python-testpypi-publish-attempt-2026-05-16.md`](audits/python-testpypi-publish-attempt-2026-05-16.md).

--- a/docs/audits/python-testpypi-publish-attempt-2026-05-16.md
+++ b/docs/audits/python-testpypi-publish-attempt-2026-05-16.md
@@ -1,0 +1,110 @@
+# Python TestPyPI Publishing Attempt Refresh
+
+Date: 2026-05-16
+
+This receipt records a guarded `Python TestPyPI Proof` workflow run with
+`publish_to_testpypi=true` after the public Python distribution was retargeted
+to `hl7v2`, the Rust v1.5.0 release was published, and the post-#705 readiness
+receipt landed.
+
+It proves the hosted wheel build and local wheel smoke still pass on current
+`main`. The TestPyPI upload/install-back proof remains blocked by missing
+Trusted Publishing configuration on TestPyPI.
+
+## Run
+
+| Field | Value |
+| --- | --- |
+| Workflow | `Python TestPyPI Proof` |
+| Workflow file | `.github/workflows/python-testpypi.yml` |
+| Trigger | `workflow_dispatch` |
+| Input | `publish_to_testpypi=true` |
+| Branch | `main` |
+| Commit | `bbb10eae8b351753f8741905fa28d64e521fed03` |
+| Run ID | `25972812666` |
+| Run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25972812666> |
+| Result | `failure` |
+
+## Verified Jobs
+
+| Job | Result | Evidence |
+| --- | --- | --- |
+| `Build and smoke wheel` | `success` | Built the wheel, installed it into a fresh virtual environment, ran `tests/python_smoke/smoke.py`, ran `tests/python_smoke/evidence_workflow_guide.py`, and uploaded the wheel artifact. |
+| `Publish to TestPyPI` | `failure` | `pypa/gh-action-pypi-publish@v1.14.0` failed during Trusted Publishing token exchange with `invalid-publisher`. |
+| `Install from TestPyPI and smoke` | `skipped` | Expected after the publish job failed; no install-back proof was completed. |
+
+Observed job IDs:
+
+```text
+Build and smoke wheel: 76347700976
+Publish to TestPyPI: 76347757507
+Install from TestPyPI and smoke: 76347774391
+```
+
+The run uploaded a short-retention wheel artifact:
+
+| Field | Value |
+| --- | --- |
+| Artifact name | `python-testpypi-wheel` |
+| Artifact ID | `7036674892` |
+| Artifact digest | `sha256:b6a5aa74d50e79e84f8560ca63d9210f09841aedf5280e5b9133c93ff6570089` |
+| Artifact URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25972812666/artifacts/7036674892> |
+| Expiration | `2026-05-23T21:00:57Z` |
+
+## Trusted Publisher Claims
+
+The publish action reported these claims for the failed exchange:
+
+| Claim | Value |
+| --- | --- |
+| `sub` | `repo:EffortlessMetrics/hl7v2-rs:environment:testpypi` |
+| `repository` | `EffortlessMetrics/hl7v2-rs` |
+| `repository_owner` | `EffortlessMetrics` |
+| `repository_owner_id` | `164865351` |
+| `workflow_ref` | `EffortlessMetrics/hl7v2-rs/.github/workflows/python-testpypi.yml@refs/heads/main` |
+| `job_workflow_ref` | `EffortlessMetrics/hl7v2-rs/.github/workflows/python-testpypi.yml@refs/heads/main` |
+| `ref` | `refs/heads/main` |
+| `environment` | `testpypi` |
+
+The workflow and repository claims match the intended setup documented in
+[`docs/guides/python-testpypi-release-proof.md`](../guides/python-testpypi-release-proof.md).
+The remaining action is to configure the corresponding TestPyPI pending
+publisher for project `hl7v2`.
+
+## Registry State
+
+Live registry checks during this receipt still found no public Python package:
+
+| Registry | URL | Result |
+| --- | --- | --- |
+| TestPyPI | <https://test.pypi.org/pypi/hl7v2/json> | `404 Not Found` at 2026-05-16T21:04:15Z |
+| PyPI | <https://pypi.org/pypi/hl7v2/json> | `404 Not Found` at 2026-05-16T20:55:16Z |
+
+## Boundaries
+
+- No TestPyPI package was published by this run.
+- No install-back from TestPyPI was completed by this run.
+- No production PyPI publishing was attempted.
+- No install-back from production PyPI was completed.
+- No token fallback was used.
+- `skip-existing` remained `false`.
+- The crates.io `hl7v2-python` v1.5.0 upload remains only a binding-backend
+  crates.io receipt; it is not a public Python package receipt.
+
+## Next Step
+
+Configure the TestPyPI Trusted Publisher for project `hl7v2` with the fields
+below. The external setup work is tracked in
+[#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563).
+
+| TestPyPI field | Value |
+| --- | --- |
+| Project name | `hl7v2` |
+| Owner | `EffortlessMetrics` |
+| Repository name | `hl7v2-rs` |
+| Workflow filename | `python-testpypi.yml` |
+| Environment name | `testpypi` |
+
+After that setup is in place, rerun the `Python TestPyPI Proof` workflow from
+`main` with `publish_to_testpypi=true` and require both publish and install-back
+jobs to pass before claiming TestPyPI proof complete.

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -133,6 +133,11 @@ public package `hl7v2`. A 2026-05-10 publishing-mode run from `main` built and
 smoke-tested the wheel, then failed during Trusted Publishing token exchange
 with `invalid-publisher`; see
 [docs/audits/python-testpypi-publish-attempt-2026-05-10.md](../audits/python-testpypi-publish-attempt-2026-05-10.md).
+A 2026-05-16 publishing-mode run from current `main` after the v1.5.0 release
+again built and smoke-tested the wheel successfully, then failed at the same
+Trusted Publishing exchange boundary with
+`repo:EffortlessMetrics/hl7v2-rs:environment:testpypi`; see
+[docs/audits/python-testpypi-publish-attempt-2026-05-16.md](../audits/python-testpypi-publish-attempt-2026-05-16.md).
 The TestPyPI upload/install-back proof remains incomplete until the TestPyPI
 Trusted Publisher is configured for project `hl7v2` and a rerun passes. Track
 the external setup blocker in


### PR DESCRIPTION
## Summary

- record the 2026-05-16 publishing-mode Python TestPyPI proof attempt
- document that the wheel build and local smoke passed, while TestPyPI upload still failed at invalid-publisher
- update status, guide, docs index, changelog, and active goal state without claiming TestPyPI/PyPI success

## Validation

- gh workflow run python-testpypi.yml --ref main -f publish_to_testpypi=true
- gh run view 25972812666 --json headSha,event,status,conclusion,url,jobs
- gh run view 25972812666 --log-failed
- gh api repos/EffortlessMetrics/hl7v2-rs/actions/runs/25972812666/artifacts
- curl -I https://test.pypi.org/pypi/hl7v2/json
- curl -I https://pypi.org/pypi/hl7v2/json
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- active.toml parse check
- git diff --check

## Boundary

No TestPyPI upload, PyPI upload, install-back, token fallback, skip-existing, npm action, or crates.io action occurred in this PR.