### PR TITLE
fix: align cli sensitive repetition redaction

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12433",
+  "message": "12459",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/evidence_bundle.rs
+++ b/crates/hl7v2-cli/src/evidence_bundle.rs
@@ -1126,7 +1126,7 @@ mod policy {
         let mut seen_paths = BTreeSet::new();
         for rule in &mut policy.rules {
             let parsed_path = parse_redaction_path(&rule.path).map_err(std::io::Error::other)?;
-            rule.path = parsed_path.canonical_path;
+            rule.path = parsed_path.canonical_path.clone();
             if !seen_paths.insert(rule.path.clone()) {
                 return Err(std::io::Error::other(format!(
                     "redaction policy contains duplicate rule for {}",
@@ -1141,8 +1141,8 @@ mod policy {
                 ))
                 .into());
             }
-            if safe_analysis_sensitive_paths().contains(rule.path.as_str())
-                && rule.action == RedactionAction::Retain
+            if rule.action == RedactionAction::Retain
+                && redaction_path_targets_builtin_sensitive_field(&parsed_path)
             {
                 return Err(std::io::Error::other(format!(
                     "redaction rule {} cannot retain a built-in sensitive field",
@@ -1236,17 +1236,21 @@ mod policy {
         message: &Message,
         policy: &SafeAnalysisPolicy,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let protected_paths: BTreeSet<&str> = policy
+        let protected_paths: Vec<_> = policy
             .rules
             .iter()
             .filter(|rule| rule.action != RedactionAction::Retain)
-            .map(|rule| rule.path.as_str())
+            .filter_map(|rule| parse_redaction_path(&rule.path).ok())
             .collect();
         let present_sensitive_paths = present_sensitive_paths(message);
-        let missing_paths: Vec<&str> = present_sensitive_paths
+        let missing_paths: BTreeSet<_> = present_sensitive_paths
             .iter()
-            .copied()
-            .filter(|path| !protected_paths.contains(path))
+            .filter(|path| {
+                !protected_paths
+                    .iter()
+                    .any(|protected| protected_path_covers_sensitive_occurrence(protected, path))
+            })
+            .map(|path| path.base_path)
             .collect();
 
         if missing_paths.is_empty() {
@@ -1255,21 +1259,50 @@ mod policy {
 
         Err(std::io::Error::other(format!(
             "redaction policy does not protect present sensitive field(s): {}",
-            missing_paths.join(", ")
+            missing_paths.into_iter().collect::<Vec<_>>().join(", ")
         ))
         .into())
     }
 
-    fn present_sensitive_paths(message: &Message) -> BTreeSet<&'static str> {
-        safe_analysis_sensitive_paths()
-            .iter()
-            .copied()
-            .filter(|path| {
-                parse_redaction_path(path).ok().is_some_and(|parsed| {
-                    message_has_nonempty_field(message, &parsed.segment_id, parsed.field_index)
-                })
-            })
-            .collect()
+    struct PresentSensitivePath {
+        base_path: &'static str,
+        segment_id: String,
+        segment_repetition: usize,
+        field_index: usize,
+    }
+
+    fn present_sensitive_paths(message: &Message) -> Vec<PresentSensitivePath> {
+        let mut paths = Vec::new();
+        for base_path in safe_analysis_sensitive_paths() {
+            let Ok(parsed) = parse_redaction_path(base_path) else {
+                continue;
+            };
+            let Some(modeled_field_index) =
+                modeled_field_index(&parsed.segment_id, parsed.field_index)
+            else {
+                continue;
+            };
+            let mut segment_repetition = 0_usize;
+            for segment in &message.segments {
+                if segment.id_str() != parsed.segment_id {
+                    continue;
+                }
+                segment_repetition = segment_repetition.saturating_add(1);
+                let Some(field) = segment.fields.get(modeled_field_index) else {
+                    continue;
+                };
+                if field_to_text(field, &message.delims).is_empty() {
+                    continue;
+                }
+                paths.push(PresentSensitivePath {
+                    base_path,
+                    segment_id: parsed.segment_id.clone(),
+                    segment_repetition,
+                    field_index: parsed.field_index,
+                });
+            }
+        }
+        paths
     }
 
     fn safe_analysis_sensitive_paths() -> BTreeSet<&'static str> {
@@ -1279,6 +1312,39 @@ mod policy {
         ]
         .into_iter()
         .collect()
+    }
+
+    fn redaction_path_targets_builtin_sensitive_field(path: &ParsedRedactionPath) -> bool {
+        if path.component.is_some() || path.subcomponent.is_some() {
+            return false;
+        }
+        safe_analysis_sensitive_paths()
+            .iter()
+            .filter_map(|sensitive_path| parse_redaction_path(sensitive_path).ok())
+            .any(|sensitive_path| {
+                path.segment_id == sensitive_path.segment_id
+                    && path.field_index == sensitive_path.field_index
+            })
+    }
+
+    fn protected_path_covers_sensitive_occurrence(
+        protected: &ParsedRedactionPath,
+        sensitive: &PresentSensitivePath,
+    ) -> bool {
+        if protected.segment_id != sensitive.segment_id
+            || protected.field_index != sensitive.field_index
+        {
+            return false;
+        }
+        if protected.component.is_some()
+            || protected.subcomponent.is_some()
+            || protected.field_repetition.is_some()
+        {
+            return false;
+        }
+        protected
+            .segment_repetition
+            .is_none_or(|repetition| repetition == sensitive.segment_repetition)
     }
 
     struct ParsedRedactionPath {
@@ -1332,19 +1398,6 @@ mod policy {
             .fields
             .get(field_index)?;
         Some(field_to_text(field, &message.delims))
-    }
-
-    fn message_has_nonempty_field(message: &Message, segment_id: &str, field_index: usize) -> bool {
-        let Some(field_index) = modeled_field_index(segment_id, field_index) else {
-            return false;
-        };
-
-        message
-            .segments
-            .iter()
-            .filter(|segment| segment.id_str() == segment_id)
-            .filter_map(|segment| segment.fields.get(field_index))
-            .any(|field| !field_to_text(field, &message.delims).is_empty())
     }
 
     fn apply_redaction_target(

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -2519,6 +2519,94 @@ reason = "Remove family name"
     }
 
     #[test]
+    fn test_redact_json_accepts_segment_repetition_sensitive_policy() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(
+            &dir,
+            "nk1-message.hl7",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r",
+        );
+        let policy_file = create_temp_file(
+            &dir,
+            "nk1-policy.toml",
+            br#"
+[[rules]]
+path = "NK1[2]-2"
+action = "drop"
+reason = "Remove populated next-of-kin name"
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message_file.to_str().unwrap(),
+                "--policy",
+                policy_file.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute redact");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        assert!(!stdout.contains("Kin^Jane"));
+        let report: serde_json::Value =
+            serde_json::from_str(&stdout).expect("redact output should be JSON");
+        let actions = report["receipt"]["actions"].as_array().unwrap();
+        assert!(actions.iter().any(|action| {
+            action["path"] == "NK1[2].2"
+                && action["action"] == "drop"
+                && action["matched_count"] == 1
+                && action["status"] == "applied"
+        }));
+    }
+
+    #[test]
+    fn test_redact_rejects_retain_for_segment_repetition_sensitive_field() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(
+            &dir,
+            "nk1-message.hl7",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r",
+        );
+        let policy_file = create_temp_file(
+            &dir,
+            "nk1-policy.toml",
+            br#"
+[[rules]]
+path = "NK1[2]-2"
+action = "retain"
+reason = "Unsafe retain"
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "redact",
+                message_file.to_str().unwrap(),
+                "--policy",
+                policy_file.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute redact");
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(
+            stderr.contains("redaction rule NK1[2].2 cannot retain a built-in sensitive field")
+        );
+        assert!(!stderr.contains("Kin^Jane"));
+        assert!(!stderr.contains("Kin"));
+        assert!(!stderr.contains("Jane"));
+    }
+
+    #[test]
     fn test_redact_json_schema_v2_returns_provenance_output_without_raw_phi() {
         let dir = create_temp_dir();
         let message_file = create_temp_hl7_with_content(&dir, "message.hl7", PHI_MESSAGE);
@@ -3214,6 +3302,78 @@ reason = "Remove family name"
                     && action["action"] == "drop"
                     && action["matched_count"] == 1)
         );
+    }
+
+    #[test]
+    fn test_bundle_accepts_segment_repetition_sensitive_policy() {
+        let dir = create_temp_dir();
+        let message_file = create_temp_hl7_with_content(
+            &dir,
+            "nk1-message.hl7",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r",
+        );
+        let profile_file = create_temp_file(
+            &dir,
+            "profile.yaml",
+            br#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "NK1"
+    max_uses: 2
+"#,
+        );
+        let policy_file = create_temp_file(
+            &dir,
+            "nk1-policy.toml",
+            br#"
+[[rules]]
+path = "NK1[2]-2"
+action = "drop"
+reason = "Remove populated next-of-kin name"
+"#,
+        );
+        let bundle_dir = dir.path().join("nk1-bundle");
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "bundle",
+            message_file.to_str().unwrap(),
+            "--profile",
+            profile_file.to_str().unwrap(),
+            "--redact-policy",
+            policy_file.to_str().unwrap(),
+            "--out",
+            bundle_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+        let redacted_message =
+            std::fs::read_to_string(bundle_dir.join("message.redacted.hl7")).unwrap();
+        assert!(!redacted_message.contains("Kin^Jane"));
+
+        let receipt: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("redaction-receipt.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(receipt["actions"].as_array().unwrap().iter().any(|action| {
+            action["path"] == "NK1[2].2"
+                && action["action"] == "drop"
+                && action["matched_count"] == 1
+                && action["status"] == "applied"
+        }));
+
+        let field_paths: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(bundle_dir.join("field-paths.json")).unwrap(),
+        )
+        .unwrap();
+        assert!(field_paths["fields"].as_array().unwrap().iter().any(
+            |field| field["canonical_path"] == "NK1.2"
+                && field["redaction_action"] == "drop"
+                && field["value_shape"] == "empty"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Align CLI safe-analysis redaction coverage with core/REST for segment-repetition-scoped built-in sensitive fields.
- Reject retain rules on built-in sensitive fields even when the CLI policy path includes a segment repetition.
- Add standalone redact and evidence-bundle regressions for NK1[2]-2 receipts and PHI-safe failure output.
- Refresh ripr badge metadata.

## Validation
- Expected pre-fix failure: rtk cargo test -p hl7v2-cli --test integration_tests segment_repetition_sensitive
- rtk cargo test -p hl7v2-cli --test integration_tests segment_repetition_sensitive
- rtk cargo test -p hl7v2-cli --test integration_tests redact_command
- rtk cargo test -p hl7v2-cli --all-features
- rtk cargo clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- rtk cargo fmt --check
- rtk git diff --check
- rtk cargo run -p xtask -- badges --check