### PR TITLE
fix: redact addressed HL7 values precisely

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12209",
+  "message": "12357",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/evidence_bundle.rs
+++ b/crates/hl7v2-cli/src/evidence_bundle.rs
@@ -5,7 +5,9 @@
 
 use super::{CliFailure, OutputOptions, RedactFormat, ReportFormat};
 use hl7v2::synthetic::corpus::compute_sha256;
-use hl7v2::{Atom, Field, Message, ValidationReport, load_profile_checked, parse, validate, write};
+use hl7v2::{
+    Atom, Comp, Field, Message, Rep, ValidationReport, load_profile_checked, parse, validate, write,
+};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -1188,19 +1190,11 @@ mod policy {
                     continue;
                 };
 
-                matched_count = matched_count.saturating_add(1);
-                match rule.action {
-                    RedactionAction::Hash => {
-                        let value = field_to_text(field, &message.delims);
-                        *field =
-                            Field::from_text(format!("hash:sha256:{}", compute_sha256(&value)));
+                if apply_redaction_target(field, &parsed_path, rule.action, &message.delims) {
+                    matched_count = matched_count.saturating_add(1);
+                    if rule.action != RedactionAction::Retain {
                         phi_removed = true;
                     }
-                    RedactionAction::Drop => {
-                        *field = Field::new();
-                        phi_removed = true;
-                    }
-                    RedactionAction::Retain => {}
                 }
             }
 
@@ -1291,6 +1285,9 @@ mod policy {
         segment_id: String,
         segment_repetition: Option<usize>,
         field_index: usize,
+        field_repetition: Option<usize>,
+        component: Option<usize>,
+        subcomponent: Option<usize>,
         canonical_path: String,
     }
 
@@ -1303,16 +1300,6 @@ mod policy {
             }
         })?;
 
-        if located.path.component.is_some() || located.path.subcomponent.is_some() {
-            return Err(format!(
-                "redaction path '{path}' must target a field, not a component"
-            ));
-        }
-        if located.path.repetition.is_some() {
-            return Err(format!(
-                "redaction path '{path}' must target a field, not a field repetition"
-            ));
-        }
         if located.path.segment == "MSH" && located.path.field < 3 {
             return Err(format!(
                 "redaction path '{path}' targets MSH.1/MSH.2, which are delimiter metadata and not redacted by this command"
@@ -1325,6 +1312,9 @@ mod policy {
             segment_id: located.path.segment,
             segment_repetition: located.segment_repetition,
             field_index: located.path.field,
+            field_repetition: located.path.repetition,
+            component: located.path.component,
+            subcomponent: located.path.subcomponent,
             canonical_path,
         })
     }
@@ -1357,11 +1347,92 @@ mod policy {
             .any(|field| !field_to_text(field, &message.delims).is_empty())
     }
 
+    fn apply_redaction_target(
+        field: &mut Field,
+        path: &ParsedRedactionPath,
+        action: RedactionAction,
+        delims: &hl7v2::Delims,
+    ) -> bool {
+        let Some(target) = select_target(field, path) else {
+            return false;
+        };
+
+        match action {
+            RedactionAction::Hash => target.hash(delims),
+            RedactionAction::Drop => target.replace_with_text(String::new()),
+            RedactionAction::Retain => {}
+        }
+
+        true
+    }
+
+    enum RedactionTarget<'a> {
+        Field(&'a mut Field),
+        Rep(&'a mut Rep),
+        Comp(&'a mut Comp),
+        Atom(&'a mut Atom),
+    }
+
+    impl RedactionTarget<'_> {
+        fn hash(self, delims: &hl7v2::Delims) {
+            let value = match &self {
+                Self::Field(field) => field_to_text(field, delims),
+                Self::Rep(rep) => rep_to_text(rep, delims),
+                Self::Comp(comp) => comp_to_text(comp, delims),
+                Self::Atom(atom) => atom_to_text(atom).to_string(),
+            };
+            self.replace_with_text(format!("hash:sha256:{}", compute_sha256(&value)));
+        }
+
+        fn replace_with_text(self, replacement: String) {
+            match self {
+                Self::Field(field) => {
+                    *field = Field::from_text(replacement);
+                }
+                Self::Rep(rep) => {
+                    *rep = Rep::from_text(replacement);
+                }
+                Self::Comp(comp) => {
+                    *comp = Comp::from_text(replacement);
+                }
+                Self::Atom(atom) => {
+                    *atom = Atom::Text(replacement);
+                }
+            }
+        }
+    }
+
+    fn select_target<'a>(
+        field: &'a mut Field,
+        path: &ParsedRedactionPath,
+    ) -> Option<RedactionTarget<'a>> {
+        if path.field_repetition.is_none() && path.component.is_none() {
+            return Some(RedactionTarget::Field(field));
+        }
+
+        let rep_index = path.field_repetition.unwrap_or(1).checked_sub(1)?;
+        let rep = field.reps.get_mut(rep_index)?;
+        let Some(component) = path.component else {
+            return Some(RedactionTarget::Rep(rep));
+        };
+
+        let component_index = component.checked_sub(1)?;
+        let comp = rep.comps.get_mut(component_index)?;
+        let Some(subcomponent) = path.subcomponent else {
+            return Some(RedactionTarget::Comp(comp));
+        };
+
+        let subcomponent_index = subcomponent.checked_sub(1)?;
+        comp.subs
+            .get_mut(subcomponent_index)
+            .map(RedactionTarget::Atom)
+    }
+
     pub(super) fn build_field_path_trace(
         message: &Message,
         receipt: &RedactionReceipt,
     ) -> FieldPathTraceReport {
-        let redaction_actions: BTreeMap<&str, RedactionAction> = receipt
+        let redaction_actions: Vec<(&str, RedactionAction)> = receipt
             .actions
             .iter()
             .map(|action| (action.path.as_str(), action.action))
@@ -1395,10 +1466,11 @@ mod policy {
                     field_index,
                     present: !field_text.is_empty(),
                     value_shape: field_value_shape(&field_text),
-                    redaction_action: redaction_actions
-                        .get(occurrence_path.as_str())
-                        .or_else(|| redaction_actions.get(canonical_path.as_str()))
-                        .copied(),
+                    redaction_action: redaction_action_for_field(
+                        &redaction_actions,
+                        &occurrence_path,
+                        &canonical_path,
+                    ),
                 });
             }
         }
