### PR TITLE
feat: add indexed query access

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12508",
+  "message": "12527",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-bench/benches/query.rs
+++ b/crates/hl7v2-bench/benches/query.rs
@@ -5,7 +5,7 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hl7v2::{
-    LocatedPath, Message, get, get_located, get_presence, get_presence_located, parse,
+    LocatedPath, Message, QueryIndex, get, get_located, get_presence, get_presence_located, parse,
     parse_located_path,
 };
 use std::hint::black_box;
@@ -111,6 +111,19 @@ fn bench_repeated_late_segment_get_located(c: &mut Criterion) {
     });
 }
 
+fn bench_repeated_late_segment_get_indexed(c: &mut Criterion) {
+    let message = parse_query_message(60);
+    let index = QueryIndex::new(&message);
+    let path = parse_query_path("OBX[60]-5");
+
+    c.bench_function("query_get_indexed_late_repeated_segment", |b| {
+        b.iter(|| {
+            let value = index.get_located(black_box(&path));
+            black_box(value);
+        });
+    });
+}
+
 fn bench_repeated_late_segment_presence(c: &mut Criterion) {
     let message = parse_query_message(60);
 
@@ -129,6 +142,19 @@ fn bench_repeated_late_segment_presence_located(c: &mut Criterion) {
     c.bench_function("query_presence_located_late_repeated_segment", |b| {
         b.iter(|| {
             let presence = get_presence_located(black_box(&message), black_box(&path));
+            black_box(presence);
+        });
+    });
+}
+
+fn bench_repeated_late_segment_presence_indexed(c: &mut Criterion) {
+    let message = parse_query_message(60);
+    let index = QueryIndex::new(&message);
+    let path = parse_query_path("NTE[60]-3");
+
+    c.bench_function("query_presence_indexed_late_repeated_segment", |b| {
+        b.iter(|| {
+            let presence = index.get_presence_located(black_box(&path));
             black_box(presence);
         });
     });
@@ -156,6 +182,21 @@ fn bench_mixed_located_query_set(c: &mut Criterion) {
         b.iter(|| {
             for path in &paths {
                 let value = get_located(black_box(&message), black_box(path));
+                black_box(value);
+            }
+        });
+    });
+}
+
+fn bench_mixed_indexed_query_set(c: &mut Criterion) {
+    let message = parse_query_message(60);
+    let index = QueryIndex::new(&message);
+    let paths = query_located_paths();
+
+    c.bench_function("query_get_mixed_indexed_path_set", |b| {
+        b.iter(|| {
+            for path in &paths {
+                let value = index.get_located(black_box(path));
                 black_box(value);
             }
         });
@@ -206,17 +247,44 @@ fn bench_located_query_by_segment_count(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_indexed_query_by_segment_count(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_get_indexed_last_obx_by_segment_count");
+
+    for obx_count in [10_usize, 50, 100] {
+        let message = parse_query_message(obx_count);
+        let path = parse_query_path(&format!("OBX[{obx_count}]-5"));
+        group.throughput(Throughput::Elements(obx_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(obx_count),
+            &(message, path),
+            |b, (message, path)| {
+                let index = QueryIndex::new(message);
+                b.iter(|| {
+                    let value = index.get_located(black_box(path));
+                    black_box(value);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     query_benches,
     bench_parse_query_paths,
     bench_repeated_late_segment_get,
     bench_repeated_late_segment_get_located,
+    bench_repeated_late_segment_get_indexed,
     bench_repeated_late_segment_presence,
     bench_repeated_late_segment_presence_located,
+    bench_repeated_late_segment_presence_indexed,
     bench_mixed_query_set,
     bench_mixed_located_query_set,
+    bench_mixed_indexed_query_set,
     bench_query_by_segment_count,
     bench_located_query_by_segment_count,
+    bench_indexed_query_by_segment_count,
 );
 
 criterion_main!(query_benches);

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -84,7 +84,7 @@ pub use model::{
 };
 pub use parser::{parse, parse_batch, parse_file_batch, parse_mllp};
 pub use query::path::{LocatedPath, Path, parse_located_path, parse_path};
-pub use query::{get, get_located, get_presence, get_presence_located};
+pub use query::{QueryIndex, get, get_located, get_presence, get_presence_located};
 pub use transport::mllp::{
     MLLP_END_1, MLLP_END_2, MLLP_START, MllpFrameIterator, find_complete_mllp_message,
     is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,

--- a/crates/hl7v2/src/query/mod.rs
+++ b/crates/hl7v2/src/query/mod.rs
@@ -40,6 +40,8 @@
 
 pub mod path;
 
+use std::collections::HashMap;
+
 use crate::model::{Atom, Message, Presence, Segment};
 
 /// Get value at path (e.g., `PID.5[1].1` or `PID-5[1].1`)
@@ -90,6 +92,105 @@ pub fn get<'a>(msg: &'a Message, path: &str) -> Option<&'a str> {
 /// The value at the path, or `None` if not found.
 pub fn get_located<'a>(msg: &'a Message, path: &self::path::LocatedPath) -> Option<&'a str> {
     let segment = find_segment(msg, path)?;
+    get_located_in_segment(msg, segment, path)
+}
+
+/// Immutable segment index for repeated queries against one message.
+///
+/// `QueryIndex` is useful when callers need to inspect many paths from the same
+/// parsed message. It builds a small segment-position map once and then reuses
+/// it for segment repetition lookups. The index borrows the message immutably,
+/// so safe Rust code cannot mutate the segment list while indexed lookups are
+/// active.
+///
+/// # Example
+///
+/// ```
+/// use hl7v2::{QueryIndex, parse};
+///
+/// let message = parse(
+///     b"MSH|^~\\&|LAB|L|EHR|E|202606010101||ORU^R01|CTRL1|P|2.5\r\
+///       OBX|1|ST|A||first\r\
+///       OBX|2|ST|B||second",
+/// )
+/// .unwrap();
+/// let index = QueryIndex::new(&message);
+///
+/// assert_eq!(index.get("OBX[2]-5"), Some("second"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct QueryIndex<'a> {
+    msg: &'a Message,
+    segment_offsets: HashMap<[u8; 3], Vec<usize>>,
+}
+
+impl<'a> QueryIndex<'a> {
+    /// Build an index for repeated lookups against `msg`.
+    #[must_use]
+    pub fn new(msg: &'a Message) -> Self {
+        let mut segment_offsets: HashMap<[u8; 3], Vec<usize>> = HashMap::new();
+        for (index, segment) in msg.segments.iter().enumerate() {
+            segment_offsets.entry(segment.id).or_default().push(index);
+        }
+
+        Self {
+            msg,
+            segment_offsets,
+        }
+    }
+
+    /// Return the message backing this index.
+    #[must_use]
+    pub fn message(&self) -> &'a Message {
+        self.msg
+    }
+
+    /// Get value at path using this index.
+    ///
+    /// This accepts the same path syntax as [`get`].
+    pub fn get(&self, path: &str) -> Option<&'a str> {
+        let parsed = self::path::parse_located_path(path).ok()?;
+        self.get_located(&parsed)
+    }
+
+    /// Get value at a pre-parsed path using this index.
+    ///
+    /// This is the indexed counterpart to [`get_located`].
+    pub fn get_located(&self, path: &self::path::LocatedPath) -> Option<&'a str> {
+        let segment = find_indexed_segment(self.msg, &self.segment_offsets, path)?;
+        get_located_in_segment(self.msg, segment, path)
+    }
+
+    /// Get presence semantics using this index.
+    ///
+    /// This accepts the same path syntax as [`get_presence`].
+    #[must_use]
+    pub fn get_presence(&self, path: &str) -> Presence {
+        let parsed = match self::path::parse_located_path(path) {
+            Ok(path) => path,
+            Err(_) => return Presence::Missing,
+        };
+        self.get_presence_located(&parsed)
+    }
+
+    /// Get presence semantics for a pre-parsed path using this index.
+    ///
+    /// This is the indexed counterpart to [`get_presence_located`].
+    #[must_use]
+    pub fn get_presence_located(&self, path: &self::path::LocatedPath) -> Presence {
+        let segment = match find_indexed_segment(self.msg, &self.segment_offsets, path) {
+            Some(segment) => segment,
+            None => return Presence::Missing,
+        };
+        get_presence_located_in_segment(self.msg, segment, path)
+    }
+}
+
+fn get_located_in_segment<'a>(
+    msg: &'a Message,
+    segment: &'a Segment,
+    path: &self::path::LocatedPath,
+) -> Option<&'a str> {
     let rep_index = path.path.repetition.unwrap_or(1);
 
     if path.path.segment == "MSH" {
@@ -169,6 +270,14 @@ pub fn get_presence_located(msg: &Message, path: &self::path::LocatedPath) -> Pr
         Some(segment) => segment,
         None => return Presence::Missing,
     };
+    get_presence_located_in_segment(msg, segment, path)
+}
+
+fn get_presence_located_in_segment(
+    msg: &Message,
+    segment: &Segment,
+    path: &self::path::LocatedPath,
+) -> Presence {
     let rep_index = path.path.repetition.unwrap_or(1);
 
     if path.path.segment == "MSH" {
@@ -205,6 +314,28 @@ fn find_segment<'a>(msg: &'a Message, path: &self::path::LocatedPath) -> Option<
         .iter()
         .filter(|segment| segment.id_str() == path.path.segment)
         .nth(segment_repetition - 1)
+}
+
+fn find_indexed_segment<'a>(
+    msg: &'a Message,
+    segment_offsets: &HashMap<[u8; 3], Vec<usize>>,
+    path: &self::path::LocatedPath,
+) -> Option<&'a Segment> {
+    let segment_repetition = path.segment_repetition.unwrap_or(1);
+    if segment_repetition == 0 {
+        return None;
+    }
+
+    let key = segment_key(&path.path.segment)?;
+    let segment_index = segment_offsets
+        .get(&key)?
+        .get(segment_repetition - 1)
+        .copied()?;
+    msg.segments.get(segment_index)
+}
+
+fn segment_key(segment: &str) -> Option<[u8; 3]> {
+    segment.as_bytes().try_into().ok()
 }
 
 fn component_and_subcomponent(

--- a/crates/hl7v2/src/query/tests.rs
+++ b/crates/hl7v2/src/query/tests.rs
@@ -399,6 +399,103 @@ fn test_get_with_segment_repetition() {
     assert_eq!(get(&message, "OBX[4]-5"), None);
 }
 
+#[test]
+fn test_query_index_gets_repeated_segments_and_preserves_free_api_behavior() {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![
+            create_test_segment(
+                "OBX",
+                vec![
+                    create_text_field(vec!["1"]),
+                    create_text_field(vec!["ST"]),
+                    create_text_field(vec!["FIRST"]),
+                    create_text_field(vec![""]),
+                    create_text_field(vec!["Alpha"]),
+                ],
+            ),
+            create_test_segment(
+                "NTE",
+                vec![
+                    create_text_field(vec!["1"]),
+                    create_text_field(vec!["L"]),
+                    create_text_field(vec!["First note"]),
+                ],
+            ),
+            create_test_segment(
+                "OBX",
+                vec![
+                    create_text_field(vec!["2"]),
+                    create_text_field(vec!["ST"]),
+                    create_text_field(vec!["SECOND"]),
+                    create_text_field(vec![""]),
+                    create_text_field(vec!["Beta"]),
+                ],
+            ),
+            create_test_segment(
+                "NTE",
+                vec![
+                    create_text_field(vec!["2"]),
+                    create_text_field(vec!["L"]),
+                    create_text_field(vec![""]),
+                ],
+            ),
+        ],
+        charsets: vec![],
+    };
+    let index = QueryIndex::new(&message);
+
+    assert_eq!(index.message().segments.len(), message.segments.len());
+    assert_eq!(index.get("OBX[1]-5"), get(&message, "OBX[1]-5"));
+    assert_eq!(index.get("OBX[2]-5"), Some("Beta"));
+    assert_eq!(index.get("OBX[3]-5"), None);
+    assert_eq!(
+        index.get_presence("NTE[1]-3"),
+        Presence::Value("First note".to_string())
+    );
+    assert_eq!(index.get_presence("NTE[2]-3"), Presence::Empty);
+
+    let parsed = match path::parse_located_path("OBX[2]-5") {
+        Ok(path) => path,
+        Err(err) => panic!("indexed path should parse: {err}"),
+    };
+    assert_eq!(index.get_located(&parsed), Some("Beta"));
+    assert_eq!(
+        index.get_presence_located(&parsed),
+        Presence::Value("Beta".to_string())
+    );
+}
+
+#[test]
+fn test_query_index_preserves_msh_delimiter_fields() {
+    let message = Message {
+        delims: Delims {
+            field: '*',
+            comp: '^',
+            rep: '~',
+            esc: '\\',
+            sub: '&',
+        },
+        segments: vec![create_test_segment(
+            "MSH",
+            vec![
+                create_text_field(vec!["^~\\&"]),
+                create_component_field(vec![vec!["SendingApp"]]),
+            ],
+        )],
+        charsets: vec![],
+    };
+    let index = QueryIndex::new(&message);
+
+    assert_eq!(index.get("MSH-1"), Some("*"));
+    assert_eq!(index.get("MSH-2"), Some("^~\\&"));
+    assert_eq!(index.get("MSH-3"), Some("SendingApp"));
+    assert_eq!(
+        index.get_presence("MSH-1"),
+        Presence::Value("*".to_string())
+    );
+}
+
 // =============================================================================
 // MSH Segment Tests
 // =============================================================================

