### PR TITLE
devex: align non-Nix setup and test TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Aligned the e2e HTTP client test dependency on rustls so all-features
+  workspace checks do not re-enable native TLS through `reqwest` defaults.
 - Added CPU and memory bounds to the Docker Compose validation sidecar smoke
   stack so local operator proof cannot consume unlimited host resources.
 - Pinned the API Contracts workflow's OpenAPI, schema, and proto toolchain
@@ -130,6 +132,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Clarified the non-Nix developer setup path, including `just` installation,
+  `xtask` fallbacks, optional local quality tools, and OpenSSL/pkg-config
+  troubleshooting boundaries.
 - Removed stale `cargo-tarpaulin` coverage workflow references from CI/testing
   docs so they match the current `cargo-llvm-cov` coverage lane.
 - Replaced the stale issues and next-steps planning snapshot with a current

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,16 @@ contribution under **AGPL-3.0-or-later**.
 ### 1. Set Up Your Environment
 
 Follow [DEVELOPMENT.md](DEVELOPMENT.md) for detailed setup instructions.
+The Nix shell is the recommended path. Non-Nix contributors should install the
+Rust 1.95 toolchain and either `just` (`cargo install just`) or use the
+equivalent `cargo run -p xtask -- ...` commands documented there.
 
 ```bash
 # Quick start
 git clone https://github.com/EffortlessMetrics/hl7v2-rs.git
 cd hl7v2-rs
-cargo build
-cargo test
+cargo run -p xtask -- setup
+cargo run -p xtask -- gate
 ```
 
 ### 2. Understand the Project Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,26 +606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,15 +930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,21 +1054,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1779,22 +1735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,11 +1752,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2344,23 +2282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,50 +2435,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "page_size"
@@ -3332,7 +3209,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "h2",
  "http",
@@ -3340,12 +3216,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3356,7 +3229,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
@@ -3533,15 +3405,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3562,29 +3425,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4153,27 +3993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,16 +4148,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -5165,17 +4974,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,39 @@
 
 Get up and running with `hl7v2-rs` development.
 
+## Prerequisites
+
+The recommended path is the Nix development shell:
+
+```bash
+nix develop
+```
+
+It provides Rust 1.95, `cargo-nextest`, `cargo-deny`, `cargo-audit`, `just`,
+schema tooling, and the native libraries used by repository tooling.
+
+For a non-Nix setup, install:
+
+- Rust 1.95 with `rustfmt` and Clippy, or use the checked-in
+  `rust-toolchain.toml`.
+- `just`, if you want to run the documented short commands:
+  `cargo install just`.
+- Optional quality tools used by the local workflow:
+  `cargo install cargo-nextest cargo-deny cargo-audit`.
+
+Every `just <task>` entry in this guide has an equivalent
+`cargo run -p xtask -- <task>` form. For example, use
+`cargo run -p xtask -- setup` if `just` is not installed yet.
+
+The default workspace HTTP client path uses rustls. Fresh non-Nix builds should
+not need OpenSSL or `pkg-config` just to run the Rust test graph. If a platform
+or local feature reports an OpenSSL/pkg-config error, use `nix develop` or
+install the platform packages before retrying:
+
+- Ubuntu/Debian: `sudo apt-get install pkg-config libssl-dev`
+- Fedora/RHEL: `sudo dnf install pkgconf-pkg-config openssl-devel`
+- macOS/Homebrew: `brew install pkg-config openssl`
+
 ## Quick Start
 
 ### 1. Setup Environment
@@ -22,6 +55,8 @@ Activate the automated git hooks and prepare the workspace:
 
 ```bash
 just setup
+# or, without just:
+cargo run -p xtask -- setup
 ```
 
 ### 3. Verify Everything
@@ -30,6 +65,8 @@ Run the gate command to verify formatting, lints, and tests:
 
 ```bash
 just gate
+# or:
+cargo run -p xtask -- gate
 ```
 
 ## Unified Development Workflow

--- a/crates/hl7v2-e2e-tests/Cargo.toml
+++ b/crates/hl7v2-e2e-tests/Cargo.toml
@@ -25,8 +25,13 @@ hl7v2-server = { version = "1.5.0", path = "../hl7v2-server" }
 # Async runtime
 tokio = { workspace = true, features = ["full", "test-util"] }
 
-# HTTP client for server API tests
-reqwest = { version = "0.12", features = ["json"] }
+# HTTP client for server API tests. Keep this aligned with the workspace
+# rustls posture so all-features test builds do not re-enable native-tls.
+reqwest = { version = "0.12", default-features = false, features = [
+    "http2",
+    "json",
+    "rustls-tls-webpki-roots",
+] }
 
 # Serialization
 serde = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -307,12 +307,24 @@ fn setup() -> Result<()> {
         }
     }
 
-    // Check for required tools
-    let tools = ["cargo-deny", "cargo-audit", "cargo-nextest", "just"];
-    for tool in tools {
-        if !command_exists(tool) {
-            println!("Note: '{tool}' not found. Consider installing it for full DevEx.");
+    let tools = [
+        ("cargo-deny", "cargo install cargo-deny"),
+        ("cargo-audit", "cargo install cargo-audit"),
+        ("cargo-nextest", "cargo install cargo-nextest"),
+        ("just", "cargo install just"),
+    ];
+    let missing_tools: Vec<_> = tools
+        .iter()
+        .filter(|(tool, _)| !command_exists(tool))
+        .collect();
+    if !missing_tools.is_empty() {
+        println!("Optional development tools are missing:");
+        for (tool, install_command) in missing_tools {
+            println!("  - {tool}: install with `{install_command}` or run `nix develop`");
         }
+        println!(
+            "The repository hooks are configured; missing optional tools only limit local DevEx commands."
+        );
     }
 
     println!("✅ Setup complete!");


### PR DESCRIPTION
## Summary

- switch hl7v2-e2e-tests reqwest usage to rustls with default features disabled
- remove native TLS/OpenSSL-only crates from Cargo.lock
- document the non-Nix setup path, just install, xtask fallbacks, and OpenSSL/pkg-config troubleshooting boundary
- make xtask setup print concrete install commands for optional local DevEx tools

## Validation

- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 check -p hl7v2-e2e-tests --all-targets --all-features
- cargo +1.95.0 test -p xtask --locked
- cargo +1.95.0 clippy -p xtask --all-targets --locked -- -D warnings
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.95.0 check --workspace --all-targets --all-features --locked
- cargo deny check
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- cargo +1.95.0 tree --workspace --all-features --target all -i native-tls returns no matching package
- cargo +1.95.0 tree --workspace --all-features --target all -i openssl-sys returns no matching package
- cargo +1.95.0 tree --workspace --all-features --target all -i hyper-tls returns no matching package

Fixes #247
Fixes #249
Fixes #250
Fixes #259