### PR TITLE
Fix temporal rules across repetitions

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12720",
+  "message": "12723",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -130,6 +130,76 @@ cross_field_rules:
     }
 
     #[test]
+    fn test_temporal_rule_checks_later_repetitions() {
+        let mut msg = String::new();
+        msg.push_str("MSH|^~\\&|SND|SF|RCV|RF|20250101000000||ADT^A01|MSG1|P|2.5.1\r");
+        msg.push_str("PID|1||123456^^^HOSP^MR||Doe^John||19800101|M||||||||||||||||\r");
+        msg.push_str("PV1|1|O|CLINIC|||||||20240101~20250101\r");
+        msg.push_str("ORC|RE|||20240201~20240101\r");
+
+        let y = r#"
+message_structure: "temporal_rule_repetitions"
+version: "2.5.1"
+segments:
+  - id: "PID"
+  - id: "PV1"
+  - id: "ORC"
+temporal_rules:
+  - id: "date-before-date"
+    description: "PV1 date should be before ORC date"
+    before: "PV1.10"
+    after: "ORC.4"
+"#;
+
+        let p: Profile = load_profile(y).unwrap();
+        let message = parse(msg.as_bytes()).unwrap();
+        let probs = validate(&message, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected temporal rule issue for later repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "TEMPORAL_RULE_VIOLATION");
+        assert_eq!(probs[0].path.as_deref(), Some("PV1.10"));
+    }
+
+    #[test]
+    fn test_temporal_rule_reports_invalid_later_repetition() {
+        let mut msg = String::new();
+        msg.push_str("MSH|^~\\&|SND|SF|RCV|RF|20250101000000||ADT^A01|MSG1|P|2.5.1\r");
+        msg.push_str("PID|1||123456^^^HOSP^MR||Doe^John||19800101|M||||||||||||||||\r");
+        msg.push_str("PV1|1|O|CLINIC|||||||20240101~BAD\r");
+        msg.push_str("ORC|RE|||20240201~20250101\r");
+
+        let y = r#"
+message_structure: "temporal_rule_invalid_repetitions"
+version: "2.5.1"
+segments:
+  - id: "PID"
+  - id: "PV1"
+  - id: "ORC"
+temporal_rules:
+  - id: "date-before-date"
+    description: "PV1 date should be before ORC date"
+    before: "PV1.10"
+    after: "ORC.4"
+"#;
+
+        let p: Profile = load_profile(y).unwrap();
+        let message = parse(msg.as_bytes()).unwrap();
+        let probs = validate(&message, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected invalid datetime issue for later repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "INVALID_DATETIME");
+        assert_eq!(probs[0].path.as_deref(), Some("PV1.10"));
+    }
+
+    #[test]
     fn debug_compare_same_dates() {
         let date_str = "20241201";
         let ts1 = parse_hl7_ts_with_precision(date_str).unwrap();

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -796,41 +796,40 @@ fn validate_hl7_table(msg: &Message, table: &HL7Table, profile: &Profile, issues
 
 /// Validate temporal rule (date/time relationships)
 fn validate_temporal_rule(msg: &Message, rule: &TemporalRule, issues: &mut Vec<Issue>) {
-    if let (Some(before_value), Some(after_value)) = (
-        crate::query::get(msg, &rule.before),
-        crate::query::get(msg, &rule.after),
-    ) {
-        // Parse the date/time values
-        if let (Some(before_time), Some(after_time)) =
-            (parse_datetime(before_value), parse_datetime(after_value))
-        {
-            // Check if before_time should be before after_time
-            let is_valid = if rule.allow_equal {
-                before_time <= after_time
-            } else {
-                before_time < after_time
-            };
+    let before_values = condition_text_values(msg, &rule.before);
+    let after_values = condition_text_values(msg, &rule.after);
 
-            if !is_valid {
-                issues.push(Issue::error(
-                    "TEMPORAL_RULE_VIOLATION",
-                    Some(rule.before.clone()),
-                    format!(
-                        "Value '{}' for {} should be before {} for {}",
-                        before_value, rule.before, after_value, rule.after
-                    ),
-                ));
-            }
-        } else {
-            // Handle the case where the date/time parsing fails
+    for (before_value, after_value) in before_values.into_iter().zip(after_values) {
+        let (Some(before_time), Some(after_time)) =
+            (parse_datetime(before_value), parse_datetime(after_value))
+        else {
             issues.push(Issue::error(
                 "INVALID_DATETIME",
                 Some(rule.before.clone()),
                 format!(
-                    "Invalid date/time value for {} or {}",
-                    rule.before, rule.after
+                    "Invalid date/time value '{}' for {} or '{}' for {}",
+                    before_value, rule.before, after_value, rule.after
                 ),
             ));
+            return;
+        };
+
+        let is_valid = if rule.allow_equal {
+            before_time <= after_time
+        } else {
+            before_time < after_time
+        };
+
+        if !is_valid {
+            issues.push(Issue::error(
+                "TEMPORAL_RULE_VIOLATION",
+                Some(rule.before.clone()),
+                format!(
+                    "Value '{}' for {} should be before {} for {}",
+                    before_value, rule.before, after_value, rule.after
+                ),
+            ));
+            return;
         }
     }
 }


### PR DESCRIPTION
Summary: validate profile `temporal_rules` across aligned repeated field values instead of only the first scalar pair; report stable `TEMPORAL_RULE_VIOLATION` and `INVALID_DATETIME` diagnostics for later repeated values. Falling-first: `cargo +1.95.0 test -p hl7v2 test_temporal_rule_checks_later_repetitions -- --nocapture` failed before the implementation with no diagnostic for the later repeated pair. Validation: `cargo +1.95.0 test -p hl7v2 temporal_rule -- --nocapture`; `cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture`; `cargo +1.95.0 fmt --check`; `cargo +1.95.0 run -p xtask -- badges --check`; `git diff --check`; `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings`; `cargo +1.95.0 test -p hl7v2 --all-features`.