### PR TITLE
docs: align current roadmap and toolchain surfaces

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,9 +11,10 @@
 
 ## Development Standards
 
-- **Rust Version:** Target **Rust 2024** and **MSRV 1.93**.
-- **Microcrate Architecture:** Follow the microcrate architecture (SRP-focused crates in `crates/`). New features should typically live in their own crate.
+- **Rust Version:** Target **Rust 2024** and **MSRV 1.95**.
+- **Crate Boundaries:** Keep the primary Rust product graph focused on `hl7v2`, `hl7v2-server`, and `hl7v2-cli`. Binding backend crates such as `hl7v2-python` are packaging/provenance surfaces for language packages, not the recommended Rust API.
+- **No Microcrate Relapse:** Do not split parser, model, redaction, MLLP, batch, or stream internals back into public Rust microcrates. Prefer SRP modules inside the existing product crates unless a future accepted ADR/spec explicitly changes the crate boundary.
 - **Security First:** Adhere to the security practices outlined in `SECURITY.md`, including constant-time comparisons (`subtle::ct_eq`) for sensitive operations like API key validation.
 - **Performance:** Prioritize stack-allocated buffers and efficient string scanning (`str::contains` fast-paths) for core parsing logic.
-- **Ecosystem Sync:** Ensure OpenAPI specifications (`schemas/openapi/`) are always in sync with the actual implementation in `crates/hl7v2-server`.
+- **Ecosystem Sync:** Ensure OpenAPI, protobuf, evidence schemas, and generated examples stay in sync with the implementation in `crates/hl7v2-server`, `crates/hl7v2-cli`, and `schemas/evidence`.
 - **Licensing:** Use AGPL-3.0-or-later for all new source files. No permissive licenses without explicit approval.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,71 +1,78 @@
-# HL7v2-rs Development Roadmap
+# HL7v2-rs Roadmap
 
-**Current Status**: v1.3.0 (Enterprise Readiness)
-**Target**: v1.4.0 (Cloud-native & Interop) / v2.0.0 (Global Scale)
-**Last Updated**: 2026-05-03
+**Current status**: v1.5.0 Rust 1.95 quality-ratchet release is published for
+`hl7v2`, `hl7v2-python`, `hl7v2-server`, and `hl7v2-cli`.
 
-## Version Strategy
+`hl7v2-python` is binding backend infrastructure for the public Python
+distribution. It is not the recommended Rust API.
 
-This roadmap balances stability with feature completeness. Each version has clear, achievable goals with backward compatibility guarantees.
+For detailed current feature state, support tiers, and receipts, use:
 
----
+- [`docs/STATUS.md`](docs/STATUS.md)
+- [`docs/status/SUPPORT_TIERS.md`](docs/status/SUPPORT_TIERS.md)
+- [`policy/evidence-parity.toml`](policy/evidence-parity.toml)
+- [`docs/guides/first-use-by-surface.md`](docs/guides/first-use-by-surface.md)
 
-## Now/Next/Later
-**Now** (Current Sprint/Immediate): 
-- Finalize WASM target for browser-based processing
-- Java (JNI) bindings development
+## Now
 
-**Next** (Upcoming): 
-- Native Cloud Storage connectors (S3/GCS)
-- Advanced analytics dashboard
+1. **Public Python proof**
+   - Configure TestPyPI Trusted Publisher for project `hl7v2`.
+   - Run `Python TestPyPI Proof` from `main` with `publish_to_testpypi=true`.
+   - Record upload, install-back, `import hl7v2`, `smoke.py`, and
+     `evidence_workflow_guide.py`.
+   - Do not use token fallback or `skip-existing`.
 
-**Later** (Future Consideration): 
-- Real-time visualization REPL
-- Automatic profile generation from sample messages
+2. **Evidence parity maintenance**
+   - Keep Rust, CLI, REST/gRPC, and local Python wheel parity routed through the
+     shared fixtures and `xtask` acceptance commands.
+   - Keep public Python parity local-wheel-scoped until TestPyPI/PyPI
+     install-back exists.
+   - Keep gRPC Beta until transport lifecycle and operational hardening catch up
+     with the artifact semantics already covered by contract tests.
 
----
+3. **Operator workflow hardening**
+   - Keep the safe support-bundle, sidecar, dirty-corpus, and artifact
+     interpretation guides aligned with executable smoke tests.
+   - Keep RIPR advisory while hosted calibration samples accumulate.
 
