### PR TITLE
feat: accept diagnostic HL7 query paths

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12144",
+  "message": "12198",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -83,7 +83,7 @@ pub use model::{
     Atom, Batch, Comp, Delims, Error, Field, FileBatch, Message, Presence, Rep, Segment,
 };
 pub use parser::{parse, parse_batch, parse_file_batch, parse_mllp};
-pub use query::path::{Path, parse_path};
+pub use query::path::{LocatedPath, Path, parse_located_path, parse_path};
 pub use query::{get, get_presence};
 pub use transport::mllp::{
     MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,

--- a/crates/hl7v2/src/query/mod.rs
+++ b/crates/hl7v2/src/query/mod.rs
@@ -7,12 +7,15 @@
 //!
 //! # Path Format
 //!
-//! Paths use the format: `SEGMENT.FIELD\[REP\].COMPONENT.SUBCOMPONENT`
+//! Paths use legacy dot notation, `SEGMENT.FIELD[REP].COMPONENT.SUBCOMPONENT`,
+//! and diagnostic dash notation, `SEGMENT[REP]-FIELD[REP].COMPONENT.SUBCOMPONENT`.
 //!
 //! Examples:
 //! - `PID.5.1` - First component of 5th field in PID segment (first repetition)
+//! - `PID-5.1` - Same field using diagnostic dash notation
 //! - `PID.5.1.2` - Second subcomponent of the first component of PID-5
 //! - `PID.5[2].1` - First component of 5th field, second repetition
+//! - `OBX[3]-5` - 5th field in the third OBX segment
 //! - `MSH.9` - 9th field of MSH segment
 //! - `MSH.9.1` - First component of 9th field of MSH segment
 //!
@@ -31,7 +34,6 @@
     clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
     clippy::manual_let_else,
-    clippy::string_slice,
     reason = "pre-existing query implementation debt moved from staged microcrate into hl7v2; cleanup is split from topology collapse"
 )]
 
@@ -39,12 +41,12 @@ pub mod path;
 
 use crate::model::{Atom, Message, Presence, Segment};
 
-/// Get value at path (e.g., `PID.5[1].1`)
+/// Get value at path (e.g., `PID.5[1].1` or `PID-5[1].1`)
 ///
 /// # Arguments
 ///
 /// * `msg` - The message to query
-/// * `path` - The path to the field (e.g., `PID.5.1`, `PID.5.1.2`, `PID.5[1].1`, `MSH.9`)
+/// * `path` - The path to the field (e.g., `PID.5.1`, `PID-5.1`, `PID.5[1].1`, `OBX[3]-5`)
 ///
 /// # Returns
 ///
@@ -67,28 +69,27 @@ use crate::model::{Atom, Message, Presence, Segment};
 /// assert!(get(&message, "PID.5.1").is_none());
 /// ```
 pub fn get<'a>(msg: &'a Message, path: &str) -> Option<&'a str> {
-    // Parse the path
-    // Format: SEGMENT.FIELD\[REP\].COMPONENT.SUBCOMPONENT
-    // Examples: `PID.5.1`, `PID.5.1.2`, `PID.5[1].1`, `MSH.9`
+    let parsed = self::path::parse_located_path(path).ok()?;
+    let segment = find_segment(msg, &parsed)?;
+    let rep_index = parsed.path.repetition.unwrap_or(1);
 
-    let mut parts = path.split('.');
-    let segment_id = parts.next()?;
-
-    // Find the segment
-    let segment = msg
-        .segments
-        .iter()
-        .find(|s| std::str::from_utf8(&s.id) == Ok(segment_id))?;
-
-    // Parse field index (1-based)
-    let field_part = parts.next()?;
-    let (field_index, rep_index) = parse_field_and_rep(field_part)?;
-
-    // Special handling for MSH segments
-    if segment_id == "MSH" {
-        get_msh_field(msg, segment, field_index, rep_index, parts)
+    if parsed.path.segment == "MSH" {
+        get_msh_field(
+            msg,
+            segment,
+            parsed.path.field,
+            rep_index,
+            parsed.path.component,
+            parsed.path.subcomponent,
+        )
     } else {
-        get_field(segment, field_index, rep_index, parts)
+        get_field(
+            segment,
+            parsed.path.field,
+            rep_index,
+            parsed.path.component,
+            parsed.path.subcomponent,
+        )
     }
 }
 
