### PR TITLE
release: refresh v1.5.0 readiness after test coverage

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -73,6 +73,7 @@ canonical_sources = [
   "docs/audits/publish-dry-run-v1.5.0-2026-05-16-normalization-ack-refresh.md",
   "docs/audits/publish-dry-run-v1.5.0-2026-05-16-evidence-parity-refresh.md",
   "docs/audits/publish-dry-run-v1.5.0-2026-05-16-grpc-enhanced-ack-refresh.md",
+  "docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md",
   "docs/audits/public-crates-install-first-use-2026-05-16.md",
   "docs/audits/grpc-enhanced-ack-parity-2026-05-16.md",
   "docs/audits/user-journey-acceptance-2026-05-15.md",
@@ -106,6 +107,43 @@ proof_commands = [
   "cargo +1.95.0 run -p xtask -- impacted-evidence --check",
   "PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- gate --check",
   "cargo +1.95.0 run -p xtask -- policy-report",
+]
+
+[[work_item]]
+id = "v1-5-0-test-coverage-readiness-refresh"
+status = "done"
+goal = "Refresh current-main readiness after synthetic evidence tests, server handler helper tests, datatype/datetime tests, and the fractional timestamp syntax fix landed through #710 and #709."
+commit = "aa548e1579f659c089162f0dd8e445219d0a2414"
+receipt = "docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface primary",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface bindings",
+  "cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable",
+  "CARGO_TARGET_DIR=F:\\cargo-target\\hl7v2-rs-readiness-2026-05-17 CARGO_INCREMENTAL=0 cargo +1.95.0 run -p xtask -- publish-dry-run --surface primary --workspace-patches --allow-dirty",
+  "CARGO_TARGET_DIR=F:\\cargo-target\\hl7v2-rs-readiness-2026-05-17 CARGO_INCREMENTAL=0 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- publish-dry-run --surface bindings --workspace-patches --allow-dirty",
+  "cargo +1.95.0 run -p xtask -- check-python-publish-policy",
+  "cargo +1.95.0 run -p xtask -- badges --check",
+  "cargo +1.95.0 run -p xtask -- impacted-evidence",
+  "cargo +1.95.0 run -p xtask -- impacted-evidence --check",
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "cargo +1.95.0 run -p xtask -- evidence-schema-check",
+  "cargo +1.95.0 run -p xtask -- check-file-policy",
+  "cargo +1.95.0 info hl7v2@1.5.0",
+  "cargo +1.95.0 info hl7v2-python@1.5.0",
+  "cargo +1.95.0 info hl7v2-server@1.5.0",
+  "cargo +1.95.0 info hl7v2-cli@1.5.0",
+  "git tag -l v1.5.0",
+  "git rev-list -n 1 v1.5.0",
+  "gh release view v1.5.0 --json tagName,name,publishedAt,isDraft,isPrerelease,url",
+  "git diff --check",
+]
+non_claims = [
+  "No new crates.io upload.",
+  "No TestPyPI upload.",
+  "No PyPI upload.",
+  "No npm package.",
+  "No new tag or GitHub release.",
+  "No Python public-registry install-back proof.",
 ]
 
 [[work_item]]

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 This document provides a transparent view of which features are fully implemented, partially implemented, or planned.
 
