### PR TITLE
docs: add editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+# EditorConfig keeps editor defaults aligned with repository formatting.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.{toml,lock}]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 2
+
+[*.ps1]
+indent_style = space
+indent_size = 4
+
+[*.rego]
+indent_style = tab

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,6 +22,10 @@ For a non-Nix setup, install:
 - Optional quality tools used by the local workflow:
   `cargo install cargo-nextest cargo-deny cargo-audit`.
 
+The checked-in `.editorconfig` keeps editor defaults aligned with repository
+formatting: UTF-8, LF line endings, final newlines, rustfmt-compatible Rust
+indentation, and two-space YAML/JSON indentation.
+
 Every `just <task>` entry in this guide has an equivalent
 `cargo run -p xtask -- <task>` form. For example, use
 `cargo run -p xtask -- setup` if `just` is not installed yet.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -70,6 +70,15 @@ reason = "Docker build-context ignore list keeps local artifacts and generated o
 covered_by = ["docker compose -f infrastructure/docker/docker-compose.yml config"]
 
 [[allow]]
+path = ".editorconfig"
+kind = "repo_config"
+owner = "EffortlessMetrics"
+surface = "developer-tooling"
+classification = "config"
+reason = "EditorConfig aligns editor defaults with repository formatting, line ending, and final-newline expectations."
+covered_by = ["cargo run -p xtask -- check-file-policy"]
+
+[[allow]]
 path = ".tokeignore"
 kind = "repo_config"
 owner = "EffortlessMetrics"


### PR DESCRIPTION
## Summary

- Add a root .editorconfig aligned with repo formatting defaults.
- Document the editor defaults in DEVELOPMENT.md.
- Add the required non-Rust file policy allowlist entry.

Closes #236.

## Validation

- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check
- pre-push hook: cargo run -p xtask -- gate --check

## Notes

- No package, registry, release, TestPyPI, PyPI, npm, deployment, or product-surface claim is changed.
- First push attempt failed locally because Python 3.14 requires PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1; rerun with that env var passed.