### PR TITLE
docs: align planning navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blocker map for public Python proof, evidence parity, operator workflows,
   dirty corpus expansion, gRPC hardening, RIPR calibration, and later
   TypeScript/WASM work.
+- Corrected the documentation index so new planning work no longer defaults to
+  the closed historical `plans/1.4.1/` directory.
 - Added crate-local context for the canonical Rust `hl7v2` crate and the
   `hl7v2-python` binding backend, preserving the Rust API versus Python
   backend boundary for future maintenance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,10 +42,13 @@ Use the smallest document type that owns the claim:
 
 Start new governance work in [proposals/](proposals/), define durable
 requirements in [specs/](specs/), use [adr/](adr/) only for architecture
-decisions, sequence execution in [../plans/1.4.1/](../plans/1.4.1/), and keep
-the current active state in [../.hl7v2/goals/](../.hl7v2/goals/). Current
-feature status still lives in [STATUS.md](STATUS.md); do not duplicate it in
-proposal, spec, plan, or receipt documents.
+decisions, sequence execution in a scoped `plans/<milestone>/` directory when
+a durable implementation plan is needed, and keep the current active state in
+[../.hl7v2/goals/](../.hl7v2/goals/). The historical
+[../plans/1.4.1/](../plans/1.4.1/) directory is closed and should not be used
+as the default target for new work. Current feature status still lives in
+[STATUS.md](STATUS.md); do not duplicate it in proposal, spec, plan, or receipt
+documents.
 
 ## Evidence Guides
 


### PR DESCRIPTION
## Summary

- Update the docs index so new implementation planning uses a scoped plans/<milestone>/ directory instead of the closed historical plans/1.4.1/ lane.
- Keep plans/1.4.1/ linked as historical context, not as the default target for future work.

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims

- No TestPyPI/PyPI upload or install-back claim.
- No npm, crates.io, tag, or GitHub release claim.