### PR TITLE
Fix contextual rules across repetitions

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12723",
+  "message": "12694",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -541,6 +541,72 @@ OBX|1~2|NM|WBC^White Blood Count||\r",
     }
 
     #[test]
+    fn test_contextual_rule_checks_later_context_repetitions() {
+        let y = r#"
+message_structure: "oru_contextual_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+contextual_rules:
+  - id: "high-flag-note"
+    description: ""
+    context_field: "OBX.8"
+    context_value: "H"
+    target_field: "NTE.3"
+    validation_type: "require"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~H|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected contextual issue for later context repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "CONTEXTUAL_VALIDATION_ERROR");
+        assert_eq!(probs[0].path.as_deref(), Some("NTE.3"));
+    }
+
+    #[test]
+    fn test_contextual_rule_validates_later_target_repetitions() {
+        let y = r#"
+message_structure: "oru_contextual_target_repetitions"
+version: "2.5.1"
+segments:
+  - id: "OBX"
+contextual_rules:
+  - id: "high-flag-numeric-value"
+    description: ""
+    context_field: "OBX.8"
+    context_value: "H"
+    target_field: "OBX.5"
+    validation_type: "validate_datatype"
+    parameters:
+      datatype: "NM"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|NM|WBC^White Blood Count||7.2~BAD|10^9/L|4.0-11.0|H|||F\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected contextual datatype issue for later target repetition: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "CONTEXTUAL_VALIDATION_ERROR");
+        assert_eq!(probs[0].path.as_deref(), Some("OBX.5"));
+    }
+
+    #[test]
     fn test_custom_rule_length_checks_later_repetitions() {
         let y = r#"
 message_structure: "oru_custom_repetitions"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -1453,110 +1453,86 @@ fn validate_contextual_rule(
     profile: &Profile,
     issues: &mut Vec<Issue>,
 ) {
-    // Check if the context field has the expected value
-    if let Some(context_value) = crate::query::get(msg, &rule.context_field) {
-        if context_value == rule.context_value {
-            // Apply the validation based on validation_type
-            match rule.validation_type.as_str() {
-                "require" => {
-                    // Check if the target field exists and is not empty
-                    if let Some(value) = crate::query::get(msg, &rule.target_field) {
-                        if value.is_empty() {
-                            issues.push(Issue::error(
-                                "CONTEXTUAL_VALIDATION_ERROR",
-                                Some(rule.target_field.clone()),
-                                if rule.description.is_empty() {
-                                    format!(
-                                        "Field {} is required when {} equals {}",
-                                        rule.target_field, rule.context_field, rule.context_value
-                                    )
-                                } else {
-                                    rule.description.clone()
-                                },
-                            ));
-                        }
-                    } else {
-                        issues.push(Issue::error(
-                            "CONTEXTUAL_VALIDATION_ERROR",
-                            Some(rule.target_field.clone()),
-                            if rule.description.is_empty() {
-                                format!(
-                                    "Field {} is required when {} equals {}",
-                                    rule.target_field, rule.context_field, rule.context_value
-                                )
-                            } else {
-                                rule.description.clone()
-                            },
-                        ));
-                    }
-                }
-                "prohibit" => {
-                    // Check if the target field exists and is not empty
-                    if let Some(value) = crate::query::get(msg, &rule.target_field) {
-                        if !value.is_empty() {
-                            issues.push(Issue::error(
-                                "CONTEXTUAL_VALIDATION_ERROR",
-                                Some(rule.target_field.clone()),
-                                if rule.description.is_empty() {
-                                    format!(
-                                        "Field {} is prohibited when {} equals {}",
-                                        rule.target_field, rule.context_field, rule.context_value
-                                    )
-                                } else {
-                                    rule.description.clone()
-                                },
-                            ));
-                        }
-                    }
-                    // If the field doesn't exist at all, that's fine (it's not present)
-                }
-                "validate_datatype" => {
-                    // Validate target field against specified data type
-                    if let Some(datatype) = rule.parameters.get("datatype") {
-                        if let Some(value) = crate::query::get(msg, &rule.target_field) {
-                            if !validate_data_type(value, datatype) {
-                                issues.push(Issue::error(
-                                    "CONTEXTUAL_VALIDATION_ERROR",
-                                    Some(rule.target_field.clone()),
-                                    if rule.description.is_empty() {
-                                        format!("Field {} does not match data type {} required when {} equals {}", 
-                                               rule.target_field, datatype, rule.context_field, rule.context_value)
-                                    } else {
-                                        rule.description.clone()
-                                    },
-                                ));
-                            }
-                        }
-                    }
-                }
-                "validate_valueset" => {
-                    // Validate target field against specified value set
-                    if let Some(valueset_name) = rule.parameters.get("valueset") {
-                        if let Some(value) = crate::query::get(msg, &rule.target_field) {
-                            // Find the value set in the profile
-                            if let Some(valueset) = find_valueset_by_name(profile, valueset_name) {
-                                if !valueset.codes.contains(&value.to_string()) {
-                                    issues.push(Issue::error(
-                                        "CONTEXTUAL_VALIDATION_ERROR",
-                                        Some(rule.target_field.clone()),
-                                        if rule.description.is_empty() {
-                                            format!("Value '{}' for {} is not in value set {} required when {} equals {}", 
-                                                   value, rule.target_field, valueset_name, rule.context_field, rule.context_value)
-                                        } else {
-                                            rule.description.clone()
-                                        },
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    // Unknown validation type, ignore
-                }
+    if !condition_text_values(msg, &rule.context_field)
+        .into_iter()
+        .any(|context_value| context_value == rule.context_value)
+    {
+        return;
+    }
+
+    match rule.validation_type.as_str() {
+        "require" if !required_path_has_value(msg, &rule.target_field) => {
+            issues.push(contextual_issue(
+                rule,
+                format!(
+                    "Field {} is required when {} equals {}",
+                    rule.target_field, rule.context_field, rule.context_value
+                ),
+            ));
+        }
+        "prohibit"
+            if path_text_values(msg, &rule.target_field)
+                .into_iter()
+                .any(|value| !value.is_empty()) =>
+        {
+            issues.push(contextual_issue(
+                rule,
+                format!(
+                    "Field {} is prohibited when {} equals {}",
+                    rule.target_field, rule.context_field, rule.context_value
+                ),
+            ));
+        }
+        "require" | "prohibit" => {}
+        "validate_datatype" => {
+            if let Some(datatype) = rule.parameters.get("datatype")
+                && path_text_values(msg, &rule.target_field)
+                    .into_iter()
+                    .any(|value| !validate_data_type(value, datatype))
+            {
+                issues.push(contextual_issue(
+                    rule,
+                    format!(
+                        "Field {} does not match data type {} required when {} equals {}",
+                        rule.target_field, datatype, rule.context_field, rule.context_value
+                    ),
+                ));
             }
         }
+        "validate_valueset" => {
+            if let Some(valueset_name) = rule.parameters.get("valueset")
+                && let Some(valueset) = find_valueset_by_name(profile, valueset_name)
+                && let Some(value) = path_text_values(msg, &rule.target_field)
+                    .into_iter()
+                    .find(|value| !valueset.codes.iter().any(|code| code.as_str() == *value))
+            {
+                issues.push(contextual_issue(
+                    rule,
+                    format!(
+                        "Value '{}' for {} is not in value set {} required when {} equals {}",
+                        value,
+                        rule.target_field,
+                        valueset_name,
+                        rule.context_field,
+                        rule.context_value
+                    ),
+                ));
+            }
+        }
+        _ => {}
     }
+}
+
+fn contextual_issue(rule: &ContextualRule, fallback: String) -> Issue {
+    Issue::error(
+        "CONTEXTUAL_VALIDATION_ERROR",
+        Some(rule.target_field.clone()),
+        if rule.description.is_empty() {
+            fallback
+        } else {
+            rule.description.clone()
+        },
+    )
 }
 
 /// Find a value set by name within a profile


### PR DESCRIPTION
Fixes contextual profile rules so later context repetitions can activate a rule and later target repetitions are validated. Falling-first proof: cargo +1.95.0 test -p hl7v2 contextual_rule -- --nocapture failed before the runtime change with both new tests returning no diagnostics. Local validation after the fix: cargo +1.95.0 fmt; cargo +1.95.0 test -p hl7v2 contextual_rule -- --nocapture; cargo +1.95.0 test -p hl7v2 conformance::profile::tests -- --nocapture; cargo +1.95.0 run -p xtask -- badges; cargo +1.95.0 fmt --check; cargo +1.95.0 run -p xtask -- badges --check; git diff --check; cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings; cargo +1.95.0 test -p hl7v2 --all-features.