### PR TITLE
ci: require explicit workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Cancellation policy:
 # - PR synchronize events cancel stale runs for the same PR.
 # - Push, label, merge_group events do NOT cancel in-progress runs.

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -27,6 +27,9 @@ on:
       - 'xtask/**'
       - '.github/workflows/contracts.yml'
 
+permissions:
+  contents: read
+
 # Cancellation policy:
 # - PR synchronize events cancel stale runs for the same PR.
 # - Push and manual runs do NOT cancel in-progress contract validation.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-${{ github.ref }}
   cancel-in-progress: true

--- a/docs/ci/ci-lane-whitelist.md
+++ b/docs/ci/ci-lane-whitelist.md
@@ -47,6 +47,7 @@ cargo run -p xtask -- check-ci-lane-whitelist
 ```
 
 The checker verifies:
+- Every checked-in workflow has an explicit top-level `permissions:` block.
 - Every governed lane points at an existing workflow and job id, or uses `*` for an aggregate workflow lane.
 - `default_pr = true` + `expensive = true` requires a valid exception.
 - No expired exceptions remain.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9891,6 +9891,45 @@ fn workflow_declares_job(workflow_text: &str, job: &str) -> bool {
     false
 }
 
+fn workflow_declares_top_level_permissions(workflow_text: &str) -> bool {
+    workflow_text.lines().any(|line| {
+        !line.starts_with(' ') && !line.starts_with('\t') && line.trim_end() == "permissions:"
+    })
+}
+
+fn workflow_permission_errors(root: &Path) -> Result<Vec<String>> {
+    let workflows_dir = root.join(".github").join("workflows");
+    let mut errors = Vec::new();
+    for entry in fs::read_dir(&workflows_dir).map_err(|e| {
+        anyhow!(
+            "cannot read workflow directory {}: {e}",
+            workflows_dir.display()
+        )
+    })? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(extension) = path.extension().and_then(|ext| ext.to_str()) else {
+            continue;
+        };
+        if !matches!(extension, "yml" | "yaml") {
+            continue;
+        }
+        let text = fs::read_to_string(&path)
+            .map_err(|e| anyhow!("cannot read workflow {}: {e}", path.display()))?;
+        if !workflow_declares_top_level_permissions(&text) {
+            let display_path = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            errors.push(format!(
+                "workflow '{display_path}' is missing a top-level `permissions:` block"
+            ));
+        }
+    }
+    Ok(errors)
+}
+
 fn today_iso() -> String {
     if let Ok(d) = env::var("CI_TODAY") {
         return d;
@@ -9936,6 +9975,7 @@ fn check_ci_lane_whitelist() -> Result<()> {
 
     let mut warnings: Vec<String> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
+    errors.extend(workflow_permission_errors(&root)?);
 
     for lane in &lanes {
         if !lane_ids.insert(lane.id.clone()) {
@@ -10611,6 +10651,15 @@ mod tests {
         assert_eq!(command_program("cargo"), "cargo.cmd");
         #[cfg(not(windows))]
         assert_eq!(command_program("cargo"), "cargo");
+    }
+
+    #[test]
+    fn workflow_permissions_must_be_top_level() {
+        let workflow = "name: CI\non: push\npermissions:\n  contents: read\njobs:\n";
+        assert!(workflow_declares_top_level_permissions(workflow));
+
+        let nested = "name: CI\non: push\njobs:\n  test:\n    permissions:\n      contents: read\n";
+        assert!(!workflow_declares_top_level_permissions(nested));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add explicit top-level permissions: contents: read to the remaining CI, contracts, and nightly workflows.
- Extend check-ci-lane-whitelist so every checked-in workflow must declare top-level permissions.
- Document the workflow-permissions check in the CI lane whitelist guide.

Closes #234.

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p xtask workflow_permissions_must_be_top_level --locked
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 test -p xtask --locked
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 clippy -p xtask --all-targets --locked -- -D warnings
- git diff --check
- Pre-push hook: cargo +1.95.0 run -p xtask -- gate --check passed with PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1

## Non-claims
- No TestPyPI, PyPI, npm, tag, release, deployment, or registry success claim.
- Public Python hl7v2 remains blocked on external TestPyPI Trusted Publisher setup.