### PR TITLE
fix: validate profile constraint patterns

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12640",
+  "message": "12652",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -292,6 +292,34 @@ OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
     }
 
     #[test]
+    fn test_pattern_constraint_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+constraints:
+  - path: "OBX.8"
+    pattern: "^[A-Z]$"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected pattern issue for later repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "PATTERN_MISMATCH");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -22,6 +22,10 @@ pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
             if let Some(allowed_values) = &constraint.r#in {
                 validate_field_in_constraint(msg, &constraint.path, allowed_values, &mut issues);
             }
+
+            if let Some(pattern) = &constraint.pattern {
+                validate_field_pattern_constraint(msg, &constraint.path, pattern, &mut issues);
+            }
         }
     }
 
@@ -255,6 +259,32 @@ fn validate_field_in_constraint(
             format!(
                 "Value '{}' for {} is not in allowed constraint values: {:?}",
                 value, path, allowed_values
+            ),
+        ));
+    }
+}
+
+/// Validate that a field value matches a regex pattern constraint
+fn validate_field_pattern_constraint(
+    msg: &Message,
+    path: &str,
+    pattern: &str,
+    issues: &mut Vec<Issue>,
+) {
+    let Ok(regex) = Regex::new(pattern) else {
+        return;
+    };
+
+    if let Some(value) = path_text_values(msg, path)
+        .into_iter()
+        .find(|value| !regex.is_match(value))
+    {
+        issues.push(Issue::error(
+            "PATTERN_MISMATCH",
+            Some(path.to_string()),
+            format!(
+                "Value '{}' for {} does not match required pattern '{}'",
+                value, path, pattern
             ),
         ));
     }


### PR DESCRIPTION
Profile constraints expose and lint a pattern field, but runtime validation did not enforce it. This adds runtime regex validation for Constraint.pattern using the existing path scalar collector, so repeated fields/components are checked consistently. Added regression coverage for repeated OBX.8 where N~BAD violates ^[A-Z]$ and reports PATTERN_MISMATCH. Failing-first proof: cargo +1.95.0 test -p hl7v2 pattern_constraint_checks_later_repetitions failed before implementation with zero issues. Validation passed: cargo +1.95.0 test -p hl7v2 pattern_constraint_checks_later_repetitions; cargo +1.95.0 fmt --check; git diff --check; cargo +1.95.0 run -p xtask -- badges --check; cargo +1.95.0 test -p hl7v2 conformance::profile::tests; cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings; cargo +1.95.0 test -p hl7v2 --all-features.