### PR TITLE
Align core evidence message type

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12465",
+  "message": "12469",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/evidence.rs
+++ b/crates/hl7v2/src/evidence.rs
@@ -134,6 +134,11 @@ reason = "Date of birth"
                 .any(|artifact| artifact == "SAFE-SHARING.md"),
             "expected safe-sharing checklist artifact",
         )?;
+        let field_trace = read_bundle_json_value(&bundle_dir, "field-paths.json")?;
+        ensure(
+            json_string(&field_trace, "message_type").as_deref() == Some("ADT^A01"),
+            "expected field trace message type to match validation report",
+        )?;
         let summary_v2 = summary.to_v2("hl7v2-python", "1.3.0");
         ensure(
             summary_v2.schema_version == "2",

--- a/crates/hl7v2/src/evidence/trace.rs
+++ b/crates/hl7v2/src/evidence/trace.rs
@@ -80,9 +80,15 @@ fn path_targets_field(action_path: &str, field_path: &str) -> bool {
 }
 
 fn message_type(message: &Message) -> String {
-    crate::get(message, "MSH.9")
-        .unwrap_or("unknown")
-        .to_string()
+    let message_code = crate::get(message, "MSH.9.1")
+        .or_else(|| crate::get(message, "MSH.9"))
+        .unwrap_or("unknown");
+    let trigger_event = crate::get(message, "MSH.9.2");
+
+    trigger_event.map_or_else(
+        || message_code.to_string(),
+        |event| format!("{message_code}^{event}"),
+    )
 }
 
 fn hl7_field_index(segment_id: &str, modeled_index: usize) -> usize {

--- a/crates/hl7v2/tests/safe_error_phi_parity.rs
+++ b/crates/hl7v2/tests/safe_error_phi_parity.rs
@@ -9,7 +9,9 @@ struct SafeErrorPhiParityFixture {
 
 #[derive(Debug, serde::Deserialize)]
 struct PhiFixture {
+    #[cfg(feature = "redact")]
     message: String,
+    #[cfg(feature = "redact")]
     policy: String,
     forbidden: Vec<String>,
 }
@@ -105,6 +107,7 @@ fn profile_lint_error_does_not_echo_manifest_profile_sentinels() -> TestResult {
 }
 
 #[test]
+#[cfg(feature = "redact")]
 fn redaction_output_does_not_echo_manifest_phi_sentinels() -> TestResult {
     let fixture = fixture()?;
     let output =


### PR DESCRIPTION
## Summary
- Align core evidence bundle field-path trace message_type with validation-report message type formatting (MSH.9.1^MSH.9.2).
- Add a regression assertion that core ield-paths.json reports ADT^A01 instead of only the first MSH-9 component.
- Gate the redaction-only PHI parity test behind the optional edact feature so default hl7v2 tests compile and still run parse/profile PHI checks.
- Refresh adges/ripr.json.

## Validation
- cargo +1.95.0 test -p hl7v2 parse_error_does_not_echo_manifest_phi_sentinels
- cargo +1.95.0 test -p hl7v2 --all-features evidence::tests::bundle_and_replay_keep_phi_out_of_reports
- cargo +1.95.0 test -p hl7v2 --all-features evidence::tests::bundle_schema_version_two_writes_v2_internal_artifacts
- cargo +1.95.0 test -p hl7v2
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 fmt --check
- git diff --check
- cargo +1.95.0 run -p xtask -- badges --check
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets --all-features -- -D warnings

## Notes
- Before the feature gate, cargo +1.95.0 test -p hl7v2 ... failed to compile because 	ests/safe_error_phi_parity.rs referenced hl7v2::redact without enabling the optional edact feature.