### PR TITLE
ci: surface nightly mutation and security failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,33 +114,77 @@ jobs:
           shared-key: mutation-nightly
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        run: cargo install cargo-mutants --version 26.1.2 --locked
 
       - name: Run mutation tests
         run: |
-          # Run mutation tests on core crates
+          set +e
           cargo mutants \
             --workspace \
             --timeout 300 \
-            --output-dir mutants-out/ \
-            --no-shuffle \
-            || echo "Mutation tests completed with some misses"
-        continue-on-error: true
+            --output target/nightly-mutation \
+            --no-shuffle
+          mutation_status=$?
+          set -e
+
+          case "$mutation_status" in
+            0)
+              echo "::notice::cargo-mutants caught every tested viable mutant."
+              ;;
+            1)
+              echo "::error::cargo-mutants failed because of invalid command-line arguments."
+              ;;
+            2)
+              echo "::error::cargo-mutants found missed mutants. Review the mutation report artifact."
+              ;;
+            3)
+              echo "::error::cargo-mutants reported timed-out tests. Review the mutation report artifact."
+              ;;
+            4)
+              echo "::error::cargo-mutants baseline tests failed before mutation."
+              ;;
+            5|6)
+              echo "::error::cargo-mutants diff input was invalid."
+              ;;
+            70)
+              echo "::error::cargo-mutants reported an internal error."
+              ;;
+            *)
+              echo "::error::cargo-mutants returned unexpected status ${mutation_status}."
+              ;;
+          esac
+
+          exit "$mutation_status"
         timeout-minutes: 60
 
       - name: Upload mutation report
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: mutation-report
-          path: mutants-out/
+          path: target/nightly-mutation/mutants.out/
           retention-days: 30
 
       - name: Parse mutation results
+        if: always()
         run: |
           echo "## Mutation Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ -f mutants-out/summary.md ]; then
-            cat mutants-out/summary.md >> $GITHUB_STEP_SUMMARY
+          out_dir="target/nightly-mutation/mutants.out"
+          if [ -d "$out_dir" ]; then
+            echo "| Outcome | Count |" >> $GITHUB_STEP_SUMMARY
+            echo "| --- | ---: |" >> $GITHUB_STEP_SUMMARY
+            for outcome in caught missed timeout unviable; do
+              file="$out_dir/${outcome}.txt"
+              if [ -f "$file" ]; then
+                count=$(grep -cve '^[[:space:]]*$' "$file" || true)
+              else
+                count=0
+              fi
+              echo "| ${outcome} | ${count} |" >> $GITHUB_STEP_SUMMARY
+            done
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "See the uploaded mutation report artifact for `outcomes.json`, logs, and diffs." >> $GITHUB_STEP_SUMMARY
           else
             echo "Mutation test results not available in expected format." >> $GITHUB_STEP_SUMMARY
           fi
@@ -198,18 +242,16 @@ jobs:
           shared-key: security-audit
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --version 0.22.1 --locked
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny --version 0.19.6 --locked
 
       - name: Run cargo audit
-        run: cargo audit
-        continue-on-error: true
+        run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings
 
       - name: Run cargo deny
         run: cargo deny check advisories licenses bans sources
-        continue-on-error: true
 
   # ============================================================================
   # Documentation Generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Surfaced nightly mutation and security audit failures instead of masking them,
+  while pinning the nightly audit and mutation tools.
 - Pinned the Security workflow's `cargo-audit` install to a specific version
   for reproducible dependency-audit runs.
 - Made routed benchmark lane failures visible while bounding the CI benchmark

--- a/policy/dependency-surface-allowlist.toml
+++ b/policy/dependency-surface-allowlist.toml
@@ -2,7 +2,7 @@ schema_version = "1.0"
 policy = "dependency-surface-allowlist"
 owner = "EffortlessMetrics"
 status = "active"
-updated = "2026-05-13"
+updated = "2026-05-19"
 
 # Dependency surfaces are governed separately from file presence so package
 # managers and external toolchains remain reviewable.
@@ -44,11 +44,11 @@ review_after = "2026-06-30"
 id = "security-audit-tooling"
 owner = "release/ci"
 surface = "security"
-behavior = "Security policy may depend on cargo-deny advisory and license checks."
-paths = ["deny.toml"]
-dependencies = ["cargo-deny", "RustSec advisory database"]
+behavior = "Security and nightly policy may depend on pinned cargo-audit and cargo-deny advisory, vulnerability, and license checks."
+paths = ["deny.toml", ".github/workflows/security.yml", ".github/workflows/nightly.yml"]
+dependencies = ["cargo-audit 0.22.1", "cargo-deny 0.19.6", "RustSec advisory database"]
 reason = "Dependency and license gates require an explicit audit tool surface."
