### PR TITLE
docs: correct TestPyPI blocker state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Corrected the v1.5.0 readiness receipt so the public Python `hl7v2`
+  TestPyPI blocker points at the still-open Trusted Publisher issue #563
+  instead of describing it as closed.
 - Clarified current-state wording for the public Python `hl7v2`
   TestPyPI/PyPI blocker after the registry proof command, workflow routing,
   parity boundary, and gap audit landed without a new upload attempt.

--- a/docs/release/1.5.0-readiness.md
+++ b/docs/release/1.5.0-readiness.md
@@ -88,7 +88,7 @@ cargo +1.95.0 run -p xtask -- check-doc-links
 | Contract workflow coverage check | Passed. Workflow still covers OpenAPI, protobuf, JSON Schema, and evidence schema checks. |
 | Python boundary check | Passed. Public Python distribution is `hl7v2`; Rust crate `hl7v2-python` remains a separate binding backend and is not included in the primary Rust product graph. |
 | RIPR evidence surface check | Passed locally with `badges --check` and `impacted-evidence --check` after #618. |
-| Known non-blockers | Public Python `hl7v2` still has no TestPyPI/PyPI upload and install-back receipt; historical Trusted Publisher issue #563 is currently closed but package endpoints still return 404; production PyPI is not released; this refresh performed no new crates.io upload, tag, or GitHub release action; hosted Actions emitted Node 20 deprecation annotations for existing actions. |
+| Known non-blockers | Public Python `hl7v2` still has no TestPyPI/PyPI upload and install-back receipt; Trusted Publisher issue #563 is open and package endpoints still return 404 until the external TestPyPI setup is completed; production PyPI is not released; this refresh performed no new crates.io upload, tag, or GitHub release action; hosted Actions emitted Node 20 deprecation annotations for existing actions. |
 | Rollback path | Before publish, revert or supersede the v1.5.0 release-prep commits. After crates.io publish, do not yank by default; prefer forward-fix unless a security or legal issue requires yanking. |
 
 ## Package-Boundary Closeout


### PR DESCRIPTION
## Summary

- correct the v1.5.0 readiness receipt so #563 is recorded as open
- clarify that TestPyPI/PyPI package endpoints still return 404 until external Trusted Publisher setup is completed
- add a narrow Unreleased changelog note for the docs correction

## Validation

- cargo +1.95.0 run -p xtask -- check-evidence-parity
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- cargo +1.95.0 run -p xtask -- publish-plan --surface primary
- cargo +1.95.0 run -p xtask -- publish-plan --surface bindings
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims

- no TestPyPI/PyPI upload or install-back claim
- no npm claim
- no crates.io upload, tag, or GitHub release action