### PR TITLE
docs(ci): document RIPR badge drift repair

### DIFF
--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -27,6 +27,25 @@ The badge boundary is deliberately narrow:
 `target/xtask/badges/` so CI can upload the generated view without mutating the
 committed endpoints.
 
+## Badge Drift
+
+If `cargo run -p xtask -- badges --check` reports that `badges/ripr.json` or
+`badges/ripr-plus.json` is stale, treat that as repository evidence-artifact
+drift. It means the checked-in badge endpoint no longer matches the generated
+repo-scoped view.
+
+The repair is deliberately mechanical:
+
+```bash
+cargo run -p xtask -- badges
+cargo run -p xtask -- badges --check
+```
+
+Commit the changed file under `badges/` only when the generated diff matches
+the PR's intended verification-surface change. Do not use badge drift as a
+shortcut for product behavior proof, and do not treat a badge refresh as runtime
+mutation, coverage, release readiness, TestPyPI, PyPI, or npm evidence.
+
 ## PR evidence
 
 The PR evidence cockpit is diff-scoped and generated under `target/`:

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -76,6 +76,13 @@ artifacts as `ripr-pr-evidence`. The lane remains advisory: findings route
 review and mutation decisions, while contract/tooling drift is the failure mode
 to repair.
 
+If the workflow fails because `badges/ripr.json` or `badges/ripr-plus.json` is
+stale, regenerate the public badge endpoints with
+`cargo run -p xtask -- badges`, rerun `cargo run -p xtask -- badges --check`,
+and commit only the resulting `badges/` endpoint diff. This is repository
+evidence-artifact drift, not proof that product behavior changed and not a
+runtime mutation result.
+
 Do not treat any single artifact as the whole truth. The initial calibration
 found that `repo-exposure.json` summary counters and generated Markdown review
 guidance can use different counter semantics. Reviewer decisions should inspect


### PR DESCRIPTION
## Summary

- Document what a stale `badges/ripr.json` / `badges/ripr-plus.json` failure means.
- Add the mechanical repair path: regenerate with `xtask badges`, then verify with `xtask badges --check`.
- Preserve the boundary that badge refreshes are evidence-endpoint freshness, not runtime mutation, product behavior, release, TestPyPI, PyPI, or npm proof.

## Validation

- `cargo +1.95.0 run -p xtask -- badges --check`
- `cargo +1.95.0 run -p xtask -- check-doc-links`
- `cargo +1.95.0 run -p xtask -- check-file-policy`
- `git diff --check`

## Non-claims

- No branch-protection rule changed.
- No required check added.
- No runtime mutation run.
- No registry, release, tag, TestPyPI, PyPI, or npm action run.