### PR TITLE
fix(transport): accept ConnectionRefused in connect-timeout test

### DIFF
--- a/crates/hl7v2/src/transport/network/tests.rs
+++ b/crates/hl7v2/src/transport/network/tests.rs
@@ -335,7 +335,15 @@ mod client_tests {
         assert!(!client.is_connected());
     }
 
-    /// Test connect timeout to non-routable address
+    /// Test connect to a non-routable address fails.
+    ///
+    /// The exact `ErrorKind` is environment-dependent: the 1 ms
+    /// `connect_timeout` races the OS network stack, so on hosts that
+    /// immediately drop traffic to RFC 5737 TEST-NET-1 the kind is
+    /// `ConnectionRefused`, and on hosts that black-hole it the timer
+    /// fires first and the kind is `TimedOut`. Both outcomes prove the
+    /// same thing: the client surfaces the underlying failure instead
+    /// of hanging.
     #[tokio::test]
     async fn test_client_connect_timeout() {
         use std::net::SocketAddr;
@@ -344,14 +352,18 @@ mod client_tests {
             .connect_timeout(Duration::from_millis(1))
             .build();
 
-        // Try to connect to a non-routable address (should timeout)
         let addr: SocketAddr = "192.0.2.1:2575".parse().unwrap();
         let result = client.connect(addr).await;
         assert!(result.is_err());
 
-        if let Err(e) = result {
-            assert_eq!(e.kind(), std::io::ErrorKind::TimedOut);
-        }
+        let kind = result.unwrap_err().kind();
+        assert!(
+            matches!(
+                kind,
+                std::io::ErrorKind::TimedOut | std::io::ErrorKind::ConnectionRefused
+            ),
+            "expected TimedOut or ConnectionRefused, got {kind:?}"
+        );
     }
 
     /// Test send_message fails when not connected


### PR DESCRIPTION
## Summary

Fix flaky `test_client_connect_timeout` in `crates/hl7v2/src/transport/network/tests.rs` by accepting either `ErrorKind::TimedOut` or `ErrorKind::ConnectionRefused`. The 1 ms `connect_timeout` races the OS network stack: on hosts that drop RFC 5737 TEST-NET-1 traffic immediately the kind is `ConnectionRefused`; on hosts that black-hole it the timer fires and the kind is `TimedOut`. Both outcomes prove the same thing — `MllpClient::connect` surfaces the failure instead of hanging.

Discovered during the code-coverage work on PRs #708, #709, #710 (the test failed reliably in this sandbox while passing on the GitHub runners).

## Diff

```diff
-        if let Err(e) = result {
-            assert_eq!(e.kind(), std::io::ErrorKind::TimedOut);
-        }
+        let kind = result.unwrap_err().kind();
+        assert!(
+            matches!(
+                kind,
+                std::io::ErrorKind::TimedOut | std::io::ErrorKind::ConnectionRefused
+            ),
+            "expected TimedOut or ConnectionRefused, got {kind:?}"
+        );
```

Plus a comment explaining the environment dependence.

## Test plan

- [x] `cargo test -p hl7v2 --lib --all-features transport::network::tests::client_tests::test_client_connect_timeout` — passes (returns `ConnectionRefused` in this sandbox, previously a hard failure)
- [x] `cargo clippy -p hl7v2 --lib --all-features --tests -- -D warnings` — clean
- [ ] CI green on GitHub runners (where the test previously got `TimedOut`)

Closes #712

https://claude.ai/code/session_01FagxMKWLQv8WQsAZ36vjSC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FagxMKWLQv8WQsAZ36vjSC)_