### PR TITLE
docs: align branch protection state

### DIFF
--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -2,22 +2,32 @@
 
 ## Current State
 
-Branch protection on `main` currently requires these individual jobs from `ci.yml`:
+For `EffortlessMetrics/hl7v2-rs`, live GitHub branch protection on `main`
+currently requires one status check from `ci.yml`:
 
 - `Fast Checks`
-- `Standard Tests`
-- `Matrix Tests`
-- `CI Success`
 
-This coupling means:
+That keeps the source/release mirror mergeable while the broader frontdoor and
+swarm routing surfaces burn in. It also means this document should not be used
+as proof that `Standard Tests`, `Matrix Tests`, `CI Success`, or `PR Gate
+Success` are currently required by branch protection.
+
+For `EffortlessMetrics/hl7v2-rs-swarm`, branch protection is intentionally not
+enabled yet. The swarm cutover plan is governed in the swarm repository by
+`docs/ops/swarm-development.md`: enable branch protection only after CX53, CX43
+fallback, and GitHub-hosted fallback are all proven, and require only
+`HL7v2 Rust Small Result`.
+
+The source-repo coupling risk remains:
 
 1. Adding a new required check requires a branch protection change.
 2. Temporarily skipping an optional lane can block merges if branch protection references it.
-3. Windows/macOS matrix jobs gating every PR inflates per-PR cost (85 LEM for `matrix_tests`).
+3. Promoting Windows/macOS matrix jobs to required on every PR would inflate
+   per-PR cost (85 LEM for `matrix_tests`).
 
-## Target State (after PR 16)
+## Source Target State
 
-Branch protection will require one check:
+The intended source-repo target is one normalized check:
 
 ```
 PR Gate Success
@@ -36,16 +46,24 @@ touching branch protection.
 
 ## Migration Steps
 
-1. PRs 01–15 land and `PR Gate Success` accumulates a run history on real PRs.
-2. PR 16 updates branch protection to require `PR Gate Success` and removes the direct
-   requirements for `Fast Checks`, `Standard Tests`, `Matrix Tests`, and `CI Success`.
-3. `ci.yml` jobs remain available but are no longer branch-protection-required after PR 16.
+1. `PR Gate Success` accumulates a run history on real PRs.
+2. A deliberate admin change updates source branch protection to require
+   `PR Gate Success` instead of `Fast Checks`.
+3. `ci.yml` jobs remain available, but source branch protection no longer points
+   at individual implementation jobs.
+
+The swarm repository has a separate target: `HL7v2 Rust Small Result` after the
+self-hosted and hosted fallback routes are all proven.
 
 ## Why Not Change Branch Protection Now?
 
-`PR Gate Success` should accumulate at least several successful runs before it becomes the
-required check. Changing branch protection before that creates a risk of a stale or
-misconfigured gate blocking merges.
+`PR Gate Success` should accumulate several successful runs before it becomes
+the source required check. Changing branch protection before that creates a risk
+of a stale or misconfigured gate blocking merges.
+
+For the swarm repository, changing branch protection before CX53, CX43 fallback,
+and GitHub-hosted fallback are all proven creates the same risk. Keep the swarm
+required check unset until those proofs exist.
 
 ## Label Impact on Branch Protection
 

--- a/docs/ci/ci-lane-whitelist.md
+++ b/docs/ci/ci-lane-whitelist.md
@@ -55,7 +55,11 @@ The checker verifies:
 - `duplicate_of` references valid lane IDs.
 - Windows/macOS/Python/Docker runners have the correct multiplier.
 
-The checker is advisory until branch protection migrates to `PR Gate Success` (PR 16).
+The checker is advisory for branch-protection selection. The source repository
+currently requires `Fast Checks`; its intended normalized target is
+`PR Gate Success`. The swarm repository uses a separate routed target,
+`HL7v2 Rust Small Result`, only after the routed CX53, CX43 fallback, and
+GitHub-hosted fallback proofs are complete.
 
 ## Inventory
 


### PR DESCRIPTION
## Summary
- align branch-protection docs with live source protection requiring only Fast Checks
- document swarm branch protection as deferred until CX53, CX43 fallback, and hosted fallback are proven
- clarify ci-lane whitelist branch-protection selection boundaries

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- git diff --check
- pre-push hook gate passed with RUSTUP_TOOLCHAIN=1.95.0 and PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1

## Non-claims
- no branch protection change
- no swarm runner proof
- no TestPyPI/PyPI upload or install-back
- no release, tag, npm, or deployment claim