### PR TITLE
fix: accept PN component separators

### DIFF
--- a/crates/hl7v2/src/conformance/validation.rs
+++ b/crates/hl7v2/src/conformance/validation.rs
@@ -471,11 +471,11 @@ pub fn is_coded_value(value: &str) -> bool {
     value.chars().all(|c| c.is_ascii() && !c.is_control())
 }
 
-/// Check if value is a person name (contains letters, spaces, hyphens, apostrophes)
+/// Check if value is a person name (allows HL7 component separators)
 pub fn is_person_name(value: &str) -> bool {
-    value
-        .chars()
-        .all(|c| c.is_alphabetic() || c.is_whitespace() || c == '-' || c == '\'' || c == '.')
+    value.chars().all(|c| {
+        c.is_alphabetic() || c.is_whitespace() || c == '-' || c == '\'' || c == '.' || c == '^'
+    })
 }
 
 /// Check if value is an extended ID (contains identifier characters)

--- a/crates/hl7v2/src/conformance/validation/tests/unit_tests.rs
+++ b/crates/hl7v2/src/conformance/validation/tests/unit_tests.rs
@@ -200,6 +200,7 @@ fn test_validate_data_type_pn() {
     assert!(validate_data_type("O'Brien", "PN"));
     assert!(validate_data_type("Mary-Jane", "PN"));
     assert!(validate_data_type("Dr. Smith", "PN"));
+    assert!(validate_data_type("Smith^John", "PN"));
 
     // Invalid person names (contains numbers)
     assert!(!validate_data_type("John123", "PN"));

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -118,6 +118,38 @@ PID|1||123456^^^HOSP^MR||Doe^John||19700101|X\r",
 }
 
 #[test]
+fn profile_facade_accepts_person_name_datatype_components() -> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+datatypes:
+  - path: "PID.5"
+    type: "PN"
+"#,
+    )?;
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        !issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("PID.5")
+                && issue.code == "INVALID_DATA_TYPE"
+        }),
+        "expected PN datatype validation to accept HL7 person-name components",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn profile_facade_rejects_empty_required_msh_fields() -> Result<(), Box<dyn Error>> {
     let profile = load_profile_checked(
         r#"


### PR DESCRIPTION
Summary:
- accept HL7 component separators in the legacy PN datatype validator
- add direct regression coverage for validate_data_type("Smith^John", "PN")
- add profile facade coverage for componentized PID-5 person names

Reproduction:
- before the fix, cargo +1.95.0 test -p hl7v2 test_validate_data_type_pn --features profile -- --nocapture failed because Smith^John was rejected as PN

Validation:
- cargo +1.95.0 test -p hl7v2 test_validate_data_type_pn --features profile -- --nocapture
- cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check