### PR TITLE
feat: add parsed query path accessors

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12486",
+  "message": "12490",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-bench/benches/query.rs
+++ b/crates/hl7v2-bench/benches/query.rs
@@ -4,7 +4,10 @@
 //! indexing or compiled-path behavior.
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use hl7v2::{Message, get, get_presence, parse, parse_located_path};
+use hl7v2::{
+    LocatedPath, Message, get, get_located, get_presence, get_presence_located, parse,
+    parse_located_path,
+};
 use std::hint::black_box;
 
 fn create_query_message(obx_count: usize) -> String {
@@ -49,19 +52,36 @@ fn query_paths() -> [&'static str; 8] {
     ]
 }
 
+fn parse_query_path(path: &str) -> LocatedPath {
+    match parse_located_path(path) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            eprintln!("query benchmark path failed to parse: {err}");
+            std::process::abort();
+        }
+    }
+}
+
+fn query_located_paths() -> [LocatedPath; 8] {
+    [
+        parse_query_path("MSH-10"),
+        parse_query_path("MSH-12"),
+        parse_query_path("PID-3[2].4"),
+        parse_query_path("PID-5.1"),
+        parse_query_path("PV1-7.2"),
+        parse_query_path("OBX[1]-5"),
+        parse_query_path("OBX[30]-5"),
+        parse_query_path("NTE[30]-3"),
+    ]
+}
+
 fn bench_parse_query_paths(c: &mut Criterion) {
     let paths = query_paths();
 
     c.bench_function("query_parse_paths_mixed_formats", |b| {
         b.iter(|| {
             for path in paths {
-                let parsed = match parse_located_path(black_box(path)) {
-                    Ok(parsed) => parsed,
-                    Err(err) => {
-                        eprintln!("query benchmark path failed to parse: {err}");
-                        std::process::abort();
-                    }
-                };
+                let parsed = parse_query_path(black_box(path));
                 black_box(parsed);
             }
         });
@@ -79,12 +99,36 @@ fn bench_repeated_late_segment_get(c: &mut Criterion) {
     });
 }
 
+fn bench_repeated_late_segment_get_located(c: &mut Criterion) {
+    let message = parse_query_message(60);
+    let path = parse_query_path("OBX[60]-5");
+
+    c.bench_function("query_get_located_late_repeated_segment", |b| {
+        b.iter(|| {
+            let value = get_located(black_box(&message), black_box(&path));
+            black_box(value);
+        });
+    });
+}
+
 fn bench_repeated_late_segment_presence(c: &mut Criterion) {
     let message = parse_query_message(60);
 
     c.bench_function("query_presence_late_repeated_segment", |b| {
         b.iter(|| {
             let presence = get_presence(black_box(&message), black_box("NTE[60]-3"));
+            black_box(presence);
+        });
+    });
+}
+
+fn bench_repeated_late_segment_presence_located(c: &mut Criterion) {
+    let message = parse_query_message(60);
+    let path = parse_query_path("NTE[60]-3");
+
+    c.bench_function("query_presence_located_late_repeated_segment", |b| {
+        b.iter(|| {
+            let presence = get_presence_located(black_box(&message), black_box(&path));
             black_box(presence);
         });
     });
@@ -98,6 +142,20 @@ fn bench_mixed_query_set(c: &mut Criterion) {
         b.iter(|| {
             for path in paths {
                 let value = get(black_box(&message), black_box(path));
+                black_box(value);
+            }
+        });
+    });
+}
+
+fn bench_mixed_located_query_set(c: &mut Criterion) {
+    let message = parse_query_message(60);
+    let paths = query_located_paths();
+
+    c.bench_function("query_get_mixed_located_path_set", |b| {
+        b.iter(|| {
+            for path in &paths {
+                let value = get_located(black_box(&message), black_box(path));
                 black_box(value);
             }
         });
@@ -126,13 +184,39 @@ fn bench_query_by_segment_count(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_located_query_by_segment_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_get_located_last_obx_by_segment_count");
+
+    for obx_count in [10_usize, 50, 100] {
+        let message = parse_query_message(obx_count);
+        let path = parse_query_path(&format!("OBX[{obx_count}]-5"));
+        group.throughput(Throughput::Elements(obx_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(obx_count),
+            &(message, path),
+            |b, (message, path)| {
+                b.iter(|| {
+                    let value = get_located(black_box(message), black_box(path));
+                    black_box(value);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     query_benches,
     bench_parse_query_paths,
     bench_repeated_late_segment_get,
+    bench_repeated_late_segment_get_located,
     bench_repeated_late_segment_presence,
+    bench_repeated_late_segment_presence_located,
     bench_mixed_query_set,
+    bench_mixed_located_query_set,
     bench_query_by_segment_count,
+    bench_located_query_by_segment_count,
 );
 
 criterion_main!(query_benches);

--- a/crates/hl7v2/README.md
+++ b/crates/hl7v2/README.md
@@ -39,6 +39,16 @@ Common operations are available at the crate root:
 use hl7v2::{ack, get, normalize, parse, validate, write};
 ```
 
+For repeated queries, parse a path once and reuse it:
+
+```rust
+use hl7v2::{get_located, parse, parse_located_path};
+
+let msg = parse(b"MSH|^~\\&|App||Fac||20250128||ORU^R01|123|P|2.5.1\rOBX|1|ST|NOTE||Alpha\r").unwrap();
+let path = parse_located_path("OBX[1]-5").unwrap();
+assert_eq!(get_located(&msg, &path), Some("Alpha"));
+```
+
 Implementer APIs are grouped under modules such as `hl7v2::model`,
 `hl7v2::parser`, `hl7v2::writer`, `hl7v2::query`, `hl7v2::transport`,
 `hl7v2::conformance`, and `hl7v2::synthetic`.

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -84,7 +84,7 @@ pub use model::{
 };
 pub use parser::{parse, parse_batch, parse_file_batch, parse_mllp};
 pub use query::path::{LocatedPath, Path, parse_located_path, parse_path};
-pub use query::{get, get_presence};
+pub use query::{get, get_located, get_presence, get_presence_located};
 pub use transport::mllp::{
     MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,
     is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,

--- a/crates/hl7v2/src/query/mod.rs
+++ b/crates/hl7v2/src/query/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides query functionality for HL7 v2 messages,
 //! including:
 //! - Path-based field access via [`get`]
+//! - Pre-parsed path access via [`get_located`]
 //! - Presence semantics via [`get_presence`]
 //!
 //! # Path Format
@@ -70,25 +71,43 @@ use crate::model::{Atom, Message, Presence, Segment};
 /// ```
 pub fn get<'a>(msg: &'a Message, path: &str) -> Option<&'a str> {
     let parsed = self::path::parse_located_path(path).ok()?;
-    let segment = find_segment(msg, &parsed)?;
-    let rep_index = parsed.path.repetition.unwrap_or(1);
+    get_located(msg, &parsed)
+}
 
-    if parsed.path.segment == "MSH" {
+/// Get a value with a pre-parsed path.
+///
+/// This is the parse-once variant of [`get`]. Use it when the same path is
+/// applied repeatedly across messages or across multiple lookups of the same
+/// message.
+///
+/// # Arguments
+///
+/// * `msg` - The message to query
+/// * `path` - A path returned by [`path::parse_located_path`]
+///
+/// # Returns
+///
+/// The value at the path, or `None` if not found.
+pub fn get_located<'a>(msg: &'a Message, path: &self::path::LocatedPath) -> Option<&'a str> {
+    let segment = find_segment(msg, path)?;
+    let rep_index = path.path.repetition.unwrap_or(1);
+
+    if path.path.segment == "MSH" {
         get_msh_field(
             msg,
             segment,
-            parsed.path.field,
+            path.path.field,
             rep_index,
-            parsed.path.component,
-            parsed.path.subcomponent,
+            path.path.component,
+            path.path.subcomponent,
         )
     } else {
         get_field(
             segment,
-            parsed.path.field,
+            path.path.field,
             rep_index,
-            parsed.path.component,
-            parsed.path.subcomponent,
+            path.path.component,
+            path.path.subcomponent,
         )
     }
 }
@@ -129,28 +148,45 @@ pub fn get_presence(msg: &Message, path: &str) -> Presence {
         Ok(path) => path,
         Err(_) => return Presence::Missing,
     };
-    let segment = match find_segment(msg, &parsed) {
+    get_presence_located(msg, &parsed)
+}
+
+/// Get presence semantics with a pre-parsed path.
+///
+/// This is the parse-once variant of [`get_presence`]. It preserves the same
+/// missing/empty/null/value behavior as the string-path API.
+///
+/// # Arguments
+///
+/// * `msg` - The message to query
+/// * `path` - A path returned by [`path::parse_located_path`]
+///
+/// # Returns
+///
+/// The presence status of the field.
+pub fn get_presence_located(msg: &Message, path: &self::path::LocatedPath) -> Presence {
+    let segment = match find_segment(msg, path) {
         Some(segment) => segment,
         None => return Presence::Missing,
     };
-    let rep_index = parsed.path.repetition.unwrap_or(1);
+    let rep_index = path.path.repetition.unwrap_or(1);
 
-    if parsed.path.segment == "MSH" {
+    if path.path.segment == "MSH" {
         get_msh_field_presence(
             msg,
             segment,
-            parsed.path.field,
+            path.path.field,
             rep_index,
-            parsed.path.component,
-            parsed.path.subcomponent,
+            path.path.component,
+            path.path.subcomponent,
         )
     } else {
         get_field_presence(
             segment,
-            parsed.path.field,
+            path.path.field,
             rep_index,
-            parsed.path.component,
-            parsed.path.subcomponent,
+            path.path.component,
+            path.path.subcomponent,
         )
     }
 }

--- a/crates/hl7v2/tests/query_facade.rs
+++ b/crates/hl7v2/tests/query_facade.rs
@@ -1,4 +1,4 @@
-use hl7v2::{Presence, get, get_presence, parse};
+use hl7v2::{Presence, get, get_located, get_presence, get_presence_located, parse};
 use std::error::Error;
 use std::fmt::Debug;
 
@@ -89,6 +89,57 @@ fn query_facade_distinguishes_empty_and_missing_presence() -> Result<(), Box<dyn
     require(
         matches!(get_presence(&message, "PID.9"), Presence::Missing),
         "expected missing PID-9",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn query_facade_reuses_parsed_located_paths() -> Result<(), Box<dyn Error>> {
+    let message = parse(
+        b"MSH|^~\\&|LAB|FAC|EHR|RF|202605030101||ORU^R01|CTRL789|P|2.5\r\
+PID|1||123456^^^HOSP^MR~ALT999^^^ALT^MR||Doe^John^A||19700101|M\r\
+OBR|1|ORD1|FILL1|CBC^Complete blood count\r\
+OBX|1|ST|NOTE^First note||Alpha\r\
+NTE|1|L|first note\r\
+OBX|2|ST|NOTE^Second note||Beta\r\
+NTE|2|L|second note\r",
+    )?;
+
+    let message_code = hl7v2::parse_located_path("MSH-9.1")?;
+    let alternate_authority = hl7v2::parse_located_path("PID-3[2].4")?;
+    let second_obx_value = hl7v2::parse_located_path("OBX[2]-5")?;
+    let second_nte_comment = hl7v2::parse_located_path("NTE[2]-3")?;
+    let missing_obx_value = hl7v2::parse_located_path("OBX[3]-5")?;
+
+    require_eq(
+        get_located(&message, &message_code),
+        get(&message, "MSH-9.1"),
+        "parsed MSH path matches string query",
+    )?;
+    require_eq(
+        get_located(&message, &alternate_authority),
+        Some("ALT"),
+        "parsed field repetition path",
+    )?;
+    require_eq(
+        get_located(&message, &second_obx_value),
+        Some("Beta"),
+        "parsed segment repetition path",
+    )?;
+    require(
+        matches!(
+            get_presence_located(&message, &second_nte_comment),
+            Presence::Value(value) if value == "second note"
+        ),
+        "expected parsed presence path value",
+    )?;
+    require(
+        matches!(
+            get_presence_located(&message, &missing_obx_value),
+            Presence::Missing
+        ),
+        "expected missing parsed segment repetition",
     )?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- Add parse-once `get_located` and `get_presence_located` APIs over the existing `LocatedPath` model.
- Keep `get` and `get_presence` as backwards-compatible string-path wrappers.
- Add facade coverage, README usage, and query benchmarks for located paths.
- Scope note: this addresses the path reparse half of #309; segment indexing remains a separate follow-up.

## Validation
- `rtk cargo +1.95.0 test -p hl7v2 --test query_facade`
- `rtk cargo +1.95.0 fmt --check`
- `rtk cargo +1.95.0 bench -p hl7v2-bench --bench query --no-run`
- `rtk cargo +1.95.0 bench -p hl7v2-bench --bench query -- --sample-size 10 --warm-up-time 1 --measurement-time 1`
- `rtk cargo +1.95.0 test -p hl7v2 --all-features`
- `rtk cargo +1.95.0 clippy -p hl7v2 -p hl7v2-bench --benches --all-features -- -D warnings`
- `rtk git diff --check`
- `rtk cargo +1.95.0 run -p xtask -- badges --check`
- Mutation: `cargo mutants -p hl7v2 --file crates/hl7v2/src/query/mod.rs -F "get_located|get_presence_located" --baseline skip -- -p hl7v2 --test query_facade` under Rust 1.95.0: 5 caught, 1 unviable (`Presence` has no `Default`).