-> **Last Updated**: 2026-05-16
+> **Last Updated**: 2026-05-17
 > **Project Status**: v1.5.0 is published to crates.io for the selected Rust graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`. `hl7v2-python` is published only as binding backend infrastructure for the public Python `hl7v2` package, not as the recommended Rust API.
 
 ## Core Components
@@ -102,7 +102,9 @@ normalization parity across CLI and local Python helper surfaces; CLI ACK parity
 for command success, ACK code/control ID preservation, MSH-9 ACK message type,
 and MLLP framing; REST ACK parity for all six supported ACK codes with MLLP
 framing; gRPC ACK payload and parsed segment-shape contract coverage for all
-six supported ACK codes; and Python enhanced ACK smoke parity through #702.
+six supported ACK codes; Python enhanced ACK smoke parity through #702; server
+handler helper tests through #710; and conformance datatype/datetime coverage
+with strict fractional timestamp syntax enforcement through #709.
 
 For navigation across current docs, historical receipts, and evidence workflow
 guides, start with [the documentation index](README.md). For the current
@@ -177,6 +179,8 @@ Evidence parity refresh:
 [`docs/audits/publish-dry-run-v1.5.0-2026-05-16-evidence-parity-refresh.md`](audits/publish-dry-run-v1.5.0-2026-05-16-evidence-parity-refresh.md).
 gRPC enhanced ACK refresh:
 [`docs/audits/publish-dry-run-v1.5.0-2026-05-16-grpc-enhanced-ack-refresh.md`](audits/publish-dry-run-v1.5.0-2026-05-16-grpc-enhanced-ack-refresh.md).
+Test-coverage refresh:
+[`docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md`](audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md).
 Publish receipt: [`docs/audits/publish-v1.5.0-2026-05-15.md`](audits/publish-v1.5.0-2026-05-15.md).
 Release graph decision: [`docs/audits/v1.5.0-release-graph-decision-2026-05-14.md`](audits/v1.5.0-release-graph-decision-2026-05-14.md).
 RIPR calibration: [`docs/audits/ripr-calibration-2026-05-15.md`](audits/ripr-calibration-2026-05-15.md).
@@ -185,7 +189,7 @@ RIPR calibration: [`docs/audits/ripr-calibration-2026-05-15.md`](audits/ripr-cal
 - ✅ **Rust floor**: MSRV is Rust 1.95 and `rust-toolchain.toml` pins Rust 1.95.0 with `rustfmt` and `clippy`.
 - ✅ **Verification rails**: lint policy, Clippy exceptions, no-panic exact identity and no-new-debt baseline, file-policy companion ledgers, advisory `ripr`, and targeted mutation routing are present.
 - ✅ **Release readiness workflow**: `.github/workflows/release-readiness.yml` records the non-publishing readiness proof bundle.
-- ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `b0bb5b5392354273946f36f797f39d741d318fc1`; current-main primary and binding surface dry-runs passed locally at `b4b7962e6f3f9d7ae5d91adf603e6328e3d13297` after #616-#618, at `cc1e3046e2496ea0c10a25239b9d077641d01c36` after #621-#622, at `425ff79b959ef5ceff1bdd072cbe074ff2a7ab04` after #624-#625, at `eb518e948d57bc07e96512ced306fe0db2dc2990` after #627, at `acfeacec0eda6d632d52e61440f2c85fda93d95f` after #629-#630, at `b0018c8760f07d738b3a6b7a11eeeda300786ef2` after #632-#633, at `fe8680c551bc3ce9248063906cbbe90ffe732a70` after #635-#636, at `483fb572a42006c07bd2e857fb7638ec91615b7d` after #638, at `915578b5cab5ab3abde7f806e5ad39c063d9cc82` after #640, at `47ba93201aaa15c95157d341bb5ec4f5f3871741` after #642, at `addbbe3e6962dc7f1629053c8a9c6810c7e37cc1` after #645, at `a12c6fdf61396de74f971c27f4887dd7c451543b` after #647, at `686dbff26afbbdcb97e4cc1915d1e33bd1404d14` after #649-#650, at `9fc95604d8950b565b6b6b7941ad275fd5624178` after #653, at `4cf501ddc0f7fc3d027b3ce2459e899fe4aa7092` after #684-#691, at `1564a1ac6a028146471e53c80fe3dbca22a32497` after #693-#695, at `c888405000384f391b24864e3e572dd0e9b6ba6a` after #696-#698, at `65c3c30ec52c9c5d65b58dae245b62f0bee9d198` after #699-#702, and at `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04` after #705.
+- ✅ **Dry-run receipt**: hosted release-readiness dry-run passed on `main` at `b0bb5b5392354273946f36f797f39d741d318fc1`; current-main primary and binding surface dry-runs passed locally at `b4b7962e6f3f9d7ae5d91adf603e6328e3d13297` after #616-#618, at `cc1e3046e2496ea0c10a25239b9d077641d01c36` after #621-#622, at `425ff79b959ef5ceff1bdd072cbe074ff2a7ab04` after #624-#625, at `eb518e948d57bc07e96512ced306fe0db2dc2990` after #627, at `acfeacec0eda6d632d52e61440f2c85fda93d95f` after #629-#630, at `b0018c8760f07d738b3a6b7a11eeeda300786ef2` after #632-#633, at `fe8680c551bc3ce9248063906cbbe90ffe732a70` after #635-#636, at `483fb572a42006c07bd2e857fb7638ec91615b7d` after #638, at `915578b5cab5ab3abde7f806e5ad39c063d9cc82` after #640, at `47ba93201aaa15c95157d341bb5ec4f5f3871741` after #642, at `addbbe3e6962dc7f1629053c8a9c6810c7e37cc1` after #645, at `a12c6fdf61396de74f971c27f4887dd7c451543b` after #647, at `686dbff26afbbdcb97e4cc1915d1e33bd1404d14` after #649-#650, at `9fc95604d8950b565b6b6b7941ad275fd5624178` after #653, at `4cf501ddc0f7fc3d027b3ce2459e899fe4aa7092` after #684-#691, at `1564a1ac6a028146471e53c80fe3dbca22a32497` after #693-#695, at `c888405000384f391b24864e3e572dd0e9b6ba6a` after #696-#698, at `65c3c30ec52c9c5d65b58dae245b62f0bee9d198` after #699-#702, at `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04` after #705, and at `aa548e1579f659c089162f0dd8e445219d0a2414` after #708-#710/#709.
 - ✅ **Release graph decision**: v1.5.0 selects `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`, with `hl7v2-python` included only as binding backend infrastructure.
 - ✅ **Publish receipt**: crates.io upload, registry resolution, `v1.5.0` tag, GitHub release, and public Rust/CLI/server install-back smoke are recorded in [`docs/audits/publish-v1.5.0-2026-05-15.md`](audits/publish-v1.5.0-2026-05-15.md). The repeatable install-back harness is recorded in [`docs/audits/public-crates-install-first-use-2026-05-16.md`](audits/public-crates-install-first-use-2026-05-16.md).
 - 🟡 **Python proof**: the public Python distribution is `hl7v2`, remains separate from the primary Rust product graph, has current-main local wheel/import/evidence smoke proof, and the 2026-05-16 publishing-mode TestPyPI run again passed wheel smoke before failing at `invalid-publisher`; Trusted Publisher upload/install-back proof is still required before any TestPyPI or PyPI success claim.
@@ -198,8 +202,8 @@ Old planning documents have been moved to `docs/plans/` for archival reference.
 **Current published release**: v1.5.0 is tested, package-verified, tagged, released on GitHub, and published to crates.io for the selected Rust graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`. `hl7v2-python` is binding backend infrastructure, not the recommended Rust API.
 
 **Current main**: records the v1.5.0 Rust 1.95 quality-ratchet publish receipt
