### PR TITLE
ci: add contracts and security concurrency controls

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -27,6 +27,13 @@ on:
       - 'xtask/**'
       - '.github/workflows/contracts.yml'
 
+# Cancellation policy:
+# - PR synchronize events cancel stale runs for the same PR.
+# - Push and manual runs do NOT cancel in-progress contract validation.
+concurrency:
+  group: contracts-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
 jobs:
   validate-openapi:
     name: Validate OpenAPI Spec

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,13 @@ permissions:
   contents: read
   security-events: write
 
+# Cancellation policy:
+# - PR synchronize events cancel stale runs for the same PR.
+# - Push and scheduled scans do NOT cancel in-progress security checks.
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+
 jobs:
   audit:
     name: Dependency Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added synchronize-only concurrency controls to the API Contracts and Security
+  workflows so stale PR updates can be canceled without canceling push,
+  scheduled, or manual proof runs.
 - Rejected non-finite float spellings such as `INF`, `Infinity`, and `NaN`
   from HL7 numeric validation.
 


### PR DESCRIPTION
## Summary

- add synchronize-only concurrency controls to API Contracts and Security workflows
- preserve push, scheduled, and manual proof runs by only canceling stale PR synchronize events
- record the CI-cost fix in the changelog

Fixes #297.
Fixes #298.

## Validation

- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check

## Non-claims

- no TestPyPI/PyPI/npm publish claim
- no crates.io/tag/GitHub release action
