### PR TITLE
fix: map grpc diagnostic locations

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12357",
+  "message": "12381",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -125,20 +125,7 @@ impl Hl7Service for Hl7ServiceImpl {
         let mut warnings = Vec::new();
 
         for issue in issues {
-            let location = issue.path.map(|p| {
-                let mut loc = Location::default();
-                let parts: Vec<&str> = p.split('.').collect();
-                if !parts.is_empty() {
-                    loc.segment = parts[0].to_string();
-                }
-                if parts.len() > 1 {
-                    loc.field = parts[1].parse().unwrap_or(0);
-                }
-                if parts.len() > 2 {
-                    loc.component = parts[2].parse().unwrap_or(0);
-                }
-                loc
-            });
+            let location = issue.path.as_deref().map(proto_location_from_issue_path);
 
             let proto_issue = ValidationIssue {
                 code: issue.code,
@@ -698,6 +685,42 @@ fn compute_sha256(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+fn proto_location_from_issue_path(path: &str) -> Location {
+    if let Ok(located) = hl7v2::parse_located_path(path) {
+        let repetition = located
+            .path
+            .repetition
+            .or(located.segment_repetition)
+            .map(usize_to_i32)
+            .unwrap_or_default();
+
+        return Location {
+            segment: located.path.segment,
+            field: usize_to_i32(located.path.field),
+            component: located.path.component.map(usize_to_i32).unwrap_or_default(),
+            repetition,
+            byte_offset: 0,
+        };
+    }
+
+    proto_location_from_legacy_issue_path(path)
+}
+
+fn proto_location_from_legacy_issue_path(path: &str) -> Location {
+    let mut loc = Location::default();
+    let parts: Vec<&str> = path.split('.').collect();
+    if !parts.is_empty() {
+        loc.segment = parts[0].to_string();
+    }
+    if parts.len() > 1 {
+        loc.field = parts[1].parse().unwrap_or(0);
+    }
+    if parts.len() > 2 {
+        loc.component = parts[2].parse().unwrap_or(0);
+    }
+    loc
 }
 
 struct GrpcRedactedQuarantineContext<'a> {
@@ -1297,6 +1320,10 @@ fn proto_corpus_value_shape_stats_from_rust(
 
 fn usize_to_u32(value: usize) -> u32 {
     u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+fn usize_to_i32(value: usize) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX)
 }
 
 fn usize_to_u64(value: usize) -> u64 {

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -610,6 +610,51 @@ constraints:
     }
 
     #[tokio::test]
+    async fn test_grpc_validate_maps_diagnostic_path_to_location() {
+        let service = service();
+        let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+constraints:
+  - path: "PID-3[2].4"
+    required: true
+"#;
+        let message = b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR~987654^^^||Doe^John||19700101|M\r";
+
+        let request = Request::new(ValidateRequest {
+            message: message.to_vec(),
+            profile: profile.to_string(),
+            mllp_framed: false,
+            options: None,
+            report_schema_version: 2,
+        });
+
+        let response = service.validate(request).await.expect("RPC should succeed");
+        let inner = response.into_inner();
+
+        assert!(!inner.valid);
+        assert_eq!(inner.errors.len(), 1);
+        assert_eq!(inner.errors[0].code, "MISSING_REQUIRED_FIELD");
+
+        let location = inner.errors[0]
+            .location
+            .as_ref()
+            .expect("Legacy issue location should exist");
+        assert_eq!(location.segment, "PID");
+        assert_eq!(location.field, 3);
+        assert_eq!(location.repetition, 2);
+        assert_eq!(location.component, 4);
+
+        let report_v2 = inner
+            .validation_report_v2
+            .expect("Validation report v2 should exist");
+        assert_eq!(report_v2.issues[0].path.as_deref(), Some("PID-3[2].4"));
+    }
+
+    #[tokio::test]
     async fn test_grpc_profile_lint_accepts_valid_profile() {
         let service = service();
         let response = service


### PR DESCRIPTION
## Summary
- map gRPC Validate legacy issue locations through the shared HL7 path parser
- preserve segment, field, repetition, and component for diagnostic paths like PID-3[2].4
- add a gRPC contract regression that proves v2 keeps the original path while legacy location fields are structured

## Validation
- rtk cargo test -p hl7v2-server --test grpc_contract_tests test_grpc_validate_maps_diagnostic_path_to_location
- rtk cargo test -p hl7v2-server --test grpc_contract_tests test_grpc_validate_separates_errors_from_warnings
- rtk cargo clippy -p hl7v2-server --all-targets --all-features -- -D warnings
- rtk cargo fmt --check
- rtk cargo test -p hl7v2-server --all-features
- rtk git diff --check