### PR TITLE
policy: require Python local wheel proof in parity manifest

### DIFF
--- a/policy/evidence-parity.toml
+++ b/policy/evidence-parity.toml
@@ -65,6 +65,7 @@ backend_crate = "hl7v2-python"
 tier = "experimental-local-wheel"
 role = "Python user package backed by hl7v2-python; public registry proof is blocked by TestPyPI Trusted Publisher setup."
 proof = [
+  "cargo run -p xtask -- python-local-wheel-proof",
   "python tests/python_smoke/smoke.py",
   "python tests/python_smoke/evidence_workflow_guide.py",
 ]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5162,6 +5162,13 @@ fn check_evidence_parity_manifest_text(text: &str) -> Result<()> {
         "issues/563",
         EVIDENCE_PARITY_MANIFEST_PATH,
     )?;
+    ensure_pyproject_array_contains(
+        &manifest,
+        "[surface.python]",
+        "proof",
+        "cargo run -p xtask -- python-local-wheel-proof",
+        EVIDENCE_PARITY_MANIFEST_PATH,
+    )?;
     ensure_pyproject_string_value(
         &manifest,
         "[surface.typescript]",
@@ -7481,6 +7488,33 @@ hl7v2 = { version = "1.5.0", path = "../hl7v2" }
             Err(err)
                 if err.to_string().contains("python state")
                     && err.to_string().contains("public registry claim") =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(anyhow!("unexpected evidence parity policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn evidence_parity_policy_requires_python_local_wheel_proof_command() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let text = fs::read_to_string(root.join(EVIDENCE_PARITY_MANIFEST_PATH))?;
+        let broken = text.replace(
+            "  \"cargo run -p xtask -- python-local-wheel-proof\",\n",
+            "",
+        );
+
+        match check_evidence_parity_manifest_text(&broken) {
+            Ok(()) => Err(anyhow!(
+                "evidence parity policy should require the Python local wheel proof command"
+            )),
+            Err(err)
+                if err
+                    .to_string()
+                    .contains("cargo run -p xtask -- python-local-wheel-proof") =>
             {
                 Ok(())
             }


### PR DESCRIPTION
## Summary

- add the self-contained \xtask python-local-wheel-proof\ command to the Python surface proof list in \policy/evidence-parity.toml\
- make \check-evidence-parity\ require that proof command for the Python local-wheel surface
- add a regression test that fails if the manifest drops the command

## Validation

- rtk cargo +1.95.0 run -p xtask -- check-evidence-parity
- rtk cargo +1.95.0 test -p xtask evidence_parity_policy --locked
- rtk cargo +1.95.0 fmt --all -- --check
- rtk git diff --check

## Notes

- Python remains experimental-local-wheel and blocked by #563 for TestPyPI/PyPI registry proof
- no TestPyPI, PyPI, npm, tag, GitHub release, or new crates.io claim
- validation artifacts were cleaned after the local run