@@ -124,39 +125,33 @@ pub fn get<'a>(msg: &'a Message, path: &str) -> Option<&'a str> {
 /// assert!(matches!(get_presence(&message, "PID.5.1"), Presence::Missing));
 /// ```
 pub fn get_presence(msg: &Message, path: &str) -> Presence {
-    // Parse the path
-    let mut parts = path.split('.');
-    let segment_id = match parts.next() {
-        Some(id) => id,
+    let parsed = match self::path::parse_located_path(path) {
+        Ok(path) => path,
+        Err(_) => return Presence::Missing,
+    };
+    let segment = match find_segment(msg, &parsed) {
+        Some(segment) => segment,
         None => return Presence::Missing,
     };
+    let rep_index = parsed.path.repetition.unwrap_or(1);
 
-    // Find the segment
-    let segment = match msg
-        .segments
-        .iter()
-        .find(|s| std::str::from_utf8(&s.id) == Ok(segment_id))
-    {
-        Some(seg) => seg,
-        None => return Presence::Missing,
-    };
-
-    // Parse field index (1-based)
-    let field_part = match parts.next() {
-        Some(part) => part,
-        None => return Presence::Missing,
-    };
-
-    let (field_index, rep_index) = match parse_field_and_rep(field_part) {
-        Some(indices) => indices,
-        None => return Presence::Missing,
-    };
-
-    // Special handling for MSH segments
-    if segment_id == "MSH" {
-        get_msh_field_presence(msg, segment, field_index, rep_index, parts)
+    if parsed.path.segment == "MSH" {
+        get_msh_field_presence(
+            msg,
+            segment,
+            parsed.path.field,
+            rep_index,
+            parsed.path.component,
+            parsed.path.subcomponent,
+        )
     } else {
-        get_field_presence(segment, field_index, rep_index, parts)
+        get_field_presence(
+            segment,
+            parsed.path.field,
+            rep_index,
+            parsed.path.component,
+            parsed.path.subcomponent,
+        )
     }
 }
 
@@ -164,54 +159,40 @@ pub fn get_presence(msg: &Message, path: &str) -> Presence {
 // Internal helper functions
 // ============================================================================
 
-/// Parse field and repetition indices from a string like `5` or `5[1]`.
-fn parse_field_and_rep(field_str: &str) -> Option<(usize, usize)> {
-    if let Some(bracket_pos) = field_str.find('[') {
-        // Has repetition index. Require the closing bracket to be the final
-        // character so malformed paths like `5[1]extra` do not silently
-        // resolve to the first repetition.
-        let field_index = field_str[..bracket_pos].parse::<usize>().ok()?;
-        let rep_part = field_str[bracket_pos + 1..].strip_suffix(']')?;
-        let rep_index = rep_part.parse::<usize>().ok()?;
-        Some((field_index, rep_index))
-    } else {
-        // No repetition index, default to 1
-        let field_index = field_str.parse::<usize>().ok()?;
-        Some((field_index, 1))
-    }
-}
-
-/// Parse optional component and subcomponent selectors from the remaining path.
-fn parse_component_and_subcomponent(
-    mut parts: std::str::Split<'_, char>,
-) -> Option<(usize, usize)> {
-    let comp_index = if let Some(comp_part) = parts.next() {
-        comp_part.parse::<usize>().ok()?
-    } else {
-        1 // Default to first component
-    };
-
-    let sub_index = if let Some(sub_part) = parts.next() {
-        sub_part.parse::<usize>().ok()?
-    } else {
-        1 // Default to first subcomponent
-    };
-
-    // More than FIELD.COMPONENT.SUBCOMPONENT is not a valid query path.
-    if parts.next().is_some() {
+fn find_segment<'a>(msg: &'a Message, path: &self::path::LocatedPath) -> Option<&'a Segment> {
+    let segment_repetition = path.segment_repetition.unwrap_or(1);
+    if segment_repetition == 0 {
         return None;
     }
 
-    Some((comp_index, sub_index))
+    msg.segments
+        .iter()
+        .filter(|segment| segment.id_str() == path.path.segment)
+        .nth(segment_repetition - 1)
+}
+
+fn component_and_subcomponent(
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> Option<(usize, usize)> {
+    let comp_index = component.unwrap_or(1);
+    let sub_index = subcomponent.unwrap_or(1);
+
+    if comp_index == 0 || sub_index == 0 {
+        None
+    } else {
+        Some((comp_index, sub_index))
+    }
 }
 
 /// Get field value from a non-MSH segment
-fn get_field<'a>(
-    segment: &'a Segment,
+fn get_field(
+    segment: &Segment,
     field_index: usize,
     rep_index: usize,
-    parts: std::str::Split<char>,
-) -> Option<&'a str> {
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> Option<&str> {
     // Convert to 0-based indexing
     if field_index == 0 {
         return None;
@@ -230,7 +211,7 @@ fn get_field<'a>(
     }
     let rep = &field.reps[rep_index - 1];
 
-    let (comp_index, sub_index) = parse_component_and_subcomponent(parts)?;
+    let (comp_index, sub_index) = component_and_subcomponent(component, subcomponent)?;
 
     if comp_index == 0 || comp_index > rep.comps.len() {
         return None;
@@ -253,7 +234,8 @@ fn get_msh_field<'a>(
     segment: &'a Segment,
     field_index: usize,
     rep_index: usize,
-    parts: std::str::Split<char>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
 ) -> Option<&'a str> {
     if field_index == 1 {
         // MSH-1 is the field separator character
@@ -268,7 +250,7 @@ fn get_msh_field<'a>(
             return None;
         }
         let rep = &field.reps[rep_index - 1];
-        let (comp_index, sub_index) = parse_component_and_subcomponent(parts)?;
+        let (comp_index, sub_index) = component_and_subcomponent(component, subcomponent)?;
         if comp_index == 0 || comp_index > rep.comps.len() {
             return None;
         }
@@ -291,7 +273,7 @@ fn get_msh_field<'a>(
             return None;
         }
         let rep = &field.reps[rep_index - 1];
-        let (comp_index, sub_index) = parse_component_and_subcomponent(parts)?;
+        let (comp_index, sub_index) = component_and_subcomponent(component, subcomponent)?;
         if comp_index == 0 || comp_index > rep.comps.len() {
             return None;
         }
@@ -311,7 +293,8 @@ fn get_field_presence(
     segment: &Segment,
     field_index: usize,
     rep_index: usize,
-    parts: std::str::Split<char>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
 ) -> Presence {
     if field_index == 0 {
         return Presence::Missing;
@@ -328,7 +311,7 @@ fn get_field_presence(
     }
     let rep = &field.reps[rep_index - 1];
 
-    let Some((comp_index, sub_index)) = parse_component_and_subcomponent(parts) else {
+    let Some((comp_index, sub_index)) = component_and_subcomponent(component, subcomponent) else {
         return Presence::Missing;
     };
 
@@ -359,7 +342,8 @@ fn get_msh_field_presence(
     segment: &Segment,
     field_index: usize,
     rep_index: usize,
-    parts: std::str::Split<char>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
 ) -> Presence {
     if field_index == 1 {
         // MSH-1 is the field separator character
@@ -373,7 +357,8 @@ fn get_msh_field_presence(
             return Presence::Missing;
         }
         let rep = &field.reps[rep_index - 1];
-        let Some((comp_index, sub_index)) = parse_component_and_subcomponent(parts) else {
+        let Some((comp_index, sub_index)) = component_and_subcomponent(component, subcomponent)
+        else {
             return Presence::Missing;
         };
         if comp_index == 0 || comp_index > rep.comps.len() {
@@ -403,7 +388,8 @@ fn get_msh_field_presence(
             return Presence::Missing;
         }
         let rep = &field.reps[rep_index - 1];
-        let Some((comp_index, sub_index)) = parse_component_and_subcomponent(parts) else {
+        let Some((comp_index, sub_index)) = component_and_subcomponent(component, subcomponent)
+        else {
             return Presence::Missing;
         };
         if comp_index == 0 || comp_index > rep.comps.len() {

--- a/crates/hl7v2/src/query/path.rs
+++ b/crates/hl7v2/src/query/path.rs
@@ -1,13 +1,18 @@
 //! HL7 v2 field path parsing and resolution.
 //!
 //! This module provides path-based access to HL7 v2 message fields,
-//! supporting the standard path notation (e.g., `PID.5.1`, `MSH.9[1].2`).
+//! supporting legacy dot notation (e.g., `PID.5.1`) and diagnostic dash
+//! notation used by operator output (e.g., `PID-5.1`, `OBX[2]-5`).
 //!
 //! # Path Format
 //!
-//! - `SEGMENT.FIELD` - Access a field (e.g., `PID.5`)
-//! - `SEGMENT.FIELD.COMPONENT` - Access a component (e.g., `PID.5.1`)
-//! - `SEGMENT.FIELD[REP].COMPONENT` - Access with repetition (e.g., `PID.5[2].1`)
+//! - `SEGMENT.FIELD` or `SEGMENT-FIELD` - Access a field (e.g., `PID.5`, `PID-5`)
+//! - `SEGMENT.FIELD.COMPONENT` or `SEGMENT-FIELD.COMPONENT` - Access a component
+//!   (e.g., `PID.5.1`, `PID-5.1`)
+//! - `SEGMENT.FIELD[REP].COMPONENT` or `SEGMENT-FIELD[REP].COMPONENT` - Access
+//!   with field repetition (e.g., `PID.5[2].1`, `PID-5[2].1`)
+//! - `SEGMENT[REP].FIELD` or `SEGMENT[REP]-FIELD` - Access a repeated segment
+//!   (e.g., `OBX[3].5`, `OBX[3]-5`)
 //! - `SEGMENT.FIELD.COMPONENT.SUBCOMPONENT` - Access subcomponent
 //!
 //! # Example
@@ -46,6 +51,47 @@ pub enum PathError {
     /// Repetition index is missing or outside the valid HL7 range.
     #[error("Invalid repetition index: {0}")]
     InvalidRepetitionIndex(String),
+}
+
+/// Represents a parsed HL7 field path plus a segment repetition selector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocatedPath {
+    /// Segment repetition index (1-based), None means first/default.
+    pub segment_repetition: Option<usize>,
+    /// Field, field repetition, component, and subcomponent selector.
+    pub path: Path,
+}
+
+impl LocatedPath {
+    /// Format as a path string, preserving any segment repetition selector.
+    pub fn to_path_string(&self) -> String {
+        let mut result = self.path.segment.clone();
+        if let Some(rep) = self.segment_repetition {
+            result.push('[');
+            result.push_str(&rep.to_string());
+            result.push(']');
+        }
+        result.push('.');
+        result.push_str(&self.path.field.to_string());
+
+        if let Some(rep) = self.path.repetition {
+            result.push('[');
+            result.push_str(&rep.to_string());
+            result.push(']');
+        }
+
+        if let Some(comp) = self.path.component {
+            result.push('.');
+            result.push_str(&comp.to_string());
+        }
+
+        if let Some(sub) = self.path.subcomponent {
+            result.push('.');
+            result.push_str(&sub.to_string());
+        }
+
+        result
+    }
 }
 
 /// Represents a parsed HL7 field path
@@ -147,9 +193,13 @@ impl std::fmt::Display for Path {
 /// # Supported Formats
 ///
 /// - `SEGMENT.FIELD` - e.g., `PID.5`
+/// - `SEGMENT-FIELD` - e.g., `PID-5`
 /// - `SEGMENT.FIELD.COMPONENT` - e.g., `PID.5.1`
+/// - `SEGMENT-FIELD.COMPONENT` - e.g., `PID-5.1`
 /// - `SEGMENT.FIELD[REP]` - e.g., `PID.5[2]`
-/// - `SEGMENT.FIELD[REP].COMPONENT` - e.g., `PID.5[2].1`
+/// - `SEGMENT-FIELD[REP]` - e.g., `PID-5[2]`
+/// - `SEGMENT[REP].FIELD` - e.g., `OBX[3].5`
+/// - `SEGMENT[REP]-FIELD` - e.g., `OBX[3]-5`
 /// - `SEGMENT.FIELD.COMPONENT.SUBCOMPONENT` - e.g., `PID.5.1.1`
 ///
 /// # Errors
@@ -169,17 +219,36 @@ impl std::fmt::Display for Path {
 /// assert_eq!(path.component, Some(1));
 /// ```
 pub fn parse_path(s: &str) -> Result<Path, PathError> {
+    let located = parse_located_path(s)?;
+    if located.segment_repetition.is_some() {
+        return Err(PathError::InvalidFormat(
+            "Segment repetition requires parse_located_path".to_string(),
+        ));
+    }
+
+    Ok(located.path)
+}
+
+/// Parse an HL7 path that may include a segment repetition selector.
+///
+/// This accepts the same field forms as [`parse_path`] plus segment repetition
+/// selectors like `OBX[3]-5` or `NTE[1].3`.
+///
+/// # Errors
+///
+/// Returns [`PathError`] when the input is empty, missing the field component,
+/// has an invalid segment identifier, or contains zero/non-numeric segment,
+/// field, repetition, component, or subcomponent indexes.
+pub fn parse_located_path(s: &str) -> Result<LocatedPath, PathError> {
     let s = s.trim();
 
     if s.is_empty() {
         return Err(PathError::InvalidFormat("Path cannot be empty".to_string()));
     }
 
-    let mut parts = s.split('.');
-    let segment_part = parts.next().unwrap_or_default();
-    let field_part = parts.next().ok_or_else(|| {
-        PathError::InvalidFormat(format!("Path must have at least SEGMENT.FIELD, got: {s}"))
-    })?;
+    let (segment_part, field_and_component_part) = split_segment_and_field(s)?;
+    let mut parts = field_and_component_part.split('.');
+    let field_part = parts.next().unwrap_or_default();
     let component_part = parts.next();
     let subcomponent_part = parts.next();
     if parts.next().is_some() {
@@ -188,14 +257,7 @@ pub fn parse_path(s: &str) -> Result<Path, PathError> {
         )));
     }
 
-    // Parse segment ID (must be 3 characters, start with letter, rest alphanumeric)
-    let segment = segment_part.to_uppercase();
-    if segment.len() != 3
-        || !segment.starts_with(|c: char| c.is_ascii_alphabetic())
-        || !segment.chars().all(|c| c.is_ascii_alphanumeric())
-    {
-        return Err(PathError::InvalidSegmentId(segment));
-    }
+    let (segment, segment_repetition) = parse_segment_part(segment_part)?;
 
     // Parse field number (may include repetition)
     let (field, repetition) = parse_field_part(field_part)?;
@@ -235,7 +297,59 @@ pub fn parse_path(s: &str) -> Result<Path, PathError> {
         path = path.with_subcomponent(sub);
     }
 
-    Ok(path)
+    Ok(LocatedPath {
+        segment_repetition,
+        path,
+    })
+}
+
+fn split_segment_and_field(s: &str) -> Result<(&str, &str), PathError> {
+    if let Some((segment_part, field_part)) = s.split_once('-') {
+        if segment_part.is_empty() || field_part.is_empty() {
+            return Err(PathError::InvalidFormat(format!(
+                "Path must have SEGMENT-FIELD, got: {s}"
+            )));
+        }
+        return Ok((segment_part, field_part));
+    }
+
+    s.split_once('.').ok_or_else(|| {
+        PathError::InvalidFormat(format!("Path must have at least SEGMENT.FIELD, got: {s}"))
+    })
+}
+
+fn parse_segment_part(s: &str) -> Result<(String, Option<usize>), PathError> {
+    let (segment, repetition) = if s.contains('[') {
+        let stripped = s.strip_suffix(']').ok_or_else(|| {
+            PathError::InvalidFormat(format!("Invalid segment format, missing ']': {s}"))
+        })?;
+        let Some((segment_str, rep_str)) = stripped.split_once('[') else {
+            return Err(PathError::InvalidFormat(format!(
+                "Invalid segment format, missing '[': {s}"
+            )));
+        };
+        let rep = rep_str
+            .parse::<usize>()
+            .map_err(|_parse_err| PathError::InvalidRepetitionIndex(rep_str.to_string()))?;
+        if rep == 0 {
+            return Err(PathError::InvalidRepetitionIndex(
+                "Segment repetition must be >= 1".to_string(),
+            ));
+        }
+        (segment_str.to_uppercase(), Some(rep))
+    } else {
+        (s.to_uppercase(), None)
+    };
+
+    // Parse segment ID (must be 3 characters, start with letter, rest alphanumeric)
+    if segment.len() != 3
+        || !segment.starts_with(|c: char| c.is_ascii_alphabetic())
+        || !segment.chars().all(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(PathError::InvalidSegmentId(segment));
+    }
+
+    Ok((segment, repetition))
 }
 
 /// Parse a field part which may include repetition index
@@ -291,7 +405,80 @@ fn parse_field_part(s: &str) -> Result<(usize, Option<usize>), PathError> {
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::panic,
+        reason = "path parser tests use explicit failure messages for unexpected parse errors"
+    )]
+
     use super::*;
+
+    #[test]
+    fn parse_path_accepts_dash_field_separator() {
+        let path = match parse_path("MSH-9.1") {
+            Ok(path) => path,
+            Err(err) => panic!("dash path should parse: {err}"),
+        };
+
+        assert_eq!(path.segment, "MSH");
+        assert_eq!(path.field, 9);
+        assert_eq!(path.repetition, None);
+        assert_eq!(path.component, Some(1));
+        assert_eq!(path.to_path_string(), "MSH.9.1");
+    }
+
+    #[test]
+    fn parse_path_accepts_dash_field_repetition() {
+        let path = match parse_path("PID-3[2].4") {
+            Ok(path) => path,
+            Err(err) => panic!("dash path should parse: {err}"),
+        };
+
+        assert_eq!(path.segment, "PID");
+        assert_eq!(path.field, 3);
+        assert_eq!(path.repetition, Some(2));
+        assert_eq!(path.component, Some(4));
+    }
+
+    #[test]
+    fn parse_path_accepts_segment_repetition() {
+        let path = match parse_located_path("OBX[3]-5") {
+            Ok(path) => path,
+            Err(err) => panic!("segment repetition should parse: {err}"),
+        };
+
+        assert_eq!(path.segment_repetition, Some(3));
+        assert_eq!(path.path.segment, "OBX");
+        assert_eq!(path.path.field, 5);
+        assert_eq!(path.to_path_string(), "OBX[3].5");
+    }
+
+    #[test]
+    fn parse_path_accepts_dot_segment_repetition_for_compatibility() {
+        let path = match parse_located_path("NTE[1].3") {
+            Ok(path) => path,
+            Err(err) => panic!("dot segment repetition should parse: {err}"),
+        };
+
+        assert_eq!(path.segment_repetition, Some(1));
+        assert_eq!(path.path.segment, "NTE");
+        assert_eq!(path.path.field, 3);
+    }
+
+    #[test]
+    fn parse_path_rejects_segment_repetition_without_dropping_it() {
+        assert!(matches!(
+            parse_path("OBX[3]-5"),
+            Err(PathError::InvalidFormat(_))
+        ));
+    }
+
+    #[test]
+    fn parse_path_rejects_zero_segment_repetition() {
+        assert!(matches!(
+            parse_located_path("OBX[0]-5"),
+            Err(PathError::InvalidRepetitionIndex(_))
+        ));
+    }
 
     #[test]
     fn parse_path_rejects_extra_components() {

--- a/crates/hl7v2/src/query/tests.rs
+++ b/crates/hl7v2/src/query/tests.rs
@@ -59,25 +59,49 @@ fn create_component_field(components: Vec<Vec<&str>>) -> Field {
 // =============================================================================
 
 #[test]
-fn test_parse_field_and_rep_simple() {
-    assert_eq!(parse_field_and_rep("5"), Some((5, 1)));
-    assert_eq!(parse_field_and_rep("1"), Some((1, 1)));
-    assert_eq!(parse_field_and_rep("10"), Some((10, 1)));
+fn test_parse_path_accepts_legacy_dot_notation() {
+    let path = match path::parse_path("PID.5[2].1") {
+        Ok(path) => path,
+        Err(err) => panic!("legacy path should parse: {err}"),
+    };
+
+    assert_eq!(path.segment, "PID");
+    assert_eq!(path.field, 5);
+    assert_eq!(path.repetition, Some(2));
+    assert_eq!(path.component, Some(1));
 }
 
 #[test]
-fn test_parse_field_and_rep_with_repetition() {
-    assert_eq!(parse_field_and_rep("5[1]"), Some((5, 1)));
-    assert_eq!(parse_field_and_rep("5[2]"), Some((5, 2)));
-    assert_eq!(parse_field_and_rep("10[5]"), Some((10, 5)));
+fn test_parse_path_accepts_target_dash_notation() {
+    let path = match path::parse_located_path("OBX[3]-5.1") {
+        Ok(path) => path,
+        Err(err) => panic!("dash path should parse: {err}"),
+    };
+
+    assert_eq!(path.segment_repetition, Some(3));
+    assert_eq!(path.path.segment, "OBX");
+    assert_eq!(path.path.field, 5);
+    assert_eq!(path.path.component, Some(1));
 }
 
 #[test]
-fn test_parse_field_and_rep_invalid() {
-    assert_eq!(parse_field_and_rep("abc"), None);
-    assert_eq!(parse_field_and_rep("5["), None);
-    assert_eq!(parse_field_and_rep("5[abc]"), None);
-    assert_eq!(parse_field_and_rep(""), None);
+fn test_parse_path_rejects_invalid_repetitions() {
+    assert!(matches!(
+        path::parse_located_path("PID-5[abc]"),
+        Err(path::PathError::InvalidRepetitionIndex(_))
+    ));
+    assert!(matches!(
+        path::parse_located_path("PID-5["),
+        Err(path::PathError::InvalidFormat(_))
+    ));
+    assert!(matches!(
+        path::parse_located_path("OBX[0]-5"),
+        Err(path::PathError::InvalidRepetitionIndex(_))
+    ));
+    assert!(matches!(
+        path::parse_located_path(""),
+        Err(path::PathError::InvalidFormat(_))
+    ));
 }
 
 // =============================================================================
@@ -122,6 +146,25 @@ fn test_get_component_field() {
 
     assert_eq!(get(&message, "PID.5.1"), Some("Doe"));
     assert_eq!(get(&message, "PID.5.2"), Some("John"));
+}
+
+#[test]
+fn test_get_accepts_dash_path_field_components() {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![create_test_segment(
+            "PID",
+            vec![
+                create_text_field(vec!["1"]),
+                create_text_field(vec![""]),
+                create_component_field(vec![vec!["123456"], vec![""], vec![""], vec!["HOSP"]]),
+            ],
+        )],
+        charsets: vec![],
+    };
+
+    assert_eq!(get(&message, "PID-3.1"), Some("123456"));
+    assert_eq!(get(&message, "PID-3.4"), Some("HOSP"));
 }
 
 #[test]
@@ -276,6 +319,84 @@ fn test_get_with_repetitions() {
     // Invalid repetition
     assert_eq!(get(&message, "PID.1[4]"), None);
     assert_eq!(get(&message, "PID.1[0]"), None);
+}
+
+#[test]
+fn test_get_with_dash_field_repetition() {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![create_test_segment(
+            "PID",
+            vec![Field {
+                reps: vec![
+                    Rep {
+                        comps: vec![Comp {
+                            subs: vec![Atom::Text("primary".to_string())],
+                        }],
+                    },
+                    Rep {
+                        comps: vec![
+                            Comp {
+                                subs: vec![Atom::Text("alternate".to_string())],
+                            },
+                            Comp {
+                                subs: vec![Atom::Text("authority".to_string())],
+                            },
+                        ],
+                    },
+                ],
+            }],
+        )],
+        charsets: vec![],
+    };
+
+    assert_eq!(get(&message, "PID-1[2].1"), Some("alternate"));
+    assert_eq!(get(&message, "PID-1[2].2"), Some("authority"));
+}
+
+#[test]
+fn test_get_with_segment_repetition() {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![
+            create_test_segment(
+                "OBX",
+                vec![
+                    create_text_field(vec!["1"]),
+                    create_text_field(vec!["ST"]),
+                    create_text_field(vec!["FIRST"]),
+                    create_text_field(vec![""]),
+                    create_text_field(vec!["Alpha"]),
+                ],
+            ),
+            create_test_segment(
+                "OBX",
+                vec![
+                    create_text_field(vec!["2"]),
+                    create_text_field(vec!["ST"]),
+                    create_text_field(vec!["SECOND"]),
+                    create_text_field(vec![""]),
+                    create_text_field(vec!["Beta"]),
+                ],
+            ),
+            create_test_segment(
+                "OBX",
+                vec![
+                    create_text_field(vec!["3"]),
+                    create_text_field(vec!["ST"]),
+                    create_text_field(vec!["THIRD"]),
+                    create_text_field(vec![""]),
+                    create_text_field(vec!["Gamma"]),
+                ],
+            ),
+        ],
+        charsets: vec![],
+    };
+
+    assert_eq!(get(&message, "OBX[1]-5"), Some("Alpha"));
+    assert_eq!(get(&message, "OBX[2]-5"), Some("Beta"));
+    assert_eq!(get(&message, "OBX[3]-5"), Some("Gamma"));
+    assert_eq!(get(&message, "OBX[4]-5"), None);
 }
 
 // =============================================================================
@@ -462,6 +583,39 @@ fn test_presence_for_subcomponent_paths() {
         Presence::Value("value".to_string())
     );
     assert_eq!(get_presence(&message, "PID.1.1.4"), Presence::Missing);
+}
+
+#[test]
+fn test_presence_accepts_dash_and_segment_repetition_paths() {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![
+            create_test_segment(
+                "NTE",
+                vec![
+                    create_text_field(vec!["1"]),
+                    create_text_field(vec!["L"]),
+                    create_text_field(vec!["First note"]),
+                ],
+            ),
+            create_test_segment(
+                "NTE",
+                vec![
+                    create_text_field(vec!["2"]),
+                    create_text_field(vec!["L"]),
+                    create_text_field(vec![""]),
+                ],
+            ),
+        ],
+        charsets: vec![],
+    };
+
+    assert_eq!(
+        get_presence(&message, "NTE[1]-3"),
+        Presence::Value("First note".to_string())
+    );
+    assert_eq!(get_presence(&message, "NTE[2]-3"), Presence::Empty);
+    assert_eq!(get_presence(&message, "NTE[3]-3"), Presence::Missing);
 }
 
 // =============================================================================

--- a/crates/hl7v2/tests/query_facade.rs
+++ b/crates/hl7v2/tests/query_facade.rs
@@ -38,6 +38,36 @@ PID|1||123456^^^HOSP^MR~ALT999^^^ALT^MR||Doe^John^A||19700101|M\r",
 }
 
 #[test]
+fn query_facade_reads_target_dash_paths_and_segment_repetitions() -> Result<(), Box<dyn Error>> {
+    let message = parse(
+        b"MSH|^~\\&|LAB|FAC|EHR|RF|202605030101||ORU^R01|CTRL456|P|2.5\r\
+PID|1||123456^^^HOSP^MR~ALT999^^^ALT^MR||Doe^John^A||19700101|M\r\
+OBR|1|ORD1|FILL1|CBC^Complete blood count\r\
+OBX|1|ST|NOTE^First note||Alpha\r\
+OBX|2|ST|NOTE^Second note||Beta\r\
+OBX|3|ST|NOTE^Third note||Gamma\r\
+NTE|1|L|operator note\r",
+    )?;
+
+    require_eq(get(&message, "MSH-9.1"), Some("ORU"), "message code")?;
+    require_eq(
+        get(&message, "PID-3[2].4"),
+        Some("ALT"),
+        "alternate assigning authority",
+    )?;
+    require_eq(get(&message, "OBX[3]-5"), Some("Gamma"), "third OBX value")?;
+    require(
+        matches!(
+            get_presence(&message, "NTE[1]-3"),
+            Presence::Value(value) if value == "operator note"
+        ),
+        "expected first NTE comment",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn query_facade_distinguishes_empty_and_missing_presence() -> Result<(), Box<dyn Error>> {
     let message =
         parse(b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||\r")?;


### PR DESCRIPTION
## Summary
- accept diagnostic dash query paths such as MSH-9.1 and PID-3[2].4 while preserving existing dot paths
- add LocatedPath / parse_located_path for segment repetition selectors such as OBX[3]-5 without adding fields to the existing public Path struct
- route get and get_presence through the shared parser and add fixture-backed query/facade coverage
- refresh adges/ripr.json so advisory ripr evidence stays current

## Validation
- tk cargo fmt --check
- tk cargo test -p hl7v2 --lib query
- tk cargo test -p hl7v2 --test query_facade
- tk cargo test -p hl7v2 --all-features query
- tk cargo clippy -p hl7v2 --all-targets --all-features -- -D warnings
- tk cargo test -p hl7v2 --all-features
- tk cargo run -p xtask -- badges --check

## Notes
- tk cargo test -p hl7v2 query was tried first and hit the existing no-feature integration-test compile issue where safe_error_phi_parity.rs references hl7v2::redact; the listed checks use the relevant focused targets and all-features suite.