### PR TITLE
test(server): add unit tests for handler helpers (schema_versions, ack_policy, corpus, error)

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12614",
+  "message": "12452",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/src/handlers/ack_policy.rs
+++ b/crates/hl7v2-server/src/handlers/ack_policy.rs
@@ -121,3 +121,220 @@ pub(super) fn ack_code_from_policy_decision(
         ))),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_MESSAGE: &str = "MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John\r";
+
+    fn empty_report(valid: bool, issue_count: usize) -> hl7v2::ValidationReport {
+        hl7v2::ValidationReport {
+            valid,
+            message_type: "ADT^A01".to_string(),
+            profile: None,
+            segment_count: 0,
+            issue_count,
+            issues: Vec::new(),
+        }
+    }
+
+    fn decision_with_code(code: &str) -> AckPolicyDecision {
+        AckPolicyDecision {
+            mode: AckPolicyMode::Original,
+            outcome: AckPolicyOutcome::Accepted,
+            reason: AckPolicyReason::Valid,
+            ack_code: code.to_string(),
+            include_error_text: false,
+            error_text: None,
+        }
+    }
+
+    #[test]
+    fn map_ack_code_covers_all_request_codes() {
+        assert_eq!(map_ack_code(AckRequestCode::Aa), hl7v2::AckCode::AA);
+        assert_eq!(map_ack_code(AckRequestCode::Ae), hl7v2::AckCode::AE);
+        assert_eq!(map_ack_code(AckRequestCode::Ar), hl7v2::AckCode::AR);
+        assert_eq!(map_ack_code(AckRequestCode::Ca), hl7v2::AckCode::CA);
+        assert_eq!(map_ack_code(AckRequestCode::Ce), hl7v2::AckCode::CE);
+        assert_eq!(map_ack_code(AckRequestCode::Cr), hl7v2::AckCode::CR);
+    }
+
+    #[test]
+    fn parse_msh_for_ack_policy_accepts_plain_message() {
+        let parsed = parse_msh_for_ack_policy(SAMPLE_MESSAGE.as_bytes(), false)
+            .expect("plain message should parse");
+        assert_eq!(parsed.segments[0].id_str(), "MSH");
+    }
+
+    #[test]
+    fn parse_msh_for_ack_policy_accepts_mllp_framed_message() {
+        let framed = hl7v2::wrap_mllp(SAMPLE_MESSAGE.as_bytes());
+        let parsed =
+            parse_msh_for_ack_policy(&framed, true).expect("MLLP framed message should parse");
+        assert_eq!(parsed.segments[0].id_str(), "MSH");
+    }
+
+    #[test]
+    fn parse_msh_for_ack_policy_rejects_message_without_msh() {
+        let err = parse_msh_for_ack_policy(b"PID|1||123^^^HOSP^MR\r", false)
+            .expect_err("message without MSH must fail");
+        assert!(
+            matches!(&err, AppError::Parse(m) if m.contains("MSH")),
+            "expected AppError::Parse mentioning MSH, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_msh_for_ack_policy_uses_only_first_segment_when_terminator_is_lf() {
+        // The helper splits on \r or \n. Confirm \n terminated input is accepted.
+        let input = "MSH|^~\\&|S|F|R|R|202605030101||ADT^A01|C1|P|2.5\nPID|1\n";
+        let parsed = parse_msh_for_ack_policy(input.as_bytes(), false)
+            .expect("LF-terminated MSH should parse");
+        assert_eq!(parsed.segments[0].id_str(), "MSH");
+    }
+
+    #[test]
+    fn ack_policy_decision_for_validation_accepts_valid_report_in_original_mode() {
+        let policy = AckPolicyConfig::default();
+        let report = empty_report(true, 0);
+
+        let decision =
+            ack_policy_decision_for_validation(&policy, &report).expect("valid report accepts");
+        assert_eq!(decision.outcome, AckPolicyOutcome::Accepted);
+        assert_eq!(decision.reason, AckPolicyReason::Valid);
+        assert_eq!(decision.ack_code, "AA");
+        assert!(!decision.include_error_text);
+        assert!(decision.error_text.is_none());
+    }
+
+    #[test]
+    fn ack_policy_decision_for_validation_accepts_valid_report_in_enhanced_mode() {
+        let policy = AckPolicyConfig {
+            mode: AckPolicyMode::Enhanced,
+            ..AckPolicyConfig::default()
+        };
+        let report = empty_report(true, 0);
+
+        let decision =
+            ack_policy_decision_for_validation(&policy, &report).expect("valid accepts enhanced");
+        assert_eq!(decision.ack_code, "CA");
+        assert_eq!(decision.outcome, AckPolicyOutcome::Accepted);
+    }
+
+    #[test]
+    fn ack_policy_decision_for_validation_rejects_invalid_report() {
+        let policy = AckPolicyConfig::default();
+        let report = empty_report(false, 3);
+
+        let decision =
+            ack_policy_decision_for_validation(&policy, &report).expect("invalid report rejects");
+        assert_eq!(decision.outcome, AckPolicyOutcome::Rejected);
+        assert_eq!(decision.reason, AckPolicyReason::ValidationError);
+        assert_eq!(decision.ack_code, "AR");
+        assert!(decision.include_error_text);
+        let text = decision
+            .error_text
+            .as_deref()
+            .expect("error text should be populated");
+        assert!(
+            text.contains("3"),
+            "error text should mention issue count: {text}"
+        );
+    }
+
+    #[test]
+    fn ack_policy_decision_for_validation_returns_error_when_policy_has_no_path() {
+        // Build a policy whose accept_on does not match a valid report and whose
+        // reject_on does not include ValidationError, leaving the helper with no
+        // decision for an invalid-report case.
+        let policy = AckPolicyConfig {
+            mode: AckPolicyMode::Original,
+            accept_on: AckPolicyAcceptOn::Valid,
+            reject_on: vec![AckPolicyRejectCondition::ParseError],
+            include_error_text: false,
+        };
+        let report = empty_report(false, 1);
+
+        let err = ack_policy_decision_for_validation(&policy, &report)
+            .expect_err("no rejection path should error");
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("ACK policy")),
+            "expected AppError::Validation mentioning ACK policy, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ack_policy_reject_decision_original_mode_uses_ar_and_includes_error_text() {
+        let policy = AckPolicyConfig::default();
+        let decision = ack_policy_reject_decision(&policy, AckPolicyReason::ParseError, 0);
+        assert_eq!(decision.ack_code, "AR");
+        assert_eq!(decision.outcome, AckPolicyOutcome::Rejected);
+        assert_eq!(decision.reason, AckPolicyReason::ParseError);
+        assert!(decision.include_error_text);
+        assert_eq!(
+            decision.error_text.as_deref(),
+            Some("message parsing failed")
+        );
+    }
+
+    #[test]
+    fn ack_policy_reject_decision_enhanced_mode_uses_cr() {
+        let policy = AckPolicyConfig {
+            mode: AckPolicyMode::Enhanced,
+            include_error_text: false,
+            ..AckPolicyConfig::default()
+        };
+        let decision = ack_policy_reject_decision(&policy, AckPolicyReason::ValidationError, 2);
+        assert_eq!(decision.ack_code, "CR");
+        assert_eq!(decision.outcome, AckPolicyOutcome::Rejected);
+        assert!(!decision.include_error_text);
+        assert!(decision.error_text.is_none());
+    }
+
+    #[test]
+    fn ack_policy_error_text_covers_every_reason() {
+        assert_eq!(
+            ack_policy_error_text(AckPolicyReason::Valid, 0),
+            "message accepted"
+        );
+        assert_eq!(
+            ack_policy_error_text(AckPolicyReason::ParseError, 7),
+            "message parsing failed"
+        );
+        assert_eq!(
+            ack_policy_error_text(AckPolicyReason::ValidationError, 4),
+            "message validation failed with 4 issue(s)"
+        );
+    }
+
+    #[test]
+    fn ack_code_from_policy_decision_maps_known_codes() {
+        assert!(matches!(
+            ack_code_from_policy_decision(&decision_with_code("AA")),
+            Ok(hl7v2::AckCode::AA)
+        ));
+        assert!(matches!(
+            ack_code_from_policy_decision(&decision_with_code("AR")),
+            Ok(hl7v2::AckCode::AR)
+        ));
+        assert!(matches!(
+            ack_code_from_policy_decision(&decision_with_code("CA")),
+            Ok(hl7v2::AckCode::CA)
+        ));
+        assert!(matches!(
+            ack_code_from_policy_decision(&decision_with_code("CR")),
+            Ok(hl7v2::AckCode::CR)
+        ));
+    }
+
+    #[test]
+    fn ack_code_from_policy_decision_rejects_unknown_code() {
+        let err = ack_code_from_policy_decision(&decision_with_code("ZZ"))
+            .expect_err("unsupported ack code must error");
+        assert!(
+            matches!(&err, AppError::Internal(m) if m.contains("ZZ")),
+            "expected AppError::Internal mentioning ZZ, got {err:?}"
+        );
+    }
+}