--- a/crates/hl7v2/tests/query_facade.rs
+++ b/crates/hl7v2/tests/query_facade.rs
@@ -1,4 +1,4 @@
-use hl7v2::{Presence, get, get_located, get_presence, get_presence_located, parse};
+use hl7v2::{Presence, QueryIndex, get, get_located, get_presence, get_presence_located, parse};
 use std::error::Error;
 use std::fmt::Debug;
 
@@ -153,6 +153,44 @@ NTE|2|L|second note\r",
             Presence::Missing
         ),
         "expected missing parsed segment repetition",
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn query_facade_reuses_indexed_segment_paths() -> Result<(), Box<dyn Error>> {
+    let message = parse(
+        b"MSH|^~\\&|LAB|FAC|EHR|RF|202605030101||ORU^R01|CTRL999|P|2.5\r\
+OBX|1|ST|NOTE^First note||Alpha\r\
+NTE|1|L|first note\r\
+OBX|2|ST|NOTE^Second note||Beta\r\
+NTE|2|L|\r",
+    )?;
+    let index = QueryIndex::new(&message);
+    let second_obx_value = hl7v2::parse_located_path("OBX[2]-5")?;
+    let second_nte_comment = hl7v2::parse_located_path("NTE[2]-3")?;
+
+    require_eq(
+        index.get("MSH-1"),
+        get(&message, "MSH-1"),
+        "indexed MSH delimiter path matches string query",
+    )?;
+    require_eq(
+        index.get_located(&second_obx_value),
+        Some("Beta"),
+        "indexed segment repetition path",
+    )?;
+    require(
+        matches!(
+            index.get_presence_located(&second_nte_comment),
+            Presence::Empty
+        ),
+        "expected indexed empty presence",
+    )?;
+    require(
+        matches!(index.get_presence("OBX[3]-5"), Presence::Missing),
+        "expected indexed missing segment repetition",
     )?;
 
     Ok(())


### PR DESCRIPTION
Summary: add immutable QueryIndex for repeated lookups against one parsed message without changing Message layout; preserve existing get/get_located behavior and MSH delimiter handling; add public facade and unit coverage plus indexed query benchmark cases for issue #309. Validation: cargo fmt --check; cargo +1.95.0 test -p hl7v2 --test query_facade; cargo +1.95.0 test -p hl7v2 --all-features; cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings; cargo +1.95.0 test -p hl7v2-bench --benches --no-run; cargo +1.95.0 bench -p hl7v2-bench --bench query -- --sample-size 10 --warm-up-time 0.1 --measurement-time 0.1; cargo +1.95.0 run -p xtask -- badges --check.