-and the post-release gRPC enhanced ACK refresh at
-`a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04`.
+and the post-release test-coverage readiness refresh at
+`aa548e1579f659c089162f0dd8e445219d0a2414`.
 The public Python `hl7v2` TestPyPI/PyPI lane remains separate and still needs
 upload and install-back proof before any Python release claim. The latest
 publishing-mode TestPyPI attempt is

--- a/docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md
+++ b/docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md
@@ -1,0 +1,110 @@
+# v1.5.0 Test-Coverage Current-Main Readiness Refresh
+
+Date: 2026-05-17
+
+This receipt records a post-release current-main readiness refresh after the
+focused test-coverage train landed through #710 and #709.
+
+This is not a new publish receipt. v1.5.0 was already published before this
+refresh, so the dry-runs correctly observed that the `1.5.0` crates already
+exist on crates.io and then verified package contents without uploading.
+
+## Context
+
+| Field | Value |
+| --- | --- |
+| Branch | `release/refresh-v1.5.0-readiness-after-test-coverage` |
+| Base commit | `aa548e1579f659c089162f0dd8e445219d0a2414` |
+| Current release | `v1.5.0` |
+| Local target dir | `F:\cargo-target\hl7v2-rs-readiness-2026-05-17` |
+| Python ABI guard | `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` for the binding dry-run |
+| Rust toolchain | `1.95.0` |
+
+The refresh covers the post-release test-coverage train after the gRPC enhanced
+ACK refresh:
+
+- #708: synthetic faker, value-source, corpus hash, and RIPR badge coverage.
+- #710: server handler helper unit coverage for schema-version validation, ACK
+  policy mapping, corpus message IDs, and safe handler error display.
+- #709: conformance datatype and datetime coverage, plus the fractional
+  timestamp syntax fix that rejects invalid fractional text instead of
+  truncating it.
+
+## Publish Surface Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `cargo +1.95.0 run -p xtask -- publish-plan --surface primary` | Pass | Primary Rust product graph remains `hl7v2`, `hl7v2-server`, `hl7v2-cli`. |
+| `cargo +1.95.0 run -p xtask -- publish-plan --surface bindings` | Pass | Binding backend graph remains `hl7v2-python`. |
+| `cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable` | Pass | All-publishable graph remains `hl7v2`, `hl7v2-python`, `hl7v2-server`, `hl7v2-cli`. |
+| `cargo +1.95.0 run -p xtask -- publish-dry-run --surface primary --workspace-patches --allow-dirty` | Pass | `hl7v2`, `hl7v2-server`, and `hl7v2-cli` packaged and verified. Cargo warned that each `1.5.0` crate already exists, which is expected after the v1.5.0 release. |
+| `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- publish-dry-run --surface bindings --workspace-patches --allow-dirty` | Pass | `hl7v2-python` package listed and dry-run verified as the binding backend. Cargo warned that `hl7v2-python@1.5.0` already exists, which is expected after the v1.5.0 release. |
+
+The binding backend package list remained narrow:
+
+```text
+.cargo_vcs_info.json
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+README.md
+src/lib.rs
+```
+
+## Policy And Evidence Results
+
+| Command | Result |
+| --- | --- |
+| `cargo +1.95.0 run -p xtask -- check-python-publish-policy` | Pass; public Python distribution is `hl7v2`, while `hl7v2-python` is a publishable binding backend crate with separate release receipts required. |
+| `cargo +1.95.0 run -p xtask -- badges --check` | Pass |
+| `cargo +1.95.0 run -p xtask -- impacted-evidence` | Pass; regenerated the local ignored impacted-evidence receipt for this checkout. |
+| `cargo +1.95.0 run -p xtask -- impacted-evidence --check` | Pass after the local receipt was generated. A fresh target path had no `target/xtask/impacted-evidence/latest.json` before generation, which is expected for this ignored artifact. |
+| `cargo +1.95.0 run -p xtask -- check-doc-links` | Pass; 192 Markdown files and 506 local links checked. |
+| `cargo +1.95.0 run -p xtask -- evidence-schema-check` | Pass; 33 evidence fixtures validated. |
+| `cargo +1.95.0 run -p xtask -- check-file-policy` | Pass; 602 tracked/untracked non-ignored files checked, with 40 allowlist entries and 32 companion ledger entries. |
+| `git diff --check` | Pass |
+
+## Registry And Release State Check
+
+These checks verify current public state. They do not upload, tag, or release
+anything.
+
+| Check | Result |
+| --- | --- |
+| `cargo +1.95.0 info hl7v2@1.5.0` | Pass; resolved `hl7v2@1.5.0` on crates.io with `rust-version: 1.95`. |
+| `cargo +1.95.0 info hl7v2-python@1.5.0` | Pass; resolved the PyO3 binding backend crate for the Python `hl7v2` package on crates.io. |
+| `cargo +1.95.0 info hl7v2-server@1.5.0` | Pass; resolved `hl7v2-server@1.5.0` on crates.io. |
+| `cargo +1.95.0 info hl7v2-cli@1.5.0` | Pass; resolved `hl7v2-cli@1.5.0` on crates.io. |
+| `git tag -l v1.5.0` | Pass; local tag exists. |
+| `git rev-list -n 1 v1.5.0` | Pass; tag resolves to `04760587b83e2b4aaf410814b46ad1818c881371`. |
+| `gh release view v1.5.0 --json tagName,name,publishedAt,isDraft,isPrerelease,url` | Pass; GitHub release `v1.5.0 - Rust 1.95 Quality Ratchet` is published, not draft, and not prerelease. |
+
+Observed crates.io registry URLs:
+
+| Crate | URL |
+| --- | --- |
+| `hl7v2@1.5.0` | <https://crates.io/crates/hl7v2/1.5.0> |
+| `hl7v2-python@1.5.0` | <https://crates.io/crates/hl7v2-python/1.5.0> |
+| `hl7v2-server@1.5.0` | <https://crates.io/crates/hl7v2-server/1.5.0> |
+| `hl7v2-cli@1.5.0` | <https://crates.io/crates/hl7v2-cli/1.5.0> |
+
+## Boundaries
+
+- This receipt did not upload any crate to crates.io.
+- This receipt did not create or move a tag.
+- This receipt did not create or update a GitHub release.
+- This receipt did not publish to TestPyPI or PyPI.
+- This receipt did not install back from TestPyPI or PyPI.
+- This receipt did not create or publish an npm package.
+- `hl7v2-python` remains binding backend infrastructure, not the recommended
+  Rust API.
+- `ripr` remains advisory static mutation-exposure proof and is not a
+  branch-protection gate.
+
+## Follow-Up
+
+The current Rust release remains v1.5.0. Future crates.io uploads from this
+post-test-coverage `main` line require a new version and a fresh release
+decision. The public Python `hl7v2` lane remains separate and still needs
+TestPyPI Trusted Publisher setup, upload, install-back, import, and smoke
+receipts before any TestPyPI or PyPI success claim.

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -17,7 +17,7 @@ post-publish crates.io, tag, GitHub release, and public install-back receipt is
 | Python distribution | Separate `hl7v2` PyPI lane from `hl7v2-python` binding backend crate |
 | TestPyPI status | Externally blocked until Trusted Publisher setup is complete |
 | Production PyPI status | Not released |