-covered_by = ["cargo run -p xtask -- audit"]
+covered_by = ["cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings", "cargo deny check advisories licenses bans sources"]
 review_after = "2026-06-30"
 
 [[allow]]
@@ -71,4 +71,15 @@ paths = [".github/workflows/mutation.yml", "policy/ci-risk-packs.toml"]
 dependencies = ["cargo-mutants 26.1.2"]
 reason = "cargo-mutants is the slower runtime backstop that complements ripr static exposure analysis."
 covered_by = [".github/workflows/mutation.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "nightly-runtime-mutation"
+owner = "core/test"
+surface = "ci"
+behavior = "The nightly workflow may install cargo-mutants 26.1.2 for scheduled runtime mutation backstop proof."
+paths = [".github/workflows/nightly.yml"]
+dependencies = ["cargo-mutants 26.1.2"]
+reason = "Nightly mutation is the slower runtime backstop that complements ripr and targeted PR-time mutation routing."
+covered_by = [".github/workflows/nightly.yml"]
 review_after = "2026-06-30"

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -2,7 +2,7 @@ schema_version = "1.0"
 policy = "process-allowlist"
 owner = "EffortlessMetrics"
 status = "active"
-updated = "2026-05-13"
+updated = "2026-05-19"
 
 # Process execution is governed separately from script/config file presence.
 
@@ -85,6 +85,21 @@ covered_by = ["docker compose -f infrastructure/docker/docker-compose.yml config
 review_after = "2026-06-30"
 
 [[allow]]
+id = "security-audit-tooling"
+owner = "release/ci"
+surface = "security"
+behavior = "Security workflows may install pinned audit tooling and run dependency, advisory, license, and source checks."
+commands = [
+  "cargo install cargo-audit --version 0.22.1 --locked",
+  "cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings",
+  "cargo install cargo-deny --version 0.19.6 --locked",
+  "cargo deny check advisories licenses bans sources",
+]
+reason = "Security and nightly audit proof should fail on real dependency or policy violations without unpinned tool drift."
+covered_by = ["cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings", "cargo deny check advisories licenses bans sources"]
+review_after = "2026-06-30"
+
+[[allow]]
 id = "ripr-static-exposure"
 owner = "release/ci"
 surface = "ci"
@@ -119,4 +134,17 @@ commands = [
 ]
 reason = "Runtime mutation should remain a targeted risk proof without becoming default PR cost."
 covered_by = [".github/workflows/mutation.yml"]
+review_after = "2026-06-30"
+
+[[allow]]
+id = "nightly-runtime-mutation"
+owner = "core/test"
+surface = "ci"
+behavior = "The nightly lane may install pinned cargo-mutants and run the scheduled workspace mutation backstop."
+commands = [
+  "cargo install cargo-mutants --version 26.1.2 --locked",
+  "cargo mutants --workspace --timeout 300 --output target/nightly-mutation --no-shuffle",
+]
+reason = "Nightly runtime mutation should remain slower scheduled proof while surfacing missed mutants, timeouts, and tool failures."
+covered_by = [".github/workflows/nightly.yml"]
 review_after = "2026-06-30"


### PR DESCRIPTION
﻿## Summary
- Pin nightly cargo-mutants, cargo-audit, and cargo-deny installs.
- Remove nightly continue-on-error masking from mutation and security audit steps.
- Replace stale cargo-mutants output handling with --output, upload mutation artifacts even on failure, and summarize caught/missed/timeout/unviable counts from mutants.out.
- Update companion dependency/process ledgers for the new pinned nightly tool surfaces.

## Validation
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- policy-report
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0097 --deny warnings
- cargo install cargo-deny --version 0.19.6 --locked --root target/cargo-deny-smoke
- 	arget/cargo-deny-smoke/bin/cargo-deny.exe check advisories licenses bans sources
- cargo install cargo-mutants --version 26.1.2 --locked --root target/cargo-mutants-smoke
- 	arget/cargo-mutants-smoke/bin/cargo-mutants.exe mutants --workspace --timeout 300 --output target/nightly-mutation-smoke --no-shuffle --list
- python YAML parse for .github/workflows/nightly.yml
- git diff --check

## Notes
- Full workspace mutation execution was not run locally; it is the scheduled expensive nightly backstop. The pinned cargo-mutants install and command-line surface were validated with --list.
- cargo-mutants exit-code handling follows the documented exit-code categories: https://mutants.rs/exit-codes.html
- cargo-mutants report handling follows the documented mutants.out layout: https://mutants.rs/mutants-out.html

Closes #244
Closes #248
