### PR TITLE
cli: add support-bundle alias

### DIFF
--- a/crates/hl7v2-cli/README.md
+++ b/crates/hl7v2-cli/README.md
@@ -50,7 +50,7 @@ Redact a message for safe analysis:
 hl7v2-cli redact message.hl7 --policy safe-analysis.toml --format json
 hl7v2-cli redact message.hl7 --policy safe-analysis.toml --format json --schema-version 2
 hl7v2-cli redact message.hl7 --policy safe-analysis.toml --format hl7 > message.redacted.hl7
-hl7v2-cli bundle message.hl7 --profile profiles/adt_a01.yaml --redact-policy safe-analysis.toml --out issue-bundle/ --schema-version 2
+hl7v2-cli support-bundle message.hl7 --profile profiles/adt_a01.yaml --redact-policy safe-analysis.toml --out issue-bundle/ --schema-version 2
 hl7v2-cli replay issue-bundle/ --format json --schema-version 2
 ```
 
@@ -78,7 +78,9 @@ field unless `optional = true` is set. Built-in sensitive fields such as
 `PID.3`, `PID.5`, `PID.7`, `PID.11`, `PID.13`, `PID.19`, and next-of-kin
 fields must be protected when present and cannot be retained.
 
-`hl7v2-cli bundle` writes a redacted evidence packet containing:
+`hl7v2-cli support-bundle` is an operator-focused alias for
+`hl7v2-cli bundle`, which remains available as the compatibility spelling. It
+writes a redacted evidence packet containing:
 
 - `manifest.json`
 - `README.md`

--- a/crates/hl7v2-cli/src/cli.rs
+++ b/crates/hl7v2-cli/src/cli.rs
@@ -260,6 +260,7 @@ pub(crate) enum Commands {
     },
 
     /// Create a redacted support/debug evidence bundle
+    #[command(visible_alias = "support-bundle")]
     Bundle {
         /// Input HL7 file
         input: PathBuf,

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -238,6 +238,31 @@ mod cli_unit_tests {
         }
 
         #[test]
+        fn test_support_bundle_alias_parses_as_bundle_command() {
+            use crate::{Cli, Commands};
+            use clap::Parser;
+
+            let parsed = Cli::try_parse_from([
+                "hl7v2-cli",
+                "support-bundle",
+                "message.hl7",
+                "--profile",
+                "profile.yaml",
+                "--redact-policy",
+                "safe-analysis.toml",
+                "--out",
+                "issue-bundle",
+            ]);
+
+            assert!(matches!(
+                parsed,
+                Ok(Cli {
+                    command: Commands::Bundle { .. }
+                })
+            ));
+        }
+
+        #[test]
         fn test_replay_command_exists() {
             use crate::Cli;
             let schema = Cli::command();

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -87,6 +87,10 @@ mod help_and_version {
                 &["bundle", "--help"],
                 "Create a redacted support/debug evidence bundle",
             ),
+            (
+                &["support-bundle", "--help"],
+                "Create a redacted support/debug evidence bundle",
+            ),
             (&["replay", "--help"], "Replay a redacted evidence bundle"),
             (&["ack", "--help"], "Generate ACK"),
             (&["gen", "--help"], "Generate synthetic"),

--- a/docs/guides/safe-support-bundle.md
+++ b/docs/guides/safe-support-bundle.md
@@ -10,8 +10,12 @@ source checkout, use `cargo run -q -p hl7v2-cli --` before each command
 instead:
 
 ```bash
-cargo run -q -p hl7v2-cli -- bundle failing.hl7 --profile profile.yaml --redact-policy safe-analysis.toml --out issue-bundle/
+cargo run -q -p hl7v2-cli -- support-bundle failing.hl7 --profile profile.yaml --redact-policy safe-analysis.toml --out issue-bundle/
 ```
+
+`support-bundle` is the operator-focused alias for `bundle`. Both commands
+produce the same evidence packet; use `support-bundle` when the job is a safe
+handoff packet for a vendor, support engineer, data team, or agent.
 
 ## What You Will Produce
 
@@ -148,7 +152,7 @@ why `PID.8 = X` violates the profile value set.
 Create the bundle. The output directory must not already exist:
 
 ```bash
-hl7v2-cli bundle test_data/invalid_message.hl7 \
+hl7v2-cli support-bundle test_data/invalid_message.hl7 \
   --profile profiles/generic.yaml \
   --redact-policy target/hl7v2-safe-support-bundle/safe-analysis.toml \
   --out target/hl7v2-safe-support-bundle/issue-bundle \


### PR DESCRIPTION
## Summary
- add support-bundle as a visible alias for the existing undle command
- keep one implementation path through vidence_bundle::bundle_command
- update operator docs and CLI README to present the support-bundle workflow

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli cli_unit_tests::argument_parsing::test_support_bundle_alias_parses_as_bundle_command -- --nocapture
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests help_text_mentions_expected_command_purpose -- --nocapture
- cargo +1.95.0 clippy -p hl7v2-cli --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- check-no-panic-family
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check

Note: an earlier broad unit-test command passed the intended unit test but also forwarded the filter to a custom BDD test binary; I reran the unit test scoped to --bin hl7v2-cli, which passed cleanly.