### PR TITLE
fix: preserve noncanonical normalize wire bytes

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12613",
+  "message": "12617",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -25,7 +25,7 @@ use hl7v2::{
     AckCode as GenAckCode, Event, Message, Profile, ProfileLintIssue, ProfileLintReport,
     StreamParser, ValidationReport, ValidationReportProfileIdentity, ValidationReportV2, ack, get,
     is_mllp_framed, lint_profile_yaml, load_profile, load_profile_checked, normalize, parse,
-    parse_mllp, to_json, validate, wrap_mllp, write, write_mllp,
+    parse_mllp, to_json, unwrap_mllp, validate, wrap_mllp, write, write_mllp,
 };
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -1326,8 +1326,13 @@ fn norm_command(
     // Count segments before normalization
     let segment_count = message.segments.len();
 
-    // Normalize the message
-    let original_bytes = write(&message);
+    // Normalize the message. Without canonical delimiter rewriting, preserve the
+    // validated wire payload instead of parse/write normalizing escape bytes.
+    let original_bytes = if mllp_in {
+        unwrap_mllp(&contents)?.to_vec()
+    } else {
+        contents.clone()
+    };
     let normalized_bytes = if canonical_delims {
         // Use core normalization for canonical delimiters
         normalize(&original_bytes, true)?

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -613,6 +613,26 @@ mod norm_command {
     }
 
     #[test]
+    fn test_norm_without_canonical_preserves_wire_bytes() {
+        let dir = create_temp_dir();
+        let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\r\nPID|1||12345||\\H\\O\\N\\Brien^John||||\r\n";
+        let hl7_file = create_temp_file(&dir, "wire.hl7", hl7);
+        let output_file = dir.path().join("output.hl7");
+
+        let mut cmd = cli_command();
+        cmd.args([
+            "norm",
+            hl7_file.to_str().unwrap(),
+            "-o",
+            output_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+        assert_eq!(read_file(&output_file), hl7);
+    }
+
+    #[test]
     fn test_norm_canonical_delimiters_matches_shared_fixture() {
         let dir = create_temp_dir();
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/hl7v2/src/normalize.rs
+++ b/crates/hl7v2/src/normalize.rs
@@ -20,9 +20,10 @@ use crate::writer::write;
 
 /// Normalize HL7 v2 bytes.
 ///
-/// The message is parsed and rewritten using `hl7v2::writer`. When
-/// `canonical_delims` is `true`, the output message delimiters are rewritten
-/// to canonical HL7 delimiters (`|^~\&`).
+/// The message is parsed for validation. When `canonical_delims` is `false`,
+/// the original bytes are returned unchanged. When `canonical_delims` is `true`,
+/// the output message delimiters are rewritten to canonical HL7 delimiters
+/// (`|^~\&`) using `hl7v2::writer`.
 ///
 /// # Errors
 ///
@@ -30,9 +31,11 @@ use crate::writer::write;
 pub fn normalize(bytes: &[u8], canonical_delims: bool) -> Result<Vec<u8>, Error> {
     let mut message = parse(bytes)?;
 
-    if canonical_delims {
-        message.delims = Delims::default();
+    if !canonical_delims {
+        return Ok(bytes.to_vec());
     }
+
+    message.delims = Delims::default();
 
     Ok(write(&message))
 }

--- a/crates/hl7v2/src/normalize/tests.rs
+++ b/crates/hl7v2/src/normalize/tests.rs
@@ -117,6 +117,18 @@ fn normalize_preserves_escape_sequences() -> TestResult {
 }
 
 #[test]
+fn normalize_without_canonical_delimiters_preserves_wire_bytes() -> TestResult {
+    let hl7 = b"MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\r\nPID|1||12345||\\H\\O\\N\\Brien^John||||\r\n";
+
+    let normalized = normalize(hl7, false)?;
+
+    ensure(
+        normalized == hl7,
+        "non-canonical normalization changed validated wire bytes",
+    )
+}
+
+#[test]
 fn normalize_preserves_unicode_text() -> TestResult {
     let hl7 = "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250128152312||ADT^A01|ABC123|P|2.5.1\rPID|1||12345||Müller^Jöhn\r".as_bytes();
 


### PR DESCRIPTION
## Summary
- Validate non-canonical normalize inputs without rewriting their wire bytes.
- Preserve CRLF segment separators, trailing empty fields, and unknown escape forms unless canonical delimiter rewriting is explicitly requested.
- Keep CLI 
orm aligned with the core normalize contract, including MLLP input payload handling.

## Validation
- cargo +1.95.0 fmt --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 normalize -- --nocapture
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests norm_command -- --nocapture
- cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli test_command_paths_accept_mllp_inputs_through_facade -- --nocapture
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 run -p xtask -- badges --check