### PR TITLE
docs(spec): add HL7V2-SPEC-0007/0008/0009 and spec-policy guardrail

### DIFF
--- a/docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md
+++ b/docs/specs/HL7V2-SPEC-0002-python-distribution-proof.md
@@ -102,6 +102,26 @@ Production proof must show:
 - smoke, evidence workflow, and dirty evidence workflow output is recorded;
 - receipt PR lands.
 
+
+### Install-Back Identity Assertions
+
+Python install-back proof must assert all of the following for the expected release version:
+
+- package name is `hl7v2`;
+- imported module is `hl7v2`;
+- imported package version equals the expected version;
+- `tests/python_smoke/smoke.py` passes;
+- `tests/python_smoke/evidence_workflow_guide.py` passes;
+- `tests/python_smoke/dirty_evidence_workflow.py` passes;
+- receipt declares whether proof source was local wheel or selected registry index.
+
+Machine rails:
+
+- `cargo +1.95.0 run -p xtask -- python-local-wheel-proof`
+- `cargo +1.95.0 run -p xtask -- python-public-registry-proof --index testpypi --version <version>`
+- `cargo +1.95.0 run -p xtask -- python-public-registry-proof --index pypi --version <version>`
+- `cargo +1.95.0 run -p xtask -- check-python-publish-policy`
+
 ## Hard Rules
 
 - Do not publish `hl7v2-python` as part of Python TestPyPI or PyPI proof.

--- a/docs/specs/HL7V2-SPEC-0003-ci-verification-economics.md
+++ b/docs/specs/HL7V2-SPEC-0003-ci-verification-economics.md
@@ -72,6 +72,16 @@ enough for release posture.
 Cost-aware verification must route proof, not remove proof. The hard rules in
 the canonical CI policy remain binding.
 
+
+## Hard CI Visibility Rules
+
+- Required proof jobs must not hide command failures with `|| true`, `|| echo`, missing `pipefail`, or blanket `continue-on-error`.
+- Advisory jobs may use `continue-on-error` only when advisory status is documented in CI policy.
+- Routed benchmark lanes must be bounded and fail on real command failure.
+- Nightly summary jobs must fail the workflow when required nightly jobs fail.
+- CI-installed proof tools must be pinned when practical.
+- Any workflow using external installers must be represented in dependency/process/network policy ledgers.
+
 ## Acceptance Criteria
 
 - The canonical CI cost policy explains why deep and efficient verification are
@@ -90,9 +100,9 @@ the canonical CI policy remain binding.
 Docs-only CI economics PRs should run:
 
 ```powershell
-cargo +1.93.0 run -p xtask -- check-doc-links
-cargo +1.93.0 run -p xtask -- publish-plan
-$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.93.0 run -p xtask -- gate --check --changed
+cargo +1.95.0 run -p xtask -- check-doc-links
+cargo +1.95.0 run -p xtask -- publish-plan
+$env:PYO3_USE_ABI3_FORWARD_COMPATIBILITY='1'; cargo +1.95.0 run -p xtask -- gate --check --changed
 ```
 
 ## Non-Goals

--- a/docs/specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md
+++ b/docs/specs/HL7V2-SPEC-0006-cross-surface-evidence-parity.md
@@ -83,6 +83,15 @@ Pass `--include-python` only after a local `hl7v2` wheel is installed; Python
 registry availability remains governed by the separate TestPyPI/PyPI proof
 lane.
 
+
+## Python Parity Promotion Rule
+
+Python remains local-wheel-proven until TestPyPI or PyPI install-back proof passes from the target registry and runs shared parity smoke where claimed. Only then may policy promote Python to public-registry-proven for that specific registry and version.
+
+Promotion requires upload proof, install-back proof, expected version assertion, shared parity smoke coverage for claimed contracts, `policy/evidence-parity.toml` update, support-tier/status update, and an audit receipt.
+
+Local Python proof must not silently become public-registry proof.
+
 ## Fixture Rules
 
 Parity fixtures should be shared across surfaces where practical. A fixture set

