### PR TITLE
fix: use occurrence paths in evidence traces

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12465",
+  "message": "12486",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/evidence_bundle.rs
+++ b/crates/hl7v2-cli/src/evidence_bundle.rs
@@ -1513,7 +1513,7 @@ mod policy {
                 );
                 let field_text = field_to_text(field, &message.delims);
                 fields.push(FieldPathTrace {
-                    path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
+                    path: occurrence_path.clone(),
                     canonical_path: canonical_path.clone(),
                     segment_index,
                     field_index,

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -3310,7 +3310,7 @@ reason = "Remove family name"
         let message_file = create_temp_hl7_with_content(
             &dir,
             "nk1-message.hl7",
-            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNK1|2|Kin^Jane\r",
+            "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNTE|1|L|Between contacts\rNK1|2|Kin^Jane\r",
         );
         let profile_file = create_temp_file(
             &dir,
@@ -3322,6 +3322,7 @@ segments:
   - id: "MSH"
   - id: "NK1"
     max_uses: 2
+  - id: "NTE"
 "#,
         );
         let policy_file = create_temp_file(
@@ -3371,6 +3372,8 @@ reason = "Remove populated next-of-kin name"
         .unwrap();
         assert!(field_paths["fields"].as_array().unwrap().iter().any(
             |field| field["canonical_path"] == "NK1.2"
+                && field["path"] == "NK1[2].2"
+                && field["segment_index"] == 4
                 && field["redaction_action"] == "drop"
                 && field["value_shape"] == "empty"
         ));

--- a/crates/hl7v2-server/src/evidence.rs
+++ b/crates/hl7v2-server/src/evidence.rs
@@ -416,7 +416,7 @@ fn build_field_path_trace(message: &Message, receipt: &RedactionReceipt) -> Fiel
             );
             let field_text = field_to_text(field, &message.delims);
             fields.push(FieldPathTrace {
-                path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
+                path: occurrence_path.clone(),
                 canonical_path: canonical_path.clone(),
                 segment_index,
                 field_index,

--- a/crates/hl7v2-server/src/models/evidence.rs
+++ b/crates/hl7v2-server/src/models/evidence.rs
@@ -457,11 +457,11 @@ pub struct FieldPathTraceReportV2 {
 /// Field path trace record.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldPathTrace {
-    /// Segment-position-qualified path.
+    /// Segment-occurrence-qualified path, such as `OBX[2].5`.
     pub path: String,
     /// Segment and HL7 field path, such as `PID.3`.
     pub canonical_path: String,
-    /// One-based segment index.
+    /// One-based absolute segment index.
     pub segment_index: usize,
     /// One-based HL7 field index.
     pub field_index: usize,

--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -250,6 +250,54 @@ async fn test_bundle_endpoint_writes_redacted_evidence_bundle() {
 }
 
 #[tokio::test]
+async fn test_bundle_endpoint_field_trace_path_uses_segment_occurrence() {
+    let root = TempRoot::new("occurrence-path");
+    let bundle_id = "occurrence-path-case";
+    let body = json!({
+        "message": "MSH|^~\\&|LAB|L|EHR|E|202605030101||ADT^A01|CTRL123|P|2.5\rNK1|1\rNTE|1|L|Between contacts\rNK1|2|Kin^Jane\r",
+        "profile": r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "NK1"
+    max_uses: 2
+  - id: "NTE"
+"#,
+        "redaction_policy": r#"
+[[rules]]
+path = "NK1[2]-2"
+action = "drop"
+reason = "Remove populated next-of-kin name"
+"#,
+        "bundle_id": bundle_id
+    });
+
+    let response = test_router(Some(root.path().to_path_buf()))
+        .oneshot(bundle_request_with_body(body))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let bundle_dir = root.path().join(bundle_id);
+    let field_paths: Value =
+        serde_json::from_str(&fs::read_to_string(bundle_dir.join("field-paths.json")).unwrap())
+            .unwrap();
+
+    assert!(
+        field_paths["fields"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|field| field["canonical_path"] == "NK1.2"
+                && field["path"] == "NK1[2].2"
+                && field["segment_index"] == 4
+                && field["redaction_action"] == "drop"
+                && field["value_shape"] == "empty")
+    );
+}
+
+#[tokio::test]
 async fn test_bundle_endpoint_schema_version_two_writes_v2_internal_artifacts() {
     let root = TempRoot::new("v2-artifacts");
     let bundle_id = "MRN-SECRET-123";

--- a/crates/hl7v2/src/evidence.rs
+++ b/crates/hl7v2/src/evidence.rs
@@ -248,6 +248,7 @@ reason = "Date of birth"
         let bundle_dir = temp.path().join("targeted-redaction-bundle");
         let message = "MSH|^~\\&|SEND|FAC|RECV|FAC|202605090101||ORU^R01|CTRL1|P|2.5\r\
 OBX|1|ST|A||Alpha\r\
+NTE|1|L|Between observations\r\
 OBX|2|ST|B||Beta\r\
 OBX|3|ST|C||Gamma";
         let profile = r#"
@@ -256,6 +257,7 @@ version: "2.5"
 segments:
   - id: "MSH"
   - id: "OBX"
+  - id: "NTE"
 constraints:
   - path: "MSH.9"
     required: true
@@ -316,9 +318,16 @@ reason = "Targeted observation redaction"
         )?;
         ensure(
             redacted_field
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                == Some("OBX[2].5"),
+            "expected second OBX occurrence-qualified trace path",
+        )?;
+        ensure(
+            redacted_field
                 .get("segment_index")
                 .and_then(serde_json::Value::as_u64)
-                == Some(3),
+                == Some(4),
             "expected second OBX absolute segment index",
         )?;
         ensure(

--- a/crates/hl7v2/src/evidence/models.rs
+++ b/crates/hl7v2/src/evidence/models.rs
@@ -190,11 +190,11 @@ pub struct FieldPathTraceReportV2 {
 /// Field path trace record.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FieldPathTrace {
-    /// Segment-position-qualified path.
+    /// Segment-occurrence-qualified path, such as `OBX[2].5`.
     pub path: String,
     /// Segment and HL7 field path, such as `PID.3`.
     pub canonical_path: String,
-    /// One-based segment index.
+    /// One-based absolute segment index.
     pub segment_index: usize,
     /// One-based HL7 field index.
     pub field_index: usize,

--- a/crates/hl7v2/src/evidence/trace.rs
+++ b/crates/hl7v2/src/evidence/trace.rs
@@ -35,7 +35,7 @@ pub(crate) fn build_field_path_trace(
             );
             let field_text = field_to_text(field, &message.delims);
             fields.push(FieldPathTrace {
-                path: format!("{}[{}].{}", segment.id_str(), segment_index, field_index),
+                path: occurrence_path.clone(),
                 canonical_path: canonical_path.clone(),
                 segment_index,
                 field_index,

--- a/fixtures/evidence/field-path-trace-v2.json
+++ b/fixtures/evidence/field-path-trace-v2.json
@@ -96,7 +96,7 @@
       "value_shape": "present"
     },
     {
-      "path": "PID[2].1",
+      "path": "PID[1].1",
       "canonical_path": "PID.1",
       "segment_index": 2,
       "field_index": 1,
@@ -104,7 +104,7 @@
       "value_shape": "present"
     },
     {
-      "path": "PID[2].2",
+      "path": "PID[1].2",
       "canonical_path": "PID.2",
       "segment_index": 2,
       "field_index": 2,
@@ -112,7 +112,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].3",
+      "path": "PID[1].3",
       "canonical_path": "PID.3",
       "segment_index": 2,
       "field_index": 3,
@@ -121,7 +121,7 @@
       "redaction_action": "hash"
     },
     {
-      "path": "PID[2].4",
+      "path": "PID[1].4",
       "canonical_path": "PID.4",
       "segment_index": 2,
       "field_index": 4,
@@ -129,7 +129,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].5",
+      "path": "PID[1].5",
       "canonical_path": "PID.5",
       "segment_index": 2,
       "field_index": 5,
@@ -138,7 +138,7 @@
       "redaction_action": "drop"
     },
     {
-      "path": "PID[2].6",
+      "path": "PID[1].6",
       "canonical_path": "PID.6",
       "segment_index": 2,
       "field_index": 6,
@@ -146,7 +146,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].7",
+      "path": "PID[1].7",
       "canonical_path": "PID.7",
       "segment_index": 2,
       "field_index": 7,
@@ -155,7 +155,7 @@
       "redaction_action": "drop"
     },
     {
-      "path": "PID[2].8",
+      "path": "PID[1].8",
       "canonical_path": "PID.8",
       "segment_index": 2,
       "field_index": 8,
@@ -163,7 +163,7 @@
       "value_shape": "present"
     },
     {
-      "path": "PID[2].9",
+      "path": "PID[1].9",
       "canonical_path": "PID.9",
       "segment_index": 2,
       "field_index": 9,
@@ -171,7 +171,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].10",
+      "path": "PID[1].10",
       "canonical_path": "PID.10",
       "segment_index": 2,
       "field_index": 10,
@@ -179,7 +179,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].11",
+      "path": "PID[1].11",
       "canonical_path": "PID.11",
       "segment_index": 2,
       "field_index": 11,
@@ -188,7 +188,7 @@
       "redaction_action": "drop"
     },
     {
-      "path": "OBX[3].1",
+      "path": "OBX[1].1",
       "canonical_path": "OBX.1",
       "segment_index": 3,
       "field_index": 1,
@@ -196,7 +196,7 @@
       "value_shape": "present"
     },
     {
-      "path": "OBX[3].2",
+      "path": "OBX[1].2",
       "canonical_path": "OBX.2",
       "segment_index": 3,
       "field_index": 2,
@@ -204,7 +204,7 @@
       "value_shape": "present"
     },
     {
-      "path": "OBX[3].3",
+      "path": "OBX[1].3",
       "canonical_path": "OBX.3",
       "segment_index": 3,
       "field_index": 3,
@@ -213,7 +213,7 @@
       "redaction_action": "retain"
     },
     {
-      "path": "OBX[3].4",
+      "path": "OBX[1].4",
       "canonical_path": "OBX.4",
       "segment_index": 3,
       "field_index": 4,
@@ -221,7 +221,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "OBX[3].5",
+      "path": "OBX[1].5",
       "canonical_path": "OBX.5",
       "segment_index": 3,
       "field_index": 5,
@@ -230,7 +230,7 @@
       "redaction_action": "retain"
     },
     {
-      "path": "OBX[3].6",
+      "path": "OBX[1].6",
       "canonical_path": "OBX.6",
       "segment_index": 3,
       "field_index": 6,

--- a/fixtures/evidence/field-path-trace.json
+++ b/fixtures/evidence/field-path-trace.json
@@ -93,7 +93,7 @@
       "value_shape": "present"
     },
     {
-      "path": "PID[2].1",
+      "path": "PID[1].1",
       "canonical_path": "PID.1",
       "segment_index": 2,
       "field_index": 1,
@@ -101,7 +101,7 @@
       "value_shape": "present"
     },
     {
-      "path": "PID[2].2",
+      "path": "PID[1].2",
       "canonical_path": "PID.2",
       "segment_index": 2,
       "field_index": 2,
@@ -109,7 +109,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].3",
+      "path": "PID[1].3",
       "canonical_path": "PID.3",
       "segment_index": 2,
       "field_index": 3,
@@ -118,7 +118,7 @@
       "redaction_action": "hash"
     },
     {
-      "path": "PID[2].4",
+      "path": "PID[1].4",
       "canonical_path": "PID.4",
       "segment_index": 2,
       "field_index": 4,
@@ -126,7 +126,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].5",
+      "path": "PID[1].5",
       "canonical_path": "PID.5",
       "segment_index": 2,
       "field_index": 5,
@@ -135,7 +135,7 @@
       "redaction_action": "drop"
     },
     {
-      "path": "PID[2].6",
+      "path": "PID[1].6",
       "canonical_path": "PID.6",
       "segment_index": 2,
       "field_index": 6,
@@ -143,7 +143,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].7",
+      "path": "PID[1].7",
       "canonical_path": "PID.7",
       "segment_index": 2,
       "field_index": 7,
@@ -152,7 +152,7 @@
       "redaction_action": "drop"
     },
     {
-      "path": "PID[2].8",
+      "path": "PID[1].8",
       "canonical_path": "PID.8",
       "segment_index": 2,
       "field_index": 8,
@@ -160,7 +160,7 @@
       "value_shape": "present"
     },
     {
-      "path": "PID[2].9",
+      "path": "PID[1].9",
       "canonical_path": "PID.9",
       "segment_index": 2,
       "field_index": 9,
@@ -168,7 +168,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].10",
+      "path": "PID[1].10",
       "canonical_path": "PID.10",
       "segment_index": 2,
       "field_index": 10,
