### PR TITLE
docs: align coverage tooling references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Removed stale `cargo-tarpaulin` coverage workflow references from CI/testing
+  docs so they match the current `cargo-llvm-cov` coverage lane.
 - Replaced the stale issues and next-steps planning snapshot with a current
   blocker map for public Python proof, evidence parity, operator workflows,
   dirty corpus expansion, gRPC hardening, RIPR calibration, and later

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -88,16 +88,12 @@ Dedicated workflow for code coverage analysis.
 
 #### Jobs:
 
-1. **tarpaulin** - Coverage with cargo-tarpaulin
-   - Generates XML and HTML reports
-   - Uploads to Codecov
-
-2. **llvm-cov** - Coverage with cargo-llvm-cov
-   - Faster alternative to tarpaulin
-   - Generates LCOV and HTML reports
-
-3. **coverage-diff** - PR coverage comparison
-   - Compares PR coverage against base branch
+1. **Codecov Coverage** - Coverage with `cargo-llvm-cov`
+   - Installs `cargo-llvm-cov` and `cargo-nextest` through
+     `taiki-e/install-action@v2`
+   - Generates `coverage.json`, `coverage.txt`, and `lcov.info`
+   - Uploads LCOV to Codecov when `CODECOV_TOKEN` is configured
+   - Writes a claim-bounded coverage receipt under `target/coverage/`
 
 ### `.github/workflows/droid.yml` - Factory Droid Manual Review
 
@@ -232,13 +228,11 @@ The following artifacts are generated and available for download:
 
 | Workflow | Artifact | Contents |
 |----------|----------|----------|
-| ci.yml | coverage-report | HTML coverage reports |
 | ci.yml | benchmark-results | Benchmark output |
 | nightly.yml | fuzz-crash-* | Fuzz test crash inputs |
 | nightly.yml | mutation-report | Mutation testing results |
 | nightly.yml | api-docs | Generated API documentation |
-| coverage.yml | tarpaulin-coverage | Tarpaulin coverage reports |
-| coverage.yml | llvm-coverage | LLVM coverage reports |
+| coverage.yml | coverage-report | `coverage.json`, `coverage.txt`, `lcov.info`, and the coverage receipt |
 | python-wheels.yml | python-wheel-* | Smoke-test wheels for the Python binding lane |
 | python-testpypi.yml | python-testpypi-wheel | Manual TestPyPI proof wheel artifact |
 | python-pypi.yml | python-pypi-wheel | Manual production PyPI release proof wheel artifact |
@@ -364,7 +358,8 @@ performance in detail.
 3. **Update workflow versions** quarterly:
    - Actions (e.g., `actions/checkout@v4`)
    - Rust toolchain
-   - Cargo tools (tarpaulin, llvm-cov, etc.)
+   - Cargo tools installed through workflow actions, including `cargo-llvm-cov`
+     and `cargo-nextest`
 
 ## Troubleshooting
 

--- a/docs/TESTING_SUMMARY.md
+++ b/docs/TESTING_SUMMARY.md
@@ -84,11 +84,11 @@ The project has CI/CD configured with the following pipelines:
 - **Build:** cargo build --all-features
 - **Test:** cargo test --workspace
 - **Docs:** cargo doc --no-deps
-- **Coverage:** tarpaulin configured
+- **Coverage:** `cargo-llvm-cov` configured in the routed Coverage workflow
 
 ### Coverage Reporting
-- Coverage tooling configured via cargo-tarpaulin
-- Reports generated in Cobertura XML format
+- Coverage tooling is installed through `taiki-e/install-action@v2`
+- Reports generated as JSON, text summary, and LCOV
 
 ## Known Issues
 


### PR DESCRIPTION
## Summary

- Remove stale `cargo-tarpaulin` references from CI/testing docs.
- Document the current Coverage workflow shape: `cargo-llvm-cov` + `cargo-nextest` via `taiki-e/install-action@v2`, LCOV/JSON/text artifacts, and the claim-bounded coverage receipt.
- Keep the workflow unchanged because the unpinned tarpaulin install described in #273 no longer exists on current `main`.

Closes #273.

## Current-state note

The issue evidence is stale against current `main`: `.github/workflows/coverage.yml` no longer installs `cargo-tarpaulin`; it installs coverage tools through `taiki-e/install-action@v2` with `tool: cargo-llvm-cov,cargo-nextest`. This PR fixes the remaining stale documentation that still described tarpaulin artifacts and setup.

## Validation

- `rtk grep "tarpaulin" docs .github policy xtask CHANGELOG.md` only finds this changelog entry.
- `rtk cargo +1.95.0 run -p xtask -- check-doc-links`
- `rtk cargo +1.95.0 run -p xtask -- check-file-policy`
- `rtk git diff --check`

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes
- No unrelated cleanup: yes
- Policy changes are intentional: no policy changes
- No Clippy test carveouts added: yes
- No bare `#[allow(clippy::...)]` added: yes
- No-panic baseline handling is scoped: no no-panic changes
- Non-Rust allowlist changes are narrow: docs only
- CI economics: no workflow expansion
- ripr mutation-exposure framing preserved: unchanged
- Release evidence preserved: no release, registry, TestPyPI, PyPI, or npm claim
- Local validation: listed above
- CI status: pending hosted checks
- Bot comments addressed: none yet
- Follow-ups: none
