### PR TITLE
ci(python): add no-upload TestPyPI OIDC diagnostic

### DIFF
--- a/.github/workflows/python-pypi.yml
+++ b/.github/workflows/python-pypi.yml
@@ -326,6 +326,7 @@ jobs:
           PY
 
       - name: Publish package distributions to PyPI
+        if: ${{ inputs.publish_to_pypi }}
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/

--- a/.github/workflows/python-testpypi.yml
+++ b/.github/workflows/python-testpypi.yml
@@ -8,6 +8,11 @@ on:
         required: true
         type: boolean
         default: false
+      diagnose_trusted_publisher:
+        description: "Record TestPyPI trusted-publisher OIDC claims without uploading"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -100,7 +105,7 @@ jobs:
   publish_testpypi:
     name: Publish to TestPyPI
     needs: wheel_proof
-    if: ${{ inputs.publish_to_testpypi }}
+    if: ${{ inputs.publish_to_testpypi || inputs.diagnose_trusted_publisher }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:
@@ -130,7 +135,8 @@ jobs:
           {
             echo "## TestPyPI Trusted Publisher"
             echo
-            echo "This job publishes \`hl7v2==${PACKAGE_VERSION}\` to TestPyPI using OIDC Trusted Publishing."
+            echo "This job records the actual GitHub OIDC publisher claims for \`hl7v2==${PACKAGE_VERSION}\`."
+            echo "It uploads to TestPyPI only when \`publish_to_testpypi=true\`."
             echo
             echo "| Field | Expected value |"
             echo "| --- | --- |"
@@ -225,6 +231,7 @@ jobs:
           PY
 
       - name: Publish package distributions to TestPyPI
+        if: ${{ inputs.publish_to_testpypi }}
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -135,12 +135,14 @@ environment, runs `tests/python_smoke/smoke.py` plus the Python evidence guide
 and dirty evidence workflow smokes, and uploads the wheel as a short-retention
 artifact without publishing.
 
-When `publish_to_testpypi=true` is selected, the workflow publishes to TestPyPI
-using Trusted Publishing from the `testpypi` GitHub environment, then installs
-`hl7v2==<workspace version>` back from TestPyPI and reruns the smoke and
-evidence workflows. The workflow uses `id-token: write` only for the publish
-job and does not use repository PyPI tokens. Publishing mode fails early unless
-the workflow is running from `refs/heads/main`.
+When `diagnose_trusted_publisher=true` is selected, the workflow enters the
+`testpypi` GitHub environment and records the actual `audience=pypi` OIDC
+claims without uploading to TestPyPI. When `publish_to_testpypi=true` is
+selected, the same guarded job publishes to TestPyPI using Trusted Publishing,
+then installs `hl7v2==<workspace version>` back from TestPyPI and reruns the
+smoke and evidence workflows. The workflow uses `id-token: write` only for the
+guarded TestPyPI job and does not use repository PyPI tokens. Publishing mode
+fails early unless the workflow is running from `refs/heads/main`.
 
 ### `.github/workflows/python-pypi.yml` - Python PyPI Release Proof
 

--- a/docs/ISSUES_AND_NEXT_STEPS.md
+++ b/docs/ISSUES_AND_NEXT_STEPS.md
@@ -1,6 +1,6 @@
 # Issues, Blockers, Next Steps, and Friction Points
 
-> Last updated: 2026-05-18
+> Last updated: 2026-05-19
 
 This document is a current navigation aid for the remaining product gaps. It
 does not replace the status, support-tier, roadmap, parity, or receipt sources
@@ -32,6 +32,12 @@ The remaining blocker is external Trusted Publisher setup for TestPyPI:
 - Repository: `hl7v2-rs`
 - Workflow: `python-testpypi.yml`
 - Environment: `testpypi`
+
+The workflow can now be run from `main` with
+`diagnose_trusted_publisher=true` and `publish_to_testpypi=false` to record the
+actual GitHub `audience=pypi` OIDC claims through the `testpypi` environment
+without uploading. That is diagnostic evidence only; the blocker remains open
+until TestPyPI upload and install-back succeed.
 
 Required proof after setup:
 

--- a/docs/audits/python-trusted-publisher-diagnostics-2026-05-19.md
+++ b/docs/audits/python-trusted-publisher-diagnostics-2026-05-19.md
@@ -97,6 +97,18 @@ The publish jobs fail before upload if the actual `sub`, `repository`, or
 `cargo run -p xtask -- check-python-publish-policy` now rejects removing,
 weakening, or moving that diagnostic after upload.
 
+The TestPyPI proof workflow also has a no-upload diagnostic mode:
+
+```text
+publish_to_testpypi = false
+diagnose_trusted_publisher = true
+```
+
+That mode enters the same `testpypi` GitHub environment and records the actual
+`audience=pypi` OIDC claims, but the upload step remains gated on
+`publish_to_testpypi=true`. It is a diagnostic rail only; it does not prove
+TestPyPI upload or install-back.
+
 ## Remaining Blocker
 
 The GitHub-side `testpypi` environment exists. The public package indexes still

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -88,6 +88,7 @@ First run with:
 
 ```text
 publish_to_testpypi = false
+diagnose_trusted_publisher = false
 ```
 
 This builds the wheel, installs it into a fresh virtual environment, runs the
@@ -98,10 +99,25 @@ The current hosted non-publishing proof passed on `main` after the v1.5.0
 release and public `hl7v2` package retarget; see
 [`docs/audits/python-testpypi-nonpublish-proof-2026-05-15.md`](../audits/python-testpypi-nonpublish-proof-2026-05-15.md).
 
+If the TestPyPI Trusted Publisher setup still needs diagnosis, run the same
+workflow from `main` with:
+
+```text
+publish_to_testpypi = false
+diagnose_trusted_publisher = true
+```
+
+That route enters the `testpypi` GitHub environment, requests the same
+`audience=pypi` OIDC token used by Trusted Publishing, records the decoded
+publisher claims in the job summary, and skips the upload step. It is useful
+for confirming the actual GitHub `sub` claim without creating or overwriting a
+TestPyPI release. It does not prove TestPyPI upload or install-back.
+
 After the local wheel proof and non-publishing workflow pass, rerun with:
 
 ```text
 publish_to_testpypi = true
+diagnose_trusted_publisher = false
 ```
 
 Run publishing mode from `main`. The workflow fails early if

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8500,6 +8500,7 @@ struct PythonPublishWorkflowPolicy {
     path: &'static str,
     workflow_name: &'static str,
     input_name: &'static str,
+    diagnostic_input_name: Option<&'static str>,
     testpypi_proof_input: Option<&'static str>,
     publish_job: &'static str,
     install_job: &'static str,
@@ -8515,6 +8516,7 @@ const PYTHON_PUBLISH_WORKFLOWS: &[PythonPublishWorkflowPolicy] = &[
         path: ".github/workflows/python-testpypi.yml",
         workflow_name: "Python TestPyPI Proof",
         input_name: "publish_to_testpypi",
+        diagnostic_input_name: Some("diagnose_trusted_publisher"),
         testpypi_proof_input: None,
         publish_job: "publish_testpypi",
         install_job: "install_from_testpypi",
@@ -8528,6 +8530,7 @@ const PYTHON_PUBLISH_WORKFLOWS: &[PythonPublishWorkflowPolicy] = &[
         path: ".github/workflows/python-pypi.yml",
         workflow_name: "Python PyPI Release Proof",
         input_name: "publish_to_pypi",
+        diagnostic_input_name: None,
         testpypi_proof_input: Some("testpypi_proof_url"),
         publish_job: "publish_pypi",
         install_job: "install_from_pypi",
@@ -9018,6 +9021,17 @@ fn ensure_workflow_dispatch_input(
     ensure_yaml_string(input, policy.path, "type", "boolean")?;
     ensure_yaml_bool(input, policy.path, "required", true)?;
     ensure_yaml_bool(input, policy.path, "default", false)?;
+    if let Some(diagnostic_input_name) = policy.diagnostic_input_name {
+        let input = yaml_mapping_child(
+            inputs,
+            policy.path,
+            "workflow_dispatch.inputs",
+            diagnostic_input_name,
+        )?;
+        ensure_yaml_string(input, policy.path, "type", "boolean")?;
+        ensure_yaml_bool(input, policy.path, "required", true)?;
+        ensure_yaml_bool(input, policy.path, "default", false)?;
+    }
     if let Some(testpypi_proof_input) = policy.testpypi_proof_input {
         let input = yaml_mapping_child(
             inputs,
@@ -9287,6 +9301,14 @@ fn ensure_python_publish_job(
             policy.input_name
         ));
     }
+    if let Some(diagnostic_input_name) = policy.diagnostic_input_name
+        && !condition.contains(diagnostic_input_name)
+    {
+        return Err(anyhow!(
+            "{} publish job must also support `{diagnostic_input_name}` for no-upload OIDC diagnostics",
+            policy.path
+        ));
+    }
 
     let environment = yaml_child_mapping(publish_job, policy.path, "environment")?;
     ensure_yaml_string(environment, policy.path, "name", policy.environment_name)?;
@@ -9323,6 +9345,22 @@ fn ensure_python_publish_job(
 
     let publish = yaml_step_named(steps, policy.path, policy.publish_step_name)?;
     let publish_index = yaml_step_index_named(steps, policy.path, policy.publish_step_name)?;
+    let publish_condition = yaml_mapping_string(publish, policy.path, "if")?;
+    if !publish_condition.contains(policy.input_name) {
+        return Err(anyhow!(
+            "{} upload step must be gated by `{}`",
+            policy.path,
+            policy.input_name
+        ));
+    }
+    if let Some(diagnostic_input_name) = policy.diagnostic_input_name
+        && publish_condition.contains(diagnostic_input_name)
+    {
+        return Err(anyhow!(
+            "{} upload step must not be gated by `{diagnostic_input_name}`; diagnostic mode must not upload",
+            policy.path
+        ));
+    }
     if !(download_index < diagnostic_index && diagnostic_index < publish_index) {
         return Err(anyhow!(
             "{} OIDC publisher claim diagnostic step must run after artifact download and before upload",
@@ -11554,6 +11592,68 @@ bindings = "pyo3"
                 if err
                     .to_string()
                     .contains("Record actual OIDC publisher claims") =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_requires_testpypi_oidc_diagnostic_input() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .iter()
+            .find(|policy| policy.path == ".github/workflows/python-testpypi.yml")
+            .ok_or_else(|| anyhow!("expected TestPyPI workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replace(
+            r#"      diagnose_trusted_publisher:
+        description: "Record TestPyPI trusted-publisher OIDC claims without uploading"
+        required: true
+        type: boolean
+        default: false
+"#,
+            "",
+        );
+        if broken == workflow {
+            return Err(anyhow!("test setup should remove diagnostic input"));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should require the TestPyPI OIDC diagnostic input"
+            )),
+            Err(err) if err.to_string().contains("diagnose_trusted_publisher") => Ok(()),
+            Err(err) => Err(anyhow!("unexpected python publish policy error: {err}")),
+        }
+    }
+
+    #[test]
+    fn python_publish_policy_requires_upload_step_gated_by_publish_input() -> Result<()> {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+            .to_path_buf();
+        let policy = PYTHON_PUBLISH_WORKFLOWS
+            .first()
+            .ok_or_else(|| anyhow!("expected at least one Python publish workflow policy"))?;
+        let workflow = read_policy_workflow_for_mutation(&root, policy)?;
+        let broken = workflow.replace("        if: ${{ inputs.publish_to_testpypi }}\n        uses: pypa/gh-action-pypi-publish@v1.14.0", "        uses: pypa/gh-action-pypi-publish@v1.14.0");
+        if broken == workflow {
+            return Err(anyhow!("test setup should remove upload step condition"));
+        }
+
+        match check_python_publish_workflow_text(policy, &broken) {
+            Ok(()) => Err(anyhow!(
+                "python publish policy should reject upload steps without a publish input gate"
+            )),
+            Err(err)
+                if err.to_string().contains("upload step")
+                    || err.to_string().contains("missing `if`") =>
             {
                 Ok(())
             }


### PR DESCRIPTION
Summary: adds diagnose_trusted_publisher mode to Python TestPyPI Proof so maintainers can record actual GitHub OIDC publisher claims through the testpypi environment without uploading. Upload steps for TestPyPI and PyPI are explicitly gated by their publish inputs, and check-python-publish-policy now guards the diagnostic input and upload gate. Non-claims: no TestPyPI upload/install-back, no production PyPI upload/install-back, no token fallback, no skip-existing. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p xtask python_publish_policy --locked; cargo +1.95.0 run -p xtask -- check-python-publish-policy; cargo +1.95.0 run -p xtask -- check-doc-links; cargo +1.95.0 run -p xtask -- check-file-policy; cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist; cargo +1.95.0 run -p xtask -- check-evidence-parity; git diff --check.