### PR TITLE
fix: validate all datatype components

### DIFF
--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -288,17 +288,18 @@ fn validate_data_type_constraint(
     datatype: &DataTypeConstraint,
     issues: &mut Vec<Issue>,
 ) {
-    if let Some(value) = crate::query::get(msg, &datatype.path) {
-        if !validate_data_type(value, &datatype.r#type) {
-            issues.push(Issue::error(
-                "INVALID_DATA_TYPE",
-                Some(datatype.path.clone()),
-                format!(
-                    "Value '{}' for {} does not match expected data type {}",
-                    value, datatype.path, datatype.r#type
-                ),
-            ));
-        }
+    if let Some(value) = path_text_values(msg, &datatype.path)
+        .into_iter()
+        .find(|value| !validate_data_type(value, &datatype.r#type))
+    {
+        issues.push(Issue::error(
+            "INVALID_DATA_TYPE",
+            Some(datatype.path.clone()),
+            format!(
+                "Value '{}' for {} does not match expected data type {}",
+                value, datatype.path, datatype.r#type
+            ),
+        ));
     }
     // Note: We don't report an error if the field is missing but has a data type constraint
     // That would be handled by a separate presence constraint if needed

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -150,6 +150,39 @@ PID|1||123456^^^HOSP^MR||Doe^John||19700101|M\r",
 }
 
 #[test]
+fn profile_facade_rejects_field_scoped_datatype_failures_in_later_components()
+-> Result<(), Box<dyn Error>> {
+    let profile = load_profile_checked(
+        r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+datatypes:
+  - path: "PID.5"
+    type: "PN"
+"#,
+    )?;
+    let message = parse(
+        b"MSH|^~\\&|SEND|FAC|RECV|RF|202605030101||ADT^A01|CTRL123|P|2.5\r\
+PID|1||123456^^^HOSP^MR||Doe^John3||19700101|M\r",
+    )?;
+    let issues = validate(&message, &profile);
+
+    require(
+        issues.iter().any(|issue| {
+            issue.severity == Severity::Error
+                && issue.path.as_deref() == Some("PID.5")
+                && issue.code == "INVALID_DATA_TYPE"
+        }),
+        "expected PID.5 field-scoped datatype rule to inspect later components",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn profile_facade_rejects_empty_required_msh_fields() -> Result<(), Box<dyn Error>> {
     let profile = load_profile_checked(
         r#"


### PR DESCRIPTION
## Summary
- make profile datatypes constraints inspect every scalar value in the addressed path scope
- add a facade regression where PID.5 as PN rejects an invalid later component (Doe^John3)

## Validation
- Fails before fix: cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile profile_facade_rejects_field_scoped_datatype_failures_in_later_components -- --nocapture
- Passes after fix: cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile profile_facade_rejects_field_scoped_datatype_failures_in_later_components -- --nocapture
- cargo +1.95.0 test -p hl7v2 --test conformance_facade --features profile
- cargo +1.95.0 test -p hl7v2 test_validate_data_type_pn --features profile -- --nocapture
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check