### PR TITLE
ci: fail nightly summary on failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -274,5 +274,5 @@ jobs:
       - name: Check for failures
         if: contains(needs.*.result, 'failure')
         run: |
-          echo "::warning::Some nightly tests failed. Check the job results for details."
-          exit 0  # Don't fail the workflow, just warn
+          echo "::error::Some nightly tests failed. Check the job results for details."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made the nightly workflow summary fail the workflow when required nightly
+  jobs report failures instead of downgrading them to warnings.
 - Fixed the evidence-artifacts guide smoke so corpus diff count assertions use
   the current dirty real-world fixture directories instead of stale after-counts.
 - Added synchronize-only concurrency controls to the API Contracts and Security

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -70,6 +70,11 @@ Runs comprehensive testing every night at 2:00 AM UTC.
    - Builds API documentation
    - Uploads as artifact
 
+The `nightly-summary` job runs after the main nightly proof jobs and fails the
+workflow when any required nightly job reports `failure`. This keeps scheduled
+deep-verification failures visible while still allowing the summary step to run
+with `if: always()`.
+
 ### `.github/workflows/coverage.yml` - Coverage Reports
 
 Dedicated workflow for code coverage analysis.
@@ -293,10 +298,15 @@ All workflows use concurrency groups to:
 
 ### Continue on Error
 
-The following jobs use `continue-on-error: true`:
+Some exploratory or advisory steps use `continue-on-error: true` inside their
+jobs:
 - Benchmarks (performance tracking shouldn't block CI)
 - Fuzz tests (exploratory testing)
 - Mutation tests (informational)
+
+Nightly job failures that reach the workflow dependency graph are aggregated by
+the `nightly-summary` job and fail the workflow instead of being downgraded to
+warnings.
 
 ## Required Secrets
 


### PR DESCRIPTION
## Summary

- Change the nightly summary failure check from a warning-only exit 0 to an erroring exit 1.
- Document that nightly dependency failures reaching the summary job now fail the workflow.
- Keep exploratory/advisory step continue-on-error behavior documented separately.

Closes #258.

## Validation

- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims

- No TestPyPI/PyPI upload or install-back claim.
- No npm, crates.io, tag, or GitHub release claim.