### PR TITLE
python: harden public registry wheel proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build and install-back evidence uses the declared release toolchain.
 - Hardened Python wheel and public-registry proof commands to fail when the
   imported `hl7v2` module version does not match the expected package version.
+- Hardened public Python registry install-back proof to install wheel artifacts
+  only with pip caching disabled.
 - Aligned the e2e HTTP client test dependency on rustls so all-features
   workspace checks do not re-enable native TLS through `reqwest` defaults.
 - Added CPU and memory bounds to the Docker Compose validation sidecar smoke

--- a/docs/audits/python-public-registry-proof-command-2026-05-18.md
+++ b/docs/audits/python-public-registry-proof-command-2026-05-18.md
@@ -16,8 +16,8 @@ cargo +1.95.0 run -p xtask -- python-public-registry-proof --index pypi --versio
 
 It creates a scratch virtual environment, installs
 `hl7v2==<version>` from the selected public package index with
-`--no-deps --force-reinstall`, imports `hl7v2`, verifies
-`hl7v2.__version__ == <version>`, and runs:
+`--no-deps --only-binary :all: --no-cache-dir --force-reinstall`,
+imports `hl7v2`, verifies `hl7v2.__version__ == <version>`, and runs:
 
 ```text
 tests/python_smoke/smoke.py

--- a/docs/guides/python-pypi-release.md
+++ b/docs/guides/python-pypi-release.md
@@ -37,6 +37,7 @@ Before running the production publish mode, verify all of these are true:
   `tests/python_smoke/dirty_evidence_workflow.py`.
 - Optional local TestPyPI install-back reproduction passes with
   `cargo +1.95.0 run -p xtask -- python-public-registry-proof --index testpypi --version <workspace version>`.
+  That proof installs wheel-only with pip cache disabled.
 - You have the successful **Python TestPyPI Proof** workflow run URL for this
   exact version.
 - The current version is not already present on production PyPI.
@@ -123,6 +124,8 @@ This keeps the workflow proof and local reproduction path aligned. A passing
 install-back job proves only the production PyPI package for the selected
 version; it does not retroactively prove TestPyPI unless the same-commit
 TestPyPI receipt is already linked.
+The proof installs with `--only-binary :all:` and `--no-cache-dir`, so it checks
+the selected public wheel rather than a source build or cached artifact.
 
 PyPI does not allow overwriting an existing file for the same version. If the
 upload fails because the version already exists, stop and choose a new workspace

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -74,10 +74,11 @@ cargo +1.95.0 run -p xtask -- python-public-registry-proof --index testpypi --ve
 
 That command creates a scratch virtual environment, installs
 `hl7v2==<workspace version>` from `https://test.pypi.org/simple/` with
-`--no-deps --force-reinstall`, imports `hl7v2`, verifies
-`hl7v2.__version__ == <workspace version>`, and runs the same three Python
-smoke/evidence scripts. It is a TestPyPI install-back proof only after the
-package is actually visible on TestPyPI; it is not a production PyPI claim.
+`--no-deps --only-binary :all: --no-cache-dir --force-reinstall`, imports
+`hl7v2`, verifies `hl7v2.__version__ == <workspace version>`, and runs the
+same three Python smoke/evidence scripts. It is a TestPyPI install-back proof
+only after the package is actually visible on TestPyPI; it is not a production
+PyPI claim.
 
 ## Manual TestPyPI Proof
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4635,16 +4635,7 @@ fn python_public_registry_proof(
     );
     run_command_with_env_in_dir(
         &venv_python,
-        &[
-            "-m",
-            "pip",
-            "install",
-            "--index-url",
-            index_url,
-            "--no-deps",
-            "--force-reinstall",
-            &package,
-        ],
+        &python_public_registry_pip_install_args(index_url, &package),
         &[],
         Some(&workspace_root),
     )?;
@@ -4709,6 +4700,25 @@ fn python_import_version_check_script(expected_version: &str) -> String {
         "    raise SystemExit(f'expected hl7v2 version {expected}, got {actual}')",
     ]
     .join("\n")
+}
+
+fn python_public_registry_pip_install_args<'a>(
+    index_url: &'a str,
+    package: &'a str,
+) -> Vec<&'a str> {
+    vec![
+        "-m",
+        "pip",
+        "install",
+        "--index-url",
+        index_url,
+        "--no-deps",
+        "--only-binary",
+        ":all:",
+        "--no-cache-dir",
+        "--force-reinstall",
+        package,
+    ]
 }
 
 fn python_package_index_url(index: PythonPackageIndex) -> &'static str {
@@ -10237,6 +10247,26 @@ mod tests {
         assert!(script.contains("expected = \"1.5.0\""));
         assert!(script.contains("actual != expected"));
         assert!(script.contains("raise SystemExit"));
+    }
+
+    #[test]
+    fn python_public_registry_pip_install_is_wheel_only_and_cache_free() {
+        let args = python_public_registry_pip_install_args(
+            "https://test.pypi.org/simple/",
+            "hl7v2==1.5.0",
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--index-url", "https://test.pypi.org/simple/"])
+        );
+        assert!(args.contains(&"--no-deps"));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--only-binary", ":all:"])
+        );
+        assert!(args.contains(&"--no-cache-dir"));
+        assert!(args.contains(&"--force-reinstall"));
+        assert_eq!(args.last(), Some(&"hl7v2==1.5.0"));
     }
 
     #[test]


### PR DESCRIPTION
﻿## Summary

- Harden xtask python-public-registry-proof so public install-back proof installs wheel artifacts only with pip cache disabled.
- Keep TestPyPI/PyPI proof routed through the existing shared command boundary; no workflow-side bypass is added.
- Update the TestPyPI/PyPI proof docs and audit note to describe the stricter --only-binary :all: and --no-cache-dir install boundary.

## Validation

- cargo fmt --all -- --check
- cargo +1.95.0 test -p xtask python_public_registry_pip_install_is_wheel_only_and_cache_free --locked
- cargo +1.95.0 test -p xtask python --locked
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-evidence-parity
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- pre-push gate --check

## Non-claims

- No TestPyPI upload or install-back success is claimed.
- No PyPI upload or install-back success is claimed.
- No token fallback or skip-existing behavior is added.
- No npm, crates.io, tag, or GitHub release action is claimed.

## Self-review

- Scope matches PR title: yes
- Files touched are expected: yes
- No unrelated cleanup: yes
- Policy changes are intentional: yes
- No Clippy test carveouts added: yes
- No bare #[allow(clippy::...)] added: yes
- No-panic baseline handling is scoped: n/a
- Non-Rust allowlist changes are narrow: n/a
- CI economics: lanes are risk-pack appropriate: yes
- ripr mutation-exposure framing preserved: n/a
- Release evidence preserved: yes
- Local validation: listed above
- CI status: draft PR pending
- Bot comments addressed: none yet
- Follow-ups: TestPyPI Trusted Publisher setup remains external before any public package success claim
