### PR TITLE
fix: make Python parity proof guard test newline agnostic

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7502,10 +7502,11 @@ hl7v2 = { version = "1.5.0", path = "../hl7v2" }
             .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
             .to_path_buf();
         let text = fs::read_to_string(root.join(EVIDENCE_PARITY_MANIFEST_PATH))?;
-        let broken = text.replace(
-            "  \"cargo run -p xtask -- python-local-wheel-proof\",\n",
-            "",
-        );
+        let broken = text
+            .lines()
+            .filter(|line| !line.contains("cargo run -p xtask -- python-local-wheel-proof"))
+            .collect::<Vec<_>>()
+            .join("\n");
 
         match check_evidence_parity_manifest_text(&broken) {
             Ok(()) => Err(anyhow!(


### PR DESCRIPTION
## Summary

- Fixes the post-merge Windows CI failure from #764.
- Removes the Python local-wheel proof command from the negative fixture by filtering lines instead of matching a literal LF newline.
- Keeps the evidence-parity policy requirement unchanged; this is test portability only.

## Validation

- cargo +1.95.0 test -p xtask evidence_parity_policy_requires_python_local_wheel_proof_command --locked
- cargo +1.95.0 test -p xtask evidence_parity_policy --locked
- cargo +1.95.0 run -p xtask -- check-evidence-parity
- cargo +1.95.0 fmt --all -- --check
- git diff --check

## Claims

- No TestPyPI/PyPI/npm claim.
- No package publish or release claim.