-| Current-main readiness refresh | Post-release gRPC enhanced ACK readiness refresh passed locally on `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04` after gRPC `GenerateAck` parity for all six supported ACK codes landed through #705. |
+| Current-main readiness refresh | Post-release test-coverage readiness refresh passed locally on `aa548e1579f659c089162f0dd8e445219d0a2414` after synthetic evidence tests, server handler helper tests, datatype/datetime tests, and the fractional timestamp syntax fix landed through #710 and #709. |
 | crates.io publish status | Published on 2026-05-15 for `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`; see the publish receipt linked above. |
 
 ## Workflow
@@ -78,7 +78,7 @@ cargo +1.95.0 run -p xtask -- check-doc-links
 | Field | Value |
 | --- | --- |
 | Workflow run URL | <https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25814999531> for the hosted primary-graph proof; the current-main surface refreshes below were run locally. |
-| Commit SHA | Hosted proof: `b0bb5b5392354273946f36f797f39d741d318fc1`; evidence-surface refresh: `b4b7962e6f3f9d7ae5d91adf603e6328e3d13297`; parity refresh: `cc1e3046e2496ea0c10a25239b9d077641d01c36`; corpus refresh: `425ff79b959ef5ceff1bdd072cbe074ff2a7ab04`; gRPC status refresh: `eb518e948d57bc07e96512ced306fe0db2dc2990`; gRPC corpus evidence refresh: `acfeacec0eda6d632d52e61440f2c85fda93d95f`; numeric validation refresh: `b0018c8760f07d738b3a6b7a11eeeda300786ef2`; gRPC profile lint refresh: `fe8680c551bc3ce9248063906cbbe90ffe732a70`; gRPC profile explain refresh: `483fb572a42006c07bd2e857fb7638ec91615b7d`; gRPC profile test refresh: `915578b5cab5ab3abde7f806e5ad39c063d9cc82`; gRPC bundle creation refresh: `47ba93201aaa15c95157d341bb5ec4f5f3871741`; gRPC replay refresh: `addbbe3e6962dc7f1629053c8a9c6810c7e37cc1`; gRPC quarantine refresh: `a12c6fdf61396de74f971c27f4887dd7c451543b`; parity documentation refresh: `686dbff26afbbdcb97e4cc1915d1e33bd1404d14`; final pre-publish proof: `9fc95604d8950b565b6b6b7941ad275fd5624178`; post-release SRP refresh: `4cf501ddc0f7fc3d027b3ce2459e899fe4aa7092`; dirty-corpus parity refresh: `1564a1ac6a028146471e53c80fe3dbca22a32497`; normalization and ACK parity refresh: `c888405000384f391b24864e3e572dd0e9b6ba6a`; evidence parity refresh: `65c3c30ec52c9c5d65b58dae245b62f0bee9d198`; gRPC enhanced ACK refresh: `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04`. |
+| Commit SHA | Hosted proof: `b0bb5b5392354273946f36f797f39d741d318fc1`; evidence-surface refresh: `b4b7962e6f3f9d7ae5d91adf603e6328e3d13297`; parity refresh: `cc1e3046e2496ea0c10a25239b9d077641d01c36`; corpus refresh: `425ff79b959ef5ceff1bdd072cbe074ff2a7ab04`; gRPC status refresh: `eb518e948d57bc07e96512ced306fe0db2dc2990`; gRPC corpus evidence refresh: `acfeacec0eda6d632d52e61440f2c85fda93d95f`; numeric validation refresh: `b0018c8760f07d738b3a6b7a11eeeda300786ef2`; gRPC profile lint refresh: `fe8680c551bc3ce9248063906cbbe90ffe732a70`; gRPC profile explain refresh: `483fb572a42006c07bd2e857fb7638ec91615b7d`; gRPC profile test refresh: `915578b5cab5ab3abde7f806e5ad39c063d9cc82`; gRPC bundle creation refresh: `47ba93201aaa15c95157d341bb5ec4f5f3871741`; gRPC replay refresh: `addbbe3e6962dc7f1629053c8a9c6810c7e37cc1`; gRPC quarantine refresh: `a12c6fdf61396de74f971c27f4887dd7c451543b`; parity documentation refresh: `686dbff26afbbdcb97e4cc1915d1e33bd1404d14`; final pre-publish proof: `9fc95604d8950b565b6b6b7941ad275fd5624178`; post-release SRP refresh: `4cf501ddc0f7fc3d027b3ce2459e899fe4aa7092`; dirty-corpus parity refresh: `1564a1ac6a028146471e53c80fe3dbca22a32497`; normalization and ACK parity refresh: `c888405000384f391b24864e3e572dd0e9b6ba6a`; evidence parity refresh: `65c3c30ec52c9c5d65b58dae245b62f0bee9d198`; gRPC enhanced ACK refresh: `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04`; test-coverage refresh: `aa548e1579f659c089162f0dd8e445219d0a2414`. |
 | Version | `1.5.0` candidate |
 | Rust toolchain | Rust `1.95.0` |
 | Publish plan result | Passed for `primary`, `bindings`, and `all-publishable` surfaces. Primary graph remains `hl7v2`, `hl7v2-server`, `hl7v2-cli`; binding graph reports `hl7v2-python`. |
