### PR TITLE
docs(ci): refresh RIPR calibration after parity traffic

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -65,6 +65,7 @@ canonical_sources = [
   "docs/audits/publish-dry-run-v1.5.0-2026-05-15-final-prepublish.md",
   "docs/audits/publish-v1.5.0-2026-05-15.md",
   "docs/audits/ripr-calibration-2026-05-15.md",
+  "docs/audits/ripr-calibration-2026-05-17.md",
   "docs/audits/real-world-corpus-proof-2026-05-14.md",
   "docs/audits/dirty-real-world-corpus-shared-fixture-proof-2026-05-16.md",
   "docs/audits/dirty-real-world-server-corpus-parity-2026-05-16.md",
@@ -665,6 +666,33 @@ sampled_runs = [
   "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25894522063",
   "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25895990745",
   "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25899168227",
+]
+commands = [
+  "cargo +1.95.0 run -p xtask -- badges --check",
+  "cargo +1.95.0 run -p xtask -- impacted-evidence --check",
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "cargo +1.95.0 run -p xtask -- check-file-policy",
+  "git diff --check",
+]
+non_claims = [
+  "No branch-protection rule changed.",
+  "No required check added.",
+  "No runtime mutation run.",
+  "No crates.io, TestPyPI, PyPI, npm, tag, or GitHub release action.",
+]
+
+[[work_item]]
+id = "ripr-calibration-after-parity-traffic"
+status = "done"
+goal = "Refresh the advisory ripr evidence calibration after evidence-parity, Python-proof, and refactor PR traffic without making it branch-protection blocking."
+receipt = "docs/audits/ripr-calibration-2026-05-17.md"
+sampled_runs = [
+  "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25990753620",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25997492068",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25998379659",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25998977833",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/25999837574",
+  "https://github.com/EffortlessMetrics/hl7v2-rs/actions/runs/26000683148",
 ]
 commands = [
   "cargo +1.95.0 run -p xtask -- badges --check",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Recorded a second hosted-traffic calibration audit for the advisory `ripr`
+  evidence surface after evidence-parity and Python-proof PR traffic, keeping
+  the lane non-blocking.
 - Updated the current-main TestPyPI publishing-mode proof retry after the
   v1.5.0 refactor cleanup readiness refresh; wheel smoke passed, while upload
   remains blocked by TestPyPI Trusted Publisher setup.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -219,7 +219,7 @@ Refactor cleanup readiness refresh:
 [`docs/audits/publish-dry-run-v1.5.0-2026-05-17-refactor-refresh.md`](audits/publish-dry-run-v1.5.0-2026-05-17-refactor-refresh.md).
 Publish receipt: [`docs/audits/publish-v1.5.0-2026-05-15.md`](audits/publish-v1.5.0-2026-05-15.md).
 Release graph decision: [`docs/audits/v1.5.0-release-graph-decision-2026-05-14.md`](audits/v1.5.0-release-graph-decision-2026-05-14.md).
-RIPR calibration: [`docs/audits/ripr-calibration-2026-05-15.md`](audits/ripr-calibration-2026-05-15.md).
+RIPR calibration: [`docs/audits/ripr-calibration-2026-05-17.md`](audits/ripr-calibration-2026-05-17.md).
 
 - ✅ **Published release**: workspace package versions are published as `1.5.0` for the selected Rust crates.io graph: `hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
 - ✅ **Rust floor**: MSRV is Rust 1.95 and `rust-toolchain.toml` pins Rust 1.95.0 with `rustfmt` and `clippy`.

--- a/docs/audits/ripr-calibration-2026-05-17.md
+++ b/docs/audits/ripr-calibration-2026-05-17.md
@@ -1,0 +1,108 @@
+# RIPR Calibration Audit - 2026-05-17
+
+This audit refreshes the advisory `ripr` static mutation-exposure calibration
+after the evidence-parity and Python-proof PR traffic on 2026-05-17. It is a
+signal-quality receipt only. It is not a branch-protection change, runtime
+mutation result, release readiness refresh, crates.io publish receipt,
+TestPyPI receipt, PyPI receipt, npm receipt, tag, or GitHub release receipt.
+
+## Scope
+
+| Field | Value |
+| --- | --- |
+| Repository line | post-v1.5.0 evidence-parity and Python-proof traffic |
+| Base checkout | `9086b7c773016e6c32e5cf6baf24487ecd7a7a64` |
+| Lane | Advisory `ripr` static mutation-exposure |
+| Workflow | `.github/workflows/ripr.yml` |
+| Artifact name | `ripr-pr-evidence` |
+| Policy ledger | `policy/ripr-suppressions.toml` |
+| Runtime mutation relationship | Targeted backstop, not replaced by `ripr` |
+
+## Sampled Traffic
+
+| Pull request | Workflow run | Observed signal |
+| --- | --- | --- |
+| #731, evidence parity acceptance runner | `25990753620` | One `no_static_path` severe gap, zero review comments, and `targeted` impacted-evidence routing. Useful as a routing signal for new orchestrator code, but not enough by itself to require runtime mutation on every similar PR. |
+| #737, Python dirty evidence workflow smoke | `25997492068` | Zero severe gaps, zero review comments, and `fast_only` impacted-evidence routing across 20 changed files. Good evidence that normal test-heavy Python smoke additions do not automatically create a mutation tax. |
+| #738, Python wheel dirty smoke workflow | `25998379659` | Zero severe gaps, zero review comments, and `fast_only` impacted-evidence routing across 3 changed files. Good advisory behavior for narrow CI/Python-smoke wiring. |
+| #743, Python Wheels policy CRLF guard | `25998977833` | Zero severe gaps, zero review comments, and `fast_only` impacted-evidence routing for a one-file xtask policy fix. |
+| #742, server validation helper refactor | `25999837574` | Fifteen `no_static_path` severe gaps, 3 line annotations, 7 summary-only recommendations, and `targeted` impacted-evidence routing. Useful for catching refactor seams in server validation plumbing. |
+| #740, duplicated value generation refactor | `26000683148` | Zero severe gaps but 3 line annotations and 7 summary-only recommendations. `impacted-evidence` stayed `fast_only`, which is the right split: useful reviewer guidance without mutation escalation. |
+
+The artifact sample was downloaded locally with `gh run download ... -n
+ripr-pr-evidence` into a temporary directory and inspected from
+`repo-exposure.json`, `summary.md`, `comments.json`, `comments.md`, and
+`target/xtask/impacted-evidence/latest.md`.
+
+## Calibration Findings
+
+The lane is still useful as advisory review evidence:
+
+- Severe-gap routing is not merely theoretical. #731 and #742 both routed to
+  `targeted` impacted evidence when `ripr_severe_gap = true`.
+- Ordinary Python smoke, CI policy, and test-heavy parity PRs stayed on
+  `fast_only` when severe static gaps were zero.
+- Review guidance can be useful even when mutation routing stays fast-only.
+  #740 produced line and summary guidance while leaving
+  `requires_targeted_mutation = false`.
+- `policy/ripr-suppressions.toml` did not need an active suppression for this
+  sample. The sampled recommendations should stay review input, not source
+  suppressions.
+
+The lane is not ready to become branch-protection blocking:
+
+- The same class of focused PR traffic can produce very different advisory
+  shapes: zero severe gaps for CI/Python smoke changes, targeted routing for
+  server refactor seams, and guidance-only output for helper refactors.
+- `repo-exposure.json` and `comments.json` still represent different views.
+  In #742, `repo-exposure.json` recorded zero `comments` and zero
+  `summary_only`, while the review guidance artifact recorded 3 line comments
+  and 7 summary-only recommendations. Gates must not use one artifact alone to
+  claim there was no reviewer guidance.
+- `ripr` still does not execute mutation. `impacted-evidence` routes work; it
+  does not prove the runtime mutation backstop passed.
+
+## Current Decision
+
+Keep `ripr` advisory:
+
+- run it on relevant PRs;
+- publish the JSON, Markdown, annotation, badge, and impacted-evidence
+  artifacts;
+- use severe-gap and impacted-evidence signals as reviewer and
+  mutation-routing input;
+- keep runtime mutation as the targeted or release-time backstop;
+- do not add branch-protection requirements for `ripr` yet.
+
+## Follow-Ups
+
+- Align or document the counter semantics between `repo-exposure.json`,
+  `comments.json`, `summary.md`, and `comments.md`.
+- Keep collecting hosted samples before deciding whether any `ripr` severity or
+  routing result can become blocking.
+- Track cost and latency once enough PR traffic exists to calculate a useful
+  envelope.
+- Consider a focused test follow-up for server validation helper seams if the
+  #742 guidance maps to meaningful untested behavior.
+
+## Non-Claims
+
+- No branch-protection rule was changed.
+- No required check was added.
+- No runtime mutation was run by this audit.
+- No `ripr` finding was treated as release-blocking.
+- No crates.io, TestPyPI, PyPI, npm, tag, or GitHub release action was run.
+
+## Validation
+
+This audit PR was validated with:
+
+| Command | Result |
+| --- | --- |
+| `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.hl7v2/goals/active.toml').read_text())"` | pass |
+| `cargo +1.95.0 run -p xtask -- badges --check` | pass |
+| `cargo +1.95.0 run -p xtask -- impacted-evidence` | pass; generated the local impacted-evidence receipt for `--check` |
+| `cargo +1.95.0 run -p xtask -- impacted-evidence --check` | pass |
+| `cargo +1.95.0 run -p xtask -- check-doc-links` | pass; 201 Markdown files and 568 local links checked |
+| `cargo +1.95.0 run -p xtask -- check-file-policy` | pass; 618 tracked/untracked non-ignored files checked |
+| `git diff --check` | pass |

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -28,7 +28,9 @@ The initial lane is advisory:
 
 The first calibration pass over hosted PR artifacts is recorded in
 [`docs/audits/ripr-calibration-2026-05-15.md`](../audits/ripr-calibration-2026-05-15.md).
-That audit keeps `ripr` advisory: severe-gap and impacted-evidence output can
+A later post-parity traffic sample is recorded in
+[`docs/audits/ripr-calibration-2026-05-17.md`](../audits/ripr-calibration-2026-05-17.md).
+Those audits keep `ripr` advisory: severe-gap and impacted-evidence output can
 route review and targeted mutation, but branch protection must not depend on
 `ripr` until artifact counter semantics and traffic patterns are better
 understood.


### PR DESCRIPTION
﻿## Summary
- add a 2026-05-17 RIPR calibration audit from recent hosted PR artifacts
- update the RIPR docs and status pointer to the latest advisory calibration
- record the calibration work item in the active goal manifest without changing branch protection or workflow behavior

## Validation
- python active.toml parse check
- cargo +1.95.0 run -p xtask -- badges --check
- cargo +1.95.0 run -p xtask -- impacted-evidence
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims
- no branch-protection change
- no required-check change
- no runtime mutation run
- no crates.io, TestPyPI, PyPI, npm, tag, or GitHub release action
