### PR TITLE
fix: align cli stats field paths

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12457",
+  "message": "12465",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -2508,11 +2508,12 @@ fn collect_stats(message: &Message, distributions: bool) -> StatsReport {
 
             // Get field values (simplified - just first few fields)
             for (field_idx, field) in segment.fields.iter().enumerate().take(5) {
-                if field_idx == 0 {
-                    continue; // Skip segment ID field
-                }
-
-                let path = format!("{}.{}", segment_id, field_idx);
+                let field_number = if segment_id == "MSH" {
+                    field_idx + 2
+                } else {
+                    field_idx + 1
+                };
+                let path = format!("{}.{}", segment_id, field_number);
                 // Get the first text value from the field
                 let value = field.first_text().unwrap_or("").to_string();
 

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -843,8 +843,17 @@ constraints:
             assert!(stats.field_distributions.is_some());
             let dists = stats.field_distributions.unwrap();
             assert!(!dists.is_empty());
-            // Should contain MSH.3, etc. (skips MSH.0 as per logic)
-            assert!(dists.iter().any(|d| d.path == "MSH.3"));
+            let msh_3 = dists
+                .iter()
+                .find(|dist| dist.path == "MSH.3")
+                .expect("MSH.3 distribution should be present");
+            assert_eq!(msh_3.sample_values, vec!["SendingApp".to_string()]);
+
+            let pid_1 = dists
+                .iter()
+                .find(|dist| dist.path == "PID.1")
+                .expect("PID.1 distribution should be present");
+            assert_eq!(pid_1.sample_values, vec!["1".to_string()]);
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- fix stats --distributions to report HL7 field numbers instead of shifted internal vector indexes
- preserve the MSH-specific offset so MSH.3 maps to Sending Application while ordinary segments start at field 1
- add regression assertions for MSH.3 and PID.1 sample values
- refresh adges/ripr.json

## Validation
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli test_collect_stats_with_distributions
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli test_collect_stats_basic
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli test_stats_command_execution
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli
- cargo +1.95.0 test -p hl7v2-cli --all-targets
- cargo +1.95.0 fmt --check
- git diff --check
- cargo +1.95.0 run -p xtask -- badges --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets --all-features -- -D warnings
- pre-push gate --check