### PR TITLE
test: cover grpc sensitive segment repetition redaction

### DIFF
--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -1157,6 +1157,97 @@ reason = "Remove family name"
     }
 
     #[tokio::test]
+    async fn test_grpc_validate_redacted_accepts_segment_repetition_sensitive_policy() {
+        let service = service();
+        let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "NK1"
+    required: true
+    max_uses: 2
+"#;
+        let policy = r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "drop"
+reason = "Remove populated next-of-kin name"
+"#;
+        let request = Request::new(ValidateRedactedRequest {
+            message: b"MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r".to_vec(),
+            profile: profile.to_string(),
+            redaction_policy: policy.to_string(),
+            mllp_framed: false,
+            include_redacted_hl7: true,
+            report_schema_version: 0,
+            redaction_receipt_schema_version: 0,
+            quarantine_schema_version: 0,
+        });
+
+        let response = service
+            .validate_redacted(request)
+            .await
+            .expect("RPC should succeed");
+        let inner = response.into_inner();
+        let report = inner
+            .validation_report
+            .expect("Validation report should exist");
+        let receipt = inner
+            .redaction_receipt
+            .expect("Redaction receipt should exist");
+        let redacted_hl7 =
+            String::from_utf8(inner.redacted_hl7.expect("Redacted HL7 should be included"))
+                .expect("Redacted HL7 should be UTF-8");
+
+        assert!(report.valid);
+        assert!(!redacted_hl7.contains("Kin^Jane"));
+        assert!(receipt.actions.iter().any(|action| {
+            action.path == "NK1[2].2"
+                && action.action == "drop"
+                && action.matched_count == 1
+                && action.status == "applied"
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_grpc_validate_redacted_rejects_retain_for_segment_repetition_sensitive_field() {
+        let service = service();
+        let policy = r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "retain"
+reason = "Unsafe retain"
+"#;
+        let request = Request::new(ValidateRedactedRequest {
+            message: b"MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r".to_vec(),
+            profile: PROFILE.to_string(),
+            redaction_policy: policy.to_string(),
+            mllp_framed: false,
+            include_redacted_hl7: true,
+            report_schema_version: 0,
+            redaction_receipt_schema_version: 0,
+            quarantine_schema_version: 0,
+        });
+
+        let err = service
+            .validate_redacted(request)
+            .await
+            .expect_err("unsafe retain policy should fail the RPC");
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("Failed to redact HL7"));
+        assert!(
+            err.message()
+                .contains("redaction rule NK1[2].2 cannot retain a built-in sensitive field")
+        );
+        assert!(!err.message().contains("Kin^Jane"));
+        assert!(!err.message().contains("Kin"));
+        assert!(!err.message().contains("Jane"));
+    }
+
+    #[tokio::test]
     async fn test_grpc_validate_redacted_omits_redacted_hl7_unless_requested() {
         let service = service();
         let request = Request::new(ValidateRedactedRequest {


### PR DESCRIPTION
## Summary
- Add gRPC validate-redacted parity coverage for segment-repetition-scoped built-in sensitive fields.
- Assert NK1[2]-2 redaction emits receipt path NK1[2].2 with one applied match and no raw NK1 name in redacted HL7.
- Assert unsafe retain on NK1[2]-2 fails with the explicit built-in sensitive field error and does not echo the NK1 PHI in the gRPC status message.

## Validation
- rtk cargo test -p hl7v2-server --test grpc_contract_tests segment_repetition_sensitive
- rtk cargo test -p hl7v2-server --test grpc_contract_tests validate_redacted
- rtk cargo test -p hl7v2-server --test grpc_contract_tests
- rtk cargo test -p hl7v2-server --all-features
- rtk cargo clippy -p hl7v2-server --all-targets --all-features -- -D warnings
- rtk cargo fmt --check
- rtk git diff --check
- rtk cargo run -p xtask -- badges --check