### PR TITLE
fix: return MSH-1 query value

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12490",
+  "message": "12508",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/query/mod.rs
+++ b/crates/hl7v2/src/query/mod.rs
@@ -221,6 +221,22 @@ fn component_and_subcomponent(
     }
 }
 
+fn ascii_delimiter_value(delimiter: char) -> Option<&'static str> {
+    static ASCII_STRINGS: std::sync::OnceLock<[String; 128]> = std::sync::OnceLock::new();
+
+    if !delimiter.is_ascii() {
+        return None;
+    }
+
+    let values = ASCII_STRINGS.get_or_init(|| {
+        std::array::from_fn(|index| match u8::try_from(index) {
+            Ok(byte) => char::from(byte).to_string(),
+            Err(_err) => String::new(),
+        })
+    });
+    Some(values[delimiter as usize].as_str())
+}
+
 /// Get field value from a non-MSH segment
 fn get_field(
     segment: &Segment,
@@ -266,7 +282,7 @@ fn get_field(
 
 /// Get field value from an MSH segment
 fn get_msh_field<'a>(
-    _msg: &'a Message,
+    msg: &'a Message,
     segment: &'a Segment,
     field_index: usize,
     rep_index: usize,
@@ -275,7 +291,7 @@ fn get_msh_field<'a>(
 ) -> Option<&'a str> {
     if field_index == 1 {
         // MSH-1 is the field separator character
-        None // We can't return a reference to a temporary
+        ascii_delimiter_value(msg.delims.field)
     } else if field_index == 2 {
         // MSH-2 is the encoding characters
         if segment.fields.is_empty() {

--- a/crates/hl7v2/tests/query_facade.rs
+++ b/crates/hl7v2/tests/query_facade.rs
@@ -95,6 +95,19 @@ fn query_facade_distinguishes_empty_and_missing_presence() -> Result<(), Box<dyn
 }
 
 #[test]
+fn query_facade_returns_msh_field_separator_value() -> Result<(), Box<dyn Error>> {
+    let message = parse(b"MSH*^~\\&*SEND*FAC*RECV*RF*202605030101**ADT^A01*CTRL123*P*2.5\r")?;
+
+    require_eq(get(&message, "MSH.1"), Some("*"), "MSH-1 value")?;
+    require(
+        matches!(get_presence(&message, "MSH.1"), Presence::Value(value) if value == "*"),
+        "expected MSH-1 presence value",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn query_facade_reuses_parsed_located_paths() -> Result<(), Box<dyn Error>> {
     let message = parse(
         b"MSH|^~\\&|LAB|FAC|EHR|RF|202605030101||ORU^R01|CTRL789|P|2.5\r\


### PR DESCRIPTION
## Summary
- Return the MSH-1 field separator from `get`/`get_located` instead of `None`.
- Keep value lookup aligned with existing `get_presence` behavior for MSH-1.
- Add a custom-delimiter facade regression for `MSH.1`.
- Refresh the ripr badge count after adding the test.

## Repro
- Before the fix, `rtk cargo +1.95.0 test -p hl7v2 --test query_facade query_facade_returns_msh_field_separator_value` failed with `expected Some("*"), got None`.

## Validation
- `rtk cargo +1.95.0 test -p hl7v2 --test query_facade query_facade_returns_msh_field_separator_value`
- `rtk cargo +1.95.0 test -p hl7v2 --test query_facade`
- `rtk cargo +1.95.0 test -p hl7v2 query::tests::test_presence_msh_field_1`
- `rtk cargo +1.95.0 fmt --check`
- `rtk cargo +1.95.0 clippy -p hl7v2 --all-features -- -D warnings`
- `rtk cargo +1.95.0 test -p hl7v2 --all-features`
- `rtk cargo +1.95.0 run -p xtask -- badges --check`
- `rtk git diff --check`