### PR TITLE
fix: validate repeated profile coded values

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12617",
+  "message": "12636",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -177,6 +177,92 @@ table_precedence:
     }
 
     #[test]
+    fn test_literal_in_constraint_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+constraints:
+  - path: "OBX.8"
+    in: ["N", "H"]
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(probs.len(), 1, "expected later repetition issue: {probs:?}");
+        assert_eq!(probs[0].code, "VALUE_NOT_IN_CONSTRAINT");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
+    fn test_inline_valueset_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+valuesets:
+  - path: "OBX.8"
+    name: "abnormal_flags"
+    codes: ["N", "H"]
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(probs.len(), 1, "expected later repetition issue: {probs:?}");
+        assert_eq!(probs[0].code, "VALUE_NOT_IN_SET");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
+    fn test_hl7_table_valueset_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+valuesets:
+  - path: "OBX.8"
+    name: "HL70078"
+hl7_tables:
+  - id: "HL70078"
+    name: "Abnormal Flags"
+    version: "2.5.1"
+    codes:
+      - value: "N"
+        description: "Normal"
+        status: "A"
+      - value: "H"
+        description: "High"
+        status: "A"
+table_precedence:
+  - "HL70078"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(probs.len(), 1, "expected later repetition issue: {probs:?}");
+        assert_eq!(probs[0].code, "VALUE_NOT_IN_HL7_TABLE");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -244,17 +244,19 @@ fn validate_field_in_constraint(
     allowed_values: &[String],
     issues: &mut Vec<Issue>,
 ) {
-    if let Some(value) = crate::query::get(msg, path) {
-        if !allowed_values.contains(&value.to_string()) {
-            issues.push(Issue::error(
-                "VALUE_NOT_IN_CONSTRAINT",
-                Some(path.to_string()),
-                format!(
-                    "Value '{}' for {} is not in allowed constraint values: {:?}",
-                    value, path, allowed_values
-                ),
-            ));
-        }
+    if let Some(value) = path_text_values(msg, path).into_iter().find(|value| {
+        !allowed_values
+            .iter()
+            .any(|allowed| allowed.as_str() == *value)
+    }) {
+        issues.push(Issue::error(
+            "VALUE_NOT_IN_CONSTRAINT",
+            Some(path.to_string()),
+            format!(
+                "Value '{}' for {} is not in allowed constraint values: {:?}",
+                value, path, allowed_values
+            ),
+        ));
     }
 }
 
@@ -266,17 +268,18 @@ fn validate_value_set(msg: &Message, valueset: &ValueSet, issues: &mut Vec<Issue
         return;
     }
 
-    if let Some(value) = crate::query::get(msg, &valueset.path) {
-        if !valueset.codes.contains(&value.to_string()) {
-            issues.push(Issue::error(
-                "VALUE_NOT_IN_SET",
-                Some(valueset.path.clone()),
-                format!(
-                    "Value '{}' for {} is not in allowed set: {:?}",
-                    value, valueset.path, valueset.codes
-                ),
-            ));
-        }
+    if let Some(value) = path_text_values(msg, &valueset.path)
+        .into_iter()
+        .find(|value| !valueset.codes.iter().any(|code| code.as_str() == *value))
+    {
+        issues.push(Issue::error(
+            "VALUE_NOT_IN_SET",
+            Some(valueset.path.clone()),
+            format!(
+                "Value '{}' for {} is not in allowed set: {:?}",
+                value, valueset.path, valueset.codes
+            ),
+        ));
     }
     // Note: We don't report an error if the field is missing but has a value set constraint
     // That would be handled by a separate presence constraint if needed
@@ -407,28 +410,26 @@ fn validate_hl7_tables_with_precedence(msg: &Message, profile: &Profile, issues:
     // Validate value sets with table precedence
     for valueset in &profile.valuesets {
         if let Some(table_id) = table_map.get(valueset.name.as_str()) {
-            if let Some(value) = crate::query::get(msg, &valueset.path) {
-                // Only validate if the field is not empty
-                if !value.is_empty() {
-                    // Check if the value exists in the table
-                    let is_valid = table_id.codes.iter().any(|entry| {
-                        entry.value == value
+            if let Some(value) = path_text_values(msg, &valueset.path)
+                .into_iter()
+                .filter(|value| !value.is_empty())
+                .find(|value| {
+                    !table_id.codes.iter().any(|entry| {
+                        entry.value == *value
                             && (entry.status.is_empty()
                                 || entry.status == "A"
                                 || entry.status == "active")
-                    });
-
-                    if !is_valid {
-                        issues.push(Issue::error(
-                            "VALUE_NOT_IN_HL7_TABLE",
-                            Some(valueset.path.clone()),
-                            format!(
-                                "Value '{}' for {} is not in HL7 table {} ({})",
-                                value, valueset.path, table_id.id, table_id.name
-                            ),
-                        ));
-                    }
-                }
+                    })
+                })
+            {
+                issues.push(Issue::error(
+                    "VALUE_NOT_IN_HL7_TABLE",
+                    Some(valueset.path.clone()),
+                    format!(
+                        "Value '{}' for {} is not in HL7 table {} ({})",
+                        value, valueset.path, table_id.id, table_id.name
+                    ),
+                ));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Validate all scalar values for profile literal in constraints instead of only the first value.
- Validate all scalar values for inline value sets and HL7 table-backed value sets.
- Add repeated OBX-8 fixture-style tests proving bad later repetitions are reported.

## Validation
- cargo +1.95.0 fmt --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 later_repetitions -- --nocapture
- cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 run -p xtask -- badges --check