### PR TITLE
docs: align TestPyPI OIDC claim receipt

### DIFF
--- a/docs/audits/python-testpypi-oidc-diagnostic-2026-05-19.md
+++ b/docs/audits/python-testpypi-oidc-diagnostic-2026-05-19.md
@@ -61,9 +61,10 @@ environment with these expected values configured:
 | --- | --- |
 | `sub` | `repo:EffortlessMetrics/hl7v2-rs:environment:testpypi` |
 | `repository` | `EffortlessMetrics/hl7v2-rs` |
+| `environment` | `testpypi` |
 | `ref` | `refs/heads/main` |
 
-The workflow step exits non-zero if any of those three claims differ. The
+The workflow step exits non-zero if any of those four claims differ. The
 successful step therefore proves that GitHub supplied a matching OIDC identity
 for the TestPyPI Trusted Publisher subject.
 
@@ -113,4 +114,3 @@ After that external setup, rerun **Python TestPyPI Proof** from `main` with
 - No `skip-existing` path was added or used.
 - No npm package was published.
 - No new crates.io release, tag, or GitHub release was created.
-

--- a/docs/guides/python-testpypi-release-proof.md
+++ b/docs/guides/python-testpypi-release-proof.md
@@ -126,7 +126,8 @@ Run publishing mode from `main`. The workflow fails early if
 Before upload, the publish job writes both the expected TestPyPI Trusted
 Publisher fields and the actual decoded GitHub OIDC publisher claims to the
 GitHub Actions job summary. It fails before upload if the actual `sub`,
-`repository`, or `ref` does not match the expected trusted-publisher identity.
+`repository`, `environment`, or `ref` does not match the expected
+trusted-publisher identity.
 
 If the upload still fails with `invalid-publisher` after the actual `sub` is
 `repo:EffortlessMetrics/hl7v2-rs:environment:testpypi`, the GitHub side is


### PR DESCRIPTION
## Summary
- update the TestPyPI release-proof guide to include the decoded OIDC environment claim in the pre-upload assertion set
- update the 2026-05-19 OIDC diagnostic receipt to record the expected environment claim
- preserve the boundary that this is not a TestPyPI/PyPI upload or install-back claim

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-python-publish-policy
- git diff --check

## Notes
- Initial commit/push hooks needed RUSTUP_TOOLCHAIN=1.95.0; pre-push also needed PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 because the local Python is 3.14.