### PR TITLE
fix: validate repeated advanced datatype values

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12636",
+  "message": "12640",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -263,6 +263,35 @@ OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
     }
 
     #[test]
+    fn test_advanced_datatype_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+advanced_datatypes:
+  - path: "OBX.8"
+    type: "ID"
+    max_length: 1
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected advanced datatype issue for later repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "VALUE_TOO_LONG");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -314,87 +314,102 @@ fn validate_advanced_data_type(
     datatype: &AdvancedDataTypeConstraint,
     issues: &mut Vec<Issue>,
 ) {
-    if let Some(value) = crate::query::get(msg, &datatype.path) {
-        // First check basic data type
-        if !validate_data_type(value, &datatype.r#type) {
-            issues.push(Issue::error(
-                "INVALID_DATA_TYPE",
-                Some(datatype.path.clone()),
-                format!(
-                    "Value '{}' for {} does not match expected data type {}",
-                    value, datatype.path, datatype.r#type
-                ),
-            ));
-            return;
-        }
+    let values = path_text_values(msg, &datatype.path);
 
-        // Check length constraints
-        if let Some(min_length) = datatype.min_length {
-            if value.len() < min_length {
-                issues.push(Issue::error(
-                    "VALUE_TOO_SHORT",
-                    Some(datatype.path.clone()),
-                    format!(
-                        "Value '{}' for {} is shorter than minimum length of {} characters",
-                        value, datatype.path, min_length
-                    ),
-                ));
-            }
-        }
+    // First check basic data type
+    if let Some(value) = values
+        .iter()
+        .copied()
+        .find(|value| !validate_data_type(value, &datatype.r#type))
+    {
+        issues.push(Issue::error(
+            "INVALID_DATA_TYPE",
+            Some(datatype.path.clone()),
+            format!(
+                "Value '{}' for {} does not match expected data type {}",
+                value, datatype.path, datatype.r#type
+            ),
+        ));
+        return;
+    }
 
-        if let Some(max_length) = datatype.max_length {
-            if value.len() > max_length {
-                issues.push(Issue::error(
-                    "VALUE_TOO_LONG",
-                    Some(datatype.path.clone()),
-                    format!(
-                        "Value '{}' for {} exceeds maximum length of {} characters",
-                        value, datatype.path, max_length
-                    ),
-                ));
-            }
-        }
+    // Check length constraints
+    if let Some(min_length) = datatype.min_length
+        && let Some(value) = values
+            .iter()
+            .copied()
+            .find(|value| value.len() < min_length)
+    {
+        issues.push(Issue::error(
+            "VALUE_TOO_SHORT",
+            Some(datatype.path.clone()),
+            format!(
+                "Value '{}' for {} is shorter than minimum length of {} characters",
+                value, datatype.path, min_length
+            ),
+        ));
+    }
 
-        // Check regex pattern if specified
-        if let Some(pattern) = &datatype.pattern {
-            if let Ok(regex) = Regex::new(pattern) {
-                if !regex.is_match(value) {
-                    issues.push(Issue::error(
-                        "PATTERN_MISMATCH",
-                        Some(datatype.path.clone()),
-                        format!(
-                            "Value '{}' for {} does not match required pattern '{}'",
-                            value, datatype.path, pattern
-                        ),
-                    ));
-                }
-            }
-        }
+    if let Some(max_length) = datatype.max_length
+        && let Some(value) = values
+            .iter()
+            .copied()
+            .find(|value| value.len() > max_length)
+    {
+        issues.push(Issue::error(
+            "VALUE_TOO_LONG",
+            Some(datatype.path.clone()),
+            format!(
+                "Value '{}' for {} exceeds maximum length of {} characters",
+                value, datatype.path, max_length
+            ),
+        ));
+    }
 
-        // Check format if specified
-        if let Some(format) = &datatype.format {
-            if !matches_format(value, format, &datatype.r#type) {
-                issues.push(Issue::error(
-                    "FORMAT_MISMATCH",
-                    Some(datatype.path.clone()),
-                    format!(
-                        "Value '{}' for {} does not match required format '{}'",
-                        value, datatype.path, format
-                    ),
-                ));
-            }
-        }
+    // Check regex pattern if specified
+    if let Some(pattern) = &datatype.pattern
+        && let Ok(regex) = Regex::new(pattern)
+        && let Some(value) = values.iter().copied().find(|value| !regex.is_match(value))
+    {
+        issues.push(Issue::error(
+            "PATTERN_MISMATCH",
+            Some(datatype.path.clone()),
+            format!(
+                "Value '{}' for {} does not match required pattern '{}'",
+                value, datatype.path, pattern
+            ),
+        ));
+    }
 
-        // Check checksum if specified
-        if let Some(checksum) = &datatype.checksum {
-            if !validate_checksum(value, checksum) {
-                issues.push(Issue::error(
-                    "CHECKSUM_MISMATCH",
-                    Some(datatype.path.clone()),
-                    format!("Checksum validation failed for {}", datatype.path),
-                ));
-            }
-        }
+    // Check format if specified
+    if let Some(format) = &datatype.format
+        && let Some(value) = values
+            .iter()
+            .copied()
+            .find(|value| !matches_format(value, format, &datatype.r#type))
+    {
+        issues.push(Issue::error(
+            "FORMAT_MISMATCH",
+            Some(datatype.path.clone()),
+            format!(
+                "Value '{}' for {} does not match required format '{}'",
+                value, datatype.path, format
+            ),
+        ));
+    }
+
+    // Check checksum if specified
+    if let Some(checksum) = &datatype.checksum
+        && let Some(_value) = values
+            .iter()
+            .copied()
+            .find(|value| !validate_checksum(value, checksum))
+    {
+        issues.push(Issue::error(
+            "CHECKSUM_MISMATCH",
+            Some(datatype.path.clone()),
+            format!("Checksum validation failed for {}", datatype.path),
+        ));
     }
 }
 


### PR DESCRIPTION
Profile advanced datatype rules used first-value lookup, so an invalid later repetition could evade max_length, pattern, format, or checksum checks. This changes advanced datatype validation to inspect all scalar values addressed by the path and adds a repeated OBX.8 regression where N~BAD now reports VALUE_TOO_LONG. Failing-first proof: cargo +1.95.0 test -p hl7v2 advanced_datatype_checks_later_repetitions failed before the implementation with zero issues. Validation passed: cargo +1.95.0 test -p hl7v2 advanced_datatype_checks_later_repetitions; cargo +1.95.0 test -p hl7v2 conformance::profile::tests; cargo +1.95.0 fmt --check; git diff --check; cargo +1.95.0 run -p xtask -- badges --check; cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings; cargo +1.95.0 test -p hl7v2 --all-features.