### PR TITLE
test: cover MSH query bounds

### DIFF
--- a/crates/hl7v2/tests/query_facade.rs
+++ b/crates/hl7v2/tests/query_facade.rs
@@ -29,6 +29,16 @@ PID|1||123456^^^HOSP^MR~ALT999^^^ALT^MR||Doe^John^A||19700101|M\r",
     )?;
 
     require_eq(get(&message, "MSH.10"), Some("CTRL123"), "control id")?;
+    require_eq(get(&message, "MSH.12"), Some("2.5"), "version id")?;
+    require_eq(get(&message, "MSH.13"), None, "missing field after version")?;
+    require(
+        matches!(get_presence(&message, "MSH.12"), Presence::Value(value) if value == "2.5"),
+        "expected MSH-12 version presence",
+    )?;
+    require(
+        matches!(get_presence(&message, "MSH.13"), Presence::Missing),
+        "expected missing MSH-13",
+    )?;
     require_eq(get(&message, "PID.3.1"), Some("123456"), "primary MRN")?;
     require_eq(get(&message, "PID.3[2].1"), Some("ALT999"), "alternate MRN")?;
     require_eq(get(&message, "PID.5.1"), Some("Doe"), "family name")?;


### PR DESCRIPTION
Adds query facade assertions for parsed-message MSH upper-bound remapping: MSH.12 returns the version ID and MSH.13 is missing, through both get and get_presence. This targets the field_index - 2 remap and adjusted_field_index >= segment.fields.len() guards in get_msh_field and get_msh_field_presence. Mutation receipt: scoped cargo-mutants over crates/hl7v2/src/query/mod.rs with filter :(267|268|382|383): found 6 mutants and caught 6 using --test query_facade. Validation: rtk cargo +1.95.0 test -p hl7v2 --test query_facade; rtk cargo +1.95.0 test -p hl7v2; rtk cargo +1.95.0 test -p hl7v2 --all-features; rtk cargo +1.95.0 fmt --check; rtk git diff --check; rtk cargo +1.95.0 run -p xtask -- badges --check; RUSTUP_TOOLCHAIN=1.95.0 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets --all-features -- -D warnings.