### PR TITLE
fix: accept located paths in profile lint

### DIFF
--- a/crates/hl7v2/src/conformance/profile/lint.rs
+++ b/crates/hl7v2/src/conformance/profile/lint.rs
@@ -813,7 +813,7 @@ fn lint_custom_rules(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
 }
 
 fn lint_hl7_path(path: &str, location: String, issues: &mut Vec<ProfileLintIssue>) {
-    if let Err(err) = crate::query::path::parse_path(path) {
+    if let Err(err) = crate::query::path::parse_located_path(path) {
         issues.push(ProfileLintIssue::error(
             "invalid_hl7_path",
             Some(location),

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -357,6 +357,32 @@ constraints:
     }
 
     #[test]
+    fn test_lint_profile_yaml_accepts_diagnostic_segment_repetition_paths() {
+        let y = r#"
+message_structure: "ORU_R01"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+  - id: "OBX"
+constraints:
+  - path: "OBX[3]-5"
+    required: true
+valuesets:
+  - path: "OBX[3]-2"
+    name: "ValueType"
+    codes: ["ST", "NM"]
+datatypes:
+  - path: "OBX[3]-14"
+    type: "TS"
+"#;
+
+        let report = lint_profile_yaml(y);
+
+        assert!(report.valid, "unexpected lint report: {report:?}");
+        assert_eq!(report.issue_count, 0);
+    }
+
+    #[test]
     fn test_lint_profile_yaml_reports_structural_errors() {
         let y = r#"
 message_structure: ""

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -149,6 +149,46 @@ PID|1||123456^^^HOSP^MR||Longname^John||19700101|M\r",
 }
 
 #[test]
+fn profile_facade_accepts_diagnostic_segment_repetition_paths() -> Result<(), Box<dyn Error>> {
+    let yaml = r#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "OBX"
+constraints:
+  - path: "OBX[3]-5"
+    required: true
+valuesets:
+  - path: "OBX[3]-2"
+    name: "ThirdObservationValueType"
+    codes: ["NM"]
+"#;
+    let lint = lint_profile_yaml(yaml);
+    require(lint.valid, "expected diagnostic paths to pass profile lint")?;
+
+    let profile = load_profile_checked(yaml)?;
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ORU^R01|CTRL123|P|2.5\r\
+OBX|1|NM|CODE1^First||1\r\
+OBX|2|NM|CODE2^Second||2\r\
+OBX|3|ST|CODE3^Third||third\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("OBX[3]-2")
+                && issue.code == "VALUE_NOT_IN_SET"
+        }),
+        "expected diagnostic path value set violation",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn profile_facade_explains_profile_contract_shape() -> Result<(), Box<dyn Error>> {
     let yaml = r#"
 message_structure: "ADT_A01"

--- a/schemas/profile/profile-v1.schema.json
+++ b/schemas/profile/profile-v1.schema.json
@@ -58,9 +58,9 @@
       "properties": {
         "path": {
           "type": "string",
-          "description": "HL7 field path (e.g., PID.3, MSH.9.1)",
-          "pattern": "^[A-Z0-9]{3}(\\.[0-9]+(\\[[0-9]+\\])?(\\.[0-9]+)?)?$",
-          "examples": ["PID.3", "MSH.9.1", "OBX.5[1].1"]
+          "description": "HL7 field path (e.g., PID.3, MSH-9.1, OBX[3]-5)",
+          "pattern": "^[A-Z0-9]{3}(\\[[0-9]+\\])?((\\.|-)[0-9]+(\\[[0-9]+\\])?(\\.[0-9]+(\\.[0-9]+)?)?)?$",
+          "examples": ["PID.3", "MSH-9.1", "OBX.5[1].1", "OBX[3]-5"]
         },
         "constraint_type": {
           "type": "string",
@@ -116,7 +116,7 @@
         "if_path": {
           "type": "string",
           "description": "Conditional path for contextual rules",
-          "pattern": "^[A-Z0-9]{3}(\\.[0-9]+(\\[[0-9]+\\])?(\\.[0-9]+)?)?$"
+          "pattern": "^[A-Z0-9]{3}(\\[[0-9]+\\])?((\\.|-)[0-9]+(\\[[0-9]+\\])?(\\.[0-9]+(\\.[0-9]+)?)?)?$"
         },
         "if_value": {
           "type": "string",
@@ -125,7 +125,7 @@
         "then_path": {
           "type": "string",
           "description": "Path to validate if condition is met",
-          "pattern": "^[A-Z0-9]{3}(\\.[0-9]+(\\[[0-9]+\\])?(\\.[0-9]+)?)?$"
+          "pattern": "^[A-Z0-9]{3}(\\[[0-9]+\\])?((\\.|-)[0-9]+(\\[[0-9]+\\])?(\\.[0-9]+(\\.[0-9]+)?)?)?$"
         },
         "then_constraint": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Use the shared located HL7 path parser for profile lint path checks.
- Add profile lint and facade validation coverage for diagnostic segment repetition paths such as OBX[3]-5 and OBX[3]-2.
- Update the profile v1 JSON schema path regex/examples so schema validation accepts the same diagnostic path shape.

## Validation
- PASS: rtk cargo test -p hl7v2 --features profile --lib test_lint_profile_yaml_accepts_diagnostic_segment_repetition_paths
- PASS: rtk cargo test -p hl7v2 --features profile --test conformance_facade profile_facade_accepts_diagnostic_segment_repetition_paths
- PASS: rtk cargo test -p hl7v2 --features profile --test conformance_facade
- PASS: rtk cargo test -p hl7v2 --all-features profile_lint
- PASS: rtk cargo fmt --check
- PASS: rtk cargo clippy -p hl7v2 --all-targets --all-features -- -D warnings
- PASS: rtk cargo test -p hl7v2 --all-features
- PASS: rtk powershell -NoProfile -Command 'npx --yes -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 ajv compile -c ajv-formats -s schemas/profile/profile-v1.schema.json --spec=draft7'
- PASS: AJV validation of a temporary repo-relative profile containing OBX[3]-5, MSH-9.1, and OBX[3]-5 contextual paths; scratch file was deleted afterward.
- EXPECTED FAIL BEFORE FIX: the new lint regression test failed before changing lint from parse_path to parse_located_path.
- KNOWN EXISTING: rtk cargo test -p hl7v2 --features profile profile_lint still compiles no-feature integration tests and fails in safe_error_phi_parity.rs because hl7v2::redact is feature-gated.