### PR TITLE
ci: bound benchmark lane runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          cargo bench --workspace 2>&1 | tee benchmark-results.txt
+          cargo bench -p hl7v2-bench -- --sample-size 10 --warm-up-time 1 --measurement-time 1 --noplot 2>&1 | tee benchmark-results.txt
         timeout-minutes: 10
 
       - name: Upload benchmark artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
 
       - name: Run benchmarks
         run: |
+          set -o pipefail
           cargo bench -p hl7v2-bench -- --sample-size 10 --warm-up-time 1 --measurement-time 1 --noplot 2>&1 | tee benchmark-results.txt
         timeout-minutes: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Made routed benchmark lane failures visible by removing benchmark command
-  masking from the CI workflow.
+- Made routed benchmark lane failures visible while bounding the CI benchmark
+  sample to the internal benchmark harness.
 - Made the nightly workflow summary fail the workflow when required nightly
   jobs report failures instead of downgrading them to warnings.
 - Fixed the evidence-artifacts guide smoke so corpus diff count assertions use

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -42,7 +42,7 @@ The primary CI workflow that runs on every push and pull request.
    - Codecov upload
 
 5. **benchmarks** - Routed performance tracking (main branch or label)
-   - Runs all benchmarks
+   - Runs the `hl7v2-bench` harness with a bounded Criterion sample
    - Stores results for comparison
    - Fails when the routed benchmark command fails
 
@@ -317,7 +317,10 @@ warnings.
 Benchmarks are not a default ordinary-PR lane, but once the benchmark lane is
 routed on `main`, manual dispatch, or a labeled PR, benchmark command failures
 fail the `Benchmarks` job. They are not aggregated into `CI Success`, so
-routing benchmarks does not change the required branch-protection summary.
+routing benchmarks does not change the required branch-protection summary. CI
+uses a bounded Criterion sample to prove the benchmark harness still compiles
+and runs; maintainers can run longer local benchmark sessions when comparing
+performance in detail.
 
 ## Required Secrets
 


### PR DESCRIPTION
## Summary
- route CI benchmarks through the internal hl7v2-bench harness instead of the whole workspace
- keep benchmark failures visible while using a bounded Criterion sample for hosted CI
- preserve benchmark failure propagation through set -o pipefail
- update CI docs and changelog wording

Follow-up to #802 / #254 after post-merge main exposed the benchmark lane timeout.

## CI Economics
| Item | Value |
| --- | --- |
| LEM impact | Bounded routed benchmark lane; no ordinary-PR default cost increase |
| Workflows touched | .github/workflows/ci.yml only |
| Branch protection | No change; benchmarks remain outside CI Success aggregation |
| Failure mode | Benchmark compile/runtime failures are visible when the lane is routed |
| Cheaper signal | Bounded Criterion sample proves harness health; longer local runs remain available for detailed performance comparison |
| Rollback path | Revert this PR to restore the previous benchmark command shape |

## Validation
- cargo +1.95.0 bench -p hl7v2-bench -- --sample-size 10 --warm-up-time 1 --measurement-time 1 --noplot
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check

## Non-claims
- no TestPyPI/PyPI/npm/crates.io/tag/release claim
- no change to public Python proof status
- benchmarks remain routed/deep, not a default ordinary-PR tax