### PR TITLE
test: align evidence artifacts guide corpus counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the evidence-artifacts guide smoke so corpus diff count assertions use
+  the current dirty real-world fixture directories instead of stale after-counts.
 - Added synchronize-only concurrency controls to the API Contracts and Security
   workflows so stale PR updates can be canceled without canceling push,
   scheduled, or manual proof runs.

--- a/docs/audits/evidence-artifacts-guide-smoke-2026-05-18.md
+++ b/docs/audits/evidence-artifacts-guide-smoke-2026-05-18.md
@@ -22,7 +22,8 @@ The command proves the local, non-registry artifact reader path:
 - generates a validation report for `test_data/invalid_message.hl7` and checks
   the expected `PID.8` validation issue;
 - generates corpus summary, fingerprint, and diff reports from the shared
-  dirty real-world fixtures;
+  dirty real-world fixtures, including the current direct fixture counts
+  for the before/after diff directories;
 - generates redaction preview evidence and checks retained-field receipt data;
 - creates a `support-bundle` packet and verifies bundle summary, manifest,
   environment, field-path, redaction receipt, replay scripts, README, and

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6318,6 +6318,8 @@ fn check_evidence_artifacts_guide() -> Result<()> {
     ensure_existing_file(&profile)?;
     ensure_existing_file(&valid_message)?;
     ensure_existing_file(&invalid_message)?;
+    let dirty_before_file_count = count_regular_files(&dirty_before)?;
+    let dirty_after_file_count = count_regular_files(&dirty_after)?;
 
     fs::copy(&valid_message, valid_fixtures.join("valid-message.hl7"))?;
     fs::copy(
@@ -6513,10 +6515,30 @@ fn check_evidence_artifacts_guide() -> Result<()> {
     let diff = read_json_file(&corpus_diff)?;
     let diff_label = path_to_arg(&corpus_diff)?;
     ensure_json_path_string(&diff, &["diff_version"], "1", &diff_label)?;
-    ensure_json_path_u64(&diff, &["file_count", "before"], 2, &diff_label)?;
-    ensure_json_path_u64(&diff, &["file_count", "after"], 5, &diff_label)?;
-    ensure_json_path_u64(&diff, &["parse_error_count", "before"], 2, &diff_label)?;
-    ensure_json_path_u64(&diff, &["parse_error_count", "after"], 5, &diff_label)?;
+    ensure_json_path_u64(
+        &diff,
+        &["file_count", "before"],
+        dirty_before_file_count,
+        &diff_label,
+    )?;
+    ensure_json_path_u64(
+        &diff,
+        &["file_count", "after"],
+        dirty_after_file_count,
+        &diff_label,
+    )?;
+    ensure_json_path_u64(
+        &diff,
+        &["parse_error_count", "before"],
+        dirty_before_file_count,
+        &diff_label,
+    )?;
+    ensure_json_path_u64(
+        &diff,
+        &["parse_error_count", "after"],
+        dirty_after_file_count,
+        &diff_label,
+    )?;
     ensure_file_lacks_phi_sentinels(&corpus_diff)?;
 
     let redaction_preview = reports.join("redaction-preview.json");
@@ -7011,6 +7033,23 @@ fn ensure_existing_file(path: &Path) -> Result<()> {
         return Err(anyhow!("expected file to exist: {}", path.display()));
     }
     Ok(())
+}
+
+fn count_regular_files(path: &Path) -> Result<u64> {
+    if !path.is_dir() {
+        return Err(anyhow!("expected directory to exist: {}", path.display()));
+    }
+
+    let mut count = 0_u64;
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            count = count
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("too many files to count under {}", path.display()))?;
+        }
+    }
+    Ok(count)
 }
 
 fn read_json_file(path: &Path) -> Result<serde_json::Value> {


### PR DESCRIPTION
## Summary

- derive the evidence-artifacts guide corpus diff expectations from the current dirty-corpus fixture directories
- refresh the guide-smoke receipt wording so it documents that boundary
- record the smoke repair in the changelog

## Validation

- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 run -p xtask -- check-evidence-artifacts-guide
- cargo +1.95.0 run -p xtask -- check-dirty-corpus-parity
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 test -p xtask --locked
- git diff --check

## Non-claims

- no TestPyPI/PyPI/npm publish claim
- no crates.io/tag/GitHub release action
