### PR TITLE
Improve profile loader unit tests

### DIFF
--- a/crates/hl7v2/src/conformance/profile/loader.rs
+++ b/crates/hl7v2/src/conformance/profile/loader.rs
@@ -410,8 +410,22 @@ mod tests {
     )]
 
     use super::*;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_loader(cache_size: usize) -> ProfileLoader {
+        ProfileLoader {
+            cache: Arc::new(RwLock::new(LruCache::new(
+                std::num::NonZeroUsize::new(cache_size)
+                    .unwrap_or(std::num::NonZeroUsize::new(1).unwrap()),
+            ))),
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .unwrap_or_default(),
+            timeout: Duration::from_secs(5),
+        }
+    }
 
     #[tokio::test]
     async fn test_load_from_url() {
@@ -424,12 +438,13 @@ mod tests {
             .mount(&server)
             .await;
 
-        let loader = ProfileLoader::new();
+        let loader = test_loader(100);
         let url = format!("{}/profile.yaml", server.uri());
         let result = loader.load(&url).await.unwrap();
 
         assert_eq!(result.profile.message_structure, "ADT_A01");
         assert!(!result.from_cache);
+        assert_eq!(result.etag, None);
     }
 
     #[tokio::test]
@@ -447,24 +462,91 @@ mod tests {
             .mount(&server)
             .await;
 
-        let loader = ProfileLoader::new();
+        let loader = test_loader(100);
         let url = format!("{}/profile.yaml", server.uri());
 
-        // First load
-        let _ = loader.load(&url).await.unwrap();
+        // First load populates the cache with the response ETag.
+        let first = loader.load(&url).await.unwrap();
+        assert!(!first.from_cache);
+        assert_eq!(first.etag.as_deref(), Some("v1"));
 
-        // Second load (should be from cache if we don't have conditional request logic yet,
-        // or should use ETag)
-        // Let's mock the 304 response
+        // Second load should revalidate with If-None-Match and satisfy 304s from cache.
         server.reset().await;
         Mock::given(method("GET"))
             .and(path("/profile.yaml"))
+            .and(header("if-none-match", "v1"))
             .respond_with(ResponseTemplate::new(304))
+            .expect(1)
             .mount(&server)
             .await;
 
         let result = loader.load(&url).await.unwrap();
         assert!(result.from_cache);
+        assert_eq!(result.profile.message_structure, "ADT_A01");
+        assert_eq!(result.etag.as_deref(), Some("v1"));
+    }
+
+    #[tokio::test]
+    async fn test_load_from_url_updates_cache_when_remote_profile_changes() {
+        let server = MockServer::start().await;
+        let first_profile_yaml = "message_structure: ADT_A01\nversion: '2.5'\nsegments: []";
+        let second_profile_yaml = "message_structure: ORU_R01\nversion: '2.5'\nsegments: []";
+
+        Mock::given(method("GET"))
+            .and(path("/profile.yaml"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(first_profile_yaml)
+                    .insert_header("ETag", "v1"),
+            )
+            .mount(&server)
+            .await;
+
+        let loader = test_loader(100);
+        let url = format!("{}/profile.yaml", server.uri());
+        let first = loader.load(&url).await.unwrap();
+        assert_eq!(first.profile.message_structure, "ADT_A01");
+        assert_eq!(first.etag.as_deref(), Some("v1"));
+
+        server.reset().await;
+        Mock::given(method("GET"))
+            .and(path("/profile.yaml"))
+            .and(header("if-none-match", "v1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(second_profile_yaml)
+                    .insert_header("ETag", "v2"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let second = loader.load(&url).await.unwrap();
+        assert!(!second.from_cache);
+        assert_eq!(second.profile.message_structure, "ORU_R01");
+        assert_eq!(second.etag.as_deref(), Some("v2"));
+    }
+
+    #[tokio::test]
+    async fn test_file_scheme_loads_and_reuses_local_file_cache() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("profile.yaml");
+        let profile_yaml = "message_structure: PPR_PC1\nversion: '2.5'\nsegments: []";
+        std::fs::write(&file_path, profile_yaml).unwrap();
+
+        let loader = ProfileLoader::new();
+        let path = file_path.to_str().unwrap();
+        let file_url = format!("file://{path}");
+
+        let first = loader.load(&file_url).await.unwrap();
+        assert_eq!(first.profile.message_structure, "PPR_PC1");
+        assert!(!first.from_cache);
+        assert!(loader.is_cached(path).await);
+        assert!(!loader.is_cached(&file_url).await);
+
+        let second = loader.load(&file_url).await.unwrap();
+        assert!(second.from_cache);
+        assert_eq!(second.profile.message_structure, "PPR_PC1");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Make profile loader tests robust against host HTTP proxy settings and exercise ETag-based caching behavior more thoroughly.
- Ensure `file://` handling and cache key semantics are validated to prevent regressions in local vs remote load paths.

### Description
- Add a proxy-free test helper `test_loader` that builds a `ProfileLoader` with `reqwest::Client::builder().no_proxy()` to isolate wiremock interactions (file: `crates/hl7v2/src/conformance/profile/loader.rs`).
- Strengthen remote tests to assert ETag capture and revalidation by checking `If-None-Match`, handling `304 Not Modified` from cache, and updating cache on a changed `200` response.
- Add a new test that verifies `file://` local profile loading and that the cache key uses the filesystem path (so subsequent `file://` loads hit the same cached entry).
- Small test refactors and assertions added (`assert_eq!(result.etag, None)` and explicit `expect(1)` on mocked revalidation requests).

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test -p hl7v2 --lib conformance::profile::loader::tests` and the targeted test module passed (all tests in the module OK).
- Ran the full unit test suite with `cargo test -p hl7v2 --lib` and it completed successfully with `483 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1cac64c833395260b720722785f)