### PR TITLE
ci: route Python registry proof through xtask

### DIFF
--- a/.github/workflows/python-pypi.yml
+++ b/.github/workflows/python-pypi.yml
@@ -269,19 +269,16 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.95.0
+
       - name: Install published wheel from PyPI
         shell: bash
         env:
           PACKAGE_VERSION: ${{ needs.wheel_proof.outputs.package_version }}
         run: |
-          python -m venv .venv-pypi
-          . .venv-pypi/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install \
-            --index-url https://pypi.org/simple/ \
-            --no-deps \
-            --force-reinstall \
-            "hl7v2==${PACKAGE_VERSION}"
-          python tests/python_smoke/smoke.py
-          python tests/python_smoke/evidence_workflow_guide.py
-          python tests/python_smoke/dirty_evidence_workflow.py
+          cargo run -p xtask -- python-public-registry-proof \
+            --index pypi \
+            --version "${PACKAGE_VERSION}"

--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -169,19 +169,16 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.95.0
+
       - name: Install published wheel from TestPyPI
         shell: bash
         env:
           PACKAGE_VERSION: ${{ needs.wheel_proof.outputs.package_version }}
         run: |
-          python -m venv .venv-testpypi
-          . .venv-testpypi/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install \
-            --index-url https://test.pypi.org/simple/ \
-            --no-deps \
-            --force-reinstall \
-            "hl7v2==${PACKAGE_VERSION}"
-          python tests/python_smoke/smoke.py
-          python tests/python_smoke/evidence_workflow_guide.py
-          python tests/python_smoke/dirty_evidence_workflow.py
+          cargo run -p xtask -- python-public-registry-proof \
+            --index testpypi \
+            --version "${PACKAGE_VERSION}"

