### PR TITLE
fix: preserve MSH field numbers in JSON

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12527",
+  "message": "12528",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/writer/json/mod.rs
+++ b/crates/hl7v2/src/writer/json/mod.rs
@@ -81,7 +81,12 @@ pub fn to_json(msg: &Message) -> serde_json::Value {
                         None
                     } else {
                         let field_value = field_to_json(field);
-                        Some(((index + 1).to_string(), field_value))
+                        let field_number = if segment.id == *b"MSH" {
+                            index + 2
+                        } else {
+                            index + 1
+                        };
+                        Some((field_number.to_string(), field_value))
                     }
                 })
                 .collect();

--- a/crates/hl7v2/tests/json_facade.rs
+++ b/crates/hl7v2/tests/json_facade.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "json")]
 
-use hl7v2::{Comp, Delims, Field, Message, Rep, Segment, to_json, to_json_string_pretty};
+use hl7v2::{Comp, Delims, Field, Message, Rep, Segment, parse, to_json, to_json_string_pretty};
 use std::error::Error;
 use std::fmt::Debug;
 
@@ -76,6 +76,35 @@ fn json_facade_pretty_output_is_valid_json() -> Result<(), Box<dyn Error>> {
 
     require(json.contains('\n'), "expected pretty JSON newlines")?;
     require(parsed.is_object(), "expected object JSON")?;
+
+    Ok(())
+}
+
+#[test]
+fn json_facade_preserves_msh_field_numbering() -> Result<(), Box<dyn Error>> {
+    let message = parse(b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r")?;
+
+    let json = to_json(&message);
+    let segments = json
+        .get("segments")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| std::io::Error::other("missing segments"))?;
+    let fields = segments
+        .first()
+        .and_then(|segment| segment.get("fields"))
+        .ok_or_else(|| std::io::Error::other("missing MSH fields"))?;
+
+    let msh2 = serde_json::json!([[["^~\\&"]]]);
+    let msh3 = serde_json::json!([[["SEND"]]]);
+    let msh10 = serde_json::json!([[["CTRL123"]]]);
+
+    require(
+        fields.get("1").is_none(),
+        "MSH-1 should stay in delimiter metadata",
+    )?;
+    require_eq(fields.get("2"), Some(&msh2), "MSH-2 encoding characters")?;
+    require_eq(fields.get("3"), Some(&msh3), "MSH-3 sending application")?;
+    require_eq(fields.get("10"), Some(&msh10), "MSH-10 control id")?;
 
     Ok(())
 }


### PR DESCRIPTION
Summary
- preserve HL7 field numbering for MSH fields in JSON output
- keep MSH-1 delimiter metadata out of the JSON fields map
- add a facade regression test for MSH-2, MSH-3, and MSH-10 numbering

Validation
- cargo +1.95.0 test -p hl7v2 --test json_facade json_facade_preserves_msh_field_numbering --features json -- --nocapture
- cargo +1.95.0 test -p hl7v2 --test json_facade --features json
- cargo +1.95.0 test -p hl7v2 writer::json::tests --features json
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 run -p xtask -- badges --check