### PR TITLE
fix: validate required composite fields

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12528",
+  "message": "12569",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -1,4 +1,4 @@
-use crate::model::Message;
+use crate::model::{Atom, Comp, Field, Message, Rep, Segment};
 use regex::Regex;
 
 use super::*;
@@ -75,18 +75,7 @@ pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
 
 /// Validate that a required field is present
 fn validate_field_required(msg: &Message, path: &str, issues: &mut Vec<Issue>) {
-    // Use the query module to retrieve the value.
-    if let Some(value) = crate::query::get(msg, path) {
-        // If we get a value, check if it's empty
-        if value.is_empty() {
-            issues.push(Issue::error(
-                "MISSING_REQUIRED_FIELD",
-                Some(path.to_string()),
-                format!("Required field {} is missing", path),
-            ));
-        }
-    } else {
-        // If we get None, the field is truly missing
+    if !required_path_has_value(msg, path) {
         issues.push(Issue::error(
             "MISSING_REQUIRED_FIELD",
             Some(path.to_string()),
@@ -139,14 +128,113 @@ fn check_condition(msg: &Message, condition: &Condition) -> bool {
 /// Validate that a required MSH field is present
 fn validate_msh_field_required(msg: &Message, path: &str, issues: &mut Vec<Issue>) {
     let full_path = format!("MSH.{}", path);
-    // Use the query module to retrieve the value.
-    if crate::query::get(msg, &full_path).is_none_or(str::is_empty) {
+    if !required_path_has_value(msg, &full_path) {
         issues.push(Issue::error(
             "MISSING_REQUIRED_FIELD",
             Some(full_path),
             format!("Required MSH field {} is missing", path),
         ));
     }
+}
+
+fn required_path_has_value(msg: &Message, path: &str) -> bool {
+    let Ok(path) = crate::query::path::parse_located_path(path) else {
+        return false;
+    };
+    let Some(segment) = required_segment(msg, &path) else {
+        return false;
+    };
+
+    if path.path.is_msh() && path.path.field == 1 {
+        return true;
+    }
+
+    let Some(field) = required_field(segment, &path.path) else {
+        return false;
+    };
+
+    field_has_required_value(
+        field,
+        path.path.repetition,
+        path.path.component,
+        path.path.subcomponent,
+    )
+}
+
+fn required_segment<'a>(
+    msg: &'a Message,
+    path: &crate::query::path::LocatedPath,
+) -> Option<&'a Segment> {
+    let segment_repetition = path.segment_repetition.unwrap_or(1);
+    if segment_repetition == 0 {
+        return None;
+    }
+
+    msg.segments
+        .iter()
+        .filter(|segment| segment.id_str() == path.path.segment)
+        .nth(segment_repetition - 1)
+}
+
+fn required_field<'a>(segment: &'a Segment, path: &crate::query::path::Path) -> Option<&'a Field> {
+    let field_index = if path.is_msh() {
+        path.msh_stored_field_index()?
+    } else {
+        path.field.checked_sub(1)?
+    };
+
+    segment.fields.get(field_index)
+}
+
+fn field_has_required_value(
+    field: &Field,
+    repetition: Option<usize>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> bool {
+    if let Some(repetition) = repetition {
+        return repetition
+            .checked_sub(1)
+            .and_then(|index| field.reps.get(index))
+            .is_some_and(|rep| rep_has_required_value(rep, component, subcomponent));
+    }
+
+    field
+        .reps
+        .iter()
+        .any(|rep| rep_has_required_value(rep, component, subcomponent))
+}
+
+fn rep_has_required_value(
+    rep: &Rep,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> bool {
+    if let Some(component) = component {
+        return component
+            .checked_sub(1)
+            .and_then(|index| rep.comps.get(index))
+            .is_some_and(|comp| comp_has_required_value(comp, subcomponent));
+    }
+
+    rep.comps
+        .iter()
+        .any(|comp| comp_has_required_value(comp, subcomponent))
+}
+
+fn comp_has_required_value(comp: &Comp, subcomponent: Option<usize>) -> bool {
+    if let Some(subcomponent) = subcomponent {
+        return subcomponent
+            .checked_sub(1)
+            .and_then(|index| comp.subs.get(index))
+            .is_some_and(atom_has_required_value);
+    }
+
+    comp.subs.iter().any(atom_has_required_value)
+}
+
+fn atom_has_required_value(atom: &Atom) -> bool {
+    matches!(atom, Atom::Text(text) if !text.is_empty())
 }
 
 /// Validate that a field value is in the allowed values

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -146,6 +146,39 @@ constraints:
 }
 
 #[test]
+fn profile_facade_accepts_required_composite_fields_with_later_components()
+-> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ORU_R01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "OBX"
+constraints:
+  - path: "OBX[1]-5"
+    required: true
+"#,
+    )?;
+    let message = parse(
+        b"MSH|^~\\&|LAB|FAC|EHR|RF|202605030101||ORU^R01|CTRL123|P|2.5\r\
+OBX|1|XPN|NAME^Patient name||^Jane^A\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        !issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("OBX[1]-5")
+                && issue.code == "MISSING_REQUIRED_FIELD"
+        }),
+        "expected later OBX-5 components to satisfy required field validation",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn profile_facade_reports_length_constraint_failures() -> Result<(), Box<dyn Error>> {
     let profile = load_profile_checked(
         r#"


### PR DESCRIPTION
Summary
- validate required profile paths against model-wide presence inside the addressed field/component scope
- allow required composite fields such as OBX[1]-5 to pass when later components carry the value
- preserve exact required diagnostics for missing or fully empty paths

Reproduction
- before the fix, profile_facade_accepts_required_composite_fields_with_later_components failed because OBX[1]-5 with value ^Jane^A was reported as MISSING_REQUIRED_FIELD

Validation
- cargo +1.95.0 test -p hl7v2 --test conformance_facade profile_facade_accepts_required_composite_fields_with_later_components --features profile -- --nocapture
- cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo fmt --check
- cargo +1.95.0 run -p xtask -- badges --check