### PR TITLE
ci: create nightly mutation output directory

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,6 +121,7 @@ jobs:
 
       - name: Run mutation tests
         run: |
+          mkdir -p target/nightly-mutation
           set +e
           cargo mutants \
             --workspace \


### PR DESCRIPTION
﻿## Summary
- create the cargo-mutants output parent before nightly mutation runs
- fixes the scheduled Nightly Tests failure where cargo-mutants could not create target/nightly-mutation because target/ did not exist

## Evidence
- failing workflow: Nightly Tests run 26138632127 in hl7v2-rs-swarm
- failing job: Mutation Tests
- error: create output parent directory target/nightly-mutation: No such file or directory

## Validation
- cargo +1.95.0 run -p xtask -- check-ci-lane-whitelist
- cargo +1.95.0 run -p xtask -- check-file-policy
- git diff --check
- pre-push hook: cargo run -p xtask -- gate --check

## Boundaries
- CI-only fix.
- No TestPyPI/PyPI, release, npm, deployment, or branch-protection claim.
