### PR TITLE
Harden HL7 parser edge cases

### DIFF
--- a/crates/hl7v2/src/model/mod.rs
+++ b/crates/hl7v2/src/model/mod.rs
@@ -177,8 +177,19 @@ impl Delims {
         let esc_char = msh.chars().nth(6).ok_or(Error::BadDelimLength)?;
         let sub_char = msh.chars().nth(7).ok_or(Error::BadDelimLength)?;
 
-        // Check that all delimiters are distinct
+        // HL7 delimiters are single-byte ASCII separator characters. Rejecting
+        // multibyte or line-break delimiters keeps downstream segment slicing on
+        // byte offsets safe and prevents control characters from masquerading as
+        // separators.
         let delimiters = [field_sep, comp_char, rep_char, esc_char, sub_char];
+        if delimiters
+            .iter()
+            .any(|delimiter| !delimiter.is_ascii() || matches!(delimiter, '\r' | '\n'))
+        {
+            return Err(Error::BadDelimLength);
+        }
+
+        // Check that all delimiters are distinct
         for i in 0..delimiters.len() {
             for j in (i + 1)..delimiters.len() {
                 if delimiters[i] == delimiters[j] {

--- a/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
+++ b/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
@@ -63,6 +63,31 @@ fn test_parse_adt_a04() {
     assert_eq!(get(&message, "PID.5.2"), Some("Jane"));
 }
 
+#[test]
+fn test_parse_accepts_crlf_and_lf_segment_separators() {
+    let crlf = b"MSH|^~\\&|App|Fac|Recv|Fac|20260516120000||ADT^A01|CTRL|P|2.5\r\nPID|1||12345^^^HOSP^MR||Doe^Jane\r\n";
+    let crlf_message = parse(crlf).unwrap();
+    assert_eq!(crlf_message.segments.len(), 2);
+    assert_eq!(get(&crlf_message, "PID.5.2"), Some("Jane"));
+
+    let lf = b"MSH|^~\\&|App|Fac|Recv|Fac|20260516120000||ADT^A01|CTRL|P|2.5\nPID|1||12345^^^HOSP^MR||Doe^John\n";
+    let lf_message = parse(lf).unwrap();
+    assert_eq!(lf_message.segments.len(), 2);
+    assert_eq!(get(&lf_message, "PID.5.2"), Some("John"));
+}
+
+#[test]
+fn test_parse_rejects_segment_without_configured_field_separator() {
+    let missing_separator = b"MSH|^~\\&|App|Fac\rPID1||12345^^^HOSP^MR||Doe^Jane\r";
+    assert!(parse(missing_separator).is_err());
+}
+
+#[test]
+fn test_parse_rejects_multibyte_delimiters_without_panicking() {
+    let multibyte_delimiter = "MSH§^~\\&§App§Fac\r";
+    assert!(parse(multibyte_delimiter.as_bytes()).is_err());
+}
+
 // =============================================================================
 // Delimiter Tests
 // =============================================================================

--- a/crates/hl7v2/src/parser/mod.rs
+++ b/crates/hl7v2/src/parser/mod.rs
@@ -73,7 +73,7 @@ pub fn parse(bytes: &[u8]) -> Result<Message, Error> {
     let text = std::str::from_utf8(bytes).map_err(|_| Error::InvalidCharset)?;
 
     // Split into lines (segments)
-    let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
+    let lines = segment_lines(text);
 
     if lines.is_empty() {
         std::hint::cold_path();
@@ -161,7 +161,7 @@ pub fn parse_batch(bytes: &[u8]) -> Result<Batch, Error> {
     let text = std::str::from_utf8(bytes).map_err(|_| Error::InvalidCharset)?;
 
     // Split into lines (segments)
-    let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
+    let lines = segment_lines(text);
 
     if lines.is_empty() {
         return Err(Error::InvalidSegmentId);
@@ -198,7 +198,7 @@ pub fn parse_file_batch(bytes: &[u8]) -> Result<FileBatch, Error> {
     let text = std::str::from_utf8(bytes).map_err(|_| Error::InvalidCharset)?;
 
     // Split into lines (segments)
-    let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
+    let lines = segment_lines(text);
 
     if lines.is_empty() {
         return Err(Error::InvalidSegmentId);
@@ -225,6 +225,19 @@ pub fn parse_file_batch(bytes: &[u8]) -> Result<FileBatch, Error> {
 // Internal parsing functions
 // ============================================================================
 
+/// Split raw HL7 text into non-empty segment lines.
+///
+/// HL7 messages are commonly delimited by carriage returns, but file-oriented
+/// transports and fixtures may normalize segment separators to LF or CRLF.
+/// Treat either byte as a segment boundary so the parser accepts all three
+/// common line-ending forms while still rejecting embedded line breaks through
+/// segment ID validation when they do not start a valid segment.
+fn segment_lines(text: &str) -> Vec<&str> {
+    text.split(['\r', '\n'])
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
 /// Parse a single segment
 fn parse_segment(line: &str, delims: &Delims) -> Result<Segment, Error> {
     if line.len() < 3 {
@@ -245,11 +258,16 @@ fn parse_segment(line: &str, delims: &Delims) -> Result<Segment, Error> {
         }
     }
 
-    // Parse fields
-    let fields_str = if line.len() > 4 {
+    // Parse fields. If a segment has fields, byte 4 must be the configured
+    // single-byte field separator. A bare three-character segment ID is allowed
+    // as an empty segment.
+    let fields_str = if line.len() == 3 {
+        ""
+    } else if line.as_bytes().get(3) == Some(&(delims.field as u8)) {
         &line[4..] // Skip segment ID and field separator
     } else {
-        ""
+        std::hint::cold_path();
+        return Err(Error::InvalidSegmentId);
     };
 
     let mut fields = parse_fields(fields_str, delims).map_err(|e| Error::ParseError {


### PR DESCRIPTION
### Motivation

- Accept common segment separators (CR, LF, CRLF) used in different transports and fixtures so parsing is robust across inputs.
- Reject segments that do not use the configured single-byte field separator to avoid silent mis-parsing and unsafe byte-slicing assumptions.
- Prevent multibyte or control-character delimiters (including CR/LF) from being treated as valid MSH delimiters to protect downstream byte-offset logic.

### Description

- Added a shared `segment_lines` helper and switched `parse`, `parse_batch`, and `parse_file_batch` to use it so CR/LF/CRLF are handled consistently (`crates/hl7v2/src/parser/mod.rs`).
- Hardened `parse_segment` to validate that a segment with fields actually contains the configured single-byte field separator at byte index 3 and return `Error::InvalidSegmentId` otherwise (`crates/hl7v2/src/parser/mod.rs`).
- Tightened `Delims::parse_from_msh` to reject multibyte or line-break delimiter characters and return `Error::BadDelimLength` for such cases (`crates/hl7v2/src/model/mod.rs`).
- Added edge-case unit tests covering CRLF/LF parsing, rejection of segments missing the configured field separator, and rejection of multibyte delimiters without panicking (`crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs`).
- Minor formatting/test harness adjustments to keep tests stable across platforms.

### Testing

- Ran `cargo fmt --all -- --check` and it succeeded.
- Ran targeted parser tests with `cargo test -p hl7v2 test_parse_ -- --nocapture` and they passed.
- Ran full test suite with `NO_PROXY=127.0.0.1,localhost cargo test -p hl7v2 --all-targets` and all tests passed.
- Ran static checks with `cargo clippy -p hl7v2 --all-targets -- -D warnings` and it completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d214e9cc8333b0f3c15e20f1df86)