--- a/crates/hl7v2-server/src/handlers/corpus.rs
+++ b/crates/hl7v2-server/src/handlers/corpus.rs
@@ -146,3 +146,172 @@ pub(super) fn compute_sha256(value: &str) -> String {
     hasher.update(value.as_bytes());
     format!("{:x}", hasher.finalize())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message_input(id: Option<&str>, body: &str) -> CorpusMessageInput {
+        CorpusMessageInput {
+            id: id.map(str::to_string),
+            message: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_corpus_message_id_accepts_simple_identifier() {
+        validate_corpus_message_id("alpha-001.txt").expect("alpha-001.txt is allowed");
+        validate_corpus_message_id("a").expect("single char allowed");
+        validate_corpus_message_id("UPPER_lower-1.2").expect("mixed allowed chars");
+    }
+
+    #[test]
+    fn validate_corpus_message_id_accepts_max_length_128() {
+        let label = "a".repeat(128);
+        validate_corpus_message_id(&label).expect("128 chars allowed");
+    }
+
+    #[test]
+    fn validate_corpus_message_id_rejects_129_characters() {
+        let label = "a".repeat(129);
+        let err = validate_corpus_message_id(&label).expect_err("129 chars must fail");
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("1-128")),
+            "expected Validation mentioning 1-128, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_corpus_message_id_rejects_empty() {
+        let err = validate_corpus_message_id("").expect_err("empty id must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn validate_corpus_message_id_rejects_dot_and_dot_dot() {
+        assert!(matches!(
+            validate_corpus_message_id("."),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_corpus_message_id(".."),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn validate_corpus_message_id_rejects_leading_or_trailing_whitespace() {
+        // Whitespace is outside the allowed `[A-Za-z0-9._-]` set, so the
+        // validator must reject both leading and trailing whitespace.
+        assert!(matches!(
+            validate_corpus_message_id(" leading"),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_corpus_message_id("trailing "),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_corpus_message_id("middle space"),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_corpus_message_id("tab\tchar"),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn validate_corpus_message_id_rejects_disallowed_punctuation() {
+        for bad in [
+            "msg/1", "msg\\1", "msg:1", "msg?1", "msg*1", "msg+1", "msg=1",
+        ] {
+            let err =
+                validate_corpus_message_id(bad).expect_err("disallowed punctuation must fail");
+            assert!(
+                matches!(&err, AppError::Validation(m) if m.contains("ASCII")),
+                "expected Validation mentioning ASCII for {bad}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_corpus_message_id_rejects_non_ascii_letters() {
+        let err = validate_corpus_message_id("messäge").expect_err("non-ASCII must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn validated_corpus_message_ids_rejects_empty_list() {
+        let err =
+            validated_corpus_message_ids(&[], "messages", "msg").expect_err("empty list must fail");
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("messages") && m.contains("at least one")),
+            "expected Validation mentioning field name and 'at least one', got {err:?}"
+        );
+    }
+
+    #[test]
+    fn validated_corpus_message_ids_uses_default_prefix_for_missing_ids() {
+        let inputs = vec![
+            message_input(None, "msg body 1"),
+            message_input(None, "msg body 2"),
+        ];
+        let ids = validated_corpus_message_ids(&inputs, "messages", "auto")
+            .expect("default ids must validate");
+        assert_eq!(ids, vec!["auto-1".to_string(), "auto-2".to_string()]);
+    }
+
+    #[test]
+    fn validated_corpus_message_ids_keeps_user_supplied_ids() {
+        let inputs = vec![
+            message_input(Some("first.id"), "body"),
+            message_input(None, "body"),
+            message_input(Some("third-id"), "body"),
+        ];
+        let ids =
+            validated_corpus_message_ids(&inputs, "messages", "auto").expect("ids must validate");
+        assert_eq!(
+            ids,
+            vec![
+                "first.id".to_string(),
+                "auto-2".to_string(),
+                "third-id".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn validated_corpus_message_ids_rejects_invalid_supplied_id() {
+        let inputs = vec![message_input(Some("bad/id"), "body")];
+        let err = validated_corpus_message_ids(&inputs, "messages", "auto")
+            .expect_err("invalid id must fail");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn validated_corpus_message_ids_does_not_deduplicate() {
+        // The helper validates each id individually. Duplicates are not rejected
+        // here; pin the behavior so future changes are intentional.
+        let inputs = vec![
+            message_input(Some("same"), "a"),
+            message_input(Some("same"), "b"),
+        ];
+        let ids = validated_corpus_message_ids(&inputs, "messages", "auto")
+            .expect("duplicate ids are not rejected by this helper");
+        assert_eq!(ids, vec!["same".to_string(), "same".to_string()]);
+    }
+
+    #[test]
+    fn compute_sha256_produces_stable_hex_digest() {
+        // Empty input is a well-known SHA-256 fixture.
+        assert_eq!(
+            compute_sha256(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+        // Same input must produce the same digest each call.
+        assert_eq!(compute_sha256("hello"), compute_sha256("hello"));
+        // Different inputs must differ.
+        assert_ne!(compute_sha256("a"), compute_sha256("b"));
+    }
+}

--- a/crates/hl7v2-server/src/handlers/error.rs
+++ b/crates/hl7v2-server/src/handlers/error.rs
@@ -266,3 +266,151 @@ impl From<hl7v2::conformance::profile::ProfileLoadError> for AppError {
         AppError::ProfileLoad(PROFILE_LOAD_SAFE_MESSAGE.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evidence::EvidenceBundleError;
+
+    #[test]
+    fn from_evidence_bundle_error_maps_each_variant_to_a_bundle_app_error() {
+        let invalid: AppError =
+            EvidenceBundleError::InvalidRequest("bad request".to_string()).into();
+        assert!(
+            matches!(&invalid, AppError::Bundle(m) if m == "bad request"),
+            "got {invalid:?}"
+        );
+
+        let conflict: AppError = EvidenceBundleError::Conflict("dup".to_string()).into();
+        assert!(
+            matches!(&conflict, AppError::Conflict(m) if m == "dup"),
+            "got {conflict:?}"
+        );
+
+        let io_err: AppError = EvidenceBundleError::Io("disk full".to_string()).into();
+        assert!(
+            matches!(&io_err, AppError::BundleOutputNotReady(m) if m == "disk full"),
+            "got {io_err:?}"
+        );
+    }
+
+    #[test]
+    fn quarantine_from_evidence_error_maps_each_variant_to_quarantine_app_error() {
+        let invalid = AppError::quarantine_from_evidence_error(
+            EvidenceBundleError::InvalidRequest("bad request".to_string()),
+        );
+        assert!(
+            matches!(&invalid, AppError::Quarantine(m) if m == "bad request"),
+            "got {invalid:?}"
+        );
+
+        let conflict = AppError::quarantine_from_evidence_error(EvidenceBundleError::Conflict(
+            "exists".to_string(),
+        ));
+        assert!(
+            matches!(&conflict, AppError::QuarantineConflict(m) if m == "exists"),
+            "got {conflict:?}"
+        );
+
+        let io_err = AppError::quarantine_from_evidence_error(EvidenceBundleError::Io(
+            "io fail".to_string(),
+        ));
+        assert!(
+            matches!(&io_err, AppError::QuarantineOutputNotReady(m) if m == "io fail"),
+            "got {io_err:?}"
+        );
+    }
+
+    #[test]
+    fn display_prefixes_each_variant_with_a_meaningful_label() {
+        // Variants carrying a message should embed that message verbatim.
+        assert_eq!(
+            AppError::Parse("oops".to_string()).to_string(),
+            "Parse error: oops"
+        );
+        assert_eq!(
+            AppError::Validation("bad".to_string()).to_string(),
+            "Validation error: bad"
+        );
+        assert_eq!(
+            AppError::Redaction("policy".to_string()).to_string(),
+            "Redaction error: policy"
+        );
+        assert_eq!(
+            AppError::Bundle("write".to_string()).to_string(),
+            "Bundle error: write"
+        );
+        assert_eq!(
+            AppError::Conflict("exists".to_string()).to_string(),
+            "Bundle conflict: exists"
+        );
+        assert_eq!(
+            AppError::BundleNotFound("missing".to_string()).to_string(),
+            "Bundle not found: missing"
+        );
+        assert_eq!(
+            AppError::BundleOutputNotReady("not ready".to_string()).to_string(),
+            "Bundle output root is not ready: not ready"
+        );
+        assert_eq!(
+            AppError::Quarantine("q".to_string()).to_string(),
+            "Quarantine error: q"
+        );
+        assert_eq!(
+            AppError::QuarantineConflict("qc".to_string()).to_string(),
+            "Quarantine conflict: qc"
+        );
+        assert_eq!(
+            AppError::QuarantineOutputNotReady("qr".to_string()).to_string(),
+            "Quarantine output root is not ready: qr"
+        );
+        assert_eq!(
+            AppError::Internal("boom".to_string()).to_string(),
+            "Internal error: boom"
+        );
+    }
+
+    #[test]
+    fn display_for_unit_variants_emits_a_human_readable_message() {
+        assert_eq!(
+            AppError::BundleOutputNotConfigured.to_string(),
+            "Bundle output root is not configured"
+        );
+        assert_eq!(
+            AppError::QuarantineOutputNotConfigured.to_string(),
+            "Quarantine output path is not configured"
+        );
+    }
+
+    #[test]
+    fn display_for_profile_load_uses_safe_message_rather_than_raw_detail() {
+        // The Display impl must hide the original error detail and use the
+        // shared safe message string so logs never leak profile content.
+        let raw_detail = "this should not appear";
+        let display = AppError::ProfileLoad(raw_detail.to_string()).to_string();
+        assert!(
+            display.contains(PROFILE_LOAD_SAFE_MESSAGE),
+            "display should use safe message, got {display}"
+        );
+        assert!(
+            !display.contains(raw_detail),
+            "display must not leak inner detail, got {display}"
+        );
+    }
+
+    #[test]
+    fn from_hl7v2_error_maps_to_parse_variant() {
+        let app_error: AppError = hl7v2::Error::InvalidSegmentId.into();
+        assert!(matches!(app_error, AppError::Parse(_)));
+    }
+
+    #[test]
+    fn from_profile_load_error_returns_safe_app_error_variant() {
+        let app_error: AppError =
+            hl7v2::conformance::profile::ProfileLoadError::YamlParse("bad yaml".to_string()).into();
+        assert!(
+            matches!(&app_error, AppError::ProfileLoad(m) if m == PROFILE_LOAD_SAFE_MESSAGE),
+            "got {app_error:?}"
+        );
+    }
+}

--- a/crates/hl7v2-server/src/handlers/schema_versions.rs
+++ b/crates/hl7v2-server/src/handlers/schema_versions.rs
@@ -85,3 +85,171 @@ pub(super) fn requested_corpus_diff_schema_version(version: Option<u8>) -> Resul
         ))),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each validator follows the same `None=>1, 1=>1, 2=>2, other=>Err` shape.
+    /// `Validator` lets the same matrix exercise every function.
+    type Validator = fn(Option<u8>) -> Result<u8, AppError>;
+
+    const VALIDATORS: &[(&str, Validator)] = &[
+        (
+            "validation report",
+            requested_report_schema_version as Validator,
+        ),
+        (
+            "redaction receipt",
+            requested_redaction_receipt_schema_version as Validator,
+        ),
+        (
+            "quarantine",
+            requested_quarantine_schema_version as Validator,
+        ),
+        (
+            "bundle artifact",
+            requested_bundle_artifact_schema_version as Validator,
+        ),
+        (
+            "replay report",
+            requested_replay_report_schema_version as Validator,
+        ),
+        (
+            "corpus summary",
+            requested_corpus_summary_schema_version as Validator,
+        ),
+        (
+            "corpus fingerprint",
+            requested_corpus_fingerprint_schema_version as Validator,
+        ),
+        (
+            "corpus diff",
+            requested_corpus_diff_schema_version as Validator,
+        ),
+    ];
+
+    #[test]
+    fn none_defaults_to_one_for_every_validator() {
+        for (label, validator) in VALIDATORS {
+            let actual = validator(None);
+            assert!(
+                matches!(actual, Ok(1)),
+                "{label} validator should default None to 1, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_one_returns_one_for_every_validator() {
+        for (label, validator) in VALIDATORS {
+            let actual = validator(Some(1));
+            assert!(
+                matches!(actual, Ok(1)),
+                "{label} validator should accept 1, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_two_returns_two_for_every_validator() {
+        for (label, validator) in VALIDATORS {
+            let actual = validator(Some(2));
+            assert!(
+                matches!(actual, Ok(2)),
+                "{label} validator should accept 2, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_is_rejected_for_every_validator() {
+        for (label, validator) in VALIDATORS {
+            let actual = validator(Some(0));
+            assert!(
+                matches!(actual, Err(AppError::Validation(_))),
+                "{label} validator should reject 0, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn three_is_rejected_for_every_validator() {
+        for (label, validator) in VALIDATORS {
+            let actual = validator(Some(3));
+            assert!(
+                matches!(actual, Err(AppError::Validation(_))),
+                "{label} validator should reject 3, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_u8_is_rejected_for_every_validator() {
+        for (label, validator) in VALIDATORS {
+            let actual = validator(Some(u8::MAX));
+            assert!(
+                matches!(actual, Err(AppError::Validation(_))),
+                "{label} validator should reject 255, got {actual:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn error_messages_mention_unsupported_value_and_expected_versions() {
+        // Sample one validator to verify the human-readable wording so
+        // callers get a useful diagnostic from the error path.
+        let err = requested_report_schema_version(Some(7))
+            .expect_err("unsupported version must return Err");
+        assert!(
+            matches!(&err, AppError::Validation(m) if m.contains("7") && m.contains("1 or 2")),
+            "expected Validation mentioning '7' and '1 or 2', got {err:?}"
+        );
+    }
+
+    #[test]
+    fn each_validator_emits_its_own_label_in_the_error_message() {
+        let cases = [
+            (
+                requested_report_schema_version as Validator,
+                "validation report",
+            ),
+            (
+                requested_redaction_receipt_schema_version as Validator,
+                "redaction receipt",
+            ),
+            (
+                requested_quarantine_schema_version as Validator,
+                "quarantine output",
+            ),
+            (
+                requested_bundle_artifact_schema_version as Validator,
+                "bundle artifact",
+            ),
+            (
+                requested_replay_report_schema_version as Validator,
+                "replay report",
+            ),
+            (
+                requested_corpus_summary_schema_version as Validator,
+                "corpus summary",
+            ),
+            (
+                requested_corpus_fingerprint_schema_version as Validator,
+                "corpus fingerprint",
+            ),
+            (
+                requested_corpus_diff_schema_version as Validator,
+                "corpus diff",
+            ),
+        ];
+
+        for (validator, expected_label) in cases {
+            let err = validator(Some(9)).expect_err("unsupported version must return Err");
+            assert!(
+                matches!(&err, AppError::Validation(m) if m.contains(expected_label)),
+                "expected Validation mentioning '{expected_label}', got {err:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add inline `#[cfg(test)] mod tests` blocks to four `hl7v2-server` handler helper files. All four were at **0% lib coverage**; they were previously exercised only via HTTP integration tests, leaving the pure helpers (validators, decision mappers, error converters) without unit coverage.

### `handlers/schema_versions.rs` (8 tests)
8 nearly-identical `Option<u8> -> Result<u8, AppError>` validators. Pin behavior for `None` (defaults to 1), `Some(1)`, `Some(2)` (accepted), and `Some(0)` / `Some(3)` / `Some(255)` (rejected with `AppError::Validation`). Plus error wording (`"1 or 2"`) and per-validator label sampling.

### `handlers/ack_policy.rs` (14 tests)
- `map_ack_code`: full `AckCode` enum mapping
- `parse_msh_for_ack_policy`: plain message, MLLP-wrapped, LF-terminated, missing-MSH error
- `ack_policy_decision_for_validation`: accept/reject in Original + Enhanced modes, silent-policy error path
- `ack_policy_reject_decision`: Original (AR + error text) and Enhanced (CR, no text)
- `ack_policy_error_text`: every `AckPolicyReason` variant
- `ack_code_from_policy_decision`: known codes (AA/AR/CA/CR) + unknown-code `Internal` error

### `handlers/corpus.rs` (14 tests)
- `validate_corpus_message_id`: simple identifier, 128 chars (accepted), 129 chars (rejected with "1-128"), empty, `.`, `..`, leading/trailing/middle whitespace, tab, disallowed punctuation (slash, backslash, colon, etc.), non-ASCII letters
- `validated_corpus_message_ids`: empty list rejected, default-prefix label generation, validation propagation
- Pins that duplicate IDs are NOT rejected (behavior pin, not a bug fix)
- `compute_sha256`: stability check

### `handlers/error.rs` (7 tests)
- `From<EvidenceBundleError>`: all 3 variants → `AppError::{Bundle, Conflict, BundleOutputNotReady}`
- `quarantine_from_evidence_error`: all 3 variants → quarantine equivalents
- `Display`: every variant produces a meaningful label; raw inner detail is not leaked in the `ProfileLoad` case
- `From<hl7v2::Error>` → `AppError::Parse`
- `From<ProfileLoadError>` → uses `PROFILE_LOAD_SAFE_MESSAGE` (does not echo YAML)

## Test plan
- [x] `cargo test -p hl7v2-server --lib` — 80 passed
- [x] `cargo fmt --all`
- [x] `cargo clippy -p hl7v2-server --lib --all-features --tests -- -D warnings` — clean
- [x] `cargo run -p xtask -- gate --check` — passes

https://claude.ai/code/session_01FagxMKWLQv8WQsAZ36vjSC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FagxMKWLQv8WQsAZ36vjSC)_