### PR TITLE
fix: reject cyclic profile inheritance

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12018",
+  "message": "12038",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/loading.rs
+++ b/crates/hl7v2/src/conformance/profile/loading.rs
@@ -82,7 +82,12 @@ where
 
     // If there's a parent, recursively load and merge it
     if let Some(parent_name) = &profile.parent {
-        let parent_profile = load_profile_with_inheritance_recursive(parent_name, &profile_loader)?;
+        let mut inheritance_stack = Vec::new();
+        let parent_profile = load_profile_with_inheritance_recursive(
+            parent_name,
+            &profile_loader,
+            &mut inheritance_stack,
+        )?;
         return Ok(merge_profiles(parent_profile, profile));
     }
 
@@ -93,20 +98,38 @@ where
 fn load_profile_with_inheritance_recursive<F>(
     parent_name: &str,
     profile_loader: &F,
+    inheritance_stack: &mut Vec<String>,
 ) -> Result<Profile, ProfileLoadError>
 where
     F: Fn(&str) -> Result<Profile, ProfileLoadError>,
 {
-    let parent_profile = profile_loader(parent_name)?;
-
-    // If the parent also has a parent, recursively load and merge it
-    if let Some(grandparent_name) = &parent_profile.parent {
-        let grandparent_profile =
-            load_profile_with_inheritance_recursive(grandparent_name, profile_loader)?;
-        return Ok(merge_profiles(grandparent_profile, parent_profile));
+    if let Some(first_seen) = inheritance_stack
+        .iter()
+        .position(|seen_parent| seen_parent == parent_name)
+    {
+        let mut cycle = inheritance_stack[first_seen..].to_vec();
+        cycle.push(parent_name.to_string());
+        return Err(ProfileLoadError::InheritanceCycle(cycle.join(" -> ")));
     }
 
-    Ok(parent_profile)
+    inheritance_stack.push(parent_name.to_string());
+    let result = (|| {
+        let parent_profile = profile_loader(parent_name)?;
+
+        // If the parent also has a parent, recursively load and merge it
+        if let Some(grandparent_name) = parent_profile.parent.clone() {
+            let grandparent_profile = load_profile_with_inheritance_recursive(
+                &grandparent_name,
+                profile_loader,
+                inheritance_stack,
+            )?;
+            return Ok(merge_profiles(grandparent_profile, parent_profile));
+        }
+
+        Ok(parent_profile)
+    })();
+    inheritance_stack.pop();
+    result
 }
 
 /// Merge two profiles, with the child profile taking precedence

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -207,7 +207,7 @@ custom_rules:
 
 #[cfg(test)]
 mod profile_load_error_tests {
-    use super::super::{ProfileLoadError, load_profile_checked};
+    use super::super::{ProfileLoadError, load_profile_checked, load_profile_with_inheritance};
 
     #[test]
     fn test_load_profile_checked_valid() {
@@ -286,6 +286,45 @@ segments:
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let load_err: ProfileLoadError = io_err.into();
         assert!(matches!(load_err, ProfileLoadError::Io(_)));
+    }
+
+    #[test]
+    fn test_load_profile_with_inheritance_rejects_parent_cycle() {
+        let child = r#"
+message_structure: "CHILD"
+version: "2.5.1"
+parent: "base"
+segments:
+  - id: "MSH"
+"#;
+
+        let result = load_profile_with_inheritance(child, |name| match name {
+            "base" => load_profile_checked(
+                r#"
+message_structure: "BASE"
+version: "2.5.1"
+parent: "loop"
+segments:
+  - id: "MSH"
+"#,
+            ),
+            "loop" => load_profile_checked(
+                r#"
+message_structure: "LOOP"
+version: "2.5.1"
+parent: "base"
+segments:
+  - id: "MSH"
+"#,
+            ),
+            other => Err(ProfileLoadError::ParentNotFound(other.to_string())),
+        });
+
+        assert!(matches!(
+            result,
+            Err(ProfileLoadError::InheritanceCycle(ref cycle))
+                if cycle == "base -> loop -> base"
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary
- reject cyclic profile parent chains with the existing `ProfileLoadError::InheritanceCycle` path instead of recursing until stack overflow
- track the active inheritance stack while resolving parent profiles, then unwind it on success or error
- add regression coverage for a `child -> base -> loop -> base` hostile profile chain

## Security self-review
- Trust boundary: profile YAML and parent resolver input can be supplied by users/operators and must be treated as hostile.
- Deny-by-default behavior: cyclic inheritance now fails closed with a structured load error before deeper recursion.
- Secret/PHI exposure: no raw HL7 payloads, secrets, or profile contents are logged or echoed by this change.
- Scope: no release, TestPyPI/PyPI, npm, deployment, or swarm branch-protection changes.

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p hl7v2 test_load_profile_with_inheritance_rejects_parent_cycle --all-features --locked`
- `cargo +1.95.0 test -p hl7v2 --all-features --locked`
- `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features --locked -- -D warnings`
- `git diff --check`

Closes #224