### PR TITLE
fix: validate profile component constraints

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12652",
+  "message": "12689",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -320,6 +320,40 @@ OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
     }
 
     #[test]
+    fn test_component_constraint_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+constraints:
+  - path: "OBX.3"
+    components:
+      max: 2
+  - path: "OBX.6"
+    components:
+      min: 2
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count~WBC^White^Blood||7.2|10^9/L~BAD|4.0-11.0|N|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            2,
+            "expected component count issues for later repetitions: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "TOO_MANY_COMPONENTS");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.3"));
+        assert_eq!(probs[1].code, "TOO_FEW_COMPONENTS");
+        assert_eq!(probs[1].path.as_deref(), Some("OBX.6"));
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -26,6 +26,10 @@ pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
             if let Some(pattern) = &constraint.pattern {
                 validate_field_pattern_constraint(msg, &constraint.path, pattern, &mut issues);
             }
+
+            if let Some(components) = &constraint.components {
+                validate_field_component_constraint(msg, &constraint.path, components, &mut issues);
+            }
         }
     }
 
@@ -288,6 +292,74 @@ fn validate_field_pattern_constraint(
             ),
         ));
     }
+}
+
+fn validate_field_component_constraint(
+    msg: &Message,
+    path: &str,
+    components: &ComponentConstraint,
+    issues: &mut Vec<Issue>,
+) {
+    let Ok(path_ref) = crate::query::path::parse_located_path(path) else {
+        return;
+    };
+    let Some(segment) = required_segment(msg, &path_ref) else {
+        return;
+    };
+    let Some(field) = required_field(segment, &path_ref.path) else {
+        return;
+    };
+
+    if let Some((count, min)) = field_component_counts(field, path_ref.path.repetition)
+        .into_iter()
+        .find_map(|count| {
+            components
+                .min
+                .filter(|min| count < *min)
+                .map(|min| (count, min))
+        })
+    {
+        issues.push(Issue::error(
+            "TOO_FEW_COMPONENTS",
+            Some(path.to_string()),
+            format!(
+                "Field {} has {} components, fewer than minimum of {}",
+                path, count, min
+            ),
+        ));
+        return;
+    }
+
+    if let Some((count, max)) = field_component_counts(field, path_ref.path.repetition)
+        .into_iter()
+        .find_map(|count| {
+            components
+                .max
+                .filter(|max| count > *max)
+                .map(|max| (count, max))
+        })
+    {
+        issues.push(Issue::error(
+            "TOO_MANY_COMPONENTS",
+            Some(path.to_string()),
+            format!(
+                "Field {} has {} components, more than maximum of {}",
+                path, count, max
+            ),
+        ));
+    }
+}
+
+fn field_component_counts(field: &Field, repetition: Option<usize>) -> Vec<usize> {
+    if let Some(repetition) = repetition {
+        return repetition
+            .checked_sub(1)
+            .and_then(|index| field.reps.get(index))
+            .map(|rep| vec![rep.comps.len()])
+            .unwrap_or_default();
+    }
+
+    field.reps.iter().map(|rep| rep.comps.len()).collect()
 }
 
 /// Validate that a field value is in the allowed value set


### PR DESCRIPTION
## Summary
- enforce profile `constraints.components.min` and `constraints.components.max` during runtime validation
- check all repetitions addressed by the constrained path and report stable component-count diagnostics
- add a regression covering min/max violations in later repetitions

## Failing-first proof
- before implementation: `rtk cargo +1.95.0 test -p hl7v2 component_constraint_checks_later_repetitions -- --nocapture` failed with `expected component count issues for later repetitions: []`

## Validation
- rtk git diff --check
- rtk cargo +1.95.0 fmt --check
- rtk cargo +1.95.0 run -p xtask -- badges --check
- rtk cargo +1.95.0 test -p hl7v2 component_constraint_checks_later_repetitions -- --nocapture
- rtk cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture
- rtk cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- rtk cargo +1.95.0 test -p hl7v2 --all-features