### PR TITLE
test(xtask): make Python Wheels policy guard CRLF-safe

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7983,9 +7983,14 @@ bindings = "pyo3"
             .to_path_buf();
         let workflow = fs::read_to_string(root.join(PYTHON_WHEELS_WORKFLOW_PATH))?;
         let broken = workflow.replace(
-            "      - name: Run Python dirty evidence workflow smoke test\n        run: python tests/python_smoke/dirty_evidence_workflow.py\n",
-            "",
+            "python tests/python_smoke/dirty_evidence_workflow.py",
+            "python tests/python_smoke/smoke.py",
         );
+        if broken == workflow {
+            return Err(anyhow!(
+                "test setup should remove the Python Wheels dirty evidence smoke command"
+            ));
+        }
 
         match check_python_wheels_workflow_text(&broken) {
             Ok(()) => Err(anyhow!(


### PR DESCRIPTION
﻿## Summary

- make the Python Wheels negative policy test CRLF-safe on Windows checkouts
- mutate the dirty evidence smoke command instead of deleting an LF-only YAML block
- keep the Python Wheels workflow guard behavior unchanged

## Validation

- cargo +1.95.0 test -p xtask python_publish_policy_rejects_python_wheels_missing_dirty_smoke --locked
- cargo +1.95.0 test -p xtask python_publish_policy --locked
- cargo +1.95.0 test -p xtask --locked
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- git diff --check

## Failure addressed

Post-merge main CI failed in CI / Matrix Tests (windows-latest, stable) on tests::python_publish_policy_rejects_python_wheels_missing_dirty_smoke. The test assumed LF line endings when deleting the workflow step, so CRLF checkouts left the dirty smoke step in place and the negative test did not become negative.

## Non-claims

- No workflow behavior changes
- No registry, TestPyPI, PyPI, npm, tag, or release claim
