### PR TITLE
test: trim redacted support bundle fixture

### DIFF
--- a/test_data/dirty-real-world/after/redacted-support-bundle.hl7
+++ b/test_data/dirty-real-world/after/redacted-support-bundle.hl7
@@ -1,4 +1,3 @@
 MSH|^~\&|SUPPORTBUNDLE|SANITIZED|EHR|HOSP|202605140109||ADT^A01|CTRL-SAFE-BUNDLE|P|2.5
 PID|1||hash:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa||""||""|U
 ZSB|SAFE-SHARING|message.redacted.hl7|manifest-hashes-pass
-


### PR DESCRIPTION
## Summary
- remove the extra blank line at EOF in the redacted support-bundle dirty corpus fixture
- keep the source fixture compatible with git diff --check before syncing into swarm

## Validation
- rtk proxy git diff --cached --check

## Non-claims
- No TestPyPI/PyPI upload or install-back.
- No npm, crates.io, tag, GitHub release, deployment, or branch-protection change.