### PR TITLE
docs: remove Grafana admin password default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   version so the flake no longer emits a floating `latest` image tag.
 - Pinned the Kubernetes deployment image tag and version labels to v1.5.0
   instead of the previous floating `latest` image reference.
+- Removed the remaining Grafana documentation example that defaulted the
+  administrator password to `admin`.
 - Aligned the e2e HTTP client test dependency on rustls so all-features
   workspace checks do not re-enable native TLS through `reqwest` defaults.
 - Added CPU and memory bounds to the Docker Compose validation sidecar smoke

--- a/infrastructure/grafana/README.md
+++ b/infrastructure/grafana/README.md
@@ -80,7 +80,7 @@ services:
       - grafana_data:/var/lib/grafana
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set}
       - GF_INSTALL_PLUGINS=
     ports:
       - "3000:3000"
@@ -109,6 +109,10 @@ Start the monitoring stack:
 export GRAFANA_ADMIN_PASSWORD="your-secure-password"
 docker-compose up -d
 ```
+
+The monitoring stack intentionally fails closed when `GRAFANA_ADMIN_PASSWORD`
+is missing; do not use a default Grafana admin password in shared or production
+environments.
 
 Access:
 - **Grafana**: http://localhost:3000 (admin / your-password)


### PR DESCRIPTION
## Summary

- remove the remaining Grafana README example that defaulted the admin password to admin
- document that GRAFANA_ADMIN_PASSWORD is required and the monitoring stack should fail closed
- record the security-doc cleanup in the changelog

Fixes #230

## Validation

- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- targeted stale-token assertion for weak password defaults in active docs/infrastructure

## Security boundary

- This is documentation/config-example hardening only. No real secrets are committed and no runtime deployment is claimed.

## Non-claims

- No crates.io, TestPyPI, PyPI, npm, tag, GitHub release, deployment, or install-back claim.