### PR TITLE
ci: move checkout actions to Node 24-compatible major

### DIFF
--- a/.github/workflows/ci-policy.yml
+++ b/.github/workflows/ci-policy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -93,7 +93,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -135,7 +135,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -192,7 +192,7 @@ jobs:
             rust: '1.95'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -232,7 +232,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -275,7 +275,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -44,7 +44,7 @@ jobs:
       risk_packs: ${{ steps.plan.outputs.risk_packs }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -197,7 +197,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@v1
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify markdown is readable
         run: |

--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -38,7 +38,7 @@ jobs:
       tier: ${{ steps.plan.outputs.tier }}
       matched_packs: ${{ steps.plan.outputs.matched_packs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -358,7 +358,7 @@ performance in detail.
 2. **Monitor benchmark results** for performance regressions
 
 3. **Update workflow versions** quarterly:
-   - Actions (e.g., `actions/checkout@v4`)
+   - Actions (e.g., `actions/checkout@v6`)
    - Rust toolchain
    - Cargo tools installed through workflow actions, including `cargo-llvm-cov`
      and `cargo-nextest`

--- a/docs/TESTING_ARCHITECTURE.md
+++ b/docs/TESTING_ARCHITECTURE.md
@@ -751,7 +751,7 @@ jobs:
     name: Fast Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       
@@ -772,7 +772,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: fast-tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       
@@ -789,7 +789,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: fast-tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       
@@ -801,7 +801,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration-tests, property-tests]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -822,7 +822,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       
@@ -843,7 +843,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       
       - name: Install cargo-fuzz


### PR DESCRIPTION
## Summary
- update current workflow uses of actions/checkout from v4 to v6
- refresh current CI docs/examples to point at checkout@v6
- leave archived historical plans/receipts unchanged

## Validation
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- grep confirmed no actions/checkout@v4 remains in current workflows or current CI docs

## Non-claims
- no crates.io, TestPyPI, PyPI, or npm publish
- no release, tag, deployment, or branch-protection change
- no swarm runner/admin change