--- a/docs/specs/HL7V2-SPEC-0007-evidence-artifact-compatibility.md
+++ b/docs/specs/HL7V2-SPEC-0007-evidence-artifact-compatibility.md
@@ -1,0 +1,28 @@
+# HL7V2-SPEC-0007: Evidence Artifact Compatibility
+
+Status: Accepted
+Date: 2026-05-19
+Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md)
+Related parity spec: [HL7V2-SPEC-0006](HL7V2-SPEC-0006-cross-surface-evidence-parity.md)
+
+## Contract
+
+Evidence artifacts are product contracts once documented as stable. They are not logs.
+
+For each stable artifact contract we define: stable fields, advisory fields, `schema_version` behavior, PHI posture, replayability/shareability posture, semver impact for breaking changes, proof command, and owning schema path.
+
+Covered artifacts: ValidationReport, RedactionReceipt, EvidenceBundle, ReplayReport, CorpusSummary, CorpusFingerprint, CorpusDiff, SafeError, ProfileLintReport, ProfileExplainReport, ProfileTestReport, QuarantineSummary.
+
+## Machine Rails
+
+- Schemas: `schemas/evidence/**`
+- Contract index: `docs/contracts/evidence-contract-index.md`
+- Parity manifest: `policy/evidence-parity.toml`
+- Required checks:
+  - `cargo +1.95.0 run -p xtask -- evidence-schema-check`
+  - `cargo +1.95.0 run -p xtask -- check-schema-version-parity`
+  - `cargo +1.95.0 run -p xtask -- check-safe-error-phi-parity`
+
+## Acceptance Rule
+
+A new stable evidence field must update schema, contract index, parity manifest, fixture/golden proof, and this compatibility spec whenever the public contract behavior changes.

--- a/docs/specs/HL7V2-SPEC-0008-deployment-provenance.md
+++ b/docs/specs/HL7V2-SPEC-0008-deployment-provenance.md
@@ -1,0 +1,26 @@
+# HL7V2-SPEC-0008: Deployment Provenance
+
+Status: Accepted
+Date: 2026-05-19
+Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md)
+
+## Contract
+
+Deployment examples must not use floating images.
+
+- Version tags are acceptable for examples/dev/local deployment docs.
+- Digest pinning is required for production/provenance examples once an image is published.
+- Deployment success must not be claimed without deploy/smoke receipt proof.
+
+## Machine Rails
+
+- `policy/deployment-provenance.toml`
+- `policy/dependency-surface-allowlist.toml`
+- `policy/process-allowlist.toml`
+- `policy/network-allowlist.toml`
+
+Required checks:
+
+- `cargo +1.95.0 run -p xtask -- check-deployment-provenance`
+- `cargo +1.95.0 run -p xtask -- check-file-policy`
+- `cargo +1.95.0 run -p xtask -- policy-report`

--- a/docs/specs/HL7V2-SPEC-0009-user-journey-acceptance.md
+++ b/docs/specs/HL7V2-SPEC-0009-user-journey-acceptance.md
@@ -1,0 +1,22 @@
+# HL7V2-SPEC-0009: User Journey Acceptance
+
+Status: Accepted
+Date: 2026-05-19
+Source-of-truth stack: [HL7V2-SPEC-0001](HL7V2-SPEC-0001-source-of-truth-stack.md)
+Related parity spec: [HL7V2-SPEC-0006](HL7V2-SPEC-0006-cross-surface-evidence-parity.md)
+
+## Contract
+
+Any guide that presents a copy-paste evidence workflow must either be executable with an xtask smoke runner, or be explicitly marked conceptual/non-executable.
+
+## Machine Rails
+
+- `policy/user-journey-guides.toml`
+- `cargo +1.95.0 run -p xtask -- check-first-use-guides`
+- `cargo +1.95.0 run -p xtask -- check-first-10-minutes-guide`
+- `cargo +1.95.0 run -p xtask -- check-first-use-by-surface-guide`
+- `cargo +1.95.0 run -p xtask -- check-evidence-artifacts-guide`
+- `cargo +1.95.0 run -p xtask -- check-safe-support-bundle-guide`
+- `cargo +1.95.0 run -p xtask -- check-vendor-upgrade-diff-guide`
+- `cargo +1.95.0 run -p xtask -- check-operator-error-guidance-guide`
+- `cargo +1.95.0 run -p xtask -- check-sidecar-guide`

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -23,3 +23,7 @@ rollback, and use `docs/STATUS.md` for current feature status.
 | [HL7V2-SPEC-0004](HL7V2-SPEC-0004-binding-backend-release-proof.md) | Binding Backend Release Proof | Accepted |
 | [HL7V2-SPEC-0005](HL7V2-SPEC-0005-npm-wasm-binding-package-model.md) | npm and WASM Binding Package Model | Accepted |
 | [HL7V2-SPEC-0006](HL7V2-SPEC-0006-cross-surface-evidence-parity.md) | Cross-Surface Evidence Parity | Accepted |
+
+| [HL7V2-SPEC-0007](HL7V2-SPEC-0007-evidence-artifact-compatibility.md) | Evidence Artifact Compatibility | Accepted |
+| [HL7V2-SPEC-0008](HL7V2-SPEC-0008-deployment-provenance.md) | Deployment Provenance | Accepted |
+| [HL7V2-SPEC-0009](HL7V2-SPEC-0009-user-journey-acceptance.md) | User Journey Acceptance | Accepted |

--- a/policy/deployment-provenance.toml
+++ b/policy/deployment-provenance.toml
@@ -1,0 +1,3 @@
+[rules]
+forbid_latest = true
+warn_missing_digest_for_production = true

