### PR TITLE
fix: reject malformed custom msh delimiters

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12610",
+  "message": "12613",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -687,7 +687,7 @@ values: {}
         #[test]
         fn test_canonical_delimiters_normalization() {
             // Create a message with non-canonical delimiters
-            let content = "MSH|@#$\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||12345^^^HOSP^MR||Doe^John\r";
+            let content = "MSH*%$!?*SendingApp*SendingFac*ReceivingApp*ReceivingFac*20250128152312**ADT%A01*ABC123*P*2.5.1\rPID*1**12345%%%HOSP%MR**Doe%John\r";
 
             // Parse and normalize with canonical delimiters
             let message = parse(content.as_bytes()).expect("Parse should succeed");

--- a/crates/hl7v2-e2e-tests/tests/e2e/cli_integration_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/cli_integration_tests.rs
@@ -749,9 +749,9 @@ mod workflows {
 
         // Message with non-standard delimiters
         let custom_message = concat!(
-            "MSH#$*@!SendingApp#SendingFac#ReceivingApp#ReceivingFac#",
+            "MSH#$*@!#SendingApp#SendingFac#ReceivingApp#ReceivingFac#",
             "20250128152312##ADT$A01#ABC123#P#2.5.1\r",
-            "PID#1##123456^^^HOSP^MR##Doe$John$A##19800101#M###C#\r"
+            "PID#1##123456$$$HOSP$MR##Doe$John$A##19800101#M###C#\r"
         );
 
         let input_file = create_hl7_file(&dir, "custom.hl7", custom_message);

--- a/crates/hl7v2-test-utils/src/fixtures.rs
+++ b/crates/hl7v2-test-utils/src/fixtures.rs
@@ -227,7 +227,7 @@ const EDGE_CASE_SPECIAL_CHARS: &str = concat!(
 );
 
 const EDGE_CASE_CUSTOM_DELIMS: &str = concat!(
-    "MSH#$*@!App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\r",
+    "MSH#$*@!#App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\r",
     "PID#1##123##Name$First\r"
 );
 

--- a/crates/hl7v2/src/model/mod.rs
+++ b/crates/hl7v2/src/model/mod.rs
@@ -177,6 +177,12 @@ impl Delims {
         let esc_char = msh.chars().nth(6).ok_or(Error::BadDelimLength)?;
         let sub_char = msh.chars().nth(7).ok_or(Error::BadDelimLength)?;
 
+        if let Some(next_char) = msh.chars().nth(8)
+            && next_char != field_sep
+        {
+            return Err(Error::MshFieldMalformed);
+        }
+
         let delimiters = [field_sep, comp_char, rep_char, esc_char, sub_char];
         if delimiters
             .iter()

--- a/crates/hl7v2/src/model/tests.rs
+++ b/crates/hl7v2/src/model/tests.rs
@@ -129,8 +129,8 @@ mod delims_tests {
 
     #[test]
     fn test_parse_from_msh_custom() {
-        // MSH*:+\&|...
-        let msh = "MSH*:+\\&|SendingApp|ReceivingApp|...";
+        // MSH*:+\&*...
+        let msh = "MSH*:+\\&*SendingApp*ReceivingApp*...";
         let delims = Delims::parse_from_msh(msh).unwrap();
 
         assert_eq!(delims.field, '*');
@@ -145,6 +145,13 @@ mod delims_tests {
         let delims = Delims::parse_from_msh("MSH|^~\\&").unwrap();
 
         assert_eq!(delims, Delims::default());
+    }
+
+    #[test]
+    fn test_parse_from_msh_rejects_unterminated_encoding_chars() {
+        let result = Delims::parse_from_msh("MSH#$*@!SendingApp#SendingFac");
+
+        assert!(matches!(result, Err(Error::MshFieldMalformed)));
     }
 
     #[test]

--- a/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
+++ b/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
@@ -71,7 +71,7 @@ fn test_parse_adt_a04() {
 fn test_parse_custom_delimiters() {
     // Message with custom delimiters: #$*@!
     let hl7 =
-        b"MSH#$*@!App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\rPID#1##123##Name$First\r";
+        b"MSH#$*@!#App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\rPID#1##123##Name$First\r";
     let message = parse(hl7).unwrap();
 
     assert_eq!(message.delims.field, '#');
@@ -80,6 +80,15 @@ fn test_parse_custom_delimiters() {
     assert_eq!(message.delims.esc, '@');
     assert_eq!(message.delims.sub, '!');
     assert_eq!(message.segments.len(), 2);
+    assert_eq!(get(&message, "MSH.3"), Some("App"));
+}
+
+#[test]
+fn test_parse_rejects_unterminated_custom_msh_encoding_chars() {
+    let hl7 =
+        b"MSH#$*@!App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\rPID#1##123##Name$First\r";
+
+    assert!(parse(hl7).is_err());
 }
 
 #[test]

--- a/docs/TESTING_ARCHITECTURE.md
+++ b/docs/TESTING_ARCHITECTURE.md
@@ -263,7 +263,7 @@ pub mod edge_cases {
 
     /// Message with custom delimiters
     pub const CUSTOM_DELIMS: &str = concat!(
-        "MSH#$*@!App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\r",
+        "MSH#$*@!#App#Fac#Rec#RecFac#20250128120000##ADT$A01#1#P#2.5\r",
         "PID#1##123##Name$First\r"
     );
 


### PR DESCRIPTION
## Summary
- Reject custom MSH delimiters when MSH-2 is not followed by the configured field separator.
- Add regression tests for malformed unterminated encoding characters.
- Align custom delimiter fixtures/docs and refresh the ripr badge.

## Validation
- cargo +1.95.0 fmt --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli test_canonical_delimiters_normalization -- --nocapture
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests test_norm_canonical_delimiters_matches_shared_fixture -- --nocapture
- cargo +1.95.0 test -p hl7v2-e2e-tests test_workflow_normalize_and_validate -- --nocapture
- cargo +1.95.0 test -p hl7v2-test-utils
- cargo +1.95.0 run -p xtask -- badges --check