### PR TITLE
Fix custom rule lengths across repetitions

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12720",
+  "message": "12719",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -471,6 +471,61 @@ OBX|1~2|NM|WBC^White Blood Count||\r",
     }
 
     #[test]
+    fn test_custom_rule_length_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_custom_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+custom_rules:
+  - id: "abnormal-flag-length"
+    description: ""
+    script: "field(OBX.8).length() > 1"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|OK~N|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected custom rule issue for later repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "CUSTOM_RULE_VIOLATION");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
+    fn test_custom_rule_length_keeps_unqualified_path_scalar() {
+        let y = r#"
+message_structure: "oru_custom_scalar"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+custom_rules:
+  - id: "identifier-length"
+    description: ""
+    script: "field(OBX.3).length() > 2"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^X||7.2|10^9/L|4.0-11.0|N|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert!(
+            probs.is_empty(),
+            "custom rule should not match later components for an unqualified path: {probs:?}"
+        );
+    }
+
+    #[test]
     fn test_expression_guardrails() {
         let y = r#"
 message_structure: "expression_guardrails"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -838,23 +838,24 @@ fn evaluate_custom_rule_script(
             let path = &captures[1];
             let required_length: usize = captures[2].parse().map_err(|_| ())?;
 
-            if let Some(value) = crate::query::get(msg, path) {
-                if value.len() <= required_length {
-                    issues.push(Issue::error(
-                        "CUSTOM_RULE_VIOLATION",
-                        Some(path.to_string()),
-                        if rule.description.is_empty() {
-                            format!(
-                                "Field {} length {} is not greater than {}",
-                                path,
-                                value.len(),
-                                required_length
-                            )
-                        } else {
-                            rule.description.clone()
-                        },
-                    ));
-                }
+            if let Some(value) = condition_text_values(msg, path)
+                .into_iter()
+                .find(|value| value.len() <= required_length)
+            {
+                issues.push(Issue::error(
+                    "CUSTOM_RULE_VIOLATION",
+                    Some(path.to_string()),
+                    if rule.description.is_empty() {
+                        format!(
+                            "Field {} length {} is not greater than {}",
+                            path,
+                            value.len(),
+                            required_length
+                        )
+                    } else {
+                        rule.description.clone()
+                    },
+                ));
             }
             return Ok(());
         }
@@ -1202,26 +1203,26 @@ fn evaluate_custom_rule_simple(msg: &Message, rule: &CustomRule, issues: &mut Ve
         // Pattern: "field(PATH).length() > N"
         if let Some(path_end) = rule.script.find(").length() > ") {
             let path = &rule.script[6..path_end];
-            if let Some(value) = crate::query::get(msg, path) {
-                let length_str = &rule.script[path_end + 13..];
-                if let Ok(required_length) = length_str.parse::<usize>() {
-                    if value.len() <= required_length {
-                        issues.push(Issue::error(
-                            "CUSTOM_RULE_VIOLATION",
-                            Some(path.to_string()),
-                            if rule.description.is_empty() {
-                                format!(
-                                    "Field {} length {} is not greater than {}",
-                                    path,
-                                    value.len(),
-                                    required_length
-                                )
-                            } else {
-                                rule.description.clone()
-                            },
-                        ));
-                    }
-                }
+            let length_str = &rule.script[path_end + 13..];
+            if let Ok(required_length) = length_str.parse::<usize>()
+                && let Some(value) = condition_text_values(msg, path)
+                    .into_iter()
+                    .find(|value| value.len() <= required_length)
+            {
+                issues.push(Issue::error(
+                    "CUSTOM_RULE_VIOLATION",
+                    Some(path.to_string()),
+                    if rule.description.is_empty() {
+                        format!(
+                            "Field {} length {} is not greater than {}",
+                            path,
+                            value.len(),
+                            required_length
+                        )
+                    } else {
+                        rule.description.clone()
+                    },
+                ));
             }
         }
     } else if rule.script.starts_with("field(") && rule.script.contains(") in [") {


### PR DESCRIPTION
Summary: validate custom rule `field(PATH).length() > N` expressions across repeated field values; keep unqualified custom rule paths scalar for components/subcomponents; add regression coverage for later repetitions and scalar path behavior. Validation: `cargo +1.95.0 test -p hl7v2 custom_rule_length -- --nocapture`; `cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture`; `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings`; `cargo +1.95.0 test -p hl7v2 --all-features`; `cargo +1.95.0 fmt --check`; `cargo +1.95.0 run -p xtask -- badges --check`; `git diff --check`.