--- a/policy/user-journey-guides.toml
+++ b/policy/user-journey-guides.toml
@@ -1,0 +1,12 @@
+[[guide]]
+path = "docs/guides/first-10-minutes.md"
+claim = "first useful evidence receipt"
+proof = "cargo +1.95.0 run -p xtask -- check-first-10-minutes-guide"
+status = "executable"
+
+[[guide]]
+path = "docs/guides/python-testpypi-release-proof.md"
+claim = "public Python registry proof process"
+proof = "cargo +1.95.0 run -p xtask -- python-public-registry-proof --index testpypi --version <version>"
+status = "blocked-external"
+blocker = "#563"

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -101,6 +101,8 @@ pub(crate) enum Commands {
     CheckFilePolicy,
     /// Verify explicit local Markdown links point at checked-in repository targets
     CheckDocLinks,
+    /// Verify spec index and spec-linked policy/proof references stay in sync
+    CheckSpecPolicyLinks,
     /// Verify Python TestPyPI/PyPI release workflow safety controls
     CheckPythonPublishPolicy,
     /// Build, install, and smoke-test the Python hl7v2 wheel in a local venv

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -58,6 +58,7 @@ fn main() -> Result<()> {
         },
         Commands::CheckFilePolicy => check_file_policy()?,
         Commands::CheckDocLinks => check_doc_links()?,
+        Commands::CheckSpecPolicyLinks => check_spec_policy_links()?,
         Commands::CheckPythonPublishPolicy => check_python_publish_policy()?,
         Commands::PythonLocalWheelProof {
             root,
@@ -12410,4 +12411,51 @@ mode = "blocking"
         }
         Ok(())
     }
+}
+
+fn check_spec_policy_links() -> Result<()> {
+    let specs_dir = Path::new("docs/specs");
+    let readme = fs::read_to_string(specs_dir.join("README.md"))?;
+    let spec_files: Vec<_> = fs::read_dir(specs_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("HL7V2-SPEC-") && n.ends_with(".md"))
+        })
+        .collect();
+    for path in &spec_files {
+        let name = path.file_name().unwrap().to_string_lossy();
+        if !readme.contains(name.as_ref()) {
+            return Err(anyhow!("spec README missing index entry for {}", name));
+        }
+        let text = fs::read_to_string(path)?;
+        if text.contains("Status: Accepted")
+            && !(text.contains("policy/") || text.contains("cargo "))
+        {
+            return Err(anyhow!(
+                "accepted spec {} missing policy links or proof command",
+                name
+            ));
+        }
+        for cap in text.match_indices("policy/") {
+            let frag = &text[cap.0..];
+            if let Some(end) = frag.find(".toml") {
+                let rel = &frag[..end + 5];
+                if rel.contains("*") || rel.contains("<") || rel.contains(">") {
+                    continue;
+                }
+                if !Path::new(rel).exists() {
+                    return Err(anyhow!(
+                        "spec {} references missing policy file {}",
+                        name,
+                        rel
+                    ));
+                }
+            }
+        }
+    }
+    println!("spec index/policy links OK");
+    Ok(())
 }


### PR DESCRIPTION
### Motivation

- Lock newer durable contracts that have been living in PR bodies and receipts into accepted specs for reuse and machine enforcement. 
- Prevent receipt-driven truth by requiring explicit install-back/version assertions for Python and explicit promotion rules for public-registry parity. 
- Define evidence artifact compatibility and deployment provenance so CI, support, and operator tooling can rely on stable artifact contracts and non-floating deployment examples. 
- Ensure guides that present copy-paste evidence workflows remain executable or are explicitly marked conceptual to avoid drift. 

### Description

- Added three new accepted spec documents: `docs/specs/HL7V2-SPEC-0007-evidence-artifact-compatibility.md`, `docs/specs/HL7V2-SPEC-0008-deployment-provenance.md`, and `docs/specs/HL7V2-SPEC-0009-user-journey-acceptance.md`. 
- Updated `docs/specs/HL7V2-SPEC-0002` to require install-back identity/version assertions and added corresponding `xtask` proof command rails. 
- Updated `docs/specs/HL7V2-SPEC-0003` to use Rust `+1.95.0` in proof examples and added hard CI visibility/tool-pinning rules, and extended `docs/specs/HL7V2-SPEC-0006` with an explicit Python parity promotion rule. 
- Added policy skeletons `policy/deployment-provenance.toml` and `policy/user-journey-guides.toml`, updated `docs/specs/README.md`, and added an `xtask` guard command `check-spec-policy-links` with CLI wiring plus a small resilience tweak to skip wildcard policy references. 

### Testing

- Ran `cargo fmt --all` which completed successfully. 
- Built and executed the new guard check with `cargo run -p xtask -- check-spec-policy-links` and it printed `spec index/policy links OK` indicating the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1373f8148333bbc6e4b4e1cfea74)