@@ -691,6 +691,46 @@ uploading.
 It does not claim a new crates.io upload, PyPI/TestPyPI upload, npm package,
 tag, GitHub release, or production Python install-back proof.
 
+## Current-Main Refresh After Test Coverage Updates
+
+After #708, #710, and #709 landed, the current `main` branch was refreshed
+locally at commit `aa548e1579f659c089162f0dd8e445219d0a2414`.
+
+The refresh covered:
+
+- synthetic faker, value-source, corpus hash, and RIPR badge coverage from
+  #708;
+- server handler helper unit coverage for schema-version validation, ACK
+  policy mapping, corpus message IDs, and safe handler error display from
+  #710;
+- conformance datatype and datetime coverage plus the fractional timestamp
+  syntax fix from #709;
+- primary, binding, and all-publishable Rust publish plans;
+- primary Rust product and binding-backend publish dry-runs;
+- Python publish-policy boundary checks;
+- RIPR badge and impacted-evidence checks;
+- evidence-schema fixture validation;
+- doc-link and file-policy checks;
+- registry, tag, and GitHub release state checks for the already-published
+  v1.5.0 release.
+
+See the dedicated test-coverage readiness refresh:
+[`docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md`](../audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md).
+
+This post-release refresh preserves the selected v1.5.0 crates.io graph:
+
+1. `hl7v2`
+2. `hl7v2-python`
+3. `hl7v2-server`
+4. `hl7v2-cli`
+
+Because v1.5.0 is already published, Cargo correctly reported that the `1.5.0`
+crates already exist while still packaging and verifying the surfaces without
+uploading.
+
+It does not claim a new crates.io upload, PyPI/TestPyPI upload, npm package,
+tag, GitHub release, or production Python install-back proof.
+
 ## Current-Main Refresh After Dirty-Corpus Parity Updates
 
 After #693, #694, and #695 landed, the current `main` branch was refreshed
