### PR TITLE
docs: add source-of-truth agent rails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Read these before changing files:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.hl7v2/goals/active.toml`
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+## Scope rule
+
+Implement one work item per PR.
+
+Docs-only artifacts should stay separate unless the selected plan item says
+otherwise:
+
+- proposal PRs explain why;
+- spec PRs define behavior;
+- ADR PRs record durable decisions;
+- plan PRs define sequencing;
+- active-goal PRs define current execution;
+- runtime/code PRs link to the spec and plan item they implement.
+
+Do not create a new lane or broaden a lane unless the user explicitly asks for
+that source-of-truth change.
+
+## Proof rule
+
+Run the proof commands listed in the selected plan item and run
+`git diff --check` before reporting success.
+
+If a proof command cannot run, record:
+
+- the exact command;
+- why it was unavailable;
+- substitute evidence, if any;
+- whether the missing proof blocks merge.
+
+Do not claim release, registry, TestPyPI, PyPI, npm, support-tier, or runtime
+success without the corresponding receipt or support-tier proof pointer.
+
+## Generated status rule
+
+Do not hand-edit generated status. Run the generator/checker named by the plan
+or stop and report that the generator is unavailable.
+
+## Policy rule
+
+If you add or broaden an exception, update the relevant `policy/*.toml` ledger
+with owner, reason, `covered_by`, `created`, `review_after`, and expiry when the
+exception is temporary.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing or stale;
+- linked specs, ADRs, or plans are missing;
+- no ready work item is identifiable;
+- proof commands cannot run;
+- generated status is dirty;
+- unrelated staged changes exist;
+- requested work conflicts with an ADR;
+- the task would mix proposal/spec/ADR/plan/runtime changes without an explicit plan item.

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,129 @@
+# Repo source-of-truth system
+
+This repo uses a linked source-of-truth stack so humans and agents can find the
+one place that owns each kind of durable truth.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR where needed
+        -> Implementation plan
+          -> Active goal
+            -> Issue / PR
+              -> Proof
+```
+
+The rule is: do not make every document do every job. Separate why, what,
+decision, how, what now, and what proves it.
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, high-level lanes | PR queue, generated metrics, proof receipts |
+| Proposal | Why the work exists, users, alternatives, success criteria | Behavior contract, detailed PR sequence, current metric state |
+| Spec | Required behavior, acceptance examples, proof requirements | Product rationale, PR order, active queue |
+| ADR | Durable architecture or operating decisions | Task lists, live status, implementation queue |
+| Implementation plan | PR-sized work order, dependencies, proof commands, rollback | Product rationale, durable architecture, generated status truth |
+| Active goal | Current machine-readable objective, ready work items, claim boundaries | Long prose, generated metrics, durable decisions |
+| Support tiers | Public support claims and proof pointers | Feature design, campaign rationale |
+| Policy ledgers | Exceptions, CI/policy intent, coverage, owner, review date | Broad architecture or product strategy |
+| Audit / receipt | What happened and what was proven | Future behavior requirements |
+
+## Canonical locations
+
+| Question | Source of truth |
+| --- | --- |
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What architecture decision did we make? | `docs/adr/` |
+| What PR lands next? | `plans/<lane>/implementation-plan.md` |
+| What is the agent actively executing? | `.hl7v2/goals/active.toml` |
+| What proves a public claim? | `docs/status/SUPPORT_TIERS.md`, receipts, and CI |
+| What exceptions exist? | `policy/*.toml` |
+
+Current product status still lives in `docs/STATUS.md`; do not duplicate it in
+proposal, spec, ADR, plan, or active-goal prose.
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan item explicitly says otherwise.
+3. Proposals explain why; specs define behavior; ADRs record durable decisions.
+4. Plans define sequencing and proof commands; active goals define current execution.
+5. Generated status is updated by tools, not by hand.
+6. Public claims require a support-tier row, receipt, or equivalent proof pointer.
+7. Policy exceptions require owner, reason, coverage, and review date.
+8. Proof commands must be run or marked unavailable with an explicit reason and merge impact.
+
+## Required metadata
+
+Use the repository's established casing and fields, but every durable proposal,
+spec, ADR, and plan should declare the applicable form of:
+
+- `Status:`
+- `Owner:` or equivalent accountable owner when known
+- `Created:` / `Date:` when known
+- linked proposal, specs, ADRs, plan, issues, and PRs when applicable
+- support-tier impact
+- policy impact
+
+Use `n/a` when a field is intentionally not applicable.
+
+## Agent workflow
+
+Agents must:
+
+1. read root repo instructions such as `AGENTS.md` or `CLAUDE.md`;
+2. read this file;
+3. read `.hl7v2/goals/active.toml`;
+4. read the linked implementation plan;
+5. read the linked proposal only for why;
+6. read the linked spec for acceptance and proof;
+7. read linked ADRs for constraints;
+8. inspect git status for unrelated work;
+9. pick exactly one ready work item;
+10. implement only that work item;
+11. run the listed proof commands plus `git diff --check`;
+12. update status, receipts, and policy ledgers only when the work item requires it.
+
+If there is no ready work item, do not invent one. Stop and report the missing
+rail or create a handoff only when explicitly asked.
+
+## Stop conditions
+
+Stop instead of guessing when:
+
+- the active goal is missing, stale, or contradictory;
+- linked proposal, spec, ADR, or plan files do not exist;
+- the selected work item lacks proof commands;
+- proof commands cannot run and no substitute evidence is authorized;
+- generated status differs from committed status;
+- unrelated staged changes exist;
+- the requested work conflicts with an ADR;
+- a public claim lacks support-tier proof;
+- the requested change would mix proposal/spec/ADR/plan/runtime work without an explicit plan item.
+
+## Active goal lifecycle
+
+`.hl7v2/goals/active.toml` is the single active execution manifest. A paused
+state should use `status = "paused"` with a reason. Archive replaced manifests
+under `.hl7v2/goals/archive/` before creating a new active manifest.
+
+## Closeout
+
+At the end of a lane, write a closeout or audit that records:
+
+- what shipped;
+- proof commands and receipts;
+- PRs and CI runs;
+- support-tier or policy updates;
+- what did not ship;
+- deferred work;
+- claim boundaries;
+- next-lane recommendations.
+
+Closeout prevents future humans and agents from rediscovering old work.


### PR DESCRIPTION
### Motivation

- Provide a single, machine- and human-visible boot order and guardrails so agents and contributors know where each kind of durable truth lives and how to proceed without guessing.
- Reduce agent drift and accidental mixing of proposal/spec/plan/ADR/runtime work by enforcing a one-work-item rule, proof requirement, generated-status guardrail, and stop conditions.

### Description

- Add `AGENTS.md` with the repo boot order, one-work-item scope rule, proof rule, generated-status rule, policy-ledger expectations, and explicit stop conditions for agents.
- Add `docs/reference/SPEC_SYSTEM.md` that codifies the linked source-of-truth stack, artifact roles, canonical locations, required metadata, agent workflow, active-goal lifecycle, and closeout guidance.
- These are documentation-only changes that do not modify runtime behavior or CI workflows and are intended to make future plan/spec/ADR/PR work self-describing.

### Testing

- Ran `git diff --check` and it completed with no check failures.
- Ran `cargo +1.95.0 run -p xtask -- check-doc-links` and the repository markdown link check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a18349724833388abd7c3d73f1f23)