-## v1.3.x (Current - Enterprise Readiness) - ✅ 80% COMPLETE
+## Next
 
-**Status**: 🚀 **CORE ENTERPRISE FEATURES**
+1. **Production PyPI decision**
+   - Decide explicitly after same-commit TestPyPI proof exists.
+   - Publish production PyPI only with upload and install-back receipts.
 
-### Key Features
-- ✅ **Full gRPC Service**: Native high-performance protobuf interface (Tonic) for all core operations.
-- ✅ **Message Lifecycle**: Enterprise-grade archival state machines and legal hold management.
-- ✅ **Rust 2024 Migration**: Full adoption of modern Rust standards and 1.93 toolchain.
-- ✅ **Statistical Guard**: Baseline learning for message flow anomaly detection.
-- ✅ **Python Bindings**: Official support via PyO3 for high-performance Python integration.
-- 🚧 **WASM Target**: Browser-based parsing and validation (In Progress).
-- 🚧 **Java Bindings**: JNI-based integration (In Progress).
+2. **Public Python parity promotion**
+   - Promote Python evidence parity from local wheel proof to public package
+     proof only after public registry install-back passes.
 
----
+3. **Real-world corpus expansion**
+   - Expand synthetic/redacted dirty HL7 fixtures for vendor-shaped ADT/ORU
+     data, Z-segments, malformed delimiters, legacy timestamp formats, large
+     OBX payloads, partial batches, and MLLP wrapper/failure traces.
 
-## v1.4.0 (Cloud & Interop - Next 3-6 months)
+## Later
 
-### Component Targets
-- **`hl7v2-server`**: Complete tonic-based gRPC endpoints and bi-directional streaming.
-- **`hl7v2-prof`**: Implement dynamic rule evaluation using a safe script engine.
-- **`hl7v2-wasm`**: Create a specialized target for web-based health apps.
+1. **TypeScript and WASM**
+   - Plan and implement only after Python public proof is resolved or
+     deliberately parked.
+   - Public npm package identity is `@effortlessmetrics/hl7v2`, not
+     `hl7v2-rs`.
+   - Rust backend crates such as `hl7v2-wasm` or `hl7v2-node` remain binding
+     infrastructure, not a return to public parser/model/redaction microcrates.
 
----
+2. **Broader deployment polish**
+   - Continue making sidecar deployment, container smoke, and operator
+     evidence handoff boring.
+   - Keep expensive verification routed by risk instead of making it an
+     ordinary PR tax.
 
-## v2.0.0 (Cloud-Native & Advanced Compliance - Next 6-12 months)
+## Boundaries
 
-**Status**: 🚧 **LONG-TERM VISION**
-
-### Primary Goals
-1. **Advanced Analytics**: Real-time message flow monitoring dashboard with Grafana integration.
-2. **Cloud Storage**: Native connectors for S3, GCS, and Azure Blob.
-3. **Audit Trails**: Distributed ledger or secure audit logs for every message lifecycle event.
-4. **Enterprise Connectors**: Direct persistence to Snowflake and Databricks.
-
----
-
-## Success Metrics (v1.2.x)
-- **Performance**: Verified 150k+ messages/min on standard hardware.
-- **Reliability**: 100% test pass rate across Unit, Integration, E2E, and Property-based suites (120+ tests).
-- **Security**: Zero known vulnerabilities in `cargo audit` (pyo3, rand, rustls-webpki updated).
-
----
-
-## Release v1.2.0 with v1.2.x enhancements is officially ready for deployment.
+- Do not split parser, model, redaction, MLLP, batch, or stream internals back
+  into public Rust crates.
+- Do not claim TestPyPI, PyPI, npm, tag, GitHub release, or crates.io success
+  without registry resolution or upload/install-back proof.
+- Do not treat `hl7v2-python` crates.io publication as public Python package
+  proof.
+- Do not start npm/WASM implementation until Python public proof is resolved or
+  explicitly parked.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ with the current sources below before reading older planning documents.
 | Need | Start here |
 | --- | --- |
 | Current release and feature status | [STATUS.md](STATUS.md) |
+| Current roadmap and next work | [../ROADMAP.md](../ROADMAP.md) |
 | Support tiers and proof commands | [status/SUPPORT_TIERS.md](status/SUPPORT_TIERS.md) |
 | Contributor workflow | [../CONTRIBUTING.md](../CONTRIBUTING.md), [../DEVELOPMENT.md](../DEVELOPMENT.md) |
 | Task-focused evidence workflows | [guides/README.md](guides/README.md) |