@@ -796,6 +836,11 @@ The gRPC enhanced ACK refresh passed locally at commit
 `a8ac4cf5b9ab9e33a1a0aa61287901e00b13ab04` after gRPC `GenerateAck` support
 for all six supported ACK codes landed through #705.
 
+The test-coverage refresh passed locally at commit
+`aa548e1579f659c089162f0dd8e445219d0a2414` after synthetic evidence tests,
+server handler helper tests, conformance datatype/datetime tests, and the
+fractional timestamp syntax fix landed through #710 and #709.
+
 The parity documentation refresh passed locally at commit
 `686dbff26afbbdcb97e4cc1915d1e33bd1404d14` after the Python ACK local binding
 claim sync and gRPC parity surface documentation sync.
@@ -900,6 +945,9 @@ See the evidence parity refresh:
 
 See the gRPC enhanced ACK refresh:
 [`docs/audits/publish-dry-run-v1.5.0-2026-05-16-grpc-enhanced-ack-refresh.md`](../audits/publish-dry-run-v1.5.0-2026-05-16-grpc-enhanced-ack-refresh.md).
+
+See the test-coverage refresh:
+[`docs/audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md`](../audits/publish-dry-run-v1.5.0-2026-05-17-test-coverage-refresh.md).
 
 ## Boundaries
 