--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -96,6 +96,7 @@ canonical_sources = [
   "docs/audits/sidecar-guide-smoke-2026-05-18.md",
   "docs/audits/python-local-wheel-proof-2026-05-15.md",
   "docs/audits/python-public-registry-proof-command-2026-05-18.md",
+  "docs/audits/python-public-registry-proof-workflow-routing-2026-05-18.md",
   "docs/audits/python-testpypi-nonpublish-proof-2026-05-15.md",
   "docs/audits/python-testpypi-nonpublish-proof-2026-05-16.md",
   "docs/audits/python-testpypi-publish-attempt-2026-05-16.md",
@@ -152,6 +153,35 @@ commands = [
   "cargo +1.95.0 run -p xtask -- check-doc-links",
   "cargo +1.95.0 run -p xtask -- check-file-policy",
   "cargo +1.95.0 run -p xtask -- check-python-publish-policy",
+  "cargo +1.95.0 run -p xtask -- badges --check",
+  "cargo +1.95.0 run -p xtask -- impacted-evidence",
+  "cargo +1.95.0 run -p xtask -- impacted-evidence --check",
+  "git diff --check",
+]
+non_claims = [
+  "No TestPyPI upload.",
+  "No TestPyPI install-back success claim.",
+  "No PyPI upload.",
+  "No PyPI install-back success claim.",
+  "No token fallback.",
+  "No skip-existing.",
+  "No npm package.",
+  "No new crates.io release.",
+]
+
+[[work_item]]
+id = "python-public-registry-proof-workflow-routing"
+status = "done"
+goal = "Route TestPyPI and PyPI hosted install-back jobs through the shared python-public-registry-proof command so workflow proof and local reproduction use one proof boundary."
+receipt = "docs/audits/python-public-registry-proof-workflow-routing-2026-05-18.md"
+commands = [
+  "cargo +1.95.0 fmt --all -- --check",
+  "cargo +1.95.0 test -p xtask python_publish_policy --locked",
+  "cargo +1.95.0 test -p xtask python_public_registry --locked",
+  "cargo +1.95.0 run -p xtask -- check-python-publish-policy",
+  "cargo +1.95.0 clippy -p xtask --all-targets --locked -- -D warnings",
+  "cargo +1.95.0 run -p xtask -- check-doc-links",
+  "cargo +1.95.0 run -p xtask -- check-file-policy",
   "cargo +1.95.0 run -p xtask -- badges --check",
   "cargo +1.95.0 run -p xtask -- impacted-evidence",
   "cargo +1.95.0 run -p xtask -- impacted-evidence --check",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `xtask python-public-registry-proof` to install `hl7v2` from TestPyPI
   or PyPI in a scratch venv and run the same Python smoke/evidence scripts
   after public registry upload succeeds.
+- Routed TestPyPI/PyPI install-back workflow jobs through
+  `xtask python-public-registry-proof` so hosted public-registry proof and
+  local reproduction use the same command boundary.
 - Added local Python dirty real-world validate/redact/bundle/replay workflow
   proof using the shared Z-segment fixture.
 - Added the dirty real-world Python evidence workflow smoke to the hosted

--- a/docs/audits/python-public-registry-proof-workflow-routing-2026-05-18.md
+++ b/docs/audits/python-public-registry-proof-workflow-routing-2026-05-18.md
@@ -1,0 +1,48 @@
+# Python Public Registry Proof Workflow Routing
+
+Date: 2026-05-18
+
+## Scope
+
+This receipt records the repo-side workflow routing change that makes future
+TestPyPI and PyPI install-back jobs use the shared
+`xtask python-public-registry-proof` command.
+
+## Change
+
+- `.github/workflows/python-testpypi.yml` still builds and smokes the local
+  wheel before upload. When `publish_to_testpypi=true` and the upload succeeds,
+  the install-back job now runs:
+
+  ```bash
+  cargo run -p xtask -- python-public-registry-proof --index testpypi --version "${PACKAGE_VERSION}"
+  ```
+
+- `.github/workflows/python-pypi.yml` still requires the same-commit successful
+  TestPyPI proof before production upload. When `publish_to_pypi=true` and the
+  upload succeeds, the install-back job now runs:
+
+  ```bash
+  cargo run -p xtask -- python-public-registry-proof --index pypi --version "${PACKAGE_VERSION}"
+  ```
+
+- `cargo run -p xtask -- check-python-publish-policy` now rejects publish
+  workflows whose install-back jobs bypass the shared public-registry proof
+  command or use the wrong package index.
+
+## Boundary
+
+This change does not publish anything. It does not configure TestPyPI or PyPI
+Trusted Publishing. It does not claim TestPyPI or PyPI upload/install-back
+success.
+
+## Non-Claims
+
+- No TestPyPI upload occurred.
+- No TestPyPI install-back success is claimed.
+- No PyPI upload occurred.
+- No PyPI install-back success is claimed.
+- No token fallback was added.
+- No `skip-existing` behavior was added.
+- No npm package was created.
+- No new crates.io release, tag, or GitHub release occurred.

--- a/docs/guides/python-pypi-release.md
+++ b/docs/guides/python-pypi-release.md
@@ -111,6 +111,18 @@ This does three things:
    virtual environment and reruns the Python smoke, evidence workflow guide,
    and dirty evidence workflow smoke.
 
+The hosted install-back job runs the same proof boundary as the local
+reproduction command:
+
+```bash
+cargo run -p xtask -- python-public-registry-proof --index pypi --version "${PACKAGE_VERSION}"
+```
+
+This keeps the workflow proof and local reproduction path aligned. A passing
+install-back job proves only the production PyPI package for the selected
+version; it does not retroactively prove TestPyPI unless the same-commit
+TestPyPI receipt is already linked.
+
 PyPI does not allow overwriting an existing file for the same version. If the
 upload fails because the version already exists, stop and choose a new workspace
 version for the next proof attempt. Do not use `skip-existing` for release

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -119,6 +119,17 @@ This does three things:
    `tests/python_smoke/evidence_workflow_guide.py`, and
    `tests/python_smoke/dirty_evidence_workflow.py`.
 
+The hosted install-back job runs the same proof boundary as the local
+reproduction command:
+
+```bash
+cargo run -p xtask -- python-public-registry-proof --index testpypi --version "${PACKAGE_VERSION}"
+```
+
+This keeps the workflow proof and local reproduction path aligned. A passing
+install-back job proves only the TestPyPI package for the selected version; it
+does not claim production PyPI availability.
+
 TestPyPI does not allow overwriting an existing file for the same version. If
 the upload fails because the version already exists, stop and choose a new
 workspace version for the next proof attempt. Do not use `skip-existing` for

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8289,7 +8289,7 @@ struct PythonPublishWorkflowPolicy {
     install_job: &'static str,
     environment_name: &'static str,
     artifact_name: &'static str,
-    package_index_url: &'static str,
+    package_index_arg: &'static str,
     publish_repository_url: Option<&'static str>,
     publish_step_name: &'static str,
 }
@@ -8304,7 +8304,7 @@ const PYTHON_PUBLISH_WORKFLOWS: &[PythonPublishWorkflowPolicy] = &[
         install_job: "install_from_testpypi",
         environment_name: "testpypi",
         artifact_name: "python-testpypi-wheel",
-        package_index_url: "https://test.pypi.org/simple/",
+        package_index_arg: "testpypi",
         publish_repository_url: Some("https://test.pypi.org/legacy/"),
         publish_step_name: "Publish package distributions to TestPyPI",
     },
@@ -8317,7 +8317,7 @@ const PYTHON_PUBLISH_WORKFLOWS: &[PythonPublishWorkflowPolicy] = &[
         install_job: "install_from_pypi",
         environment_name: "pypi",
         artifact_name: "python-pypi-wheel",
-        package_index_url: "https://pypi.org/simple/",
+        package_index_arg: "pypi",
         publish_repository_url: None,
         publish_step_name: "Publish package distributions to PyPI",
     },
@@ -9058,6 +9058,16 @@ fn ensure_python_install_back_job(
     ensure_yaml_sequence_contains(needs, policy.path, "needs", policy.publish_job)?;
 
     let steps = yaml_child_sequence(install_job, policy.path, "steps")?;
+    let rust_toolchain = yaml_step_named(steps, policy.path, "Install Rust toolchain")?;
+    ensure_yaml_string(
+        rust_toolchain,
+        policy.path,
+        "uses",
+        "dtolnay/rust-toolchain@v1",
+    )?;
+    let rust_toolchain_with = yaml_child_mapping(rust_toolchain, policy.path, "with")?;
+    ensure_yaml_string(rust_toolchain_with, policy.path, "toolchain", "1.95.0")?;
+
     let install = steps
         .iter()
         .filter_map(serde_yaml::Value::as_mapping)
@@ -9068,13 +9078,10 @@ fn ensure_python_install_back_job(
         .ok_or_else(|| anyhow!("{} is missing install-back step", policy.path))?;
     let run = yaml_mapping_string(install, policy.path, "run")?;
     for expected in [
-        policy.package_index_url,
-        "--no-deps",
-        "--force-reinstall",
-        "hl7v2==${PACKAGE_VERSION}",
-        "tests/python_smoke/smoke.py",
-        "tests/python_smoke/evidence_workflow_guide.py",
-        "tests/python_smoke/dirty_evidence_workflow.py",
+        "cargo run -p xtask -- python-public-registry-proof",
+        "--index",
+        policy.package_index_arg,
+        "--version \"${PACKAGE_VERSION}\"",
     ] {
         if !run.contains(expected) {
             return Err(anyhow!(
@@ -10948,6 +10955,59 @@ bindings = "pyo3"
             {
                 Ok(())
             }
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_requires_public_registry_install_back_command() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replace(
+            "cargo run -p xtask -- python-public-registry-proof",
+            "python -m pip install --index-url https://test.pypi.org/simple/",
+        );
+        if broken == workflow {
+            return Err(anyhow!(
+                "test setup should remove the public-registry proof command"
+            ));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject install-back jobs that bypass xtask public-registry proof"
+            )),
+            Err(err) if err.to_string().contains("python-public-registry-proof") => Ok(()),
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_rejects_wrong_public_registry_index() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replace("--index testpypi", "--index pypi");
+        if broken == workflow {
+            return Err(anyhow!("test setup should change the install-back index"));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject install-back jobs that use the wrong public index"
+            )),
+            Err(err) if err.to_string().contains("testpypi") => Ok(()),
             Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
         }
     }


### PR DESCRIPTION
## Summary

- route TestPyPI and PyPI hosted install-back jobs through \\xtask python-public-registry-proof\\
- teach \\check-python-publish-policy\\ to reject workflow install-back jobs that bypass the shared proof command or use the wrong index
- document the workflow routing receipt and keep TestPyPI/PyPI non-claims explicit

## Validation

- \\cargo +1.95.0 fmt --all -- --check\\
- \\cargo +1.95.0 test -p xtask python_publish_policy --locked\\
- \\cargo +1.95.0 test -p xtask python_public_registry --locked\\
- \\cargo +1.95.0 run -p xtask -- check-python-publish-policy\\
- \\cargo +1.95.0 clippy -p xtask --all-targets --locked -- -D warnings\\
- \\cargo +1.95.0 run -p xtask -- check-doc-links\\
- \\cargo +1.95.0 run -p xtask -- check-file-policy\\
- \\cargo +1.95.0 run -p xtask -- badges --check\\
- \\cargo +1.95.0 run -p xtask -- impacted-evidence\\
- \\cargo +1.95.0 run -p xtask -- impacted-evidence --check\\
- \\git diff --check\\

## Non-claims

- no TestPyPI upload or install-back success claimed
- no PyPI upload or install-back success claimed
- no token fallback or skip-existing
- no npm, crates.io, tag, or GitHub release claim