### PR TITLE
fix: include grpc validate profile digest

### DIFF
--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -175,7 +175,7 @@ impl Hl7Service for Hl7ServiceImpl {
                     label: profile.message_structure.clone(),
                     message_structure: Some(profile.message_structure.clone()),
                     version: Some(profile.version.clone()),
-                    sha256: None,
+                    sha256: Some(compute_sha256(&req.profile)),
                 });
                 proto_validation_report_v2_from_rust(&report.to_v2(
                     "hl7v2-server-grpc",

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -602,6 +602,7 @@ constraints:
             identity.version.as_deref(),
             Some(fixture.validation.profile_version.as_str())
         );
+        assert_eq!(identity.sha256.as_deref().unwrap().len(), 64);
         assert_eq!(
             report_v2.issues[0].code,
             fixture.validation.required_issue_code


### PR DESCRIPTION
## Summary
- include the inline profile SHA-256 in gRPC Validate v2 profile identity
- assert the digest is present in the gRPC validate contract test

## Validation
- rtk cargo test -p hl7v2-server --test grpc_contract_tests test_grpc_validate_separates_errors_from_warnings
- rtk cargo test -p hl7v2-server --test validate_endpoint_test test_validate_report_schema_v2_returns_nested_provenance_report
- rtk cargo test -p hl7v2-server --test validate_redacted_endpoint_test test_validate_redacted_report_schema_v2_returns_nested_provenance_report
- rtk cargo test -p hl7v2-server --test validate_redacted_endpoint_test test_validate_redacted_report_schema_v2_returns_nested_provenance_report_without_phi
- rtk cargo test -p hl7v2-cli --test integration_tests test_validation_report_schema_v2_includes_provenance
- rtk cargo clippy -p hl7v2-server --all-targets --all-features -- -D warnings
- rtk cargo fmt --check
- rtk cargo test -p hl7v2-server --all-features
- rtk git diff --check