### PR TITLE
test: cover minimal MSH delimiters

### DIFF
--- a/crates/hl7v2/src/model/tests.rs
+++ b/crates/hl7v2/src/model/tests.rs
@@ -141,6 +141,13 @@ mod delims_tests {
     }
 
     #[test]
+    fn test_parse_from_msh_accepts_minimal_delimiter_prefix() {
+        let delims = Delims::parse_from_msh("MSH|^~\\&").unwrap();
+
+        assert_eq!(delims, Delims::default());
+    }
+
+    #[test]
     fn test_parse_from_msh_too_short() {
         // Too short
         let msh = "MSH|";


### PR DESCRIPTION
Summary: add a model unit test proving the minimal legal MSH delimiter prefix, MSH|^~\\&, parses to default delimiters. This targets the Nightly Tests mutation finding where the Delims::parse_from_msh length boundary survived when the exact 8-byte delimiter prefix was not covered. Validation: rtk cargo +1.95.0 test -p hl7v2 --lib model::tests::delims_tests::test_parse_from_msh_accepts_minimal_delimiter_prefix -- --exact; rtk cargo +1.95.0 test -p hl7v2 --lib model::tests::delims_tests; scoped cargo-mutants run with RUSTUP_TOOLCHAIN=1.95.0 for the three Delims::parse_from_msh '<' boundary mutants, all 3 caught; rtk cargo +1.95.0 test -p hl7v2; rtk cargo +1.95.0 test -p hl7v2 --all-features; rtk cargo +1.95.0 fmt --check; rtk git diff --check; rtk cargo +1.95.0 run -p xtask -- badges --check; workspace all-targets all-features clippy with RUSTUP_TOOLCHAIN=1.95.0 and PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1; commit hook passed; pre-push hook gate passed. Note: this reduces one deterministic mutation gap from Nightly Tests; it does not claim the full nightly mutation backlog is resolved.