### PR TITLE
fix(parser): harden edge case parsing

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "11788",
+  "message": "11816",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/model/mod.rs
+++ b/crates/hl7v2/src/model/mod.rs
@@ -177,8 +177,15 @@ impl Delims {
         let esc_char = msh.chars().nth(6).ok_or(Error::BadDelimLength)?;
         let sub_char = msh.chars().nth(7).ok_or(Error::BadDelimLength)?;
 
-        // Check that all delimiters are distinct
         let delimiters = [field_sep, comp_char, rep_char, esc_char, sub_char];
+        if delimiters
+            .iter()
+            .any(|delimiter| !delimiter.is_ascii() || matches!(delimiter, '\r' | '\n'))
+        {
+            return Err(Error::BadDelimLength);
+        }
+
+        // Check that all delimiters are distinct
         for i in 0..delimiters.len() {
             for j in (i + 1)..delimiters.len() {
                 if delimiters[i] == delimiters[j] {

--- a/crates/hl7v2/src/parser/batch.rs
+++ b/crates/hl7v2/src/parser/batch.rs
@@ -9,7 +9,7 @@
 
 use crate::model::{Batch, Delims, Error, FileBatch};
 
-use super::message::parse;
+use super::message::{parse, segment_lines};
 use super::segment::parse_segment;
 
 /// Parse HL7 v2 batch from bytes.
@@ -23,7 +23,7 @@ use super::segment::parse_segment;
 /// The parsed `Batch`, or an error if parsing fails
 pub fn parse_batch(bytes: &[u8]) -> Result<Batch, Error> {
     let text = std::str::from_utf8(bytes).map_err(|_| Error::InvalidCharset)?;
-    let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
+    let lines = segment_lines(text);
 
     if lines.is_empty() {
         return Err(Error::InvalidSegmentId);
@@ -57,7 +57,7 @@ pub fn parse_batch(bytes: &[u8]) -> Result<Batch, Error> {
 /// The parsed `FileBatch`, or an error if parsing fails
 pub fn parse_file_batch(bytes: &[u8]) -> Result<FileBatch, Error> {
     let text = std::str::from_utf8(bytes).map_err(|_| Error::InvalidCharset)?;
-    let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
+    let lines = segment_lines(text);
 
     if lines.is_empty() {
         return Err(Error::InvalidSegmentId);

--- a/crates/hl7v2/src/parser/charset.rs
+++ b/crates/hl7v2/src/parser/charset.rs
@@ -4,21 +4,30 @@ use crate::model::{Atom, Segment};
 
 /// Extract character sets from MSH-18 field.
 pub(super) fn extract_charsets(segments: &[Segment]) -> Vec<String> {
-    if let Some(msh_segment) = segments.first()
-        && &msh_segment.id == b"MSH"
-        && let Some(field_18) = msh_segment.fields.get(17)
-        && let Some(rep) = field_18.reps.first()
-    {
-        let mut charsets = Vec::new();
-        for comp in &rep.comps {
-            if let Some(Atom::Text(text)) = comp.subs.first()
-                && !text.is_empty()
-            {
-                charsets.push(text.clone());
-            }
-        }
+    const MSH_18_INDEX: usize = 16;
 
-        return charsets;
+    let Some(msh_segment) = segments.first() else {
+        return vec![];
+    };
+    if &msh_segment.id != b"MSH" {
+        return vec![];
     }
-    vec![]
+
+    let Some(field_18) = msh_segment.fields.get(MSH_18_INDEX) else {
+        return vec![];
+    };
+
+    field_18
+        .reps
+        .iter()
+        .filter_map(|rep| {
+            rep.comps
+                .first()
+                .and_then(|comp| comp.subs.first())
+                .and_then(|atom| match atom {
+                    Atom::Text(text) if !text.is_empty() => Some(text.clone()),
+                    _ => None,
+                })
+        })
+        .collect()
 }

--- a/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
+++ b/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
@@ -83,6 +83,18 @@ fn test_parse_custom_delimiters() {
 }
 
 #[test]
+fn test_parse_rejects_multibyte_delimiters_without_panicking() {
+    let hl7 = "MSH§^~\\&§App§Fac\r";
+
+    assert!(parse(hl7.as_bytes()).is_err());
+}
+
+#[test]
+fn test_parse_rejects_line_break_delimiter() {
+    assert!(Delims::parse_from_msh("MSH|^~\\\n").is_err());
+}
+
+#[test]
 fn test_default_delimiters() {
     let delims = Delims::default();
     assert_eq!(delims.field, '|');
@@ -391,10 +403,26 @@ fn test_msh_encoding_characters_field() {
 
 #[test]
 fn test_charset_extraction() {
-    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5|||||||ASCII\r";
+    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5||||||ASCII\r";
     let message = parse(hl7).unwrap();
 
     assert_eq!(message.charsets, vec!["ASCII"]);
+}
+
+#[test]
+fn test_charset_extraction_uses_msh_18_not_msh_19() {
+    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5|||||||NOT_A_CHARSET\r";
+    let message = parse(hl7).unwrap();
+
+    assert!(message.charsets.is_empty());
+}
+
+#[test]
+fn test_charset_extraction_handles_repetitions() {
+    let hl7 = b"MSH|^~\\&|App|Fac|||20250128120000||ADT^A01|1|P|2.5||||||ASCII~UNICODE UTF-8\r";
+    let message = parse(hl7).unwrap();
+
+    assert_eq!(message.charsets, vec!["ASCII", "UNICODE UTF-8"]);
 }
 
 #[test]
@@ -425,6 +453,44 @@ fn test_trailing_carriage_return() {
     assert_eq!(message.segments.len(), 2);
 }
 
+#[test]
+fn test_parse_accepts_crlf_segment_separators() {
+    let hl7 = b"MSH|^~\\&|App|Fac\r\nPID|1||123||Test\r\n";
+    let message = parse(hl7).unwrap();
+
+    assert_eq!(message.segments.len(), 2);
+    assert_eq!(get(&message, "PID.5.1"), Some("Test"));
+}
+
+#[test]
+fn test_parse_rejects_bare_lf_segment_separators() {
+    let hl7 = b"MSH|^~\\&|App|Fac\nPID|1||123||Test\n";
+
+    assert!(parse(hl7).is_err());
+}
+
+#[test]
+fn test_parse_batch_accepts_crlf_segment_separators() {
+    let hl7 = b"BHS|^~\\&|BatchApp\r\nMSH|^~\\&|App|Fac\r\nPID|1||123||Test\r\nBTS|1\r\n";
+    let batch = parse_batch(hl7).unwrap();
+
+    assert_eq!(batch.messages.len(), 1);
+    assert_eq!(get(&batch.messages[0], "PID.5.1"), Some("Test"));
+}
+
+#[test]
+fn test_parse_file_batch_accepts_crlf_segment_separators() {
+    let hl7 = b"FHS|^~\\&|FileApp\r\nBHS|^~\\&|BatchApp\r\nMSH|^~\\&|App|Fac\r\nPID|1||123||Test\r\nBTS|1\r\nFTS|1\r\n";
+    let file_batch = parse_file_batch(hl7).unwrap();
+
+    assert_eq!(file_batch.batches.len(), 1);
+    assert_eq!(file_batch.batches[0].messages.len(), 1);
+    assert_eq!(
+        get(&file_batch.batches[0].messages[0], "PID.5.1"),
+        Some("Test")
+    );
+}
+
 // =============================================================================
 // Segment ID Validation Tests
 // =============================================================================
@@ -449,4 +515,11 @@ fn test_numeric_segment_id() {
 
     assert_eq!(message.segments.len(), 2);
     assert_eq!(&message.segments[1].id, b"Z01");
+}
+
+#[test]
+fn test_parse_rejects_segment_without_configured_field_separator() {
+    let hl7 = b"MSH|^~\\&|App|Fac\rPIDx1||123||Test\r";
+
+    assert!(parse(hl7).is_err());
 }

--- a/crates/hl7v2/src/parser/message.rs
+++ b/crates/hl7v2/src/parser/message.rs
@@ -34,7 +34,7 @@ use super::segment::parse_segment;
 /// ```
 pub fn parse(bytes: &[u8]) -> Result<Message, Error> {
     let text = std::str::from_utf8(bytes).map_err(|_| Error::InvalidCharset)?;
-    let lines: Vec<&str> = text.split('\r').filter(|line| !line.is_empty()).collect();
+    let lines = segment_lines(text);
 
     if lines.is_empty() {
         std::hint::cold_path();
@@ -103,4 +103,11 @@ pub fn parse_mllp(bytes: &[u8]) -> Result<Message, Error> {
     let hl7_content =
         crate::transport::mllp::unwrap_mllp(bytes).map_err(|e| Error::Framing(e.to_string()))?;
     parse(hl7_content)
+}
+
+pub(super) fn segment_lines(text: &str) -> Vec<&str> {
+    text.split('\r')
+        .map(|line| line.strip_prefix('\n').unwrap_or(line))
+        .filter(|line| !line.is_empty())
+        .collect()
 }

--- a/crates/hl7v2/src/parser/segment.rs
+++ b/crates/hl7v2/src/parser/segment.rs
@@ -30,7 +30,24 @@ pub(super) fn parse_segment(line: &str, delims: &Delims) -> Result<Segment, Erro
         }
     }
 
-    let fields_str = line.get(4..).unwrap_or("");
+    let mut field_sep_buf = [0; 4];
+    let field_sep = delims.field.encode_utf8(&mut field_sep_buf);
+    let fields_str = if line.len() == 3 {
+        ""
+    } else if field_sep.len() == 1 && line.as_bytes().get(3) == field_sep.as_bytes().first() {
+        let Some(fields_str) = line.get(4..) else {
+            std::hint::cold_path();
+            return Err(Error::InvalidFieldFormat {
+                details: "Segment field separator must end at a UTF-8 boundary".to_string(),
+            });
+        };
+        fields_str
+    } else {
+        std::hint::cold_path();
+        return Err(Error::InvalidFieldFormat {
+            details: "Segment fields must start with the configured field separator".to_string(),
+        });
+    };
 
     let mut fields = parse_fields(fields_str, delims).map_err(|e| Error::ParseError {
         segment_id: String::from_utf8_lossy(&id).to_string(),


### PR DESCRIPTION
## Summary

- Reject non-ASCII and CR/LF delimiter characters during MSH delimiter parsing.
- Correct MSH-18 charset extraction and preserve repeated charset values.
- Validate segment field separators, accept CRLF segment separators, and keep bare LF rejected.
- Add parser regressions plus regenerated RIPR badge metadata.

Supersedes stale parser edge-case PRs #758 and #759 with a clean branch based on current main.

## Validation

- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p hl7v2 parser --all-features --locked
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- check-no-panic-family
- cargo +1.95.0 run -p xtask -- badges --check
- cargo +1.95.0 run -p xtask -- impacted-evidence --check
- git diff --check