### PR TITLE
Make server hashing and schema version handling DRY

### DIFF
--- a/crates/hl7v2-server/src/audit.rs
+++ b/crates/hl7v2-server/src/audit.rs
@@ -1,7 +1,6 @@
 //! Redacted structured audit log helpers for server evidence workflows.
 
-use sha2::{Digest, Sha256};
-
+use crate::hash::compute_sha256;
 use crate::models::{AckPolicyOutcome, AckPolicyReason};
 
 /// Structured event emitted when `/hl7/parse` completes.
@@ -90,9 +89,7 @@ fn hash_or_missing(value: &str) -> String {
     if value.is_empty() {
         "missing".to_string()
     } else {
-        let mut hasher = Sha256::new();
-        hasher.update(value.as_bytes());
-        format!("{:x}", hasher.finalize())
+        compute_sha256(value)
     }
 }
 

--- a/crates/hl7v2-server/src/evidence.rs
+++ b/crates/hl7v2-server/src/evidence.rs
@@ -1,12 +1,12 @@
 //! Evidence bundle helpers for HTTP endpoints.
 
+use crate::hash::{compute_sha256, compute_sha256_bytes};
 use crate::models::{
     EvidenceBundleEnvironment, EvidenceBundleManifest, EvidenceBundleManifestArtifact,
     EvidenceBundleSummary, FieldPathTrace, FieldPathTraceReport, FieldValueShape, QuarantineConfig,
     QuarantineOutputSummary, QuarantineReason, RedactionAction, RedactionReceipt,
 };
 use hl7v2::{Atom, Field, Message, ValidationReport};
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fs;
@@ -479,16 +479,6 @@ fn field_to_text(field: &Field, delims: &hl7v2::Delims) -> String {
         })
         .collect::<Vec<_>>()
         .join(&delims.rep.to_string())
-}
-
-fn compute_sha256(value: &str) -> String {
-    compute_sha256_bytes(value.as_bytes())
-}
-
-fn compute_sha256_bytes(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
 }
 
 fn replay_shell_script() -> &'static str {

--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -1,5 +1,6 @@
 //! gRPC service implementation for HL7v2.
 
+use crate::hash::compute_sha256;
 use crate::models::{
     EvidenceBundleSummary as ServerEvidenceBundleSummary,
     QuarantineOutputSummary as ServerQuarantineOutputSummary,
@@ -14,7 +15,6 @@ use hl7v2::{
     Comp as RustComp, Field as RustField, Message as RustMessage, Rep as RustRep,
     Segment as RustSegment, parse as rust_parse,
 };
-use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
@@ -689,12 +689,6 @@ fn grpc_requested_schema_version(version: i32, artifact: &str) -> Result<i32, St
             "unsupported {artifact} schema version {other}; expected 1 or 2"
         )),
     }
-}
-
-fn compute_sha256(input: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(input.as_bytes());
-    format!("{:x}", hasher.finalize())
 }
 
 struct GrpcRedactedQuarantineContext<'a> {

--- a/crates/hl7v2-server/src/handlers/corpus.rs
+++ b/crates/hl7v2-server/src/handlers/corpus.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 
-use sha2::{Digest, Sha256};
-
 use crate::handlers::error::AppError;
+use crate::hash::compute_sha256;
 use crate::models::CorpusMessageInput;
 
 pub(super) fn validated_corpus_message_ids(
@@ -139,10 +138,4 @@ pub(super) fn validation_report_v2_for_server(
             sha256: Some(compute_sha256(profile_yaml)),
         }),
     )
-}
-
-pub(super) fn compute_sha256(value: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(value.as_bytes());
-    format!("{:x}", hasher.finalize())
 }

--- a/crates/hl7v2-server/src/handlers/schema_versions.rs
+++ b/crates/hl7v2-server/src/handlers/schema_versions.rs
@@ -1,87 +1,52 @@
 use crate::handlers::error::AppError;
 
