### PR TITLE
Fix custom rule pairs across repetitions

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12713",
+  "message": "12720",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -574,6 +574,64 @@ OBX|1|ST|FLAG^Flag||text|unit|range|{value}|||F\r"
     }
 
     #[test]
+    fn test_custom_rule_field_equality_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_custom_pair_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+custom_rules:
+  - id: "flag-pairs-match"
+    description: ""
+    script: "field(OBX.8) == field(OBX.9)"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|ST|FLAG^Flag||text|unit|range|N~BAD|N~N||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected custom rule issue for later paired repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "CUSTOM_RULE_VIOLATION");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.8"));
+    }
+
+    #[test]
+    fn test_custom_rule_age_range_checks_later_repetitions() {
+        let y = r#"
+message_structure: "oru_custom_pair_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+custom_rules:
+  - id: "age-range"
+    description: ""
+    script: "is_valid_age_range(field(OBX.7), field(OBX.8))"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|ST|DATES^Dates||text|unit|19800101~20250101|20200101~20240101||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected custom rule issue for later age-range repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "CUSTOM_RULE_VIOLATION");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.7"));
+    }
+
+    #[test]
     fn test_custom_rule_length_keeps_unqualified_path_scalar() {
         let y = r#"
 message_structure: "oru_custom_scalar"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -278,6 +278,21 @@ fn first_condition_value_matching<'a>(
         .find(|value| predicate(value))
 }
 
+fn first_condition_pair_matching<'a>(
+    msg: &'a Message,
+    path1: &str,
+    path2: &str,
+    mut predicate: impl FnMut(&str, &str) -> bool,
+) -> Option<(&'a str, &'a str)> {
+    let values1 = condition_text_values(msg, path1);
+    let values2 = condition_text_values(msg, path2);
+
+    values1
+        .into_iter()
+        .zip(values2)
+        .find(|(value1, value2)| predicate(value1, value2))
+}
+
 fn field_condition_text_values(
     field: &Field,
     repetition: Option<usize>,
@@ -1016,23 +1031,21 @@ fn evaluate_custom_rule_script(
             let path1 = &captures[1];
             let path2 = &captures[2];
 
-            if let (Some(value1), Some(value2)) =
-                (crate::query::get(msg, path1), crate::query::get(msg, path2))
+            if let Some((value1, value2)) =
+                first_condition_pair_matching(msg, path1, path2, |value1, value2| value1 != value2)
             {
-                if value1 != value2 {
-                    issues.push(Issue::error(
-                        "CUSTOM_RULE_VIOLATION",
-                        Some(path1.to_string()),
-                        if rule.description.is_empty() {
-                            format!(
-                                "Field {} value '{}' does not equal field {} value '{}'",
-                                path1, value1, path2, value2
-                            )
-                        } else {
-                            rule.description.clone()
-                        },
-                    ));
-                }
+                issues.push(Issue::error(
+                    "CUSTOM_RULE_VIOLATION",
+                    Some(path1.to_string()),
+                    if rule.description.is_empty() {
+                        format!(
+                            "Field {} value '{}' does not equal field {} value '{}'",
+                            path1, value1, path2, value2
+                        )
+                    } else {
+                        rule.description.clone()
+                    },
+                ));
             }
             return Ok(());
         }
@@ -1141,20 +1154,23 @@ fn evaluate_custom_rule_script(
             let path1 = &captures[1];
             let path2 = &captures[2];
 
-            if let (Some(value1), Some(value2)) =
-                (crate::query::get(msg, path1), crate::query::get(msg, path2))
+            if let Some((value1, value2)) =
+                first_condition_pair_matching(msg, path1, path2, |value1, value2| {
+                    !is_valid_age_range(value1, value2)
+                })
             {
-                if !is_valid_age_range(value1, value2) {
-                    issues.push(Issue::error(
-                        "CUSTOM_RULE_VIOLATION",
-                        Some(path1.to_string()),
-                        if rule.description.is_empty() {
-                            format!("Age range between {} and {} is not valid", path1, path2)
-                        } else {
-                            rule.description.clone()
-                        },
-                    ));
-                }
+                issues.push(Issue::error(
+                    "CUSTOM_RULE_VIOLATION",
+                    Some(path1.to_string()),
+                    if rule.description.is_empty() {
+                        format!(
+                            "Age range between {} value '{}' and {} value '{}' is not valid",
+                            path1, value1, path2, value2
+                        )
+                    } else {
+                        rule.description.clone()
+                    },
+                ));
             }
             return Ok(());
         }


### PR DESCRIPTION
Summary: validate pairwise custom rule expressions across aligned repeated field values instead of only the first scalar lookup; covers `field(PATH1) == field(PATH2)` and `is_valid_age_range(field(PATH1), field(PATH2))`; keeps single-value behavior unchanged while catching hidden later paired repetitions. Falling-first: `cargo +1.95.0 test -p hl7v2 custom_rule_ -- --nocapture` failed before the implementation with no diagnostics for the new equality and age-range later-repetition cases. Validation: `cargo +1.95.0 test -p hl7v2 custom_rule_ -- --nocapture`; `cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture`; `cargo +1.95.0 fmt --check`; `cargo +1.95.0 run -p xtask -- badges --check`; `git diff --check`; `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings`; `cargo +1.95.0 test -p hl7v2 --all-features`.