### PR TITLE
infra: pin Kubernetes deployment image version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Derived the Nix package version and Docker image tag from the workspace
   version so the flake no longer emits a floating `latest` image tag.
+- Pinned the Kubernetes deployment image tag and version labels to v1.5.0
+  instead of the previous floating `latest` image reference.
 - Aligned the e2e HTTP client test dependency on rustls so all-features
   workspace checks do not re-enable native TLS through `reqwest` defaults.
 - Added CPU and memory bounds to the Docker Compose validation sidecar smoke

--- a/infrastructure/k8s/deployment.yaml
+++ b/infrastructure/k8s/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hl7v2-server
   labels:
     app: hl7v2-server
-    version: v1.2.1
+    version: v1.5.0
 spec:
   replicas: 3
   selector:
@@ -19,7 +19,7 @@ spec:
     metadata:
       labels:
         app: hl7v2-server
-        version: v1.2.1
+        version: v1.5.0
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
@@ -33,7 +33,7 @@ spec:
 
       containers:
       - name: hl7v2
-        image: hl7v2-rs:latest
+        image: hl7v2-rs:1.5.0
         imagePullPolicy: IfNotPresent  # Kyverno compliance: pinned digest required
 
         ports:


### PR DESCRIPTION
## Summary

- pin the Kubernetes deployment image tag to hl7v2-rs:1.5.0 instead of latest
- align deployment and pod template version labels to v1.5.0
- record the deployment-versioning fix in the changelog

Fixes #225

## Validation

- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check
- targeted stale-token check for hl7v2-rs:latest and v1.2.1 in infrastructure/k8s/deployment.yaml

## Follow-up boundary

- This removes the floating Kubernetes image tag. Digest pinning and broader Kyverno/deployment-hardening concerns remain tracked separately by #233.

## Non-claims

- No crates.io, TestPyPI, PyPI, npm, tag, GitHub release, or deployment success claim.