-pub(super) fn requested_report_schema_version(version: Option<u8>) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
+const DEFAULT_SCHEMA_VERSION: u8 = 1;
+const LATEST_SCHEMA_VERSION: u8 = 2;
+
+fn requested_schema_version(version: Option<u8>, artifact: &str) -> Result<u8, AppError> {
+    match version.unwrap_or(DEFAULT_SCHEMA_VERSION) {
+        DEFAULT_SCHEMA_VERSION => Ok(DEFAULT_SCHEMA_VERSION),
+        LATEST_SCHEMA_VERSION => Ok(LATEST_SCHEMA_VERSION),
         other => Err(AppError::Validation(format!(
-            "unsupported validation report schema version {other}; expected 1 or 2"
+            "unsupported {artifact} schema version {other}; expected {DEFAULT_SCHEMA_VERSION} or {LATEST_SCHEMA_VERSION}"
         ))),
     }
+}
+
+pub(super) fn requested_report_schema_version(version: Option<u8>) -> Result<u8, AppError> {
+    requested_schema_version(version, "validation report")
 }
 
 pub(super) fn requested_redaction_receipt_schema_version(
     version: Option<u8>,
 ) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported redaction receipt schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "redaction receipt")
 }
 
 pub(super) fn requested_quarantine_schema_version(version: Option<u8>) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported quarantine output schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "quarantine output")
 }
 
 pub(super) fn requested_bundle_artifact_schema_version(
     version: Option<u8>,
 ) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported bundle artifact schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "bundle artifact")
 }
 
 pub(super) fn requested_replay_report_schema_version(version: Option<u8>) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported replay report schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "replay report")
 }
 
 pub(super) fn requested_corpus_summary_schema_version(version: Option<u8>) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported corpus summary schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "corpus summary")
 }
 
 pub(super) fn requested_corpus_fingerprint_schema_version(
     version: Option<u8>,
 ) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported corpus fingerprint schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "corpus fingerprint")
 }
 
 pub(super) fn requested_corpus_diff_schema_version(version: Option<u8>) -> Result<u8, AppError> {
-    match version.unwrap_or(1) {
-        1 => Ok(1),
-        2 => Ok(2),
-        other => Err(AppError::Validation(format!(
-            "unsupported corpus diff schema version {other}; expected 1 or 2"
-        ))),
-    }
+    requested_schema_version(version, "corpus diff")
 }

--- a/crates/hl7v2-server/src/hash.rs
+++ b/crates/hl7v2-server/src/hash.rs
@@ -1,0 +1,13 @@
+//! Shared hashing helpers for server-side evidence, audit, and API adapters.
+
+use sha2::{Digest, Sha256};
+
+pub(crate) fn compute_sha256(value: &str) -> String {
+    compute_sha256_bytes(value.as_bytes())
+}
+
+pub(crate) fn compute_sha256_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}

--- a/crates/hl7v2-server/src/lib.rs
+++ b/crates/hl7v2-server/src/lib.rs
@@ -47,6 +47,7 @@
 )]
 
 mod audit;
+mod hash;
 
 pub mod evidence;
 pub mod grpc;

--- a/crates/hl7v2-server/src/redaction.rs
+++ b/crates/hl7v2-server/src/redaction.rs
@@ -1,11 +1,11 @@
 //! Safe-analysis redaction helpers for HTTP evidence endpoints.
 
+use crate::hash::compute_sha256;
 use crate::models::{
     RedactionAction, RedactionActionReceipt, RedactionActionStatus, RedactionReceipt,
 };
 use hl7v2::{Atom, Field, Message};
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 
 #[derive(Debug, Deserialize)]
@@ -279,10 +279,4 @@ fn field_to_text(field: &Field, delims: &hl7v2::Delims) -> String {
         })
         .collect::<Vec<_>>()
         .join(&delims.rep.to_string())
-}
-
-fn compute_sha256(value: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(value.as_bytes());
-    format!("{:x}", hasher.finalize())
 }


### PR DESCRIPTION
### Motivation

- Reduce duplicated SHA-256 implementations and repeated schema-version validation logic across the server crate to make maintenance easier and avoid drift.
- Centralize hashing and schema-version rules so future updates (e.g., algorithm changes or new schema versions) only require a single change.

### Description

- Add a new internal module `crates/hl7v2-server/src/hash.rs` exposing `compute_sha256` and `compute_sha256_bytes` for shared SHA-256 hashing.
- Replace local `sha2` usages with calls to `crate::hash::compute_sha256` (and `compute_sha256_bytes` where appropriate) in `audit.rs`, `evidence.rs`, `grpc.rs`, `redaction.rs`, and `handlers/corpus.rs` and register the module in `lib.rs` with `mod hash;`.
- Replace many nearly-identical `requested_*_schema_version` functions with a single `requested_schema_version` helper and small artifact-specific wrappers in `handlers/schema_versions.rs`, and introduce `DEFAULT_SCHEMA_VERSION` and `LATEST_SCHEMA_VERSION` constants.
- Remove duplicated hashing helper functions from multiple files and tidy up imports so the server uses the centralized helpers.

### Testing

- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p hl7v2-server` and all server tests (unit, integration, and BDD scenarios) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b893d4948333b98c387a68ff1ade)