### PR TITLE
docs: route full evidence receipt paths

### DIFF
--- a/docs/guides/first-use-by-surface.md
+++ b/docs/guides/first-use-by-surface.md
@@ -215,6 +215,31 @@ First useful receipt:
 import smoke + validation report dict + corpus summary dict
 ```
 
+## Full Receipt Path By Surface
+
+If your first job is the complete evidence loop, route by surface instead of
+learning repository internals:
+
+```text
+message.hl7
+  -> validate
+  -> redact
+  -> bundle
+  -> replay
+  -> evidence summary
+```
+
+| Surface | Start here | What it gives you |
+| --- | --- | --- |
+| CLI | [First 10 Minutes](first-10-minutes.md) and [Safe Support Bundle](safe-support-bundle.md) | Copy/paste commands for validation, redaction, bundle creation, replay, and shareable operator evidence. |
+| Python | [Python Evidence Workflow](python-evidence-workflow.md) | The same evidence job from a local wheel install until public `hl7v2` TestPyPI/PyPI proof lands. |
+| Server | [Deploy Validation Sidecar](deploy-validation-sidecar.md) | REST/gRPC sidecar routes for readiness, redacted validation, evidence bundles, replay, and operational checks. |
+| Rust | [Rust Library](#rust-library), [Evidence artifact architecture](../architecture/evidence-artifacts.md), and [HL7V2-SPEC-0006](../specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Embed the shared evidence contracts directly in an application; use the CLI guide as the operational reference for the full support-bundle path. |
+
+Use [Evidence Artifacts For Operators](evidence-artifacts-for-operators.md)
+after any route above to interpret what each receipt proves, what it does not
+prove, and whether it is safe to share.
+
 ## What Not To Infer
 
 - A crates.io `hl7v2-python` backend proof is not a PyPI `hl7v2` proof.


### PR DESCRIPTION
## Summary
- add a full receipt path routing section to the first-use guide
- point CLI, Python, server, and Rust users to existing canonical evidence workflow docs
- preserve the public Python boundary: local wheel proof is not TestPyPI/PyPI proof

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check