@@ -1408,6 +1480,28 @@ mod policy {
             field_count: fields.len(),
             fields,
         }
+    }
+
+    fn redaction_action_for_field(
+        actions: &[(&str, RedactionAction)],
+        occurrence_path: &str,
+        canonical_path: &str,
+    ) -> Option<RedactionAction> {
+        actions.iter().find_map(|(action_path, action)| {
+            (path_targets_field(action_path, occurrence_path)
+                || path_targets_field(action_path, canonical_path))
+            .then_some(*action)
+        })
+    }
+
+    fn path_targets_field(action_path: &str, field_path: &str) -> bool {
+        if action_path == field_path {
+            return true;
+        }
+
+        action_path
+            .strip_prefix(field_path)
+            .is_some_and(|suffix| suffix.starts_with('.') || suffix.starts_with('['))
     }
 
     fn hl7_field_index(segment_id: &str, modeled_index: usize) -> usize {
@@ -1440,23 +1534,31 @@ mod policy {
         field
             .reps
             .iter()
-            .map(|rep| {
-                rep.comps
-                    .iter()
-                    .map(|comp| {
-                        comp.subs
-                            .iter()
-                            .map(|atom| match atom {
-                                Atom::Text(text) => text.as_str(),
-                                Atom::Null => "\"\"",
-                            })
-                            .collect::<Vec<_>>()
-                            .join(&delims.sub.to_string())
-                    })
-                    .collect::<Vec<_>>()
-                    .join(&delims.comp.to_string())
-            })
+            .map(|rep| rep_to_text(rep, delims))
             .collect::<Vec<_>>()
             .join(&delims.rep.to_string())
+    }
+
+    fn rep_to_text(rep: &Rep, delims: &hl7v2::Delims) -> String {
+        rep.comps
+            .iter()
+            .map(|comp| comp_to_text(comp, delims))
+            .collect::<Vec<_>>()
+            .join(&delims.comp.to_string())
+    }
+
+    fn comp_to_text(comp: &Comp, delims: &hl7v2::Delims) -> String {
+        comp.subs
+            .iter()
+            .map(atom_to_text)
+            .collect::<Vec<_>>()
+            .join(&delims.sub.to_string())
+    }
+
+    fn atom_to_text(atom: &Atom) -> &str {
+        match atom {
+            Atom::Text(text) => text.as_str(),
+            Atom::Null => "\"\"",
+        }
     }
 }

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2472,6 +2472,53 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
     }
 
     #[test]
+    fn test_redact_json_redacts_component_without_dropping_neighbor_components() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(
+            &dir,
+            "component-message.hl7",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ORU^R01|CTRL123|P|2.5\rOBX|1|XPN|PATIENT_NAME||Doe^Jane^A\r",
+        );
+        let policy = r#"
+[[rules]]
+path = "OBX-5.1"
+action = "drop"
+reason = "Remove family name"
+"#;
+        let policy_file = create_temp_file(&dir, "component-policy.toml", policy.as_bytes());
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message_file.to_str().unwrap(),
+                "--policy",
+                policy_file.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute redact");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains("Doe^Jane^A"));
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("redact output should be JSON");
+        assert!(
+            report["redacted_hl7"]
+                .as_str()
+                .is_some_and(|hl7| hl7.contains("OBX|1|XPN|PATIENT_NAME||^Jane^A"))
+        );
+        assert!(report["receipt"]["actions"].as_array().unwrap().iter().any(
+            |action| action["path"] == "OBX.5.1"
+                && action["action"] == "drop"
+                && action["matched_count"] == 1
+                && action["status"] == "applied"
+        ));
+    }
+
+    #[test]
     fn test_redact_json_schema_v2_returns_provenance_output_without_raw_phi() {
         let dir = create_temp_dir();
         let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
@@ -2618,9 +2665,9 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
             "bad-policy.toml",
             br#"
 [[rules]]
-path = "PID.5.1"
+path = "PID.5.1.1.1"
 action = "drop"
-reason = "component targeting is not supported by this policy"
+reason = "malformed path"
 "#,
         );
 
@@ -2633,7 +2680,7 @@ reason = "component targeting is not supported by this policy"
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("must target a field"));
+        .stderr(predicate::str::contains("invalid"));
     }
 
     #[test]
@@ -3089,6 +3136,84 @@ reason = "non-PHI synthetic observation value shape is needed for analysis"
         assert_eq!(report["output_dir"], ".");
         assert_eq!(report["message_type"], "ADT^A01");
         assert_eq!(report["validation_valid"], true);
+    }
+
+    #[test]
+    fn test_bundle_marks_component_redaction_on_parent_field_trace() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(
+            &dir,
+            "component-message.hl7",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ORU^R01|CTRL123|P|2.5\rOBX|1|XPN|PATIENT_NAME||Doe^Jane^A\r",
+        );
+        let profile_file = create_temp_file(
+            &dir,
+            "profile.yaml",
+            br#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "OBX"
+constraints:
+  - path: "OBX-5.2"
+    required: true
+"#,
+        );
+        let policy_file = create_temp_file(
+            &dir,
+            "component-policy.toml",
+            br#"
+[[rules]]
+path = "OBX-5.1"
+action = "drop"
+reason = "Remove family name"
+"#,
+        );
+        let bundle_dir = dir.path().join("component-bundle");
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "bundle",
+            message_file.to_str().unwrap(),
+            "--profile",
+            profile_file.to_str().unwrap(),
+            "--redact-policy",
+            policy_file.to_str().unwrap(),
+            "--out",
+            bundle_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+        let redacted_message =
+            std::fs::read_to_string(bundle_dir.join("message.redacted.hl7")).unwrap();
+        assert!(redacted_message.contains("OBX|1|XPN|PATIENT_NAME||^Jane^A"));
+        assert!(!redacted_message.contains("Doe^Jane^A"));
+
+        let field_paths: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("field-paths.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(field_paths["fields"].as_array().unwrap().iter().any(
+            |field| field["canonical_path"] == "OBX.5"
+                && field["redaction_action"] == "drop"
+                && field["value_shape"] == "present"
+        ));
+
+        let receipt: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("redaction-receipt.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(
+            receipt["actions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|action| action["path"] == "OBX.5.1"
+                    && action["action"] == "drop"
+                    && action["matched_count"] == 1)
+        );
     }
 
     #[test]

