### PR TITLE
Improve parser edge-case handling for segment fields and MSH-18 charset extraction

### DIFF
--- a/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
+++ b/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
@@ -279,6 +279,12 @@ fn test_error_invalid_segment_id() {
 }
 
 #[test]
+fn test_error_segment_rejects_non_delimiter_after_segment_id() {
+    let result = parse(b"MSH|^~\\&|App|Fac\rPIDx1||123||Test\r");
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_error_invalid_charset() {
     // Non-UTF8 bytes should fail
     let result = parse(&[0xFF, 0xFE, 0xFD]);
@@ -391,10 +397,26 @@ fn test_msh_encoding_characters_field() {
 
 #[test]
 fn test_charset_extraction() {
-    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5|||||||ASCII\r";
+    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5||||||ASCII\r";
     let message = parse(hl7).unwrap();
 
     assert_eq!(message.charsets, vec!["ASCII"]);
+}
+
+#[test]
+fn test_charset_extraction_uses_msh_18_not_msh_19() {
+    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5|||||||NOT_A_CHARSET\r";
+    let message = parse(hl7).unwrap();
+
+    assert!(message.charsets.is_empty());
+}
+
+#[test]
+fn test_charset_extraction_handles_repetitions() {
+    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5||||||ASCII~UNICODE UTF-8\r";
+    let message = parse(hl7).unwrap();
+
+    assert_eq!(message.charsets, vec!["ASCII", "UNICODE UTF-8"]);
 }
 
 #[test]

--- a/crates/hl7v2/src/parser/mod.rs
+++ b/crates/hl7v2/src/parser/mod.rs
@@ -245,11 +245,19 @@ fn parse_segment(line: &str, delims: &Delims) -> Result<Segment, Error> {
         }
     }
 
-    // Parse fields
-    let fields_str = if line.len() > 4 {
-        &line[4..] // Skip segment ID and field separator
-    } else {
-        ""
+    // Parse fields. If a segment has content beyond the three-byte segment ID,
+    // it must be introduced by the configured field separator.
+    let fields_str = match line.get(3..) {
+        Some("") | None => "",
+        Some(after_id) => {
+            if !after_id.starts_with(delims.field) {
+                return Err(Error::InvalidFieldFormat {
+                    details: "Segment fields must start with the configured field separator"
+                        .to_string(),
+                });
+            }
+            &after_id[delims.field.len_utf8()..]
+        }
     };
 
     let mut fields = parse_fields(fields_str, delims).map_err(|e| Error::ParseError {
@@ -412,27 +420,34 @@ fn parse_atom(atom_str: &str, delims: &Delims) -> Result<Atom, Error> {
 
 /// Extract character sets from MSH-18 field
 fn extract_charsets(segments: &[Segment]) -> Vec<String> {
-    // Look for the MSH segment (should be the first one)
-    if let Some(msh_segment) = segments.first()
-        && &msh_segment.id == b"MSH"
-        && msh_segment.fields.len() > 17
-        && let field_18 = &msh_segment.fields[17]
-        && !field_18.reps.is_empty()
-    {
-        let rep = &field_18.reps[0];
+    // Parsed MSH fields start at MSH-2 because MSH-1 is the field separator,
+    // so MSH-18 is stored at zero-based index 16.
+    const MSH_18_INDEX: usize = 16;
 
-        let mut charsets = Vec::new();
-        for comp in &rep.comps {
-            if let Some(Atom::Text(text)) = comp.subs.first()
-                && !text.is_empty()
-            {
-                charsets.push(text.clone());
-            }
-        }
-
-        return charsets;
+    let Some(msh_segment) = segments.first() else {
+        return vec![];
+    };
+    if &msh_segment.id != b"MSH" {
+        return vec![];
     }
-    vec![]
+
+    let Some(field_18) = msh_segment.fields.get(MSH_18_INDEX) else {
+        return vec![];
+    };
+
+    field_18
+        .reps
+        .iter()
+        .filter_map(|rep| {
+            rep.comps
+                .first()
+                .and_then(|comp| comp.subs.first())
+                .and_then(|atom| match atom {
+                    Atom::Text(text) if !text.is_empty() => Some(text.clone()),
+                    _ => None,
+                })
+        })
+        .collect()
 }
 
 /// Parse a batch that starts with BHS


### PR DESCRIPTION
### Motivation
- Fix parser edge cases where segment content after the 3-byte segment ID could be misinterpreted if it does not start with the configured field separator. 
- Ensure charset extraction reads the intended MSH-18 field (accounting for MSH-1 being the field separator) and handles repeated charset values correctly. 

### Description
- Require any characters following the three-byte segment ID to begin with the active field separator and return `Error::InvalidFieldFormat` if not, implemented in `parse_segment` in `crates/hl7v2/src/parser/mod.rs` via an explicit `starts_with(delims.field)` check. 
- Adjust MSH charset extraction to use the correct parsed field index (`MSH-18` is at zero-based index `16`) and collect non-empty repetitions, implemented in `extract_charsets` in `crates/hl7v2/src/parser/mod.rs`. 
- Add regression tests covering malformed segment field separators and MSH-18 extraction edge cases in `crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs`, including `test_error_segment_rejects_non_delimiter_after_segment_id`, `test_charset_extraction_uses_msh_18_not_msh_19`, and `test_charset_extraction_handles_repetitions`. 
- Minor test file line-ending/format normalization to keep diffs tidy. 

### Testing
- Ran `cargo fmt --all -- --check` which succeeded. 
- Ran targeted tests `cargo test -q -p hl7v2 test_charset_extraction` and `cargo test -q -p hl7v2 test_error_segment_rejects_non_delimiter_after_segment_id`, both of which passed. 
- Ran `cargo clippy -q -p hl7v2 --lib -- -D warnings` which completed without warnings. 
- Ran the full crate tests `cargo test -q -p hl7v2`, which showed 482 tests passed and 2 pre-existing failures (`test_cache_invalidation` and `test_load_from_url`) caused by HTTP 403 responses from local URL loader tests and are unrelated to these parser changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d214e9cc8333b0f3c15e20f1df86)