### PR DESCRIPTION
﻿## Summary

- record the post-release v1.5.0 readiness refresh at a548e1579f659c089162f0dd8e445219d0a2414
- add the dedicated test-coverage refresh audit for #708, #710, and #709
- sync docs/STATUS.md, docs/release/1.5.0-readiness.md, and .hl7v2/goals/active.toml

## Validation

- cargo +1.95.0 run -p xtask -- publish-plan --surface primary
- cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
- cargo +1.95.0 run -p xtask -- publish-plan --surface all-publishable
- cargo +1.95.0 run -p xtask -- publish-dry-run --surface primary --workspace-patches --allow-dirty
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 run -p xtask -- publish-dry-run --surface bindings --workspace-patches --allow-dirty
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- cargo +1.95.0 run -p xtask -- badges --check
- cargo +1.95.0 run -p xtask -- impacted-evidence
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- evidence-schema-check
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 info hl7v2@1.5.0
- cargo +1.95.0 info hl7v2-python@1.5.0
- cargo +1.95.0 info hl7v2-server@1.5.0
- cargo +1.95.0 info hl7v2-cli@1.5.0
- git tag -l v1.5.0
- git rev-list -n 1 v1.5.0
- gh release view v1.5.0 --json tagName,name,publishedAt,isDraft,isPrerelease,url
- python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.hl7v2/goals/active.toml').read_text()); print('active.toml ok')"
- git diff --check

## Boundaries

- no crates.io upload
- no TestPyPI or PyPI upload
- no npm package
- no tag or GitHub release change
- no Python public-registry install-back claim
