### PR TITLE
fix: validate field-scoped length values

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12569",
+  "message": "12610",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -435,22 +435,115 @@ fn validate_hl7_tables_with_precedence(msg: &Message, profile: &Profile, issues:
 
 /// Validate that a field value does not exceed the maximum length
 fn validate_length_constraint(msg: &Message, length: &LengthConstraint, issues: &mut Vec<Issue>) {
-    if let Some(value) = crate::query::get(msg, &length.path) {
-        if let Some(max_length) = length.max {
-            if value.len() > max_length {
-                issues.push(Issue::error(
-                    "VALUE_TOO_LONG",
-                    Some(length.path.clone()),
-                    format!(
-                        "Value '{}' for {} exceeds maximum length of {} characters",
-                        value, length.path, max_length
-                    ),
-                ));
-            }
+    if let Some(max_length) = length.max {
+        if let Some(value) = path_text_values(msg, &length.path)
+            .into_iter()
+            .find(|value| value.len() > max_length)
+        {
+            issues.push(Issue::error(
+                "VALUE_TOO_LONG",
+                Some(length.path.clone()),
+                format!(
+                    "Value '{}' for {} exceeds maximum length of {} characters",
+                    value, length.path, max_length
+                ),
+            ));
         }
     }
     // Note: We don't report an error if the field is missing but has a length constraint
     // That would be handled by a separate presence constraint if needed
+}
+
+fn path_text_values<'a>(msg: &'a Message, path: &str) -> Vec<&'a str> {
+    let Ok(path) = crate::query::path::parse_located_path(path) else {
+        return Vec::new();
+    };
+
+    if path.path.is_msh() && path.path.field == 1 {
+        return crate::query::get_located(msg, &path).into_iter().collect();
+    }
+
+    let Some(segment) = required_segment(msg, &path) else {
+        return Vec::new();
+    };
+    let Some(field) = required_field(segment, &path.path) else {
+        return Vec::new();
+    };
+
+    field_text_values(
+        field,
+        path.path.repetition,
+        path.path.component,
+        path.path.subcomponent,
+    )
+}
+
+fn field_text_values(
+    field: &Field,
+    repetition: Option<usize>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> Vec<&str> {
+    let mut values = Vec::new();
+
+    if let Some(repetition) = repetition {
+        if let Some(rep) = repetition
+            .checked_sub(1)
+            .and_then(|index| field.reps.get(index))
+        {
+            collect_rep_text_values(&mut values, rep, component, subcomponent);
+        }
+        return values;
+    }
+
+    for rep in &field.reps {
+        collect_rep_text_values(&mut values, rep, component, subcomponent);
+    }
+
+    values
+}
+
+fn collect_rep_text_values<'a>(
+    values: &mut Vec<&'a str>,
+    rep: &'a Rep,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) {
+    if let Some(component) = component {
+        if let Some(comp) = component
+            .checked_sub(1)
+            .and_then(|index| rep.comps.get(index))
+        {
+            collect_comp_text_values(values, comp, subcomponent);
+        }
+        return;
+    }
+
+    for comp in &rep.comps {
+        collect_comp_text_values(values, comp, subcomponent);
+    }
+}
+
+fn collect_comp_text_values<'a>(
+    values: &mut Vec<&'a str>,
+    comp: &'a Comp,
+    subcomponent: Option<usize>,
+) {
+    if let Some(subcomponent) = subcomponent {
+        if let Some(Atom::Text(text)) = subcomponent
+            .checked_sub(1)
+            .and_then(|index| comp.subs.get(index))
+        {
+            values.push(text.as_str());
+        }
+        return;
+    }
+
+    for atom in &comp.subs {
+        if let Atom::Text(text) = atom {
+            values.push(text.as_str());
+        }
+    }
 }
 
 /// Validate that a field value is in the allowed HL7 table

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -210,6 +210,40 @@ PID|1||123456^^^HOSP^MR||Longname^John||19700101|M\r",
 }
 
 #[test]
+fn profile_facade_reports_field_scoped_length_failures_in_later_components()
+-> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+lengths:
+  - path: "PID.5"
+    max: 5
+    policy: "no-truncate"
+"#,
+    )?;
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR||Doe^Jonathan||19700101|M\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("PID.5")
+                && issue.code == "VALUE_TOO_LONG"
+        }),
+        "expected PID.5 field-scoped length rule to inspect later components",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn profile_facade_accepts_diagnostic_segment_repetition_paths() -> Result<(), Box<dyn Error>> {
     let yaml = r#"
 message_structure: "ORU_R01"


### PR DESCRIPTION
Summary:
- validate profile length constraints across every scalar in the addressed field/component/repetition scope
- catch field-scoped length violations when later components exceed the policy
- add regression coverage for PID.5 where PID-5.1 passes but PID-5.2 is too long

Reproduction:
- before the fix, profile_facade_reports_field_scoped_length_failures_in_later_components failed because PID.5 only inspected the first scalar value Doe and missed Jonathan

Validation:
- cargo +1.95.0 test -p hl7v2 --test conformance_facade profile_facade_reports_field_scoped_length_failures_in_later_components --features profile -- --nocapture
- cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check