@@ -140,7 +141,6 @@ for live navigation.
 | [MICROCRATE_ANALYSIS.md](MICROCRATE_ANALYSIS.md) | Historical analysis of the retired microcrate structure. |
 | [ISSUES_AND_NEXT_STEPS.md](ISSUES_AND_NEXT_STEPS.md) | Pre-release planning snapshot, not the current work queue. |
 | [TASK_COMPLETION_SUMMARY.md](TASK_COMPLETION_SUMMARY.md) | Earlier documentation alignment receipt. |
-| [../ROADMAP.md](../ROADMAP.md) | Historical roadmap snapshot; current status lives in `docs/STATUS.md`. |
 | [../TESTING.md](../TESTING.md) | Historical root testing guide; current gates live in `DEVELOPMENT.md` and `docs/CI_PIPELINE.md`. |
 | [../SESSION_SUMMARY.md](../SESSION_SUMMARY.md) | Historical session receipt from 2025-11-19. |
 | [plans/](plans/) and [audits/](audits/) | Historical plans and verification receipts. |

--- a/docs/ci/hl7v2-rollout-plan.md
+++ b/docs/ci/hl7v2-rollout-plan.md
@@ -1,6 +1,12 @@
 # hl7v2-rs CI Economics Rollout Plan
 
-## Current State (as of 2026-05-09)
+> Historical rollout note: this document records the CI economics plan that
+> started from the pre-v1.5.0 Rust 1.93 baseline. Current status lives in
+> [`docs/STATUS.md`](../STATUS.md), lane routing in
+> [`test-evidence-lanes.md`](test-evidence-lanes.md), RIPR status in
+> [`ripr.md`](ripr.md), and CI policy ledgers under [`policy/`](../../policy/).
+
+## Starting State (as of 2026-05-09)
 
 `hl7v2-rs` already satisfies the following baseline:
 
@@ -17,10 +23,10 @@
 - Pre-commit hook: `cargo run -p xtask -- lint-fix`
 - Pre-push hook: `cargo run -p xtask -- gate --check`
 
-## Assumptions
+## Original Assumptions
 
 - `hl7v2-rs` already satisfies the MSRV 1.93 strict-lint baseline.
-- The current rollout focuses on CI lane economics, lane inventory, risk routing, ripr
+- The original rollout focused on CI lane economics, lane inventory, risk routing, ripr
   advisory, and actuals — not adding stricter Clippy enforcement.
 - The ordinary PR target is below 35 LEM where possible.
 - Full matrix, Python wheel, coverage, full property tests, release/publish, OpenAPI/gRPC
@@ -47,7 +53,7 @@ Making CI economics explicit so that:
 5. ripr provides oracle-gap signal at static-analysis prices.
 6. LEM actuals feed back into learned estimates.
 
-## PR Stack
+## Original PR Stack
 
 | PR | Title                                              | Status  |
 | -- | -------------------------------------------------- | ------- |
@@ -81,7 +87,7 @@ Making CI economics explicit so that:
 
 Independent: 06, 07, 08, 10, 11, 12
 
-## Immediate Highest-Value Changes
+## Original Highest-Value Changes
 
 1. Move platform matrix off ordinary PR path (PR 07)
 2. Add PR Plan + LEM (PR 04)

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for the standalone HL7v2 validation sidecar.
 
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.95-bookworm AS builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl-dev pkg-config \


### PR DESCRIPTION
## Summary

- Update the Docker sidecar builder image from Rust 1.93 to Rust 1.95.
- Align `GEMINI.md` with the current Rust 1.95, primary product graph, binding-backend, and no-microcrate-relapse rules.
- Replace the stale root roadmap with the current public-Python/evidence-parity/operator-workflow roadmap and route it from the docs index.
- Mark the older CI economics rollout plan as historical so it no longer reads as current 1.93 work.

## Validation

- `cargo +1.95.0 run -p xtask -- check-doc-links`
- `cargo +1.95.0 run -p xtask -- check-file-policy`
- `docker compose -f infrastructure/docker/docker-compose.yml config`
- `git diff --check`
- targeted stale-current grep for `Current Status.*v1.3.0`, `Rust Version.*1.93`, `Microcrate Architecture`, `rust:1.93`, and `Historical roadmap snapshot`

## Non-claims

- No Docker image build or publish.
- No crates.io, TestPyPI, PyPI, npm, tag, or GitHub release action.
- No runtime behavior change outside the Docker builder toolchain image.