### PR TITLE
ci: pin cargo-audit in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --version 0.22.1 --locked
 
       - name: Run Audit
         run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pinned the Security workflow's `cargo-audit` install to a specific version
+  for reproducible dependency-audit runs.
 - Made routed benchmark lane failures visible while bounding the CI benchmark
   sample to the internal benchmark harness.
 - Made the nightly workflow summary fail the workflow when required nightly


### PR DESCRIPTION
## Summary
- Pin the Security workflow cargo-audit install to 