### PR TITLE
fix: reject empty required MSH fields

### DIFF
--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -140,7 +140,7 @@ fn check_condition(msg: &Message, condition: &Condition) -> bool {
 fn validate_msh_field_required(msg: &Message, path: &str, issues: &mut Vec<Issue>) {
     let full_path = format!("MSH.{}", path);
     // Use the query module to retrieve the value.
-    if crate::query::get(msg, &full_path).is_none() {
+    if crate::query::get(msg, &full_path).is_none_or(str::is_empty) {
         issues.push(Issue::error(
             "MISSING_REQUIRED_FIELD",
             Some(full_path),

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -118,6 +118,34 @@ PID|1||123456^^^HOSP^MR||Doe^John||19700101|X\r",
 }
 
 #[test]
+fn profile_facade_rejects_empty_required_msh_fields() -> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+constraints:
+  - path: "MSH.10"
+    required: true
+"#,
+    )?;
+    let message = parse(b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01||P|2.5\r")?;
+    let issues = validate(&message, &profile);
+
+    require(
+        issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("MSH.10")
+                && issue.code == "MISSING_REQUIRED_FIELD"
+        }),
+        "expected empty MSH.10 to fail required validation",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn profile_facade_reports_length_constraint_failures() -> Result<(), Box<dyn Error>> {
     let profile = load_profile_checked(
         r#"


### PR DESCRIPTION
Summary
- treat empty required MSH fields as missing during profile validation
- add a facade regression for empty MSH.10 control ID

Validation
- cargo +1.95.0 test -p hl7v2 --test conformance_facade profile_facade_rejects_empty_required_msh_fields --features profile -- --nocapture
- cargo fmt --check
- cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- badges --check