@@ -176,7 +176,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "PID[2].11",
+      "path": "PID[1].11",
       "canonical_path": "PID.11",
       "segment_index": 2,
       "field_index": 11,
@@ -185,7 +185,7 @@
       "redaction_action": "drop"
     },
     {
-      "path": "OBX[3].1",
+      "path": "OBX[1].1",
       "canonical_path": "OBX.1",
       "segment_index": 3,
       "field_index": 1,
@@ -193,7 +193,7 @@
       "value_shape": "present"
     },
     {
-      "path": "OBX[3].2",
+      "path": "OBX[1].2",
       "canonical_path": "OBX.2",
       "segment_index": 3,
       "field_index": 2,
@@ -201,7 +201,7 @@
       "value_shape": "present"
     },
     {
-      "path": "OBX[3].3",
+      "path": "OBX[1].3",
       "canonical_path": "OBX.3",
       "segment_index": 3,
       "field_index": 3,
@@ -210,7 +210,7 @@
       "redaction_action": "retain"
     },
     {
-      "path": "OBX[3].4",
+      "path": "OBX[1].4",
       "canonical_path": "OBX.4",
       "segment_index": 3,
       "field_index": 4,
@@ -218,7 +218,7 @@
       "value_shape": "empty"
     },
     {
-      "path": "OBX[3].5",
+      "path": "OBX[1].5",
       "canonical_path": "OBX.5",
       "segment_index": 3,
       "field_index": 5,
@@ -227,7 +227,7 @@
       "redaction_action": "retain"
     },
     {
-      "path": "OBX[3].6",
+      "path": "OBX[1].6",
       "canonical_path": "OBX.6",
       "segment_index": 3,
       "field_index": 6,

--- a/schemas/evidence/field-path-trace-v1.schema.json
+++ b/schemas/evidence/field-path-trace-v1.schema.json
@@ -35,6 +35,7 @@
       ],
       "properties": {
         "path": {
+          "description": "Segment-occurrence-qualified path, for example OBX[2].5. The segment_index field keeps the absolute one-based segment position.",
           "type": "string"
         },
         "canonical_path": {

--- a/schemas/evidence/field-path-trace-v2.schema.json
+++ b/schemas/evidence/field-path-trace-v2.schema.json
@@ -52,6 +52,7 @@
       ],
       "properties": {
         "path": {
+          "description": "Segment-occurrence-qualified path, for example OBX[2].5. The segment_index field keeps the absolute one-based segment position.",
           "type": "string"
         },
         "canonical_path": {


### PR DESCRIPTION
Summary: makes field-path trace path values use the stable segment occurrence coordinate already used for redaction matching, while keeping segment_index as the absolute one-based segment position. Updates core, CLI, and server producers; schema descriptions; model comments; and interleaved repeated-segment tests. Also refreshes badges/ripr.json after xtask badges reported it stale. Validation: rtk cargo +1.95.0 test -p hl7v2 --features profile,redact bundle_field_trace_marks_segment_specific_redaction; rtk cargo +1.95.0 test -p hl7v2-cli --test integration_tests test_bundle_accepts_segment_repetition_sensitive_policy; rtk cargo +1.95.0 test -p hl7v2-server --test bundle_endpoint_test test_bundle_endpoint_field_trace_path_uses_segment_occurrence; rtk cargo +1.95.0 fmt --check; rtk git diff --check; rtk cargo +1.95.0 run -p xtask -- evidence-schema-check; rtk cargo +1.95.0 test -p hl7v2 --all-features; rtk cargo +1.95.0 test -p hl7v2-server --test bundle_endpoint_test; rtk cargo +1.95.0 test -p hl7v2-cli --test integration_tests bundle_command; rtk cargo +1.95.0 run -p xtask -- badges --check; RUSTUP_TOOLCHAIN=1.95.0 PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets --all-features -- -D warnings.