### PR TITLE
nix: version Docker image from workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Derived the Nix package version and Docker image tag from the workspace
+  version so the flake no longer emits a floating `latest` image tag.
 - Aligned the e2e HTTP client test dependency on rustls so all-features
   workspace checks do not re-enable native TLS through `reqwest` defaults.
 - Added CPU and memory bounds to the Docker Compose validation sidecar smoke

--- a/NIX_USAGE.md
+++ b/NIX_USAGE.md
@@ -82,8 +82,10 @@ Build Docker image with Nix:
 ```bash
 nix build .#docker
 docker load < result
-docker run -p 8080:8080 hl7v2-rs:latest
+docker run -p 8080:8080 hl7v2-rs:1.5.0
 ```
+
+The Nix Docker image tag follows the workspace package version.
 
 ### Checks
 

--- a/docs/adr/0005-nix-for-reproducible-builds.md
+++ b/docs/adr/0005-nix-for-reproducible-builds.md
@@ -227,9 +227,13 @@ It includes only the Rust toolchain, OpenSSL, pkg-config, and ajv-cli for schema
 Container images are built using Nix's `dockerTools.buildLayeredImage`, which produces layered images without a base OS:
 
 ```nix
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  workspaceVersion = cargoToml.workspace.package.version;
+in
 packages.docker = pkgs.dockerTools.buildLayeredImage {
   name = "hl7v2-rs";
-  tag = "latest";
+  tag = workspaceVersion;
   contents = [ self.packages.${system}.default ];
   config = {
     Cmd = [ "${self.packages.${system}.default}/bin/hl7v2-server" ];

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,14 @@
   outputs = { self, nixpkgs, rust-overlay, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        workspaceVersion = cargoToml.workspace.package.version;
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
           inherit system overlays;
         };
 
-        # Pin Rust version to match MSRV (1.92 = edition 2024)
+        # Rust toolchain for Nix builds.
         # Note: Using stable Rust toolchain from rust-overlay
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-analyzer" "clippy" "rustfmt" ];
@@ -80,7 +82,7 @@
         # Default package
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "hl7v2-rs";
-          version = "1.2.0";
+          version = workspaceVersion;
 
           src = ./.;
 
@@ -175,7 +177,7 @@ EOF
         # Docker image
         packages.docker = pkgs.dockerTools.buildLayeredImage {
           name = "hl7v2-rs";
-          tag = "latest";
+          tag = workspaceVersion;
 
           contents = [ self.packages.${system}.default ];
 


### PR DESCRIPTION
## Summary

- derive the Nix package version from Cargo.toml workspace package metadata
- tag the Nix Docker image with the workspace version instead of latest
- update the Nix usage and ADR examples plus changelog

Fixes #304

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- targeted stale-token checks for version = 1.2.0, tag = latest, and hl7v2-rs:latest in current Nix surfaces

## Validation gap

- nix is not installed in this local Windows checkout, so local nix flake check / nix build .#docker could not be run here.

## Non-claims

- No crates.io, TestPyPI, PyPI, npm, tag, or GitHub release claim.