### PR TITLE
ci(python): record actual PyPI OIDC claims

### DIFF
--- a/.github/workflows/python-pypi.yml
+++ b/.github/workflows/python-pypi.yml
@@ -246,6 +246,85 @@ jobs:
           name: python-pypi-wheel
           path: dist
 
+      - name: Record actual OIDC publisher claims
+        shell: bash
+        env:
+          EXPECTED_SUBJECT: repo:${{ github.repository }}:environment:pypi
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_REF: refs/heads/main
+        run: |
+          python - <<'PY'
+          import base64
+          import json
+          import os
+          import sys
+          import urllib.parse
+          import urllib.request
+
+          request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+          request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+          if not request_url or not request_token:
+              print(
+                  "::error::GitHub OIDC request environment is missing; publish job needs id-token: write",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          separator = "&" if urllib.parse.urlsplit(request_url).query else "?"
+          token_url = f"{request_url}{separator}audience=pypi"
+          request = urllib.request.Request(
+              token_url,
+              headers={"Authorization": f"Bearer {request_token}"},
+          )
+          with urllib.request.urlopen(request, timeout=20) as response:
+              token_response = json.load(response)
+          token = token_response.get("value")
+          if not token:
+              print("::error::GitHub OIDC response did not include a token value", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              payload = token.split(".")[1]
+              payload += "=" * (-len(payload) % 4)
+              claims = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+          except (IndexError, json.JSONDecodeError, ValueError) as error:
+              print(f"::error::failed to decode GitHub OIDC claims: {error}", file=sys.stderr)
+              sys.exit(1)
+
+          expected = {
+              "sub": os.environ["EXPECTED_SUBJECT"],
+              "repository": os.environ["EXPECTED_REPOSITORY"],
+              "ref": os.environ["EXPECTED_REF"],
+          }
+          summary_fields = [
+              "sub",
+              "repository",
+              "repository_owner",
+              "ref",
+              "environment",
+              "workflow_ref",
+              "job_workflow_ref",
+              "sha",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Actual GitHub OIDC publisher claims\n\n")
+              summary.write("| Claim | Value |\n| --- | --- |\n")
+              for field in summary_fields:
+                  summary.write(f"| `{field}` | `{claims.get(field, '')}` |\n")
+              summary.write("\n")
+
+          errors = []
+          for claim, expected_value in expected.items():
+              actual = claims.get(claim)
+              if actual != expected_value:
+                  errors.append(f"{claim}: expected {expected_value!r}, got {actual!r}")
+
+          if errors:
+              for error in errors:
+                  print(f"::error::OIDC publisher claim mismatch: {error}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:

--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -145,6 +145,85 @@ jobs:
             echo "If upload fails with \`invalid-publisher\`, configure the pending publisher on TestPyPI with these values and rerun this workflow."
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: Record actual OIDC publisher claims
+        shell: bash
+        env:
+          EXPECTED_SUBJECT: repo:${{ github.repository }}:environment:testpypi
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_REF: refs/heads/main
+        run: |
+          python - <<'PY'
+          import base64
+          import json
+          import os
+          import sys
+          import urllib.parse
+          import urllib.request
+
+          request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL")
+          request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+          if not request_url or not request_token:
+              print(
+                  "::error::GitHub OIDC request environment is missing; publish job needs id-token: write",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          separator = "&" if urllib.parse.urlsplit(request_url).query else "?"
+          token_url = f"{request_url}{separator}audience=pypi"
+          request = urllib.request.Request(
+              token_url,
+              headers={"Authorization": f"Bearer {request_token}"},
+          )
+          with urllib.request.urlopen(request, timeout=20) as response:
+              token_response = json.load(response)
+          token = token_response.get("value")
+          if not token:
+              print("::error::GitHub OIDC response did not include a token value", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              payload = token.split(".")[1]
+              payload += "=" * (-len(payload) % 4)
+              claims = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+          except (IndexError, json.JSONDecodeError, ValueError) as error:
+              print(f"::error::failed to decode GitHub OIDC claims: {error}", file=sys.stderr)
+              sys.exit(1)
+
+          expected = {
+              "sub": os.environ["EXPECTED_SUBJECT"],
+              "repository": os.environ["EXPECTED_REPOSITORY"],
+              "ref": os.environ["EXPECTED_REF"],
+          }
+          summary_fields = [
+              "sub",
+              "repository",
+              "repository_owner",
+              "ref",
+              "environment",
+              "workflow_ref",
+              "job_workflow_ref",
+              "sha",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Actual GitHub OIDC publisher claims\n\n")
+              summary.write("| Claim | Value |\n| --- | --- |\n")
+              for field in summary_fields:
+                  summary.write(f"| `{field}` | `{claims.get(field, '')}` |\n")
+              summary.write("\n")
+
+          errors = []
+          for claim, expected_value in expected.items():
+              actual = claims.get(claim)
+              if actual != expected_value:
+                  errors.append(f"{claim}: expected {expected_value!r}, got {actual!r}")
+
+          if errors:
+              for error in errors:
+                  print(f"::error::OIDC publisher claim mismatch: {error}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:

--- a/docs/guides/python-pypi-release.md
+++ b/docs/guides/python-pypi-release.md
@@ -104,6 +104,11 @@ uploading unless `testpypi_proof_url` points at a successful manual
 the current version is visible on TestPyPI, and the current version is absent
 from production PyPI.
 
+Before upload, the publish job records the decoded GitHub OIDC publisher claims
+in the job summary and fails closed if the actual `sub`, `repository`, or `ref`
+does not match the production trusted-publisher identity
+`repo:EffortlessMetrics/hl7v2-rs:environment:pypi`.
+
 This does three things:
 
 1. Builds and smoke-tests the wheel.

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -107,11 +107,17 @@ publish_to_testpypi = true
 Run publishing mode from `main`. The workflow fails early if
 `publish_to_testpypi=true` is selected from any other ref.
 
-Before upload, the publish job writes the expected TestPyPI Trusted Publisher
-fields to the GitHub Actions job summary. If the upload fails with
-`invalid-publisher`, compare the summary fields to the TestPyPI pending
-publisher configuration and fix TestPyPI before rerunning. Do not switch to a
-repository token or `skip-existing` as a shortcut around Trusted Publishing.
+Before upload, the publish job writes both the expected TestPyPI Trusted
+Publisher fields and the actual decoded GitHub OIDC publisher claims to the
+GitHub Actions job summary. It fails before upload if the actual `sub`,
+`repository`, or `ref` does not match the expected trusted-publisher identity.
+
+If the upload still fails with `invalid-publisher` after the actual `sub` is
+`repo:EffortlessMetrics/hl7v2-rs:environment:testpypi`, the GitHub side is
+presenting the right identity and TestPyPI still needs the pending publisher
+configuration for project `hl7v2`. Fix TestPyPI before rerunning. Do not switch
+to a repository token or `skip-existing` as a shortcut around Trusted
+Publishing.
 
 This does three things:
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9203,6 +9203,78 @@ fn ensure_python_publish_artifact(
     Ok(())
 }
 
+fn ensure_python_oidc_claim_diagnostic(
+    policy: &PythonPublishWorkflowPolicy,
+    steps: &[serde_yaml::Value],
+) -> Result<usize> {
+    let diagnostic_index =
+        yaml_step_index_named(steps, policy.path, "Record actual OIDC publisher claims")?;
+    let diagnostic = steps
+        .get(diagnostic_index)
+        .and_then(serde_yaml::Value::as_mapping)
+        .ok_or_else(|| {
+            anyhow!(
+                "{} OIDC claim diagnostic step must be a mapping",
+                policy.path
+            )
+        })?;
+    ensure_yaml_string(diagnostic, policy.path, "shell", "bash")?;
+
+    let env = yaml_child_mapping(diagnostic, policy.path, "env")?;
+    let expected_subject = format!(
+        "repo:${{{{ github.repository }}}}:environment:{}",
+        policy.environment_name
+    );
+    ensure_yaml_string(env, policy.path, "EXPECTED_SUBJECT", &expected_subject)?;
+    ensure_yaml_string(
+        env,
+        policy.path,
+        "EXPECTED_REPOSITORY",
+        "${{ github.repository }}",
+    )?;
+    ensure_yaml_string(env, policy.path, "EXPECTED_REF", "refs/heads/main")?;
+
+    let run = yaml_mapping_string(diagnostic, policy.path, "run")?;
+    for expected in [
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        "audience=pypi",
+        "base64.urlsafe_b64decode",
+        "GITHUB_STEP_SUMMARY",
+        "\"sub\": os.environ[\"EXPECTED_SUBJECT\"]",
+        "\"repository\": os.environ[\"EXPECTED_REPOSITORY\"]",
+        "\"ref\": os.environ[\"EXPECTED_REF\"]",
+        "claims.get(claim)",
+        "OIDC publisher claim mismatch",
+        "sys.exit(1)",
+    ] {
+        if !run.contains(expected) {
+            return Err(anyhow!(
+                "{} OIDC publisher claim diagnostic step must contain `{expected}`",
+                policy.path
+            ));
+        }
+    }
+    for forbidden in [
+        "secrets.",
+        "PYPI_API_TOKEN",
+        "TEST_PYPI_API_TOKEN",
+        "TWINE_PASSWORD",
+        "TWINE_USERNAME",
+        "print(token",
+        "echo \"$TOKEN\"",
+    ] {
+        if run.contains(forbidden) {
+            return Err(anyhow!(
+                "{} OIDC publisher claim diagnostic step must not contain `{forbidden}`",
+                policy.path
+            ));
+        }
+    }
+
+    Ok(diagnostic_index)
+}
+
 fn ensure_python_publish_job(
     policy: &PythonPublishWorkflowPolicy,
     publish_job: &serde_yaml::Mapping,
@@ -9235,7 +9307,10 @@ fn ensure_python_publish_job(
     )?;
 
     let steps = yaml_child_sequence(publish_job, policy.path, "steps")?;
+    let diagnostic_index = ensure_python_oidc_claim_diagnostic(policy, steps)?;
+
     let download = yaml_step_named(steps, policy.path, "Download wheel artifact")?;
+    let download_index = yaml_step_index_named(steps, policy.path, "Download wheel artifact")?;
     ensure_yaml_string(
         download,
         policy.path,
@@ -9247,6 +9322,13 @@ fn ensure_python_publish_job(
     ensure_yaml_string(download_with, policy.path, "path", "dist")?;
 
     let publish = yaml_step_named(steps, policy.path, policy.publish_step_name)?;
+    let publish_index = yaml_step_index_named(steps, policy.path, policy.publish_step_name)?;
+    if !(download_index < diagnostic_index && diagnostic_index < publish_index) {
+        return Err(anyhow!(
+            "{} OIDC publisher claim diagnostic step must run after artifact download and before upload",
+            policy.path
+        ));
+    }
     ensure_yaml_string(
         publish,
         policy.path,
@@ -9463,6 +9545,17 @@ fn yaml_step_named<'a>(
         .iter()
         .filter_map(serde_yaml::Value::as_mapping)
         .find(|step| yaml_mapping_string(step, context, "name").is_ok_and(|value| value == name))
+        .ok_or_else(|| anyhow!("{context} is missing step `{name}`"))
+}
+
+fn yaml_step_index_named(steps: &[serde_yaml::Value], context: &str, name: &str) -> Result<usize> {
+    steps
+        .iter()
+        .position(|step| {
+            step.as_mapping().is_some_and(|mapping| {
+                yaml_mapping_string(mapping, context, "name").is_ok_and(|value| value == name)
+            })
+        })
         .ok_or_else(|| anyhow!("{context} is missing step `{name}`"))
 }
 
@@ -11429,6 +11522,103 @@ bindings = "pyo3"
                 "python publish policy should reject install-back jobs that bypass xtask public-registry proof"
             )),
             Err(err) if err.to_string().contains("python-public-registry-proof") => Ok(()),
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_requires_oidc_claim_diagnostic() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replace(
+            "- name: Record actual OIDC publisher claims",
+            "- name: Record intended OIDC publisher claims",
+        );
+        if broken == workflow {
+            return Err(anyhow!(
+                "test setup should remove the OIDC claim diagnostic"
+            ));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should require the actual OIDC claim diagnostic"
+            )),
+            Err(err)
+                if err
+                    .to_string()
+                    .contains("Record actual OIDC publisher claims") =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_rejects_oidc_claim_diagnostic_without_subject_check() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replace(
+            "\"sub\": os.environ[\"EXPECTED_SUBJECT\"]",
+            "\"sub\": os.environ.get(\"EXPECTED_SUBJECT_DISABLED\", \"\")",
+        );
+        if broken == workflow {
+            return Err(anyhow!("test setup should break the OIDC subject check"));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject OIDC diagnostics without the subject check"
+            )),
+            Err(err) if err.to_string().contains("EXPECTED_SUBJECT") => Ok(()),
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_requires_oidc_claim_diagnostic_before_upload() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let oidc_marker = "\n      - name: Record actual OIDC publisher claims";
+        let publish_marker = "\n      - name: Publish package distributions to TestPyPI";
+        let (before_oidc, after_oidc_marker) = workflow
+            .split_once(oidc_marker)
+            .ok_or_else(|| anyhow!("test setup should find OIDC claim diagnostic"))?;
+        let (oidc_body, after_oidc) = after_oidc_marker
+            .split_once(publish_marker)
+            .ok_or_else(|| anyhow!("test setup should find publish step after OIDC diagnostic"))?;
+        let oidc_block = format!("{oidc_marker}{oidc_body}");
+        let without_oidc = format!("{before_oidc}{publish_marker}{after_oidc}");
+        let broken = without_oidc.replacen(
+            "\n  install_from_testpypi:",
+            &format!("{oidc_block}\n  install_from_testpypi:"),
+            1,
+        );
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject OIDC diagnostics after upload"
+            )),
+            Err(err) if err.to_string().contains("before upload") => Ok(()),
             Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
         }
     }


### PR DESCRIPTION
## Summary

- decode and summarize the actual GitHub OIDC publisher claims before TestPyPI/PyPI uploads
- fail closed before upload when sub, epository, or ef do not match the expected trusted-publisher identity
- extend check-python-publish-policy so the diagnostic step cannot be removed, weakened, or moved after upload
- update Python release guides to explain the new claims summary and the remaining TestPyPI boundary

## Validation

- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p xtask python_publish_policy --locked
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-evidence-parity
- git diff --check

## Non-claims

- no TestPyPI upload or install-back proof
- no production PyPI upload or install-back proof
- no token fallback
- no skip-existing

Refs #563