### PR TITLE
docs: align TestPyPI goal claim state

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -162,7 +162,7 @@ commands = [
 result = [
   "Hosted wheel build and local wheel smoke passed.",
   "The TestPyPI environment OIDC diagnostic job passed.",
-  "The OIDC diagnostic step verified the expected sub, repository, and ref claims.",
+  "The OIDC diagnostic step verified the expected sub, repository, environment, and ref claims.",
   "The TestPyPI upload step was skipped because publish_to_testpypi=false.",
   "The TestPyPI install-back job was skipped because no upload was attempted.",
   "TestPyPI and PyPI hl7v2 JSON endpoints still returned 404.",


### PR DESCRIPTION
## Summary
- update the active goal's TestPyPI OIDC diagnostic work item to include the asserted environment claim
- keep the goal state aligned with #837, the release-proof guide, and the OIDC receipt
- preserve the non-claims around TestPyPI/PyPI upload and install-back

## Validation
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-doc-links
- git diff --check

## Notes
- commit and push hooks were run with RUSTUP_TOOLCHAIN=1.95.0, PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1, and a scoped CARGO_TARGET_DIR.