### PR TITLE
ci: pin Python wheel proof to Rust 1.95

### DIFF
--- a/.github/workflows/python-pypi.yml
+++ b/.github/workflows/python-pypi.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.95.0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.95.0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.95.0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of the previous floating `latest` image reference.
 - Removed the remaining Grafana documentation example that defaulted the
   administrator password to `admin`.
+- Pinned Python wheel proof workflows to Rust 1.95.0 so public Python package
+  build and install-back evidence uses the declared release toolchain.
 - Aligned the e2e HTTP client test dependency on rustls so all-features
   workspace checks do not re-enable native TLS through `reqwest` defaults.
 - Added CPU and memory bounds to the Docker Compose validation sidecar smoke

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8513,6 +8513,7 @@ const PYTHON_DISTRIBUTION_DESCRIPTION: &str =
     "Python package for HL7v2 parsing, validation, and evidence workflows backed by Rust.";
 const HL7V2_PYTHON_CRATE_DESCRIPTION: &str =
     "PyO3 extension crate backing the Python hl7v2 package. Rust users should depend on hl7v2.";
+const PYTHON_RELEASE_RUST_TOOLCHAIN: &str = "1.95.0";
 const PYTHON_WHEELS_WORKFLOW_PATH: &str = ".github/workflows/python-wheels.yml";
 
 fn check_python_publish_policy() -> Result<()> {
@@ -8744,6 +8745,7 @@ fn check_python_wheels_workflow_text(text: &str) -> Result<()> {
     let jobs = yaml_child_mapping(root_map, PYTHON_WHEELS_WORKFLOW_PATH, "jobs")?;
     let wheel_job = yaml_mapping_child(jobs, PYTHON_WHEELS_WORKFLOW_PATH, "jobs", "wheel-smoke")?;
     let steps = yaml_child_sequence(wheel_job, PYTHON_WHEELS_WORKFLOW_PATH, "steps")?;
+    ensure_python_release_rust_toolchain(steps, PYTHON_WHEELS_WORKFLOW_PATH)?;
 
     let build = yaml_step_named(steps, PYTHON_WHEELS_WORKFLOW_PATH, "Build wheel")?;
     let build_run = yaml_mapping_string(build, PYTHON_WHEELS_WORKFLOW_PATH, "run")?;
@@ -9113,6 +9115,8 @@ fn ensure_python_wheel_proof_job(
     wheel_job: &serde_yaml::Mapping,
 ) -> Result<()> {
     let steps = yaml_child_sequence(wheel_job, policy.path, "steps")?;
+    ensure_python_release_rust_toolchain(steps, policy.path)?;
+
     let install_maturin = yaml_step_named(steps, policy.path, "Install maturin")?;
     let install_maturin_run = yaml_mapping_string(install_maturin, policy.path, "run")?;
     if !install_maturin_run.contains("maturin==1.13.1") {
@@ -9148,6 +9152,13 @@ fn ensure_python_wheel_proof_job(
         }
     }
     Ok(())
+}
+
+fn ensure_python_release_rust_toolchain(steps: &[serde_yaml::Value], context: &str) -> Result<()> {
+    let rust_toolchain = yaml_step_named(steps, context, "Install Rust toolchain")?;
+    ensure_yaml_string(rust_toolchain, context, "uses", "dtolnay/rust-toolchain@v1")?;
+    let with = yaml_child_mapping(rust_toolchain, context, "with")?;
+    ensure_yaml_string(with, context, "toolchain", PYTHON_RELEASE_RUST_TOOLCHAIN)
 }
 
 fn ensure_python_publish_artifact(
@@ -9253,7 +9264,12 @@ fn ensure_python_install_back_job(
         "dtolnay/rust-toolchain@v1",
     )?;
     let rust_toolchain_with = yaml_child_mapping(rust_toolchain, policy.path, "with")?;
-    ensure_yaml_string(rust_toolchain_with, policy.path, "toolchain", "1.95.0")?;
+    ensure_yaml_string(
+        rust_toolchain_with,
+        policy.path,
+        "toolchain",
+        PYTHON_RELEASE_RUST_TOOLCHAIN,
+    )?;
 
     let install = steps
         .iter()
@@ -11297,6 +11313,37 @@ bindings = "pyo3"
     }
 
     #[test]
+    fn python_publish_policy_rejects_floating_wheel_build_toolchain() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replacen("toolchain: 1.95.0", "toolchain: stable", 1);
+        if broken == workflow {
+            return Err(anyhow!(
+                "test setup should change the wheel build toolchain"
+            ));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject floating stable wheel build toolchains"
+            )),
+            Err(err)
+                if err.to_string().contains("toolchain")
+                    && err.to_string().contains(PYTHON_RELEASE_RUST_TOOLCHAIN) =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
     fn python_publish_policy_rejects_wrong_public_registry_index() -> Result<()> {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -11329,6 +11376,34 @@ bindings = "pyo3"
         let workflow = fs::read_to_string(root.join(PYTHON_WHEELS_WORKFLOW_PATH))?;
 
         check_python_wheels_workflow_text(&workflow)
+    }
+
+    #[test]
+    fn python_wheels_policy_rejects_floating_wheel_smoke_toolchain() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let workflow = fs::read_to_string(root.join(PYTHON_WHEELS_WORKFLOW_PATH))?;
+        let broken = workflow.replace("toolchain: 1.95.0", "toolchain: stable");
+        if broken == workflow {
+            return Err(anyhow!(
+                "test setup should change the Python Wheels toolchain"
+            ));
+        }
+
+        match check_python_wheels_workflow_text(&broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject Python Wheels floating stable toolchains"
+            )),
+            Err(err)
+                if err.to_string().contains("toolchain")
+                    && err.to_string().contains(PYTHON_RELEASE_RUST_TOOLCHAIN) =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(anyhow!("unexpected Python Wheels policy error: {err}")),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pin Python TestPyPI, PyPI, and Python Wheels build jobs to Rust 1.95.0 instead of floating stable
- make check-python-publish-policy reject floating Rust toolchains in Python wheel proof jobs
- add regression coverage for the publish workflows and Python Wheels smoke workflow

## Validation

- cargo fmt --all -- --check
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- cargo +1.95.0 test -p xtask python --locked
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-evidence-parity
- git diff --check
- pre-commit hook passed with RUSTUP_TOOLCHAIN=1.95.0 and PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
- pre-push hook passed with RUSTUP_TOOLCHAIN=1.95.0 and PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1

## Non-claims

- No TestPyPI upload or install-back claim
- No PyPI upload or install-back claim
- No npm, tag, GitHub release, or crates.io claim

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes
- No unrelated cleanup: yes
- Policy changes are intentional: yes
- No Clippy test carveouts added: yes
- No bare #[allow(clippy::...)] added: yes
- No-panic baseline handling is scoped: not touched
- Non-Rust allowlist changes are narrow: no allowlist changes
- CI economics: no new jobs or default CI weight
- ripr mutation-exposure framing preserved: not touched
- Release evidence preserved: yes, no registry success claim added
- Local validation: listed above
- CI status: pending draft PR checks
- Bot comments addressed: none yet
- Follow-ups: external TestPyPI Trusted Publisher setup for hl7v2 remains blocked in #563