### PR TITLE
fix: accept located paths in redaction policies

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12198",
+  "message": "12209",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/evidence_bundle.rs
+++ b/crates/hl7v2-cli/src/evidence_bundle.rs
@@ -1114,7 +1114,7 @@ mod policy {
     pub(super) fn load_safe_analysis_policy(
         policy_text: &str,
     ) -> Result<SafeAnalysisPolicy, Box<dyn std::error::Error>> {
-        let policy: SafeAnalysisPolicy = toml::from_str(policy_text)?;
+        let mut policy: SafeAnalysisPolicy = toml::from_str(policy_text)?;
         if policy.rules.is_empty() {
             return Err(
                 std::io::Error::other("redaction policy must contain at least one rule").into(),
@@ -1122,8 +1122,9 @@ mod policy {
         }
 
         let mut seen_paths = BTreeSet::new();
-        for rule in &policy.rules {
-            parse_redaction_path(&rule.path).map_err(std::io::Error::other)?;
+        for rule in &mut policy.rules {
+            let parsed_path = parse_redaction_path(&rule.path).map_err(std::io::Error::other)?;
+            rule.path = parsed_path.canonical_path;
             if !seen_paths.insert(rule.path.clone()) {
                 return Err(std::io::Error::other(format!(
                     "redaction policy contains duplicate rule for {}",
@@ -1165,9 +1166,16 @@ mod policy {
         for rule in &policy.rules {
             let parsed_path = parse_redaction_path(&rule.path).map_err(std::io::Error::other)?;
             let mut matched_count = 0_usize;
+            let mut segment_match_count = 0_usize;
 
             for segment in &mut message.segments {
                 if segment.id_str() != parsed_path.segment_id {
+                    continue;
+                }
+                segment_match_count = segment_match_count.saturating_add(1);
+                if let Some(segment_repetition) = parsed_path.segment_repetition
+                    && segment_match_count != segment_repetition
+                {
                     continue;
                 }
 
@@ -1281,45 +1289,43 @@ mod policy {
 
     struct ParsedRedactionPath {
         segment_id: String,
+        segment_repetition: Option<usize>,
         field_index: usize,
+        canonical_path: String,
     }
 
     fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
-        let (segment_id, field_part) = path
-            .split_once('.')
-            .ok_or_else(|| format!("redaction path '{path}' must use SEG.field syntax"))?;
-        if segment_id.len() != 3
-            || !segment_id
-                .chars()
-                .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit())
-        {
-            return Err(format!(
-                "redaction path '{path}' must start with a three-character uppercase segment id"
-            ));
-        }
-        if field_part.contains('.') {
+        let located = hl7v2::parse_located_path(path).map_err(|error| {
+            if !path.contains('.') && !path.contains('-') {
+                format!("redaction path '{path}' must use SEG.field or SEG-FIELD syntax")
+            } else {
+                format!("redaction path '{path}' is invalid: {error}")
+            }
+        })?;
+
+        if located.path.component.is_some() || located.path.subcomponent.is_some() {
             return Err(format!(
                 "redaction path '{path}' must target a field, not a component"
             ));
         }
-
-        let field_index = field_part.parse::<usize>().map_err(|_err| {
-            format!("redaction path '{path}' must use a positive numeric field index")
-        })?;
-        if field_index == 0 {
+        if located.path.repetition.is_some() {
             return Err(format!(
-                "redaction path '{path}' must use a one-based field index"
+                "redaction path '{path}' must target a field, not a field repetition"
             ));
         }
-        if segment_id == "MSH" && field_index < 3 {
+        if located.path.segment == "MSH" && located.path.field < 3 {
             return Err(format!(
                 "redaction path '{path}' targets MSH.1/MSH.2, which are delimiter metadata and not redacted by this command"
             ));
         }
 
+        let canonical_path = located.to_path_string();
+
         Ok(ParsedRedactionPath {
-            segment_id: segment_id.to_string(),
-            field_index,
+            segment_id: located.path.segment,
+            segment_repetition: located.segment_repetition,
+            field_index: located.path.field,
+            canonical_path,
         })
     }
 
@@ -1361,12 +1367,26 @@ mod policy {
             .map(|action| (action.path.as_str(), action.action))
             .collect();
         let mut fields = Vec::new();
+        let mut segment_occurrences = BTreeMap::<String, usize>::new();
 
         for (segment_position, segment) in message.segments.iter().enumerate() {
             let segment_index = segment_position.saturating_add(1);
+            let segment_occurrence = {
+                let count = segment_occurrences
+                    .entry(segment.id_str().to_string())
+                    .or_insert(0);
+                *count = count.saturating_add(1);
+                *count
+            };
             for (modeled_index, field) in segment.fields.iter().enumerate() {
                 let field_index = hl7_field_index(segment.id_str(), modeled_index);
                 let canonical_path = format!("{}.{}", segment.id_str(), field_index);
+                let occurrence_path = format!(
+                    "{}[{}].{}",
+                    segment.id_str(),
+                    segment_occurrence,
+                    field_index
+                );
                 let field_text = field_to_text(field, &message.delims);
                 fields.push(FieldPathTrace {
                     path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
@@ -1375,7 +1395,10 @@ mod policy {
                     field_index,
                     present: !field_text.is_empty(),
                     value_shape: field_value_shape(&field_text),
-                    redaction_action: redaction_actions.get(canonical_path.as_str()).copied(),
+                    redaction_action: redaction_actions
+                        .get(occurrence_path.as_str())
+                        .or_else(|| redaction_actions.get(canonical_path.as_str()))
+                        .copied(),
                 });
             }
         }

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2420,6 +2420,58 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
     }
 
     #[test]
+    fn test_redact_json_accepts_diagnostic_policy_paths_with_canonical_receipts() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
+        let diagnostic_policy = SAFE_ANALYSIS_POLICY
+            .replace("PID.3", "PID-3")
+            .replace("PID.5", "PID-5")
+            .replace("PID.7", "PID-7")
+            .replace("PID.11", "PID-11")
+            .replace("PID.13", "PID-13")
+            .replace("MSH.9", "MSH-9")
+            .replace("MSH.10", "MSH-10")
+            .replace("OBX.3", "OBX-3")
+            .replace("OBX.5", "OBX-5");
+        let policy_file =
+            create_temp_file(&dir, "safe-analysis.toml", diagnostic_policy.as_bytes());
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message_file.to_str().unwrap(),
+                "--policy",
+                policy_file.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute redact");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains("Doe^John"));
+        assert!(!stdout.contains("123456^^^HOSP^MR"));
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("redact output should be JSON");
+        let actions = report["receipt"]["actions"].as_array().unwrap();
+        assert!(actions.iter().any(|action| {
+            action["path"] == "PID.3" && action["action"] == "hash" && action["status"] == "applied"
+        }));
+        assert!(actions.iter().any(|action| {
+            action["path"] == "MSH.9"
+                && action["action"] == "retain"
+                && action["status"] == "retained"
+        }));
+        assert!(
+            actions
+                .iter()
+                .all(|action| !action["path"].as_str().unwrap().contains('-'))
+        );
+    }
+
+    #[test]
     fn test_redact_json_schema_v2_returns_provenance_output_without_raw_phi() {
         let dir = create_temp_dir();
         let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);

--- a/crates/hl7v2-server/src/evidence.rs
+++ b/crates/hl7v2-server/src/evidence.rs
@@ -394,12 +394,26 @@ fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> Fiel
         .map(|action| (action.path.as_str(), action.action))
         .collect();
     let mut fields = Vec::new();
+    let mut segment_occurrences = BTreeMap::<String, usize>::new();
 
     for (segment_position, segment) in message.segments.iter().enumerate() {
         let segment_index = segment_position.saturating_add(1);
+        let segment_occurrence = {
+            let count = segment_occurrences
+                .entry(segment.id_str().to_string())
+                .or_insert(0);
+            *count = count.saturating_add(1);
+            *count
+        };
         for (modeled_index, field) in segment.fields.iter().enumerate() {
             let field_index = hl7_field_index(segment.id_str(), modeled_index);
             let canonical_path = format!("{}.{}", segment.id_str(), field_index);
+            let occurrence_path = format!(
+                "{}[{}].{}",
+                segment.id_str(),
+                segment_occurrence,
+                field_index
+            );
             let field_text = field_to_text(field, &message.delims);
             fields.push(FieldPathTrace {
                 path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
@@ -408,7 +422,10 @@ fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> Fiel
                 field_index,
                 present: !field_text.is_empty(),
                 value_shape: field_value_shape(&field_text),
-                redaction_action: redaction_actions.get(canonical_path.as_str()).copied(),
+                redaction_action: redaction_actions
+                    .get(occurrence_path.as_str())
+                    .or_else(|| redaction_actions.get(canonical_path.as_str()))
+                    .copied(),
             });
         }
     }

--- a/crates/hl7v2-server/src/redaction.rs
+++ b/crates/hl7v2-server/src/redaction.rs
@@ -25,7 +25,9 @@ struct SafeAnalysisPolicyRule {
 
 struct ParsedRedactionPath {
     segment_id: String,
+    segment_repetition: Option<usize>,
     field_index: usize,
+    canonical_path: String,
 }
 
 /// Apply a safe-analysis policy to a message and return a redaction receipt.
@@ -38,15 +40,16 @@ pub fn redact_message(
 }
 
 fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy, String> {
-    let policy: SafeAnalysisPolicy = toml::from_str(policy_text)
+    let mut policy: SafeAnalysisPolicy = toml::from_str(policy_text)
         .map_err(|error| format!("redaction policy is invalid TOML: {error}"))?;
     if policy.rules.is_empty() {
         return Err("redaction policy must contain at least one rule".to_string());
     }
 
     let mut seen_paths = BTreeSet::new();
-    for rule in &policy.rules {
-        parse_redaction_path(&rule.path)?;
+    for rule in &mut policy.rules {
+        let parsed_path = parse_redaction_path(&rule.path)?;
+        rule.path = parsed_path.canonical_path;
         if !seen_paths.insert(rule.path.clone()) {
             return Err(format!(
                 "redaction policy contains duplicate rule for {}",
@@ -85,9 +88,16 @@ fn apply_safe_analysis_policy(
     for rule in &policy.rules {
         let parsed_path = parse_redaction_path(&rule.path)?;
         let mut matched_count = 0_usize;
+        let mut segment_match_count = 0_usize;
 
         for segment in &mut message.segments {
             if segment.id_str() != parsed_path.segment_id {
+                continue;
+            }
+            segment_match_count = segment_match_count.saturating_add(1);
+            if let Some(segment_repetition) = parsed_path.segment_repetition
+                && segment_match_count != segment_repetition
+            {
                 continue;
             }
 
@@ -198,41 +208,37 @@ fn safe_analysis_sensitive_paths() -> BTreeSet<&'static str> {
 }
 
 fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
-    let (segment_id, field_part) = path
-        .split_once('.')
-        .ok_or_else(|| format!("redaction path '{path}' must use SEG.field syntax"))?;
-    if segment_id.len() != 3
-        || !segment_id
-            .chars()
-            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit())
-    {
-        return Err(format!(
-            "redaction path '{path}' must start with a three-character uppercase segment id"
-        ));
-    }
-    if field_part.contains('.') {
+    let located = hl7v2::parse_located_path(path).map_err(|error| {
+        if !path.contains('.') && !path.contains('-') {
+            format!("redaction path '{path}' must use SEG.field or SEG-FIELD syntax")
+        } else {
+            format!("redaction path '{path}' is invalid: {error}")
+        }
+    })?;
+
+    if located.path.component.is_some() || located.path.subcomponent.is_some() {
         return Err(format!(
             "redaction path '{path}' must target a field, not a component"
         ));
     }
-
-    let field_index = field_part.parse::<usize>().map_err(|_err| {
-        format!("redaction path '{path}' must use a positive numeric field index")
-    })?;
-    if field_index == 0 {
+    if located.path.repetition.is_some() {
         return Err(format!(
-            "redaction path '{path}' must use a one-based field index"
+            "redaction path '{path}' must target a field, not a field repetition"
         ));
     }
-    if segment_id == "MSH" && field_index < 3 {
+    if located.path.segment == "MSH" && located.path.field < 3 {
         return Err(format!(
             "redaction path '{path}' targets MSH.1/MSH.2, which are delimiter metadata and not redacted by this command"
         ));
     }
 
+    let canonical_path = located.to_path_string();
+
     Ok(ParsedRedactionPath {
-        segment_id: segment_id.to_string(),
-        field_index,
+        segment_id: located.path.segment,
+        segment_repetition: located.segment_repetition,
+        field_index: located.path.field,
+        canonical_path,
     })
 }
 

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -184,6 +184,57 @@ async fn test_validate_redacted_receipt_schema_v2_returns_nested_provenance_rece
 }
 
 #[tokio::test]
+async fn test_validate_redacted_accepts_diagnostic_policy_paths_with_canonical_receipts() {
+    let app = common::create_test_router();
+    let diagnostic_policy = REDACTION_POLICY
+        .replace("PID.3", "PID-3")
+        .replace("PID.5", "PID-5")
+        .replace("PID.7", "PID-7")
+        .replace("PID.11", "PID-11")
+        .replace("PID.13", "PID-13")
+        .replace("PID.14", "PID-14")
+        .replace("PID.19", "PID-19")
+        .replace("NK1.2", "NK1-2")
+        .replace("NK1.4", "NK1-4")
+        .replace("NK1.5", "NK1-5");
+    let request_body = json!({
+        "message": PHI_MESSAGE,
+        "profile": VALIDATION_PROFILE,
+        "redaction_policy": diagnostic_policy,
+        "include_redacted_hl7": true
+    });
+
+    let response = app
+        .oneshot(validate_redacted_request(request_body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let actions = body_json["redaction_receipt"]["actions"]
+        .as_array()
+        .unwrap();
+
+    assert!(actions.iter().any(|action| {
+        action["path"] == "PID.3" && action["action"] == "hash" && action["status"] == "applied"
+    }));
+    assert!(
+        actions
+            .iter()
+            .all(|action| !action["path"].as_str().unwrap().contains('-'))
+    );
+    assert!(
+        !body_json["redacted_hl7"]
+            .as_str()
+            .unwrap()
+            .contains("MRN-Z")
+    );
+    assert_no_phi(&body_text);
+}
+
+#[tokio::test]
 async fn test_validate_redacted_rejects_unsupported_receipt_schema_version() {
     let app = common::create_test_router();
     let request_body = json!({

--- a/crates/hl7v2/src/evidence.rs
+++ b/crates/hl7v2/src/evidence.rs
@@ -237,6 +237,97 @@ reason = "Date of birth"
     }
 
     #[test]
+    fn bundle_field_trace_marks_segment_specific_redaction()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let bundle_dir = temp.path().join("targeted-redaction-bundle");
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
+OBX|1|ST|A||Alpha\r\
+OBX|2|ST|B||Beta\r\
+OBX|3|ST|C||Gamma";
+        let profile = r#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "OBX"
+constraints:
+  - path: "MSH.9"
+    required: true
+"#;
+        let policy = r#"
+[[rules]]
+path = "OBX[2]-5"
+action = "hash"
+reason = "Targeted observation redaction"
+"#;
+
+        write_safe_analysis_bundle(message, profile, policy, &bundle_dir, "hl7v2-python")?;
+
+        let receipt = read_bundle_json_value(&bundle_dir, "redaction-receipt.json")?;
+        let actions = receipt
+            .get("actions")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| std::io::Error::other("redaction receipt should contain actions"))?;
+        ensure(
+            actions.iter().any(|action| {
+                action.get("path").and_then(serde_json::Value::as_str) == Some("OBX[2].5")
+                    && action
+                        .get("matched_count")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(1)
+            }),
+            "expected canonical segment-specific redaction receipt",
+        )?;
+
+        let trace = read_bundle_json_value(&bundle_dir, "field-paths.json")?;
+        let fields = trace
+            .get("fields")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| std::io::Error::other("field trace should contain fields"))?;
+        let redacted_fields = fields
+            .iter()
+            .filter(|field| {
+                field
+                    .get("redaction_action")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("hash")
+            })
+            .collect::<Vec<_>>();
+        ensure(
+            redacted_fields.len() == 1,
+            "expected one field trace redaction marker",
+        )?;
+        let redacted_field = redacted_fields
+            .first()
+            .copied()
+            .ok_or_else(|| std::io::Error::other("expected redacted field trace"))?;
+        ensure(
+            redacted_field
+                .get("canonical_path")
+                .and_then(serde_json::Value::as_str)
+                == Some("OBX.5"),
+            "expected OBX.5 trace path",
+        )?;
+        ensure(
+            redacted_field
+                .get("segment_index")
+                .and_then(serde_json::Value::as_u64)
+                == Some(3),
+            "expected second OBX absolute segment index",
+        )?;
+        ensure(
+            redacted_field
+                .get("value_shape")
+                .and_then(serde_json::Value::as_str)
+                == Some("hashed_sha256"),
+            "expected hashed trace value shape",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
     fn replay_accepts_legacy_bundle_without_safe_sharing_checklist()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;

--- a/crates/hl7v2/src/evidence/trace.rs
+++ b/crates/hl7v2/src/evidence/trace.rs
@@ -13,12 +13,26 @@ pub(crate) fn build_field_path_trace(
         .map(|action| (action.path.as_str(), action.action))
         .collect();
     let mut fields = Vec::new();
+    let mut segment_occurrences = BTreeMap::<String, usize>::new();
 
     for (segment_position, segment) in message.segments.iter().enumerate() {
         let segment_index = segment_position.saturating_add(1);
+        let segment_occurrence = {
+            let count = segment_occurrences
+                .entry(segment.id_str().to_string())
+                .or_insert(0);
+            *count = count.saturating_add(1);
+            *count
+        };
         for (modeled_index, field) in segment.fields.iter().enumerate() {
             let field_index = hl7_field_index(segment.id_str(), modeled_index);
             let canonical_path = format!("{}.{}", segment.id_str(), field_index);
+            let occurrence_path = format!(
+                "{}[{}].{}",
+                segment.id_str(),
+                segment_occurrence,
+                field_index
+            );
             let field_text = field_to_text(field, &message.delims);
             fields.push(FieldPathTrace {
                 path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
@@ -27,7 +41,10 @@ pub(crate) fn build_field_path_trace(
                 field_index,
                 present: !field_text.is_empty(),
                 value_shape: field_value_shape(&field_text),
-                redaction_action: redaction_actions.get(canonical_path.as_str()).copied(),
+                redaction_action: redaction_actions
+                    .get(occurrence_path.as_str())
+                    .or_else(|| redaction_actions.get(canonical_path.as_str()))
+                    .copied(),
             });
         }
     }

--- a/crates/hl7v2/src/redact.rs
+++ b/crates/hl7v2/src/redact.rs
@@ -22,13 +22,10 @@ pub use types::{
 };
 
 #[cfg(test)]
-pub(crate) use path::parse_segment_field_path;
-
-#[cfg(test)]
 mod tests {
     use super::{
-        RedactionAction, RedactionActionStatus, RedactionConfig, load_safe_analysis_policy,
-        parse_segment_field_path, redact, redact_hl7_safe_analysis,
+        RedactionAction, RedactionActionStatus, RedactionConfig, load_safe_analysis_policy, redact,
+        redact_hl7_safe_analysis,
     };
     use crate::{Delims, Field, Message, Segment};
 
@@ -73,6 +70,26 @@ mod tests {
     }
 
     #[test]
+    fn redacts_configured_dash_segment_field() {
+        let mut message = test_message_with_pid_names(&["Doe^John"]);
+        let config = RedactionConfig {
+            replacement: "XXX".to_string(),
+            fields: vec!["PID-5".to_string()],
+        };
+
+        redact(&mut message, &config);
+
+        let redacted_value = message
+            .segments
+            .iter()
+            .find(|segment| segment.id == *b"PID")
+            .and_then(|segment| segment.fields.get(4))
+            .and_then(Field::first_text);
+
+        assert_eq!(redacted_value, Some("XXX"));
+    }
+
+    #[test]
     fn hipaa_defaults_include_expected_fields() {
         let config = RedactionConfig::hipaa_defaults();
 
@@ -80,15 +97,6 @@ mod tests {
         assert_eq!(config.fields.len(), 9);
         assert!(config.fields.iter().any(|field| field == "PID.5"));
         assert!(config.fields.iter().any(|field| field == "NK1.5"));
-    }
-
-    #[test]
-    fn parse_segment_field_path_rejects_invalid_paths() {
-        assert_eq!(parse_segment_field_path("PID.5"), Some(("PID", 5)));
-        assert_eq!(parse_segment_field_path("PID"), None);
-        assert_eq!(parse_segment_field_path(".5"), None);
-        assert_eq!(parse_segment_field_path("PID.5.1"), None);
-        assert_eq!(parse_segment_field_path("PID.name"), None);
     }
 
     #[test]
@@ -241,6 +249,115 @@ optional = true
     }
 
     #[test]
+    fn safe_analysis_accepts_diagnostic_paths_and_canonicalizes_receipts()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let policy = r#"
+[[rules]]
+path = "PID-3"
+action = "hash"
+reason = "Patient identifier"
+
+[[rules]]
+path = "PID-5"
+action = "drop"
+reason = "Patient name"
+
+[[rules]]
+path = "PID-7"
+action = "drop"
+reason = "Date of birth"
+
+[[rules]]
+path = "PID-11"
+action = "drop"
+reason = "Address"
+
+[[rules]]
+path = "PID-13"
+action = "drop"
+reason = "Phone"
+"#;
+
+        let output = redact_hl7_safe_analysis(safe_analysis_message(), policy)?;
+
+        ensure(
+            !output.redacted_hl7.contains("Doe^John"),
+            "redacted HL7 leaked patient name",
+        )?;
+        ensure(
+            !output.redacted_hl7.contains("123456"),
+            "redacted HL7 leaked patient identifier",
+        )?;
+        ensure(
+            output.receipt.actions.iter().any(|action| {
+                action.path == "PID.3"
+                    && action.action == RedactionAction::Hash
+                    && action.status == RedactionActionStatus::Applied
+            }),
+            "expected canonical PID.3 hash receipt",
+        )?;
+        ensure(
+            output
+                .receipt
+                .actions
+                .iter()
+                .any(|action| action.path == "PID.13" && action.matched_count == 1),
+            "expected canonical PID.13 receipt",
+        )?;
+        ensure(
+            !output
+                .receipt
+                .actions
+                .iter()
+                .any(|action| action.path.contains('-')),
+            "expected canonical receipt paths",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_redacts_only_targeted_segment_repetition()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
+OBX|1|ST|A||Alpha\r\
+OBX|2|ST|B||Beta\r\
+OBX|3|ST|C||Gamma";
+        let policy = r#"
+[[rules]]
+path = "OBX[2]-5"
+action = "hash"
+reason = "Targeted observation redaction"
+"#;
+
+        let output = redact_hl7_safe_analysis(message, policy)?;
+
+        ensure(
+            output.redacted_hl7.contains("Alpha"),
+            "first OBX should be unchanged",
+        )?;
+        ensure(
+            !output.redacted_hl7.contains("Beta"),
+            "second OBX value should be redacted",
+        )?;
+        ensure(
+            output.redacted_hl7.contains("Gamma"),
+            "third OBX should be unchanged",
+        )?;
+        let action = output
+            .receipt
+            .actions
+            .iter()
+            .find(|action| action.path == "OBX[2].5")
+            .ok_or_else(|| std::io::Error::other("expected OBX[2].5 receipt action"))?;
+        ensure(action.matched_count == 1, "expected one OBX[2].5 match")?;
+        ensure(
+            action.status == RedactionActionStatus::Applied,
+            "expected targeted action to apply",
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn redaction_receipt_v2_embeds_tool_provenance() -> Result<(), Box<dyn std::error::Error>> {
         let output = redact_hl7_safe_analysis(safe_analysis_message(), safe_analysis_policy())?;
         let receipt_v2 = output.receipt.to_v2("hl7v2", "1.3.0");
@@ -366,6 +483,31 @@ reason = "Unsafe"
                 .to_string()
                 .contains("redaction rule PID.5 cannot retain a built-in sensitive field"),
             "expected retain-sensitive-field error",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_rejects_retaining_builtin_sensitive_field_alias()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let policy = r#"
+[[rules]]
+path = "PID-5"
+action = "retain"
+reason = "Unsafe"
+"#;
+
+        let Err(error) = load_safe_analysis_policy(policy) else {
+            return Err(std::io::Error::other(
+                "expected retaining a built-in sensitive field alias to fail",
+            )
+            .into());
+        };
+        ensure(
+            error
+                .to_string()
+                .contains("redaction rule PID.5 cannot retain a built-in sensitive field"),
+            "expected canonical retain-sensitive-field error",
         )?;
         Ok(())
     }

--- a/crates/hl7v2/src/redact/basic.rs
+++ b/crates/hl7v2/src/redact/basic.rs
@@ -1,32 +1,37 @@
 use crate::model::{Field, Message, Segment};
 
-use super::path::parse_segment_field_path;
+use super::path::{modeled_field_index, parse_redaction_path};
 use super::types::RedactionConfig;
 
 /// Redact PHI from a message based on configuration.
 pub fn redact(message: &mut Message, config: &RedactionConfig) {
     for path in &config.fields {
-        let Some((segment_id, field_index)) = parse_segment_field_path(path) else {
+        let Ok(parsed_path) = parse_redaction_path(path) else {
             continue;
         };
 
+        let mut segment_match_count = 0_usize;
         for segment in &mut message.segments {
-            if std::str::from_utf8(&segment.id) == Ok(segment_id) {
+            if segment.id_str() != parsed_path.segment_id {
+                continue;
+            }
+            segment_match_count = segment_match_count.saturating_add(1);
+            if let Some(segment_repetition) = parsed_path.segment_repetition
+                && segment_match_count != segment_repetition
+            {
+                continue;
+            }
+            if let Some(field_index) =
+                modeled_field_index(&parsed_path.segment_id, parsed_path.field_index)
+            {
                 redact_field(segment, field_index, &config.replacement);
             }
         }
     }
 }
 
-fn redact_field(segment: &mut Segment, field_index: usize, replacement: &str) {
-    if field_index == 0 {
-        return;
-    }
-
-    let Some(zero_based_index) = field_index.checked_sub(1) else {
-        return;
-    };
-    let Some(field) = segment.fields.get_mut(zero_based_index) else {
+fn redact_field(segment: &mut Segment, modeled_field_index: usize, replacement: &str) {
+    let Some(field) = segment.fields.get_mut(modeled_field_index) else {
         return;
     };
 

--- a/crates/hl7v2/src/redact/path.rs
+++ b/crates/hl7v2/src/redact/path.rs
@@ -1,57 +1,43 @@
 #[derive(Debug)]
 pub(crate) struct ParsedRedactionPath {
     pub(crate) segment_id: String,
+    pub(crate) segment_repetition: Option<usize>,
     pub(crate) field_index: usize,
-}
-
-pub(crate) fn parse_segment_field_path(path: &str) -> Option<(&str, usize)> {
-    let (segment_id, field_part) = path.split_once('.')?;
-    if segment_id.is_empty() || field_part.contains('.') {
-        return None;
-    }
-
-    field_part
-        .parse::<usize>()
-        .ok()
-        .map(|field_index| (segment_id, field_index))
+    pub(crate) canonical_path: String,
 }
 
 pub(crate) fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
-    let (segment_id, field_part) = path
-        .split_once('.')
-        .ok_or_else(|| format!("redaction path '{path}' must use SEG.field syntax"))?;
-    if segment_id.len() != 3
-        || !segment_id
-            .chars()
-            .all(|ch| ch.is_ascii_uppercase() || ch.is_ascii_digit())
-    {
-        return Err(format!(
-            "redaction path '{path}' must start with a three-character uppercase segment id"
-        ));
-    }
-    if field_part.contains('.') {
+    let located = crate::query::path::parse_located_path(path).map_err(|error| {
+        if !path.contains('.') && !path.contains('-') {
+            format!("redaction path '{path}' must use SEG.field or SEG-FIELD syntax")
+        } else {
+            format!("redaction path '{path}' is invalid: {error}")
+        }
+    })?;
+
+    if located.path.component.is_some() || located.path.subcomponent.is_some() {
         return Err(format!(
             "redaction path '{path}' must target a field, not a component"
         ));
     }
-
-    let field_index = field_part.parse::<usize>().map_err(|_err| {
-        format!("redaction path '{path}' must use a positive numeric field index")
-    })?;
-    if field_index == 0 {
+    if located.path.repetition.is_some() {
         return Err(format!(
-            "redaction path '{path}' must use a one-based field index"
+            "redaction path '{path}' must target a field, not a field repetition"
         ));
     }
-    if segment_id == "MSH" && field_index < 3 {
+    if located.path.segment == "MSH" && located.path.field < 3 {
         return Err(format!(
             "redaction path '{path}' targets MSH.1/MSH.2, which are delimiter metadata and not redacted by this command"
         ));
     }
 
+    let canonical_path = located.to_path_string();
+
     Ok(ParsedRedactionPath {
-        segment_id: segment_id.to_string(),
-        field_index,
+        segment_id: located.path.segment,
+        segment_repetition: located.segment_repetition,
+        field_index: located.path.field,
+        canonical_path,
     })
 }
 

--- a/crates/hl7v2/src/redact/policy.rs
+++ b/crates/hl7v2/src/redact/policy.rs
@@ -31,7 +31,7 @@ pub fn redact_message_safe_analysis(
 /// Returns [`RedactionError::Policy`] when TOML parsing fails or the policy is
 /// structurally unsafe.
 pub fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy, RedactionError> {
-    let policy: SafeAnalysisPolicy = toml::from_str(policy_text).map_err(|error| {
+    let mut policy: SafeAnalysisPolicy = toml::from_str(policy_text).map_err(|error| {
         RedactionError::Policy(format!("redaction policy is invalid TOML: {error}"))
     })?;
     if policy.rules.is_empty() {
@@ -42,8 +42,9 @@ pub fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy
 
     let sensitive_paths = safe_analysis_sensitive_paths();
     let mut seen_paths = BTreeSet::new();
-    for rule in &policy.rules {
-        parse_redaction_path(&rule.path).map_err(RedactionError::Policy)?;
+    for rule in &mut policy.rules {
+        let parsed_path = parse_redaction_path(&rule.path).map_err(RedactionError::Policy)?;
+        rule.path = parsed_path.canonical_path;
         if !seen_paths.insert(rule.path.clone()) {
             return Err(RedactionError::Policy(format!(
                 "redaction policy contains duplicate rule for {}",
@@ -80,9 +81,16 @@ fn apply_safe_analysis_policy(
     for rule in &policy.rules {
         let parsed_path = parse_redaction_path(&rule.path).map_err(RedactionError::Policy)?;
         let mut matched_count = 0_usize;
+        let mut segment_match_count = 0_usize;
 
         for segment in &mut message.segments {
             if segment.id_str() != parsed_path.segment_id {
+                continue;
+            }
+            segment_match_count = segment_match_count.saturating_add(1);
+            if let Some(segment_repetition) = parsed_path.segment_repetition
+                && segment_match_count != segment_repetition
+            {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- accept shared located HL7 path syntax in safe-analysis redaction policy parsers for core, CLI, and server surfaces
- canonicalize policy paths before duplicate checks, sensitive-field coverage, receipts, and retain-sensitive-field rejection
- support segment-specific whole-field redaction such as OBX[2]-5 while continuing to reject component and field-repetition redaction
- mark segment-specific redaction actions in field-path trace evidence

## Security surface
- touches PHI redaction policy parsing and fail-closed sensitive-field coverage
- keeps missing sensitive-field policy coverage and retain-sensitive-field denials enforced after path canonicalization
- does not log raw PHI, policy paths, secrets, or source files

## Validation
- PASS: rtk cargo fmt --check
- PASS: rtk cargo clippy -p hl7v2 --all-targets --all-features -- -D warnings
- PASS: rtk cargo clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- PASS: rtk cargo clippy -p hl7v2-server --all-targets --all-features -- -D warnings
- PASS: rtk cargo test -p hl7v2 --all-features
- PASS: rtk cargo test -p hl7v2-cli --test integration_tests redact_command
- PASS: rtk cargo test -p hl7v2-cli --all-features
- PASS: rtk cargo test -p hl7v2-server --test validate_redacted_endpoint_test
- PASS: rtk cargo test -p hl7v2-server --test grpc_contract_tests validate_redacted
- PASS: rtk cargo test -p hl7v2-server --test bundle_endpoint_test
- PASS: rtk cargo test -p hl7v2-server --test replay_endpoint_test
- PASS: rtk cargo test -p hl7v2-server --all-features
- PASS: rtk cargo run -p xtask -- python-local-wheel-proof

Python proof output under target/hl7v2-python-local-wheel-proof was removed after validation.