### PR TITLE
fix: cover sensitive segment repetitions

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12381",
+  "message": "12433",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/src/redaction.rs
+++ b/crates/hl7v2-server/src/redaction.rs
@@ -52,7 +52,7 @@ fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy, St
     let mut seen_paths = BTreeSet::new();
     for rule in &mut policy.rules {
         let parsed_path = parse_redaction_path(&rule.path)?;
-        rule.path = parsed_path.canonical_path;
+        rule.path = parsed_path.canonical_path.clone();
         if !seen_paths.insert(rule.path.clone()) {
             return Err(format!(
                 "redaction policy contains duplicate rule for {}",
@@ -65,8 +65,8 @@ fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy, St
                 rule.path
             ));
         }
-        if safe_analysis_sensitive_paths().contains(rule.path.as_str())
-            && rule.action == RedactionAction::Retain
+        if rule.action == RedactionAction::Retain
+            && redaction_path_targets_builtin_sensitive_field(&parsed_path)
         {
             return Err(format!(
                 "redaction rule {} cannot retain a built-in sensitive field",
@@ -159,17 +159,21 @@ fn validate_safe_analysis_policy_covers_sensitive_fields(
     message: &Message,
     policy: &SafeAnalysisPolicy,
 ) -> Result<(), String> {
-    let protected_paths: BTreeSet<&str> = policy
+    let protected_paths: Vec<_> = policy
         .rules
         .iter()
         .filter(|rule| rule.action != RedactionAction::Retain)
-        .map(|rule| rule.path.as_str())
+        .filter_map(|rule| parse_redaction_path(&rule.path).ok())
         .collect();
     let present_sensitive_paths = present_sensitive_paths(message);
-    let missing_paths: Vec<&str> = present_sensitive_paths
+    let missing_paths: BTreeSet<_> = present_sensitive_paths
         .iter()
-        .copied()
-        .filter(|path| !protected_paths.contains(path))
+        .filter(|path| {
+            !protected_paths
+                .iter()
+                .any(|protected| protected_path_covers_sensitive_occurrence(protected, path))
+        })
+        .map(|path| path.base_path)
         .collect();
 
     if missing_paths.is_empty() {
@@ -178,20 +182,48 @@ fn validate_safe_analysis_policy_covers_sensitive_fields(
 
     Err(format!(
         "redaction policy does not protect present sensitive field(s): {}",
-        missing_paths.join(", ")
+        missing_paths.into_iter().collect::<Vec<_>>().join(", ")
     ))
 }
 
-fn present_sensitive_paths(message: &Message) -> BTreeSet<&'static str> {
-    safe_analysis_sensitive_paths()
-        .iter()
-        .copied()
-        .filter(|path| {
-            parse_redaction_path(path).ok().is_some_and(|parsed| {
-                message_has_nonempty_field(message, &parsed.segment_id, parsed.field_index)
-            })
-        })
-        .collect()
+struct PresentSensitivePath {
+    base_path: &'static str,
+    segment_id: String,
+    segment_repetition: usize,
+    field_index: usize,
+}
+
+fn present_sensitive_paths(message: &Message) -> Vec<PresentSensitivePath> {
+    let mut paths = Vec::new();
+    for base_path in safe_analysis_sensitive_paths() {
+        let Ok(parsed) = parse_redaction_path(base_path) else {
+            continue;
+        };
+        let Some(modeled_field_index) = modeled_field_index(&parsed.segment_id, parsed.field_index)
+        else {
+            continue;
+        };
+        let mut segment_repetition = 0_usize;
+        for segment in &message.segments {
+            if segment.id_str() != parsed.segment_id {
+                continue;
+            }
+            segment_repetition = segment_repetition.saturating_add(1);
+            let Some(field) = segment.fields.get(modeled_field_index) else {
+                continue;
+            };
+            if field_to_text(field, &message.delims).is_empty() {
+                continue;
+            }
+            paths.push(PresentSensitivePath {
+                base_path,
+                segment_id: parsed.segment_id.clone(),
+                segment_repetition,
+                field_index: parsed.field_index,
+            });
+        }
+    }
+    paths
 }
 
 fn safe_analysis_sensitive_paths() -> BTreeSet<&'static str> {
@@ -201,6 +233,39 @@ fn safe_analysis_sensitive_paths() -> BTreeSet<&'static str> {
     ]
     .into_iter()
     .collect()
+}
+
+fn redaction_path_targets_builtin_sensitive_field(path: &ParsedRedactionPath) -> bool {
+    if path.component.is_some() || path.subcomponent.is_some() {
+        return false;
+    }
+    safe_analysis_sensitive_paths()
+        .iter()
+        .filter_map(|sensitive_path| parse_redaction_path(sensitive_path).ok())
+        .any(|sensitive_path| {
+            path.segment_id == sensitive_path.segment_id
+                && path.field_index == sensitive_path.field_index
+        })
+}
+
+fn protected_path_covers_sensitive_occurrence(
+    protected: &ParsedRedactionPath,
+    sensitive: &PresentSensitivePath,
+) -> bool {
+    if protected.segment_id != sensitive.segment_id
+        || protected.field_index != sensitive.field_index
+    {
+        return false;
+    }
+    if protected.component.is_some()
+        || protected.subcomponent.is_some()
+        || protected.field_repetition.is_some()
+    {
+        return false;
+    }
+    protected
+        .segment_repetition
+        .is_none_or(|repetition| repetition == sensitive.segment_repetition)
 }
 
 fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
@@ -229,19 +294,6 @@ fn parse_redaction_path(path: &str) -> Result<ParsedRedactionPath, String> {
         subcomponent: located.path.subcomponent,
         canonical_path,
     })
-}
-
-fn message_has_nonempty_field(message: &Message, segment_id: &str, field_index: usize) -> bool {
-    let Some(field_index) = modeled_field_index(segment_id, field_index) else {
-        return false;
-    };
-
-    message
-        .segments
-        .iter()
-        .filter(|segment| segment.id_str() == segment_id)
-        .filter_map(|segment| segment.fields.get(field_index))
-        .any(|field| !field_to_text(field, &message.delims).is_empty())
 }
 
 fn apply_redaction_target(

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -235,6 +235,101 @@ async fn test_validate_redacted_accepts_diagnostic_policy_paths_with_canonical_r
 }
 
 #[tokio::test]
+async fn test_validate_redacted_accepts_segment_repetition_sensitive_policy() {
+    let app = common::create_test_router();
+    let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "NK1"
+    required: true
+    max_uses: 2
+"#;
+    let policy = r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "drop"
+reason = "Remove populated next-of-kin name"
+"#;
+    let request_body = json!({
+        "message": "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ADT^A01|CTRL1|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r",
+        "profile": profile,
+        "redaction_policy": policy,
+        "include_redacted_hl7": true
+    });
+
+    let response = app
+        .oneshot(validate_redacted_request(request_body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json: Value = serde_json::from_slice(&body).unwrap();
+    let redacted_hl7 = body_json["redacted_hl7"].as_str().unwrap();
+    let actions = body_json["redaction_receipt"]["actions"]
+        .as_array()
+        .unwrap();
+
+    assert!(!redacted_hl7.contains("Kin^Jane"));
+    assert!(actions.iter().any(|action| {
+        action["path"] == "NK1[2].2"
+            && action["matched_count"] == 1
+            && action["status"] == "applied"
+    }));
+}
+
+#[tokio::test]
+async fn test_validate_redacted_rejects_retain_for_segment_repetition_sensitive_policy() {
+    let app = common::create_test_router();
+    let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "NK1"
+    required: true
+    max_uses: 2
+"#;
+    let policy = r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "retain"
+reason = "Unsafe"
+"#;
+    let request_body = json!({
+        "message": "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ADT^A01|CTRL1|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r",
+        "profile": profile,
+        "redaction_policy": policy,
+        "include_redacted_hl7": true
+    });
+
+    let response = app
+        .oneshot(validate_redacted_request(request_body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_text = String::from_utf8(body.to_vec()).unwrap();
+    let body_json: Value = serde_json::from_str(&body_text).unwrap();
+
+    assert_eq!(body_json["code"], "REDACTION_ERROR");
+    assert!(
+        body_json["message"]
+            .as_str()
+            .unwrap()
+            .contains("redaction rule NK1[2].2 cannot retain a built-in sensitive field")
+    );
+    assert!(!body_text.contains("Kin^Jane"));
+    assert!(!body_text.contains("Kin"));
+    assert!(!body_text.contains("Jane"));
+}
+
+#[tokio::test]
 async fn test_validate_redacted_redacts_component_without_dropping_neighbor_components() {
     let app = common::create_test_router();
     let profile = r#"

--- a/crates/hl7v2/src/redact.rs
+++ b/crates/hl7v2/src/redact.rs
@@ -385,6 +385,39 @@ reason = "Targeted observation redaction"
     }
 
     #[test]
+    fn safe_analysis_accepts_segment_repetition_sensitive_rule_when_only_that_repetition_has_phi()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ADT^A01|CTRL1|P|2.5\r\
+NK1|1\r\
+NK1|2|Kin^Jane";
+        let policy = r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "drop"
+reason = "Remove populated next-of-kin name"
+"#;
+
+        let output = redact_hl7_safe_analysis(message, policy)?;
+
+        ensure(
+            !output.redacted_hl7.contains("Kin^Jane"),
+            "redacted HL7 leaked NK1 name",
+        )?;
+        let action = output
+            .receipt
+            .actions
+            .iter()
+            .find(|action| action.path == "NK1[2].2")
+            .ok_or_else(|| std::io::Error::other("expected NK1[2].2 receipt action"))?;
+        ensure(action.matched_count == 1, "expected one NK1[2].2 match")?;
+        ensure(
+            action.status == RedactionActionStatus::Applied,
+            "expected targeted action to apply",
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn safe_analysis_redacts_only_targeted_field_repetition()
     -> Result<(), Box<dyn std::error::Error>> {
         let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
@@ -688,6 +721,31 @@ reason = "Unsafe"
                 .to_string()
                 .contains("redaction rule PID.5 cannot retain a built-in sensitive field"),
             "expected canonical retain-sensitive-field error",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn safe_analysis_rejects_retaining_segment_repetition_builtin_sensitive_field()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let policy = r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "retain"
+reason = "Unsafe"
+"#;
+
+        let Err(error) = load_safe_analysis_policy(policy) else {
+            return Err(std::io::Error::other(
+                "expected retaining a segment-specific built-in sensitive field to fail",
+            )
+            .into());
+        };
+        ensure(
+            error
+                .to_string()
+                .contains("redaction rule NK1[2].2 cannot retain a built-in sensitive field"),
+            "expected canonical segment-specific retain-sensitive-field error",
         )?;
         Ok(())
     }

--- a/crates/hl7v2/src/redact/policy.rs
+++ b/crates/hl7v2/src/redact/policy.rs
@@ -40,11 +40,10 @@ pub fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy
         ));
     }
 
-    let sensitive_paths = safe_analysis_sensitive_paths();
     let mut seen_paths = BTreeSet::new();
     for rule in &mut policy.rules {
         let parsed_path = parse_redaction_path(&rule.path).map_err(RedactionError::Policy)?;
-        rule.path = parsed_path.canonical_path;
+        rule.path = parsed_path.canonical_path.clone();
         if !seen_paths.insert(rule.path.clone()) {
             return Err(RedactionError::Policy(format!(
                 "redaction policy contains duplicate rule for {}",
@@ -57,7 +56,9 @@ pub fn load_safe_analysis_policy(policy_text: &str) -> Result<SafeAnalysisPolicy
                 rule.path
             )));
         }
-        if sensitive_paths.contains(rule.path.as_str()) && rule.action == RedactionAction::Retain {
+        if rule.action == RedactionAction::Retain
+            && redaction_path_targets_builtin_sensitive_field(&parsed_path)
+        {
             return Err(RedactionError::Policy(format!(
                 "redaction rule {} cannot retain a built-in sensitive field",
                 rule.path
@@ -149,17 +150,21 @@ fn validate_safe_analysis_policy_covers_sensitive_fields(
     message: &Message,
     policy: &SafeAnalysisPolicy,
 ) -> Result<(), RedactionError> {
-    let protected_paths: BTreeSet<&str> = policy
+    let protected_paths: Vec<_> = policy
         .rules
         .iter()
         .filter(|rule| rule.action != RedactionAction::Retain)
-        .map(|rule| rule.path.as_str())
+        .filter_map(|rule| parse_redaction_path(&rule.path).ok())
         .collect();
     let present_sensitive_paths = present_sensitive_paths(message);
-    let missing_paths: Vec<&str> = present_sensitive_paths
+    let missing_paths: BTreeSet<_> = present_sensitive_paths
         .iter()
-        .copied()
-        .filter(|path| !protected_paths.contains(path))
+        .filter(|path| {
+            !protected_paths
+                .iter()
+                .any(|protected| protected_path_covers_sensitive_occurrence(protected, path))
+        })
+        .map(|path| path.base_path)
         .collect();
 
     if missing_paths.is_empty() {
@@ -168,20 +173,48 @@ fn validate_safe_analysis_policy_covers_sensitive_fields(
 
     Err(RedactionError::Policy(format!(
         "redaction policy does not protect present sensitive field(s): {}",
-        missing_paths.join(", ")
+        missing_paths.into_iter().collect::<Vec<_>>().join(", ")
     )))
 }
 
-fn present_sensitive_paths(message: &Message) -> BTreeSet<&'static str> {
-    safe_analysis_sensitive_paths()
-        .iter()
-        .copied()
-        .filter(|path| {
-            parse_redaction_path(path).ok().is_some_and(|parsed| {
-                message_has_nonempty_field(message, &parsed.segment_id, parsed.field_index)
-            })
-        })
-        .collect()
+struct PresentSensitivePath {
+    base_path: &'static str,
+    segment_id: String,
+    segment_repetition: usize,
+    field_index: usize,
+}
+
+fn present_sensitive_paths(message: &Message) -> Vec<PresentSensitivePath> {
+    let mut paths = Vec::new();
+    for base_path in safe_analysis_sensitive_paths() {
+        let Ok(parsed) = parse_redaction_path(base_path) else {
+            continue;
+        };
+        let Some(modeled_field_index) = modeled_field_index(&parsed.segment_id, parsed.field_index)
+        else {
+            continue;
+        };
+        let mut segment_repetition = 0_usize;
+        for segment in &message.segments {
+            if segment.id_str() != parsed.segment_id {
+                continue;
+            }
+            segment_repetition = segment_repetition.saturating_add(1);
+            let Some(field) = segment.fields.get(modeled_field_index) else {
+                continue;
+            };
+            if field_to_text(field, &message.delims).is_empty() {
+                continue;
+            }
+            paths.push(PresentSensitivePath {
+                base_path,
+                segment_id: parsed.segment_id.clone(),
+                segment_repetition,
+                field_index: parsed.field_index,
+            });
+        }
+    }
+    paths
 }
 
 fn safe_analysis_sensitive_paths() -> BTreeSet<&'static str> {
@@ -193,15 +226,35 @@ fn safe_analysis_sensitive_paths() -> BTreeSet<&'static str> {
     .collect()
 }
 
-fn message_has_nonempty_field(message: &Message, segment_id: &str, field_index: usize) -> bool {
-    let Some(field_index) = modeled_field_index(segment_id, field_index) else {
+fn redaction_path_targets_builtin_sensitive_field(path: &super::path::ParsedRedactionPath) -> bool {
+    if path.component.is_some() || path.subcomponent.is_some() {
         return false;
-    };
-
-    message
-        .segments
+    }
+    safe_analysis_sensitive_paths()
         .iter()
-        .filter(|segment| segment.id_str() == segment_id)
-        .filter_map(|segment| segment.fields.get(field_index))
-        .any(|field| !field_to_text(field, &message.delims).is_empty())
+        .filter_map(|sensitive_path| parse_redaction_path(sensitive_path).ok())
+        .any(|sensitive_path| {
+            path.segment_id == sensitive_path.segment_id
+                && path.field_index == sensitive_path.field_index
+        })
+}
+
+fn protected_path_covers_sensitive_occurrence(
+    protected: &super::path::ParsedRedactionPath,
+    sensitive: &PresentSensitivePath,
+) -> bool {
+    if protected.segment_id != sensitive.segment_id
+        || protected.field_index != sensitive.field_index
+    {
+        return false;
+    }
+    if protected.component.is_some()
+        || protected.subcomponent.is_some()
+        || protected.field_repetition.is_some()
+    {
+        return false;
+    }
+    protected
+        .segment_repetition
+        .is_none_or(|repetition| repetition == sensitive.segment_repetition)
 }


### PR DESCRIPTION
## Summary
- Treat built-in sensitive safe-analysis coverage per segment occurrence so NK1[2]-2 can satisfy coverage when only the second NK1 has PHI.
- Reject retain rules on built-in sensitive fields even when the policy path is scoped to a segment repetition.
- Mirror the behavior in the validate-redacted REST path and refresh the badge count.

## Validation
- rtk cargo test -p hl7v2 --features redact safe_analysis
- rtk cargo test -p hl7v2-server --test validate_redacted_endpoint_test
- rtk cargo test -p hl7v2 --features redact
- rtk cargo test -p hl7v2-server --all-features
- rtk cargo clippy -p hl7v2 --all-targets --features redact -- -D warnings
- rtk cargo clippy -p hl7v2-server --all-targets --all-features -- -D warnings
- rtk cargo test -p hl7v2-cli --all-features
- rtk cargo clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- rtk cargo fmt --check
- rtk git diff --check
- rtk cargo run -p xtask -- badges --check