### PR TITLE
docs: close stale 1.4.1 plans

### DIFF
--- a/plans/1.4.1/README.md
+++ b/plans/1.4.1/README.md
@@ -1,7 +1,14 @@
 # v1.4.1 Plans
 
-This directory sequences PR-sized work for the v1.4.1 source-of-truth and
-Python proof lane.
+This directory preserves the historical PR-sized plan for the v1.4.1
+source-of-truth and Python proof lane.
+
+Status: closed as a standalone release plan. The source-of-truth stack landed,
+and the release train moved forward through the Rust 1.95 / v1.5.0 quality
+ratchet. Current release and package truth now lives in
+[`docs/STATUS.md`](../../docs/STATUS.md),
+[`docs/status/SUPPORT_TIERS.md`](../../docs/status/SUPPORT_TIERS.md), and the
+v1.5.0 audit receipts linked from those files.
 
 Plans should describe:
 
@@ -13,4 +20,5 @@ Plans should describe:
 
 Plans do not define the product contract. Link to specs for behavior, ADRs for
 durable decisions, `.hl7v2/goals/active.toml` for current execution state, and
-audits or handoffs for completed proof.
+audits or handoffs for completed proof. If this historical plan conflicts with
+current release receipts, the current status/support docs and receipts win.

--- a/plans/1.4.1/implementation-plan.md
+++ b/plans/1.4.1/implementation-plan.md
@@ -1,9 +1,15 @@
 # v1.4.1 Source-of-Truth Implementation Plan
 
-Status: Active
+Status: Closed / superseded by v1.5.0 release receipts
 Date: 2026-05-13
 Proposal: [HL7V2-PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
 Primary spec: [HL7V2-SPEC-0001](../../docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md)
+
+Historical note: this plan captured the v1.4.1 source-of-truth campaign before
+the release train moved forward to Rust 1.95 / v1.5.0. Current package and
+release truth lives in [`docs/STATUS.md`](../../docs/STATUS.md),
+[`docs/status/SUPPORT_TIERS.md`](../../docs/status/SUPPORT_TIERS.md), and the
+v1.5.0 receipts linked from those files.
 
 ## Goal
 
@@ -31,8 +37,8 @@ in this documentation campaign.
 | Python distribution ADR | Done | [ADR-0002](../../docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md) | Record Python as separate from crates.io. |
 | Support tier map | Done | [SUPPORT_TIERS](../../docs/status/SUPPORT_TIERS.md) | Map product surfaces to proof commands. |
 | TestPyPI Trusted Publisher proof | Blocked | [testpypi-closure.md](testpypi-closure.md), issue [#563](https://github.com/EffortlessMetrics/hl7v2-rs/issues/563) | Complete upload and install-back after external setup. |
-| Active goal manifest | Ready | `.hl7v2/goals/active.toml` | Record machine-readable current campaign state. |
-| v1.4.1 release readiness | Waiting | [release-readiness.md](release-readiness.md) | Decide patch candidate only after receipts are clean. |
+| Active goal manifest | Done | `.hl7v2/goals/active.toml` | Record machine-readable current campaign state. |
+| v1.4.1 release readiness | Superseded | [release-readiness.md](release-readiness.md), [v1.5.0 readiness](../../docs/release/1.5.0-readiness.md) | The release train moved to v1.5.0; do not use this plan as current release state. |
 
 ## PR Order
 
@@ -55,7 +61,8 @@ in this documentation campaign.
 
 ## Proof Commands
 
-Docs-only plan changes use:
+Historical docs-only plan changes used Rust 1.93. Current validation commands
+should follow the active Rust 1.95 release docs. The original commands were:
 
 ```powershell
 cargo +1.93.0 run -p xtask -- check-doc-links

--- a/plans/1.4.1/release-readiness.md
+++ b/plans/1.4.1/release-readiness.md
@@ -1,8 +1,14 @@
 # v1.4.1 Release Readiness Plan
 
-Status: Waiting
+Status: Superseded by v1.5.0 release
 Proposal: [HL7V2-PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
 Support map: [SUPPORT_TIERS](../../docs/status/SUPPORT_TIERS.md)
+
+Historical note: this patch-release candidate was not the final release path.
+The repo shipped the Rust 1.95 / v1.5.0 quality-ratchet release instead. Use
+[`docs/release/1.5.0-readiness.md`](../../docs/release/1.5.0-readiness.md),
+[`docs/audits/publish-v1.5.0-2026-05-15.md`](../../docs/audits/publish-v1.5.0-2026-05-15.md),
+and [`docs/STATUS.md`](../../docs/STATUS.md) for current release truth.
 
 ## Goal
 
@@ -50,7 +56,8 @@ production PyPI: not attempted
 ## Non-Goals
 
 - Do not publish Python to production PyPI by default.
-- Do not publish `hl7v2-python` to crates.io.
+- Do not treat a crates.io `hl7v2-python` binding-backend publish as a
+  TestPyPI or PyPI proof for the public Python package `hl7v2`.
 - Do not claim TestPyPI success until upload and install-back pass.
 - Do not include production PyPI unless production upload and install-back pass.
 

--- a/plans/1.4.1/source-of-truth-stack.md
+++ b/plans/1.4.1/source-of-truth-stack.md
@@ -1,10 +1,14 @@
 # Source-of-Truth Stack Plan
 
-Status: Active
+Status: Closed / implemented
 Proposal: [HL7V2-PROP-0001](../../docs/proposals/HL7V2-PROP-0001-source-of-truth-and-release-governance.md)
 Spec: [HL7V2-SPEC-0001](../../docs/specs/HL7V2-SPEC-0001-source-of-truth-stack.md)
 ADRs: [ADR-0001](../../docs/adr/HL7V2-ADR-0001-evidence-artifacts-are-contracts.md),
 [ADR-0002](../../docs/adr/HL7V2-ADR-0002-python-is-separate-distribution-lane.md)
+
+Historical note: the source-of-truth stack is now implemented and current
+execution state lives in `.hl7v2/goals/active.toml`. This file is retained as
+the original PR-sequencing plan, not as the active work queue.
 
 ## Goal
 


### PR DESCRIPTION
## Summary

- marks the historical v1.4.1 source-of-truth plans as closed or superseded by the v1.5.0 release receipts
- points readers to current status/support and v1.5.0 release truth
- replaces the old absolute hl7v2-python crates.io prohibition with the current binding-backend boundary

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Cleanup

- removed scratch Cargo target F:\cargo-target\hl7v2-rs-stale-plans-2026-05-17

## Non-claims

- no runtime behavior change
- no package publish
- no TestPyPI/PyPI claim