### PR TITLE
Make server endpoint tests drier

### DIFF
--- a/crates/hl7v2-server/tests/common/mod.rs
+++ b/crates/hl7v2-server/tests/common/mod.rs
@@ -5,10 +5,19 @@
     reason = "shared integration-test support is consumed by different test binaries"
 )]
 
-use axum::Router;
+use axum::{
+    Router,
+    body::Body,
+    http::{Method, Request},
+};
 use hl7v2_server::server::{AppState, Server, ServerConfig};
+use serde_json::Value;
 use std::sync::Arc;
 use std::time::Instant;
+
+const TEST_CLIENT_ADDR: ([u8; 4], u16) = ([127, 0, 0, 1], 8080);
+const CONTENT_TYPE: &str = "Content-Type";
+const APPLICATION_JSON: &str = "application/json";
 
 /// Create a test server instance with default configuration
 pub fn create_test_server() -> Server {
@@ -40,6 +49,41 @@ pub fn create_test_router() -> Router {
         quarantine: Default::default(),
     });
     hl7v2_server::routes::build_router(state)
+}
+
+/// Build a request with the standard test client connection metadata.
+pub fn request(method: Method, uri: &str, body: Body) -> Request<Body> {
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from(
+            TEST_CLIENT_ADDR,
+        )))
+        .uri(uri)
+        .method(method)
+        .body(body)
+        .unwrap()
+}
+
+/// Build a JSON request with the standard test client connection metadata.
+pub fn json_request(method: Method, uri: &str, body: impl Into<Body>) -> Request<Body> {
+    Request::builder()
+        .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from(
+            TEST_CLIENT_ADDR,
+        )))
+        .uri(uri)
+        .method(method)
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .body(body.into())
+        .unwrap()
+}
+
+/// Build a POST request with an already-serialized JSON body.
+pub fn json_post(uri: &str, body: impl Into<Body>) -> Request<Body> {
+    json_request(Method::POST, uri, body)
+}
+
+/// Build a POST request from a JSON value.
+pub fn json_value_post(uri: &str, body: Value) -> Request<Body> {
+    json_post(uri, serde_json::to_string(&body).unwrap())
 }
 
 /// Sample HL7v2 messages for testing

--- a/crates/hl7v2-server/tests/parse_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/parse_endpoint_test.rs
@@ -5,10 +5,7 @@
     reason = "legacy parse endpoint tests use static fixtures; cleanup is tracked in policy/clippy-debt.toml"
 )]
 
-use axum::{
-    body::Body,
-    http::{Request, StatusCode},
-};
+use axum::{body::Body, http::StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use tower::ServiceExt;
@@ -29,18 +26,7 @@ async fn test_parse_valid_adt_a01_message() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -61,18 +47,7 @@ async fn test_parse_valid_adt_a04_message() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -93,18 +68,7 @@ async fn test_parse_valid_oru_r01_message() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -125,18 +89,7 @@ async fn test_parse_minimal_valid_message() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -157,18 +110,7 @@ async fn test_parse_malformed_message_returns_error() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -221,18 +163,7 @@ async fn test_parse_invalid_encoding_may_succeed_if_has_msh() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -250,18 +181,7 @@ async fn test_parse_empty_request_body_returns_400() {
     let app = common::create_test_router();
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from("{}"))
-                .unwrap(),
-        )
+        .oneshot(common::json_post("/hl7/parse", "{}"))
         .await
         .unwrap();
 
@@ -278,18 +198,7 @@ async fn test_parse_invalid_json_returns_400() {
     let app = common::create_test_router();
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from("not valid json"))
-                .unwrap(),
-        )
+        .oneshot(common::json_post("/hl7/parse", "not valid json"))
         .await
         .unwrap();
 
@@ -313,18 +222,7 @@ async fn test_parse_response_contains_segments() {
     });
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-                .unwrap(),
-        )
+        .oneshot(common::json_value_post("/hl7/parse", request_body))
         .await
         .unwrap();
 
@@ -345,17 +243,11 @@ async fn test_parse_get_method_not_allowed() {
     let app = common::create_test_router();
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/parse")
-                .method("GET")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(common::request(
+            axum::http::Method::GET,
+            "/hl7/parse",
+            Body::empty(),
+        ))
         .await
         .unwrap();
 

--- a/crates/hl7v2-server/tests/validate_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_endpoint_test.rs
@@ -6,27 +6,15 @@
     reason = "legacy validate endpoint tests use static fixtures; cleanup is tracked in policy/clippy-debt.toml"
 )]
 
-use axum::{
-    body::Body,
-    http::{Request, StatusCode},
-};
+use axum::{body::Body, http::StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
 mod common;
 
-fn validate_request(request_body: Value) -> Request<Body> {
-    Request::builder()
-        .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            8080,
-        ))))
-        .uri("/hl7/validate")
-        .method("POST")
-        .header("Content-Type", "application/json")
-        .body(Body::from(serde_json::to_string(&request_body).unwrap()))
-        .unwrap()
+fn validate_request(request_body: Value) -> axum::http::Request<Body> {
+    common::json_value_post("/hl7/validate", request_body)
 }
 
 #[tokio::test]
@@ -365,18 +353,7 @@ async fn test_validate_empty_request_body_returns_400() {
     let app = common::create_test_router();
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("POST")
-                .header("Content-Type", "application/json")
-                .body(Body::from("{}"))
-                .unwrap(),
-        )
+        .oneshot(common::json_post("/hl7/validate", "{}"))
         .await
         .unwrap();
 
@@ -393,17 +370,11 @@ async fn test_validate_get_method_not_allowed() {
     let app = common::create_test_router();
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
-                    [127, 0, 0, 1],
-                    8080,
-                ))))
-                .uri("/hl7/validate")
-                .method("GET")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(common::request(
+            axum::http::Method::GET,
+            "/hl7/validate",
+            Body::empty(),
+        ))
         .await
         .unwrap();
 


### PR DESCRIPTION
### Motivation

- Reduce repetition in integration tests by centralizing common request construction and test-client metadata.
- Make intent of HTTP test requests clearer and easier to reuse across endpoint tests.

### Description

- Add shared request builders and constants in `crates/hl7v2-server/tests/common/mod.rs`: `request`, `json_request`, `json_post`, `json_value_post`, `TEST_CLIENT_ADDR`, and JSON content-type constants.
- Replace repeated `Request::builder()` blocks in `crates/hl7v2-server/tests/parse_endpoint_test.rs` with calls to `common::json_value_post`, `common::json_post`, and `common::request`.
- Update `crates/hl7v2-server/tests/validate_endpoint_test.rs` to use `common::json_value_post` via the `validate_request` helper and to reuse `common::json_post` and `common::request` for other cases.
- Simplify some imports in the modified test files to match the new helpers.

### Testing

- Ran `cargo fmt` successfully with no outstanding formatting issues.
- Ran `cargo test -p hl7v2-server --test parse_endpoint_test --test validate_endpoint_test` and all tests passed (`parse_endpoint_test`: 10 passed; `validate_endpoint_test`: 13 passed).
- Ran `cargo clippy -p hl7v2-server --tests -- -D warnings` and the clippy check completed with no warnings treated as errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b893d4948333b98c387a68ff1ade)