### PR TITLE
test: cover grpc operator error guidance

### DIFF
--- a/.hl7v2/goals/active.toml
+++ b/.hl7v2/goals/active.toml
@@ -364,7 +364,7 @@ non_claims = [
 [[work_item]]
 id = "operator-error-guidance-guide-smoke"
 status = "done"
-goal = "Add an executable source-checkout smoke for the Operator Error Guidance guide and prove representative REST and CLI safe-failure fields."
+goal = "Add an executable source-checkout smoke for the Operator Error Guidance guide and prove representative REST, gRPC, and CLI safe-failure fields."
 receipt = "docs/audits/operator-error-guidance-guide-smoke-2026-05-18.md"
 commands = [
   "cargo +1.95.0 run -p xtask -- check-operator-error-guidance-guide",

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,7 +102,7 @@ documents.
 | [First 10 Minutes guide smoke](audits/first-10-minutes-guide-smoke-2026-05-18.md) | Executable `xtask check-first-10-minutes-guide` proof for the job-first CLI onboarding guide. |
 | [First-use guide smoke](audits/first-use-guide-smoke-2026-05-18.md) | Executable `xtask check-first-use-guides` proof for the documented full evidence receipt path. |
 | [Vendor upgrade diff guide smoke](audits/vendor-upgrade-diff-guide-smoke-2026-05-18.md) | Executable `xtask check-vendor-upgrade-diff-guide` proof for the before/after corpus drift guide. |
-| [Operator error guidance guide smoke](audits/operator-error-guidance-guide-smoke-2026-05-18.md) | Executable `xtask check-operator-error-guidance-guide` proof for representative REST and CLI safe-failure guidance. |
+| [Operator error guidance guide smoke](audits/operator-error-guidance-guide-smoke-2026-05-18.md) | Executable `xtask check-operator-error-guidance-guide` proof for representative REST, gRPC, and CLI safe-failure guidance. |
 | [Safe support-bundle guide smoke](audits/safe-support-bundle-guide-smoke-2026-05-18.md) | Executable `xtask check-safe-support-bundle-guide` proof for the operator support packet recipe. |
 | [Support bundle safe-sharing checklist receipt](audits/support-bundle-safe-sharing-checklist-2026-05-18.md) | CLI, core/Python, REST, and gRPC bundle proof for generated `SAFE-SHARING.md` checklists and legacy replay compatibility. |
 | [Sidecar guide smoke](audits/sidecar-guide-smoke-2026-05-18.md) | Executable `xtask check-sidecar-guide` proof for the HTTP deployment sidecar guide. |

--- a/docs/audits/operator-error-guidance-guide-smoke-2026-05-18.md
+++ b/docs/audits/operator-error-guidance-guide-smoke-2026-05-18.md
@@ -5,9 +5,9 @@
 This receipt records an executable source-checkout smoke for
 [`docs/guides/operator-error-guidance.md`](../guides/operator-error-guidance.md).
 
-The smoke ties the guide to representative REST and CLI failure paths without
-changing runtime behavior. It verifies that operator-facing failures preserve
-safe fields, concrete next actions, and PHI-sentinel boundaries.
+The smoke ties the guide to representative REST, gRPC, and CLI failure paths
+without changing runtime behavior. It verifies that operator-facing failures
+preserve safe fields, concrete next actions, and PHI-sentinel boundaries.
 
 ## Command
 
@@ -26,6 +26,12 @@ The smoke verifies:
   to profile lint without echoing raw profile content.
 - REST unsafe bundle IDs fail closed with safe bundle-id guidance.
 - REST missing bundle roots fail closed with configuration guidance.
+- gRPC parse failures return typed parse errors without echoing forbidden
+  values.
+- gRPC profile-load failures return invalid-argument status without echoing raw
+  profile content.
+- gRPC unsafe bundle IDs and missing bundle roots fail closed through the
+  configured evidence-bundle contract tests.
 - CLI validation failures can be read from machine-readable JSON reports with
   stable `valid`, `issue_count`, `issues.code`, `issues.path`, and
   `issues.severity` fields.
@@ -36,8 +42,8 @@ The smoke verifies:
 
 This is not a TestPyPI, PyPI, npm, crates.io, tag, or GitHub release receipt.
 It does not prove public Python registry install-back. It only proves the
-source-checkout operator error guidance remains tied to executable local REST
-and CLI checks.
+source-checkout operator error guidance remains tied to executable local REST,
+gRPC, and CLI checks.
 
 ## Validation
 

--- a/docs/guides/operator-error-guidance.md
+++ b/docs/guides/operator-error-guidance.md
@@ -17,6 +17,9 @@ executable:
 cargo +1.95.0 run -p xtask -- check-operator-error-guidance-guide
 ```
 
+The check exercises representative REST, gRPC, and CLI safe-failure paths. It
+does not require a deployed server or a public Python package.
+
 ## Safe Failure Shape
 
 Every operator-facing failure should answer:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5946,6 +5946,61 @@ fn check_operator_error_guidance_guide() -> Result<()> {
         run_command("cargo", args)?;
     }
 
+    let grpc_error_tests: &[(&str, &[&str])] = &[
+        (
+            "gRPC parse safe error shape",
+            &[
+                "test",
+                "-p",
+                "hl7v2-server",
+                "--test",
+                "grpc_contract_tests",
+                "test_grpc_parse_invalid_hl7_returns_parse_error",
+                "--locked",
+            ],
+        ),
+        (
+            "gRPC profile-load safe error shape",
+            &[
+                "test",
+                "-p",
+                "hl7v2-server",
+                "--test",
+                "grpc_contract_tests",
+                "test_grpc_validate_invalid_profile_returns_invalid_argument",
+                "--locked",
+            ],
+        ),
+        (
+            "gRPC unsafe bundle id safe error shape",
+            &[
+                "test",
+                "-p",
+                "hl7v2-server",
+                "--test",
+                "grpc_contract_tests",
+                "test_grpc_create_evidence_bundle_rejects_unsafe_bundle_id_without_writing",
+                "--locked",
+            ],
+        ),
+        (
+            "gRPC missing bundle root safe error shape",
+            &[
+                "test",
+                "-p",
+                "hl7v2-server",
+                "--test",
+                "grpc_contract_tests",
+                "test_grpc_create_evidence_bundle_fails_without_configured_output_root",
+                "--locked",
+            ],
+        ),
+    ];
+    for (label, args) in grpc_error_tests {
+        println!("Checking {label}...");
+        run_command("cargo", args)?;
+    }
+
     let message = workspace_root.join("test_data/invalid_message.hl7");
     let profile = workspace_root.join("profiles/generic.yaml");
     ensure_existing_file(&message)?;
@@ -5991,6 +6046,10 @@ fn check_operator_error_guidance_guide() -> Result<()> {
             "rest_profile_load_safe_error_shape",
             "rest_unsafe_bundle_id_safe_error_shape",
             "rest_missing_bundle_root_safe_error_shape",
+            "grpc_parse_safe_error_shape",
+            "grpc_profile_load_safe_error_shape",
+            "grpc_unsafe_bundle_id_safe_error_shape",
+            "grpc_missing_bundle_root_safe_error_shape",
             "cli_validation_issue_report"
         ],
         "verified_fields": [


### PR DESCRIPTION
## Summary
- extend `check-operator-error-guidance-guide` to exercise representative gRPC safe-error paths alongside existing REST and CLI checks
- update the operator error guidance receipt, guide text, docs index, and active goal wording to reflect REST/gRPC/CLI coverage
- keep this scoped to executable guide proof only; no runtime behavior, release, registry, deployment, or swarm changes

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p xtask check_operator_error_guidance_guide --locked`
- `cargo +1.95.0 run -p xtask -- check-operator-error-guidance-guide`
- `cargo +1.95.0 run -p xtask -- check-doc-links`
- `cargo +1.95.0 run -p xtask -- check-file-policy`
- `cargo +1.95.0 clippy -p xtask --all-targets --locked -- -D warnings`
- `git diff --check`

## Non-claims
- no TestPyPI/PyPI upload or install-back claim
- no npm, release, tag, deployment, branch-protection, CX53, or CX43 claim