--- a/crates/hl7v2-server/src/evidence.rs
+++ b/crates/hl7v2-server/src/evidence.rs
@@ -5,7 +5,7 @@ use crate::models::{
     EvidenceBundleSummary, FieldPathTrace, FieldPathTraceReport, FieldValueShape, QuarantineConfig,
     QuarantineOutputSummary, QuarantineReason, RedactionAction, RedactionReceipt,
 };
-use hl7v2::{Atom, Field, Message, ValidationReport};
+use hl7v2::{Atom, Comp, Field, Message, Rep, ValidationReport};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt;
@@ -388,7 +388,7 @@ fn bundle_manifest_artifact(
 }
 
 fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> FieldPathTraceReport {
-    let redaction_actions: BTreeMap<&str, RedactionAction> = receipt
+    let redaction_actions: Vec<(&str, RedactionAction)> = receipt
         .actions
         .iter()
         .map(|action| (action.path.as_str(), action.action))
@@ -422,10 +422,11 @@ fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> Fiel
                 field_index,
                 present: !field_text.is_empty(),
                 value_shape: field_value_shape(&field_text),
-                redaction_action: redaction_actions
-                    .get(occurrence_path.as_str())
-                    .or_else(|| redaction_actions.get(canonical_path.as_str()))
-                    .copied(),
+                redaction_action: redaction_action_for_field(
+                    &redaction_actions,
+                    &occurrence_path,
+                    &canonical_path,
+                ),
             });
         }
     }
@@ -435,6 +436,28 @@ fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> Fiel
         field_count: fields.len(),
         fields,
     }
+}
+
+fn redaction_action_for_field(
+    actions: &[(&str, RedactionAction)],
+    occurrence_path: &str,
+    canonical_path: &str,
+) -> Option<RedactionAction> {
+    actions.iter().find_map(|(action_path, action)| {
+        (path_targets_field(action_path, occurrence_path)
+            || path_targets_field(action_path, canonical_path))
+        .then_some(*action)
+    })
+}
+
+fn path_targets_field(action_path: &str, field_path: &str) -> bool {
+    if action_path == field_path {
+        return true;
+    }
+
+    action_path
+        .strip_prefix(field_path)
+        .is_some_and(|suffix| suffix.starts_with('.') || suffix.starts_with('['))
 }
 
 fn message_type(message: &Message) -> String {
@@ -482,24 +505,32 @@ fn field_to_text(field: &Field, delims: &hl7v2::Delims) -> String {
     field
         .reps
         .iter()
-        .map(|rep| {
-            rep.comps
-                .iter()
-                .map(|comp| {
-                    comp.subs
-                        .iter()
-                        .map(|atom| match atom {
-                            Atom::Text(text) => text.as_str(),
-                            Atom::Null => "\"\"",
-                        })
-                        .collect::<Vec<_>>()
-                        .join(&delims.sub.to_string())
-                })
-                .collect::<Vec<_>>()
-                .join(&delims.comp.to_string())
-        })
+        .map(|rep| rep_to_text(rep, delims))
         .collect::<Vec<_>>()
         .join(&delims.rep.to_string())
+}
+
+fn rep_to_text(rep: &Rep, delims: &hl7v2::Delims) -> String {
+    rep.comps
+        .iter()
+        .map(|comp| comp_to_text(comp, delims))
+        .collect::<Vec<_>>()
+        .join(&delims.comp.to_string())
+}
+
+fn comp_to_text(comp: &Comp, delims: &hl7v2::Delims) -> String {
+    comp.subs
+        .iter()
+        .map(atom_to_text)
+        .collect::<Vec<_>>()
+        .join(&delims.sub.to_string())
+}
+
+fn atom_to_text(atom: &Atom) -> &str {
+    match atom {
+        Atom::Text(text) => text.as_str(),
+        Atom::Null => "\"\"",
+    }
 }
 
 fn compute_sha256(value: &str) -> String {

--- a/crates/hl7v2-server/src/redaction.rs
+++ b/crates/hl7v2-server/src/redaction.rs
@@ -3,7 +3,7 @@
 use crate::models::{
     RedactionAction, RedactionActionReceipt, RedactionActionStatus, RedactionReceipt,
 };
-use hl7v2::{Atom, Field, Message};
+use hl7v2::{Atom, Comp, Field, Message, Rep};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
@@ -27,6 +27,9 @@ struct ParsedRedactionPath {
     segment_id: String,
     segment_repetition: Option<usize>,
     field_index: usize,
+    field_repetition: Option<usize>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
     canonical_path: String,
 }
 
@@ -110,18 +113,11 @@ fn apply_safe_analysis_policy(
                 continue;
             };
 
-            matched_count = matched_count.saturating_add(1);
-            match rule.action {
-                RedactionAction::Hash => {
-                    let value = field_to_text(field, &message.delims);
-                    *field = Field::from_text(format!("hash:sha256:{}", compute_sha256(&value)));
+            if apply_redaction_target(field, &parsed_path, rule.action, &message.delims) {
+                matched_count = matched_count.saturating_add(1);
+                if rule.action != RedactionAction::Retain {
                     phi_removed = true;
                 }
-                RedactionAction::Drop => {
-                    *field = Field::new();
-                    phi_removed = true;
-                }
-                RedactionAction::Retain => {}
             }
         }
 
@@ -216,16 +212,6 @@ fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
         }
     })?;
 
