### PR TITLE
docs: clarify label branch protection boundary

### DIFF
--- a/docs/ci/branch-protection.md
+++ b/docs/ci/branch-protection.md
@@ -67,6 +67,10 @@ required check unset until those proofs exist.
 
 ## Label Impact on Branch Protection
 
-Labels never change which checks are *required*. The `PR Gate Success` check aggregates the
-required surface. Optional lanes triggered by labels (`full-ci`, `platform-matrix`, etc.) are
-never blocking.
+Labels never change which checks are *required* by branch protection. In the
+source repository, labels can trigger optional lanes while `Fast Checks` remains
+the current required check. After the deliberate source migration, `PR Gate
+Success` should aggregate the required surface. In the swarm repository, the
+future required check is `HL7v2 Rust Small Result` only after the routed proofs
+exist. Optional lanes triggered by labels (`full-ci`, `platform-matrix`, etc.)
+are never blocking unless branch protection is explicitly changed.

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -30,8 +30,13 @@ Labels are added in the GitHub UI on the PR sidebar. No CI file changes are need
 
 ## Label + Branch Protection
 
-Labels do not change which jobs are *required* by branch protection. The `PR Gate Success`
-check aggregates the required surface. Optional lanes triggered by labels are never blocking.
+Labels do not change which jobs are *required* by branch protection. In the
+source repository, `Fast Checks` is the current required check while
+`PR Gate Success` remains the intended normalized target. In the swarm
+repository, the future required check is `HL7v2 Rust Small Result` after CX53,
+CX43 fallback, and GitHub-hosted fallback are all proven. Optional lanes
+triggered by labels are never blocking unless branch protection is explicitly
+changed.
 
 ## Label Governance
 


### PR DESCRIPTION
## Summary
- clarify that labels do not change source branch protection while Fast Checks remains required
- keep PR Gate Success framed as the source target, not the current required check
- document the swarm required-check target as HL7v2 Rust Small Result only after routed proofs exist

## Validation
- cargo +1.95.0 run -p xtask -- check-doc-links
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- pre-push hook passed with RUSTUP_TOOLCHAIN=1.95.0 and PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1

## Non-claims
- no branch protection change
- no swarm runner proof
- no TestPyPI/PyPI upload or install-back
- no release, npm, tag, or deployment claim