### PR TITLE
docker: bound sidecar compose resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added CPU and memory bounds to the Docker Compose validation sidecar smoke
+  stack so local operator proof cannot consume unlimited host resources.
 - Pinned the API Contracts workflow's OpenAPI, schema, and proto toolchain
   installs to exact versions for reproducible contract validation.
 - Surfaced nightly mutation and security audit failures instead of masking them,

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -210,7 +210,8 @@ The smoke script exercises `/health`, `/ready`, `/hl7/validate-redacted`,
 `/hl7/bundle`, `/hl7/replay`, and `/hl7/corpus/diff` against the running
 container. It uses the local `dev-secret` API key from
 `infrastructure/docker/sidecar.env.example`; do not replace that with a real
-deployment secret.
+deployment secret. The Compose service is also CPU/memory bounded so local
+sidecar proof cannot consume unlimited host resources.
 
 ## Viewing CI Results
 

--- a/docs/guides/deploy-validation-sidecar.md
+++ b/docs/guides/deploy-validation-sidecar.md
@@ -201,6 +201,11 @@ docker compose -f infrastructure/docker/docker-compose.yml down -v
 The smoke script exercises health, readiness, redacted validation, bundle,
 replay, and corpus diff against the running sidecar.
 
+The checked-in Compose stack is intentionally bounded for local sidecar proof:
+the `hl7v2-server` service reserves 0.25 CPU and 128 MiB, and limits itself to
+1 CPU and 512 MiB. Raise those limits in a copied deployment file only after
+measuring your corpus size and expected request concurrency.
+
 The same Compose proof is available in GitHub Actions as the path-scoped
 **Server Docker Smoke** workflow. Use the manual trigger when you need hosted
 deployment proof without changing the main CI matrix.

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -26,6 +26,14 @@ services:
       timeout: 5s
       retries: 12
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.00"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

- Add CPU and memory reservations/limits to the checked-in Docker Compose validation sidecar.
- Document the bounded local sidecar proof in the deployment guide and CI pipeline guide.
- Record the operator-sidecar resource-bound fix in the changelog.

Closes #252.

## Current-state triage

While checking the related Docker scout issues, the current compose stack made two older claims stale:

- #251 references Prometheus, Grafana, Jaeger, and OPA `latest` images that are no longer present in `infrastructure/docker/docker-compose.yml`.
- #253 references missing config, init-db, and Prometheus mounts that are no longer present; `infrastructure/docker/config/server.toml` exists and `docker compose config` validates the current stack.

I will close those separately with current-state evidence rather than mixing them into this PR.

## Validation

- `rtk docker compose -f infrastructure/docker/docker-compose.yml config`
- `rtk cargo +1.95.0 run -p xtask -- check-sidecar-guide`
- `rtk cargo +1.95.0 run -p xtask -- check-doc-links`
- `rtk cargo +1.95.0 run -p xtask -- check-file-policy`
- `rtk git diff --check`

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes
- No unrelated cleanup: yes
- Policy changes are intentional: no policy ledger changes needed
- No Clippy test carveouts added: yes
- No bare `#[allow(clippy::...)]` added: yes
- No-panic baseline handling is scoped: no no-panic changes
- Non-Rust allowlist changes are narrow: compose/docs only; existing file policy covers this surface
- CI economics: no new default lane or heavier hosted proof
- ripr mutation-exposure framing preserved: unchanged
- Release evidence preserved: no release, registry, TestPyPI, PyPI, or npm claim
- Local validation: listed above
- CI status: pending hosted checks
- Bot comments addressed: none yet
- Follow-ups: close stale #251/#253 with current-state evidence
