### PR TITLE
docs: add crate context for entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Added crate-local context for the canonical Rust `hl7v2` crate and the
+  `hl7v2-python` binding backend, preserving the Rust API versus Python
+  backend boundary for future maintenance.
 - Corrected the ADR index status for ADR-0006 so it matches the proposed
   OPA policy-enforcement ADR.
 - Corrected the v1.5.0 readiness receipt so the public Python `hl7v2`

--- a/crates/hl7v2-python/CLAUDE.md
+++ b/crates/hl7v2-python/CLAUDE.md
@@ -1,0 +1,40 @@
+# hl7v2-python
+
+PyO3 binding backend crate for the public Python `hl7v2` package.
+
+This crate is language-boundary infrastructure. It is publishable on crates.io
+for packaging provenance, but it is not the recommended Rust API. Rust users
+should depend on `hl7v2`; Python users should install the public Python
+distribution named `hl7v2`.
+
+## Build And Proof
+
+```bash
+cargo +1.95.0 run -p xtask -- python-local-wheel-proof
+```
+
+The local wheel proof builds the Python `hl7v2` wheel, installs it into a
+scratch virtual environment, imports `hl7v2`, and runs the Python smoke and
+evidence workflow scripts. It does not claim TestPyPI or PyPI availability.
+
+## Public Registry Boundary
+
+TestPyPI and PyPI proof must use the public package name `hl7v2`:
+
+```bash
+cargo +1.95.0 run -p xtask -- python-public-registry-proof --index testpypi --version <version>
+cargo +1.95.0 run -p xtask -- python-public-registry-proof --index pypi --version <version>
+```
+
+Do not add token fallback, do not use `skip-existing`, and do not claim
+TestPyPI or PyPI success without upload and install-back proof.
+
+## Role
+
+Keep this crate thin over `hl7v2`. Its job is Python ABI, conversion, lifecycle,
+and packaging proof for the Python user surface. Do not move parser, model,
+redaction, MLLP, batch, or stream implementation logic here.
+
+When changing Python-exposed evidence behavior, update the shared Rust behavior
+or explicit conversion layer, then update Python smoke, evidence parity, and
+public-registry proof docs as needed.

--- a/crates/hl7v2/CLAUDE.md
+++ b/crates/hl7v2/CLAUDE.md
@@ -1,0 +1,52 @@
+# hl7v2
+
+Canonical Rust library crate for the workspace.
+
+Rust users should depend on this crate, not on retired implementation
+microcrates and not on binding backend crates such as `hl7v2-python`.
+
+## Build
+
+```bash
+cargo build -p hl7v2 --all-features
+```
+
+## Test
+
+```bash
+cargo test -p hl7v2 --all-features
+```
+
+## Lint
+
+```bash
+cargo clippy -p hl7v2 --all-targets --all-features -- -D warnings
+```
+
+## Role
+
+`hl7v2` owns the Rust API for parsing, writing, validation, normalization,
+ACK generation, MLLP framing, profiles, redaction, lifecycle metadata,
+synthetic data, and evidence artifact helpers.
+
+Keep shared HL7 semantics inside this crate as modules. Do not split parser,
+model, redaction, MLLP, batch, or stream internals back into public Rust
+microcrates without an explicit crate-boundary decision.
+
+## Evidence
+
+The CLI, server, Python binding, and future TypeScript package should preserve
+the semantics exposed here for:
+
+- parse and write behavior
+- validation reports
+- normalization and ACK behavior
+- profile lint, explain, and test reports
+- redaction receipts
+- corpus summary, fingerprint, and diff artifacts
+- bundle and replay helpers
+- safe error and PHI sentinel behavior
+- schema version handling
+
+When changing shared evidence behavior, update the schema, parity, guide, and
+receipt surfaces that claim that behavior.


### PR DESCRIPTION
Summary:
- add crate-local context for the canonical Rust hl7v2 crate
- add crate-local context for the hl7v2-python binding backend
- document the Rust API versus Python backend boundary for future maintenance

Closes #239.
Closes #267.

Validation:
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- checked every current crate directory has CLAUDE.md
- git diff --check

Non-claims:
- no TestPyPI/PyPI/npm/crates.io/tag/release claim
- no package-boundary change
- no recommendation for Rust users to depend on hl7v2-python