### PR TITLE
ci: surface benchmark lane failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,8 @@ jobs:
 
   # ============================================================================
   # Stage 3 (Parallel): Benchmarks (~15 LEM)
-  # Non-failing, tracks performance regressions
+  # Routed performance checks. Not a default PR tax, but failures are visible
+  # on main, manual runs, and labeled PRs that request this lane.
   # ============================================================================
   benchmarks:
     name: Benchmarks
@@ -286,9 +287,8 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          cargo bench --workspace 2>&1 | tee benchmark-results.txt || true
+          cargo bench --workspace 2>&1 | tee benchmark-results.txt
         timeout-minutes: 10
-        continue-on-error: true
 
       - name: Upload benchmark artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made routed benchmark lane failures visible by removing benchmark command
+  masking from the CI workflow.
 - Made the nightly workflow summary fail the workflow when required nightly
   jobs report failures instead of downgrading them to warnings.
 - Fixed the evidence-artifacts guide smoke so corpus diff count assertions use

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -41,9 +41,16 @@ The primary CI workflow that runs on every push and pull request.
    - Coverage report generation
    - Codecov upload
 
-5. **benchmarks** - Performance tracking (main branch only)
+5. **benchmarks** - Routed performance tracking (main branch or label)
    - Runs all benchmarks
    - Stores results for comparison
+   - Fails when the routed benchmark command fails
+
+6. **ci-success** - Required CI summary
+   - Aggregates required fast, standard, MSRV, and matrix lane results
+   - Allows the routed matrix lane to skip cleanly when not selected
+   - Leaves optional deep lanes such as extended tests and benchmarks to report
+     through their own jobs
 
 ### `.github/workflows/nightly.yml` - Nightly Tests
 
@@ -300,13 +307,17 @@ All workflows use concurrency groups to:
 
 Some exploratory or advisory steps use `continue-on-error: true` inside their
 jobs:
-- Benchmarks (performance tracking shouldn't block CI)
 - Fuzz tests (exploratory testing)
 - Mutation tests (informational)
 
 Nightly job failures that reach the workflow dependency graph are aggregated by
 the `nightly-summary` job and fail the workflow instead of being downgraded to
 warnings.
+
+Benchmarks are not a default ordinary-PR lane, but once the benchmark lane is
+routed on `main`, manual dispatch, or a labeled PR, benchmark command failures
+fail the `Benchmarks` job. They are not aggregated into `CI Success`, so
+routing benchmarks does not change the required branch-protection summary.
 
 ## Required Secrets
 


### PR DESCRIPTION
## Summary
- remove benchmark command failure masking from the routed benchmark lane
- document that benchmarks remain optional/deep, but routed benchmark failures fail the benchmark job
- add an Unreleased changelog note

Closes #254

## Validation
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims
- no TestPyPI/PyPI/npm/crates.io/tag/release claim
- no change to public Python proof status
- no change to required branch-protection summary policy