### PR TITLE
fix: validate profile conditions across repetitions

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12689",
+  "message": "12720",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -354,6 +354,63 @@ OBX|1|NM|WBC^White Blood Count~WBC^White^Blood||7.2|10^9/L~BAD|4.0-11.0|N|||F\r"
     }
 
     #[test]
+    fn test_condition_eq_checks_later_repetitions() {
+        let y = r#"
+message_structure: "adt_identifier_condition"
+version: "2.5.1"
+segments:
+  - id: "PID"
+constraints:
+  - path: "PID.5"
+    required: true
+    when:
+      eq: ["PID.3.5", "MR"]
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|ADT|FAC|EHR|FAC|20250101000000||ADT^A01|MSG1|P|2.5.1\r\
+PID|1||111^^^HOSP^SS~222^^^HOSP^MR|||||||||||||||||||||||\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected conditional issue for later repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "MISSING_REQUIRED_FIELD");
+        assert_eq!(probs[0].path.as_deref(), Some("PID.5"));
+    }
+
+    #[test]
+    fn test_condition_eq_keeps_unqualified_path_scalar() {
+        let y = r#"
+message_structure: "adt_identifier_condition"
+version: "2.5.1"
+segments:
+  - id: "PID"
+constraints:
+  - path: "PID.5"
+    required: true
+    when:
+      eq: ["PID.3", "MR"]
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|ADT|FAC|EHR|FAC|20250101000000||ADT^A01|MSG1|P|2.5.1\r\
+PID|1||111^^^HOSP^MR|||||||||||||||||||||||\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert!(
+            probs.is_empty(),
+            "condition should not match later components for an unqualified path: {probs:?}"
+        );
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -411,6 +411,66 @@ PID|1||111^^^HOSP^MR|||||||||||||||||||||||\r",
     }
 
     #[test]
+    fn test_condition_eq_supports_msh_field_separator() {
+        let y = r#"
+message_structure: "adt_msh_condition"
+version: "2.5.1"
+segments:
+  - id: "PID"
+constraints:
+  - path: "PID.5"
+    required: true
+    when:
+      eq: ["MSH.1", "|"]
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|ADT|FAC|EHR|FAC|20250101000000||ADT^A01|MSG1|P|2.5.1\r\
+PID|1||111^^^HOSP^MR|||||||||||||||||||||||\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected delimiter-gated required-field issue: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "MISSING_REQUIRED_FIELD");
+        assert_eq!(probs[0].path.as_deref(), Some("PID.5"));
+    }
+
+    #[test]
+    fn test_condition_eq_checks_later_repetitions_for_field_one() {
+        let y = r#"
+message_structure: "oru_field_one_condition"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+constraints:
+  - path: "OBX.5"
+    required: true
+    when:
+      eq: ["OBX.1", "2"]
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1~2|NM|WBC^White Blood Count||\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected field-one later repetition condition issue: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "MISSING_REQUIRED_FIELD");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.5"));
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -112,10 +112,9 @@ fn check_condition(msg: &Message, condition: &Condition) -> bool {
             let field_path = &eq_conditions[0];
             let expected_value = &eq_conditions[1];
 
-            if let Some(actual_value) = crate::query::get(msg, field_path) {
-                return actual_value == expected_value;
-            }
-            return false;
+            return condition_text_values(msg, field_path)
+                .into_iter()
+                .any(|actual_value| actual_value == expected_value);
         }
     }
 
@@ -243,6 +242,71 @@ fn comp_has_required_value(comp: &Comp, subcomponent: Option<usize>) -> bool {
 
 fn atom_has_required_value(atom: &Atom) -> bool {
     matches!(atom, Atom::Text(text) if !text.is_empty())
+}
+
+fn condition_text_values<'a>(msg: &'a Message, path: &str) -> Vec<&'a str> {
+    let Ok(path) = crate::query::path::parse_located_path(path) else {
+        return Vec::new();
+    };
+
+    if path.path.is_msh() && path.path.field == 1 {
+        return crate::query::get_located(msg, &path).into_iter().collect();
+    }
+
+    let Some(segment) = required_segment(msg, &path) else {
+        return Vec::new();
+    };
+    let Some(field) = required_field(segment, &path.path) else {
+        return Vec::new();
+    };
+
+    field_condition_text_values(
+        field,
+        path.path.repetition,
+        path.path.component,
+        path.path.subcomponent,
+    )
+}
+
+fn field_condition_text_values(
+    field: &Field,
+    repetition: Option<usize>,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> Vec<&str> {
+    if let Some(repetition) = repetition {
+        return repetition
+            .checked_sub(1)
+            .and_then(|index| field.reps.get(index))
+            .and_then(|rep| rep_condition_text_value(rep, component, subcomponent))
+            .into_iter()
+            .collect();
+    }
+
+    field
+        .reps
+        .iter()
+        .filter_map(|rep| rep_condition_text_value(rep, component, subcomponent))
+        .collect()
+}
+
+fn rep_condition_text_value(
+    rep: &Rep,
+    component: Option<usize>,
+    subcomponent: Option<usize>,
+) -> Option<&str> {
+    let component_index = component.unwrap_or(1).checked_sub(1)?;
+    let subcomponent_index = subcomponent.unwrap_or(1).checked_sub(1)?;
+    let atom = rep
+        .comps
+        .get(component_index)?
+        .subs
+        .get(subcomponent_index)?;
+
+    match atom {
+        Atom::Text(text) => Some(text.as_str()),
+        Atom::Null => None,
+    }
 }
 
 /// Validate that a field value is in the allowed values


### PR DESCRIPTION
Summary: evaluate profile when.eq conditions across field repetitions while preserving scalar path semantics for unqualified paths. Adds regressions for later-repetition activation and for not matching later components through an unqualified path. Validation: failing-first condition_eq_checks_later_repetitions failed before the fix; failing-first condition_eq_keeps_unqualified_path_scalar failed before the scalar-preserving helper; cargo +1.95.0 test -p hl7v2 condition_eq -- --nocapture; cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture; git diff --check; cargo +1.95.0 fmt --check; cargo +1.95.0 run -p xtask -- badges --check; cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings; cargo +1.95.0 test -p hl7v2 --all-features.