### PR TITLE
docs: align ADR-0006 index status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Corrected the ADR index status for ADR-0006 so it matches the proposed
+  OPA policy-enforcement ADR.
 - Corrected the v1.5.0 readiness receipt so the public Python `hl7v2`
   TestPyPI blocker points at the still-open Trusted Publisher issue #563
   instead of describing it as closed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ We use the format popularized by Michael Nygard:
 | [0003](0003-use-tokio-for-async-runtime.md) | Use Tokio for Async Runtime | Accepted | 2025-11-19 |
 | [0004](0004-schema-driven-validation.md) | Schema-Driven Validation | Accepted | 2025-11-19 |
 | [0005](0005-nix-for-reproducible-builds.md) | Nix for Reproducible Builds | Accepted | 2025-11-19 |
-| [0006](0006-opa-for-policy-enforcement.md) | OPA for Policy Enforcement | Accepted | 2025-11-19 |
+| [0006](0006-opa-for-policy-enforcement.md) | OPA for Policy Enforcement | Proposed | 2025-11-19 |
 | [0007](0007-axum-for-http-server.md) | Axum for HTTP Server | Accepted | 2025-11-19 |
 | [0008](0008-tonic-for-grpc.md) | Tonic for gRPC Server | Accepted | 2025-11-19 |
 | [0009](0009-serde-for-serialization.md) | Serde for Serialization | Accepted | 2025-11-19 |


### PR DESCRIPTION
## Summary

- update the ADR README index so ADR-0006 is marked Proposed, matching the ADR file
- add a narrow Unreleased changelog note

Closes #282 after merge. ADR-0008 already now records an accepted, incrementally implemented state and remains indexed as Accepted.

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- Select-String -Path docs/adr/README.md,docs/adr/0006-opa-for-policy-enforcement.md,docs/adr/0008-tonic-for-grpc.md -Pattern '0006|0008|Status'
- git diff --check

## Non-claims

- no TestPyPI/PyPI/npm/crates.io/tag/release claims
- no ADR acceptance decision change; this only makes the index match ADR-0006