-    if located.path.component.is_some() || located.path.subcomponent.is_some() {
-        return Err(format!(
-            "redaction path '{path}' must target a field, not a component"
-        ));
-    }
-    if located.path.repetition.is_some() {
-        return Err(format!(
-            "redaction path '{path}' must target a field, not a field repetition"
-        ));
-    }
     if located.path.segment == "MSH" && located.path.field < 3 {
         return Err(format!(
             "redaction path '{path}' targets MSH.1/MSH.2, which are delimiter metadata and not redacted by this command"
@@ -238,6 +224,9 @@ fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
         segment_id: located.path.segment,
         segment_repetition: located.segment_repetition,
         field_index: located.path.field,
+        field_repetition: located.path.repetition,
+        component: located.path.component,
+        subcomponent: located.path.subcomponent,
         canonical_path,
     })
 }
@@ -255,6 +244,87 @@ fn message_has_nonempty_field(message: &Message, segment_id: &str, field_index: 
         .any(|field| !field_to_text(field, &message.delims).is_empty())
 }
 
+fn apply_redaction_target(
+    field: &mut Field,
+    path: &ParsedRedactionPath,
+    action: RedactionAction,
+    delims: &hl7v2::Delims,
+) -> bool {
+    let Some(target) = select_target(field, path) else {
+        return false;
+    };
+
+    match action {
+        RedactionAction::Hash => target.hash(delims),
+        RedactionAction::Drop => target.replace_with_text(String::new()),
+        RedactionAction::Retain => {}
+    }
+
+    true
+}
+
+enum RedactionTarget<'a> {
+    Field(&'a mut Field),
+    Rep(&'a mut Rep),
+    Comp(&'a mut Comp),
+    Atom(&'a mut Atom),
+}
+
+impl RedactionTarget<'_> {
+    fn hash(self, delims: &hl7v2::Delims) {
+        let value = match &self {
+            Self::Field(field) => field_to_text(field, delims),
+            Self::Rep(rep) => rep_to_text(rep, delims),
+            Self::Comp(comp) => comp_to_text(comp, delims),
+            Self::Atom(atom) => atom_to_text(atom).to_string(),
+        };
+        self.replace_with_text(format!("hash:sha256:{}", compute_sha256(&value)));
+    }
+
+    fn replace_with_text(self, replacement: String) {
+        match self {
+            Self::Field(field) => {
+                *field = Field::from_text(replacement);
+            }
+            Self::Rep(rep) => {
+                *rep = Rep::from_text(replacement);
+            }
+            Self::Comp(comp) => {
+                *comp = Comp::from_text(replacement);
+            }
+            Self::Atom(atom) => {
+                *atom = Atom::Text(replacement);
+            }
+        }
+    }
+}
+
+fn select_target<'a>(
+    field: &'a mut Field,
+    path: &ParsedRedactionPath,
+) -> Option<RedactionTarget<'a>> {
+    if path.field_repetition.is_none() && path.component.is_none() {
+        return Some(RedactionTarget::Field(field));
+    }
+
+    let rep_index = path.field_repetition.unwrap_or(1).checked_sub(1)?;
+    let rep = field.reps.get_mut(rep_index)?;
+    let Some(component) = path.component else {
+        return Some(RedactionTarget::Rep(rep));
+    };
+
+    let component_index = component.checked_sub(1)?;
+    let comp = rep.comps.get_mut(component_index)?;
+    let Some(subcomponent) = path.subcomponent else {
+        return Some(RedactionTarget::Comp(comp));
+    };
+
+    let subcomponent_index = subcomponent.checked_sub(1)?;
+    comp.subs
+        .get_mut(subcomponent_index)
+        .map(RedactionTarget::Atom)
+}
+
 fn modeled_field_index(segment_id: &str, field_index: usize) -> Option<usize> {
     if segment_id == "MSH" {
         field_index.checked_sub(2)
@@ -267,24 +337,32 @@ fn field_to_text(field: &Field, delims: &hl7v2::Delims) -> String {
     field
         .reps
         .iter()
-        .map(|rep| {
-            rep.comps
-                .iter()
-                .map(|comp| {
-                    comp.subs
-                        .iter()
-                        .map(|atom| match atom {
-                            Atom::Text(text) => text.as_str(),
-                            Atom::Null => "\"\"",
-                        })
-                        .collect::<Vec<_>>()
-                        .join(&delims.sub.to_string())
-                })
-                .collect::<Vec<_>>()
-                .join(&delims.comp.to_string())
-        })
+        .map(|rep| rep_to_text(rep, delims))
         .collect::<Vec<_>>()
         .join(&delims.rep.to_string())
+}
+
+fn rep_to_text(rep: &Rep, delims: &hl7v2::Delims) -> String {
+    rep.comps
+        .iter()
+        .map(|comp| comp_to_text(comp, delims))
+        .collect::<Vec<_>>()
+        .join(&delims.comp.to_string())
+}
+
+fn comp_to_text(comp: &Comp, delims: &hl7v2::Delims) -> String {
+    comp.subs
+        .iter()
+        .map(atom_to_text)
+        .collect::<Vec<_>>()
+        .join(&delims.sub.to_string())
+}
+
+fn atom_to_text(atom: &Atom) -> &str {
+    match atom {
+        Atom::Text(text) => text.as_str(),
+        Atom::Null => "\"\"",
+    }
 }
 
 fn compute_sha256(value: &str) -> String {

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -1053,6 +1053,64 @@ unknown_top_level: "ignored"
     }
 
     #[tokio::test]
+    async fn test_grpc_validate_redacted_redacts_component_without_dropping_neighbor_components() {
+        let service = service();
+        let profile = r#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "OBX"
+    required: true
+constraints:
+  - path: "OBX-5.2"
+    required: true
+"#;
+        let policy = r#"
+[[rules]]
+path = "OBX-5.1"
+action = "drop"
+reason = "Remove family name"
+"#;
+        let request = Request::new(ValidateRedactedRequest {
+            message: b"MSH|^~\\&|LAB|L|EHR|E|202605030101||ORU^R01|CTRL123|P|2.5\rOBX|1|XPN|PATIENT_NAME||Doe^Jane^A\r".to_vec(),
+            profile: profile.to_string(),
+            redaction_policy: policy.to_string(),
+            mllp_framed: false,
+            include_redacted_hl7: true,
+            report_schema_version: 0,
+            redaction_receipt_schema_version: 0,
+            quarantine_schema_version: 0,
+        });
+
+        let response = service
+            .validate_redacted(request)
+            .await
+            .expect("RPC should succeed");
+        let inner = response.into_inner();
+        let report = inner
+            .validation_report
+            .expect("Validation report should exist");
+        let receipt = inner
+            .redaction_receipt
+            .expect("Redaction receipt should exist");
+        let redacted_hl7 =
+            String::from_utf8(inner.redacted_hl7.expect("Redacted HL7 should be included"))
+                .expect("Redacted HL7 should be UTF-8");
+
+        assert!(report.valid);
+        assert!(redacted_hl7.contains("OBX|1|XPN|PATIENT_NAME||^Jane^A"));
+        assert!(!redacted_hl7.contains("Doe^Jane^A"));
+        assert!(receipt.actions.iter().any(|action| {
+            action.path == "OBX.5.1"
+                && action.action == "drop"
+                && action.matched_count == 1
+                && action.status == "applied"
+        }));
+    }
+
+    #[tokio::test]
     async fn test_grpc_validate_redacted_omits_redacted_hl7_unless_requested() {
         let service = service();
         let request = Request::new(ValidateRedactedRequest {

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -235,6 +235,58 @@ async fn test_validate_redacted_accepts_diagnostic_policy_paths_with_canonical_r
 }
 
 #[tokio::test]
+async fn test_validate_redacted_redacts_component_without_dropping_neighbor_components() {
+    let app = common::create_test_router();
+    let profile = r#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "OBX"
+    required: true
+constraints:
+  - path: "OBX-5.2"
+    required: true
+"#;
+    let policy = r#"
+[[rules]]
+path = "OBX-5.1"
+action = "drop"
+reason = "Remove family name"
+"#;
+    let request_body = json!({
+        "message": "MSH|^~\\&|LAB|L|EHR|E|202605030101||ORU^R01|CTRL123|P|2.5\rOBX|1|XPN|PATIENT_NAME||Doe^Jane^A\r",
+        "profile": profile,
+        "redaction_policy": policy,
+        "include_redacted_hl7": true
+    });
+
+    let response = app
+        .oneshot(validate_redacted_request(request_body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    let redacted_hl7 = body_json["redacted_hl7"].as_str().unwrap();
+    let actions = body_json["redaction_receipt"]["actions"]
+        .as_array()
+        .unwrap();
+
+    assert!(redacted_hl7.contains("OBX|1|XPN|PATIENT_NAME||^Jane^A"));
+    assert!(!redacted_hl7.contains("Doe^Jane^A"));
+    assert!(actions.iter().any(|action| {
+        action["path"] == "OBX.5.1"
+            && action["action"] == "drop"
+            && action["matched_count"] == 1
+            && action["status"] == "applied"
+    }));
+    assert_eq!(body_json["validation_report"]["valid"], true);
+}
+
+#[tokio::test]
 async fn test_validate_redacted_rejects_unsupported_receipt_schema_version() {
     let app = common::create_test_router();
     let request_body = json!({

--- a/crates/hl7v2/src/evidence.rs
+++ b/crates/hl7v2/src/evidence.rs
@@ -328,6 +328,86 @@ reason = "Targeted observation redaction"
     }
 
     #[test]
+    fn bundle_field_trace_marks_component_redaction_on_parent_field()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let bundle_dir = temp.path().join("component-redaction-bundle");
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
+OBX|1|XPN|PATIENT_NAME||Doe^Jane^A";
+        let profile = r#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "OBX"
+constraints:
+  - path: "OBX-5.2"
+    required: true
+"#;
+        let policy = r#"
+[[rules]]
+path = "OBX-5.1"
+action = "drop"
+reason = "Remove family name"
+"#;
+
+        write_safe_analysis_bundle(message, profile, policy, &bundle_dir, "hl7v2-python")?;
+
+        let receipt = read_bundle_json_value(&bundle_dir, "redaction-receipt.json")?;
+        let actions = receipt
+            .get("actions")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| std::io::Error::other("redaction receipt should contain actions"))?;
+        ensure(
+            actions.iter().any(|action| {
+                action.get("path").and_then(serde_json::Value::as_str) == Some("OBX.5.1")
+                    && action
+                        .get("matched_count")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(1)
+            }),
+            "expected canonical component redaction receipt",
+        )?;
+
+        let redacted_hl7 = std::fs::read_to_string(bundle_dir.join("message.redacted.hl7"))?;
+        ensure(
+            redacted_hl7.contains("OBX|1|XPN|PATIENT_NAME||^Jane^A"),
+            "expected only OBX-5.1 to be cleared",
+        )?;
+
+        let trace = read_bundle_json_value(&bundle_dir, "field-paths.json")?;
+        let fields = trace
+            .get("fields")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| std::io::Error::other("field trace should contain fields"))?;
+        let redacted_field = fields
+            .iter()
+            .find(|field| {
+                field
+                    .get("canonical_path")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("OBX.5")
+            })
+            .ok_or_else(|| std::io::Error::other("expected OBX.5 field trace"))?;
+        ensure(
+            redacted_field
+                .get("redaction_action")
+                .and_then(serde_json::Value::as_str)
+                == Some("drop"),
+            "expected parent field trace to show component drop action",
+        )?;
+        ensure(
+            redacted_field
+                .get("value_shape")
+                .and_then(serde_json::Value::as_str)
+                == Some("present"),
+            "expected sibling components to keep field present",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
     fn replay_accepts_legacy_bundle_without_safe_sharing_checklist()
     -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;

--- a/crates/hl7v2/src/evidence/trace.rs
+++ b/crates/hl7v2/src/evidence/trace.rs
@@ -7,7 +7,7 @@ pub(crate) fn build_field_path_trace(
     message: &Message,
     receipt: &RedactionReceipt,
 ) -> FieldPathTraceReport {
-    let redaction_actions: BTreeMap<&str, RedactionAction> = receipt
+    let redaction_actions: Vec<(&str, RedactionAction)> = receipt
         .actions
         .iter()
         .map(|action| (action.path.as_str(), action.action))
@@ -41,10 +41,11 @@ pub(crate) fn build_field_path_trace(
                 field_index,
                 present: !field_text.is_empty(),
                 value_shape: field_value_shape(&field_text),
-                redaction_action: redaction_actions
-                    .get(occurrence_path.as_str())
-                    .or_else(|| redaction_actions.get(canonical_path.as_str()))
-                    .copied(),
+                redaction_action: redaction_action_for_field(
+                    &redaction_actions,
+                    &occurrence_path,
+                    &canonical_path,
+                ),
             });
         }
     }
@@ -54,6 +55,28 @@ pub(crate) fn build_field_path_trace(
         field_count: fields.len(),
         fields,
     }
+}
+
+fn redaction_action_for_field(
+    actions: &[(&str, RedactionAction)],
+    occurrence_path: &str,
+    canonical_path: &str,
+) -> Option<RedactionAction> {
+    actions.iter().find_map(|(action_path, action)| {
+        (path_targets_field(action_path, occurrence_path)
+            || path_targets_field(action_path, canonical_path))
+        .then_some(*action)
+    })
+}
+
+fn path_targets_field(action_path: &str, field_path: &str) -> bool {
+    if action_path == field_path {
+        return true;
+    }
+
+    action_path
+        .strip_prefix(field_path)
+        .is_some_and(|suffix| suffix.starts_with('.') || suffix.starts_with('['))
 }
 
 fn message_type(message: &Message) -> String {

--- a/crates/hl7v2/src/redact.rs
+++ b/crates/hl7v2/src/redact.rs
@@ -9,6 +9,7 @@ mod digest;
 mod path;
 mod policy;
 mod safe_analysis;
+mod target;
 mod text;
 mod types;
 
@@ -90,6 +91,33 @@ mod tests {
     }
 
     #[test]
+    fn redacts_configured_component_without_replacing_whole_field()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut message = crate::parse(
+            b"MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ADT^A01|CTRL1|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John",
+        )?;
+        let config = RedactionConfig {
+            replacement: "XXX".to_string(),
+            fields: vec!["PID-5.1".to_string()],
+        };
+
+        redact(&mut message, &config);
+
+        let redacted_value = message
+            .segments
+            .iter()
+            .find(|segment| segment.id == *b"PID")
+            .and_then(|segment| segment.fields.get(4))
+            .map(|field| super::text::field_to_text(field, &message.delims));
+
+        ensure(
+            redacted_value.as_deref() == Some("XXX^John"),
+            "expected only PID-5.1 to be replaced",
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn hipaa_defaults_include_expected_fields() {
         let config = RedactionConfig::hipaa_defaults();
 
@@ -107,7 +135,6 @@ mod tests {
             fields: vec![
                 "PID".to_string(),
                 ".5".to_string(),
-                "PID.5.1".to_string(),
                 "PID.name".to_string(),
                 "PID.0".to_string(),
                 "PID.99".to_string(),
@@ -353,6 +380,159 @@ reason = "Targeted observation redaction"
         ensure(
             action.status == RedactionActionStatus::Applied,
             "expected targeted action to apply",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_redacts_only_targeted_field_repetition()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
+OBX|1|ST|A||Alpha~Beta~Gamma";
+        let policy = r#"
+[[rules]]
+path = "OBX-5[2]"
+action = "drop"
+reason = "Remove alternate observation value"
+"#;
+
+        let output = redact_hl7_safe_analysis(message, policy)?;
+
+        ensure(
+            output.redacted_hl7.contains("OBX|1|ST|A||Alpha~~Gamma"),
+            "expected only OBX-5 repetition 2 to be cleared",
+        )?;
+        ensure(
+            !output.redacted_hl7.contains("Beta"),
+            "redacted HL7 leaked targeted repetition",
+        )?;
+        ensure(
+            output
+                .receipt
+                .actions
+                .iter()
+                .any(|action| action.path == "OBX.5[2]" && action.matched_count == 1),
+            "expected canonical field-repetition receipt",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_redacts_component_without_dropping_neighbor_components()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
+OBX|1|XPN|PATIENT_NAME||Doe^Jane^A";
+        let policy = r#"
+[[rules]]
+path = "OBX-5.1"
+action = "drop"
+reason = "Remove family name"
+"#;
+
+        let output = redact_hl7_safe_analysis(message, policy)?;
+
+        ensure(
+            output
+                .redacted_hl7
+                .contains("OBX|1|XPN|PATIENT_NAME||^Jane^A"),
+            "expected only OBX-5.1 to be cleared",
+        )?;
+        ensure(
+            !output.redacted_hl7.contains("Doe"),
+            "redacted HL7 leaked component value",
+        )?;
+        let action = output
+            .receipt
+            .actions
+            .iter()
+            .find(|action| action.path == "OBX.5.1")
+            .ok_or_else(|| std::io::Error::other("expected OBX.5.1 receipt action"))?;
+        ensure(action.matched_count == 1, "expected one component match")?;
+        ensure(
+            action.status == RedactionActionStatus::Applied,
+            "expected component action to apply",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_hashes_subcomponent_without_dropping_sibling_subcomponents()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
+OBX|1|CX|ALT_ID||ABC&Issuer&MR";
+        let policy = r#"
+[[rules]]
+path = "OBX-5.1.1"
+action = "hash"
+reason = "Hash alternate identifier"
+"#;
+
+        let output = redact_hl7_safe_analysis(message, policy)?;
+
+        ensure(
+            output.redacted_hl7.contains("hash:sha256:"),
+            "expected hashed subcomponent marker",
+        )?;
+        ensure(
+            output.redacted_hl7.contains("&Issuer&MR"),
+            "expected sibling subcomponents to remain",
+        )?;
+        ensure(
+            !output.redacted_hl7.contains("ABC&Issuer&MR"),
+            "redacted HL7 leaked original subcomponent tuple",
+        )?;
+        ensure(
+            output
+                .receipt
+                .actions
+                .iter()
+                .any(|action| action.path == "OBX.5.1.1" && action.matched_count == 1),
+            "expected canonical subcomponent receipt",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_component_rule_does_not_cover_builtin_sensitive_field()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let policy = r#"
+[[rules]]
+path = "PID.3"
+action = "hash"
+reason = "Patient identifier"
+
+[[rules]]
+path = "PID.5.1"
+action = "drop"
+reason = "Only family name"
+
+[[rules]]
+path = "PID.7"
+action = "drop"
+reason = "Date of birth"
+
+[[rules]]
+path = "PID.11"
+action = "drop"
+reason = "Address"
+
+[[rules]]
+path = "PID.13"
+action = "drop"
+reason = "Phone"
+"#;
+
+        let Err(error) = redact_hl7_safe_analysis(safe_analysis_message(), policy) else {
+            return Err(std::io::Error::other(
+                "expected partial built-in sensitive-field coverage to fail",
+            )
+            .into());
+        };
+        ensure(
+            error
+                .to_string()
+                .contains("redaction policy does not protect present sensitive field(s): PID.5"),
+            "expected PID.5 coverage error",
         )?;
         Ok(())
     }

--- a/crates/hl7v2/src/redact/basic.rs
+++ b/crates/hl7v2/src/redact/basic.rs
@@ -1,6 +1,7 @@
-use crate::model::{Field, Message, Segment};
+use crate::model::Message;
 
 use super::path::{modeled_field_index, parse_redaction_path};
+use super::target::replace_redaction_target;
 use super::types::RedactionConfig;
 
 /// Redact PHI from a message based on configuration.
@@ -23,17 +24,10 @@ pub fn redact(message: &mut Message, config: &RedactionConfig) {
             }
             if let Some(field_index) =
                 modeled_field_index(&parsed_path.segment_id, parsed_path.field_index)
+                && let Some(field) = segment.fields.get_mut(field_index)
             {
-                redact_field(segment, field_index, &config.replacement);
+                replace_redaction_target(field, &parsed_path, &config.replacement);
             }
         }
     }
-}
-
-fn redact_field(segment: &mut Segment, modeled_field_index: usize, replacement: &str) {
-    let Some(field) = segment.fields.get_mut(modeled_field_index) else {
-        return;
-    };
-
-    *field = Field::from_text(replacement);
 }

--- a/crates/hl7v2/src/redact/path.rs
+++ b/crates/hl7v2/src/redact/path.rs
@@ -3,6 +3,9 @@ pub(crate) struct ParsedRedactionPath {
     pub(crate) segment_id: String,
     pub(crate) segment_repetition: Option<usize>,
     pub(crate) field_index: usize,
+    pub(crate) field_repetition: Option<usize>,
+    pub(crate) component: Option<usize>,
+    pub(crate) subcomponent: Option<usize>,
     pub(crate) canonical_path: String,
 }
 
@@ -15,16 +18,6 @@ pub(crate) fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, St
         }
     })?;
 
-    if located.path.component.is_some() || located.path.subcomponent.is_some() {
-        return Err(format!(
-            "redaction path '{path}' must target a field, not a component"
-        ));
-    }
-    if located.path.repetition.is_some() {
-        return Err(format!(
-            "redaction path '{path}' must target a field, not a field repetition"
-        ));
-    }
     if located.path.segment == "MSH" && located.path.field < 3 {
         return Err(format!(
             "redaction path '{path}' targets MSH.1/MSH.2, which are delimiter metadata and not redacted by this command"
@@ -37,6 +30,9 @@ pub(crate) fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, St
         segment_id: located.path.segment,
         segment_repetition: located.segment_repetition,
         field_index: located.path.field,
+        field_repetition: located.path.repetition,
+        component: located.path.component,
+        subcomponent: located.path.subcomponent,
         canonical_path,
     })
 }

--- a/crates/hl7v2/src/redact/policy.rs
+++ b/crates/hl7v2/src/redact/policy.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeSet;
 
-use crate::model::{Field, Message};
+use crate::model::Message;
 
-use super::digest::compute_sha256;
 use super::path::{modeled_field_index, parse_redaction_path};
+use super::target::apply_redaction_target;
 use super::text::field_to_text;
 use super::types::{
     RedactionAction, RedactionActionReceipt, RedactionActionStatus, RedactionError,
@@ -103,18 +103,11 @@ fn apply_safe_analysis_policy(
                 continue;
             };
 
-            matched_count = matched_count.saturating_add(1);
-            match rule.action {
-                RedactionAction::Hash => {
-                    let value = field_to_text(field, &message.delims);
-                    *field = Field::from_text(format!("hash:sha256:{}", compute_sha256(&value)));
+            if apply_redaction_target(field, &parsed_path, rule.action, &message.delims) {
+                matched_count = matched_count.saturating_add(1);
+                if rule.action != RedactionAction::Retain {
                     phi_removed = true;
                 }
-                RedactionAction::Drop => {
-                    *field = Field::new();
-                    phi_removed = true;
-                }
-                RedactionAction::Retain => {}
             }
         }
 

--- a/crates/hl7v2/src/redact/target.rs
+++ b/crates/hl7v2/src/redact/target.rs
@@ -1,0 +1,104 @@
+use crate::model::{Atom, Comp, Field, Rep};
+
+use super::digest::compute_sha256;
+use super::path::ParsedRedactionPath;
+use super::text::{atom_to_text, comp_to_text, field_to_text, rep_to_text};
+use super::types::RedactionAction;
+
+pub(crate) fn apply_redaction_target(
+    field: &mut Field,
+    path: &ParsedRedactionPath,
+    action: RedactionAction,
+    delims: &crate::Delims,
+) -> bool {
+    let Some(target) = select_target(field, path) else {
+        return false;
+    };
+
+    match action {
+        RedactionAction::Hash => target.hash(delims),
+        RedactionAction::Drop => target.drop_value(),
+        RedactionAction::Retain => {}
+    }
+
+    true
+}
+
+pub(crate) fn replace_redaction_target(
+    field: &mut Field,
+    path: &ParsedRedactionPath,
+    replacement: &str,
+) -> bool {
+    let Some(target) = select_target(field, path) else {
+        return false;
+    };
+
+    target.replace_with_text(replacement.to_string());
+    true
+}
+
+enum RedactionTarget<'a> {
+    Field(&'a mut Field),
+    Rep(&'a mut Rep),
+    Comp(&'a mut Comp),
+    Atom(&'a mut Atom),
+}
+
+impl RedactionTarget<'_> {
+    fn hash(self, delims: &crate::Delims) {
+        let value = match &self {
+            Self::Field(field) => field_to_text(field, delims),
+            Self::Rep(rep) => rep_to_text(rep, delims),
+            Self::Comp(comp) => comp_to_text(comp, delims),
+            Self::Atom(atom) => atom_to_text(atom).to_string(),
+        };
+        self.replace_with_text(format!("hash:sha256:{}", compute_sha256(&value)));
+    }
+
+    fn drop_value(self) {
+        self.replace_with_text(String::new());
+    }
+
+    fn replace_with_text(self, replacement: String) {
+        match self {
+            Self::Field(field) => {
+                *field = Field::from_text(replacement);
+            }
+            Self::Rep(rep) => {
+                *rep = Rep::from_text(replacement);
+            }
+            Self::Comp(comp) => {
+                *comp = Comp::from_text(replacement);
+            }
+            Self::Atom(atom) => {
+                *atom = Atom::Text(replacement);
+            }
+        }
+    }
+}
+
+fn select_target<'a>(
+    field: &'a mut Field,
+    path: &ParsedRedactionPath,
+) -> Option<RedactionTarget<'a>> {
+    if path.field_repetition.is_none() && path.component.is_none() {
+        return Some(RedactionTarget::Field(field));
+    }
+
+    let rep_index = path.field_repetition.unwrap_or(1).checked_sub(1)?;
+    let rep = field.reps.get_mut(rep_index)?;
+    let Some(component) = path.component else {
+        return Some(RedactionTarget::Rep(rep));
+    };
+
+    let component_index = component.checked_sub(1)?;
+    let comp = rep.comps.get_mut(component_index)?;
+    let Some(subcomponent) = path.subcomponent else {
+        return Some(RedactionTarget::Comp(comp));
+    };
+
+    let subcomponent_index = subcomponent.checked_sub(1)?;
+    comp.subs
+        .get_mut(subcomponent_index)
+        .map(RedactionTarget::Atom)
+}

--- a/crates/hl7v2/src/redact/text.rs
+++ b/crates/hl7v2/src/redact/text.rs
@@ -1,27 +1,35 @@
-use crate::model::{Atom, Field, Message};
+use crate::model::{Atom, Comp, Field, Message, Rep};
 
 pub(crate) fn field_to_text(field: &Field, delims: &crate::Delims) -> String {
     field
         .reps
         .iter()
-        .map(|rep| {
-            rep.comps
-                .iter()
-                .map(|comp| {
-                    comp.subs
-                        .iter()
-                        .map(|atom| match atom {
-                            Atom::Text(text) => text.as_str(),
-                            Atom::Null => "\"\"",
-                        })
-                        .collect::<Vec<_>>()
-                        .join(&delims.sub.to_string())
-                })
-                .collect::<Vec<_>>()
-                .join(&delims.comp.to_string())
-        })
+        .map(|rep| rep_to_text(rep, delims))
         .collect::<Vec<_>>()
         .join(&delims.rep.to_string())
+}
+
+pub(crate) fn rep_to_text(rep: &Rep, delims: &crate::Delims) -> String {
+    rep.comps
+        .iter()
+        .map(|comp| comp_to_text(comp, delims))
+        .collect::<Vec<_>>()
+        .join(&delims.comp.to_string())
+}
+
+pub(crate) fn comp_to_text(comp: &Comp, delims: &crate::Delims) -> String {
+    comp.subs
+        .iter()
+        .map(atom_to_text)
+        .collect::<Vec<_>>()
+        .join(&delims.sub.to_string())
+}
+
+pub(crate) fn atom_to_text(atom: &Atom) -> &str {
+    match atom {
+        Atom::Text(text) => text.as_str(),
+        Atom::Null => "\"\"",
+    }
 }
 
 pub(crate) fn message_type(message: &Message) -> String {


### PR DESCRIPTION
## Summary
- accept safe-analysis redaction targets for field repetitions, components, and subcomponents
- keep receipts canonical and field-path traces marked on the parent field when a child value is redacted
- cover core, CLI, REST, gRPC, and Python local-wheel parity for addressed redaction

## Validation
- rtk cargo fmt --check
- rtk cargo clippy -p hl7v2 --all-targets --all-features -- -D warnings
- rtk cargo clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- rtk cargo clippy -p hl7v2-server --all-targets --all-features -- -D warnings
- rtk cargo test -p hl7v2 --all-features
- rtk cargo test -p hl7v2-cli --all-features
- rtk cargo test -p hl7v2-server --all-features
- rtk cargo run -p xtask -- python-local-wheel-proof
- rtk cargo run -p xtask -- badges --check
- rtk git diff --check

Python local-wheel proof passed locally only; no TestPyPI/PyPI availability claim.