### PR TITLE
fix: warn on ignored expression guardrail keys

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12761",
+  "message": "12776",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/lint.rs
+++ b/crates/hl7v2/src/conformance/profile/lint.rs
@@ -18,6 +18,7 @@ pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
 
     let mut issues = Vec::new();
     lint_unknown_profile_keys(&root, &mut issues);
+    lint_unknown_expression_guardrail_keys(&root, &mut issues);
 
     let profile = match serde_yaml::from_value::<Profile>(root) {
         Ok(profile) => profile,
@@ -304,6 +305,37 @@ fn lint_unknown_profile_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileL
                 "unknown_top_level_key",
                 Some(key.to_string()),
                 format!("top-level key '{key}' is ignored by the profile loader"),
+            ));
+        }
+    }
+}
+
+fn lint_unknown_expression_guardrail_keys(
+    root: &serde_yaml::Value,
+    issues: &mut Vec<ProfileLintIssue>,
+) {
+    let Some(mapping) = root.as_mapping() else {
+        return;
+    };
+    let expression_guardrails_key = serde_yaml::Value::String("expression_guardrails".to_string());
+    let Some(expression_guardrails) = mapping
+        .get(&expression_guardrails_key)
+        .and_then(serde_yaml::Value::as_mapping)
+    else {
+        return;
+    };
+
+    let known_keys = ["max_depth", "max_length", "allow_custom_scripts"];
+
+    for key in expression_guardrails
+        .keys()
+        .filter_map(serde_yaml::Value::as_str)
+    {
+        if !known_keys.contains(&key) {
+            issues.push(ProfileLintIssue::warning(
+                "unknown_expression_guardrail_key",
+                Some(format!("expression_guardrails.{key}")),
+                format!("expression_guardrails key '{key}' is ignored by the profile loader"),
             ));
         }
     }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -1235,4 +1235,40 @@ description: "profile metadata"
                 .any(|issue| issue.path.as_deref() == Some("rules"))
         );
     }
+
+    #[test]
+    fn test_lint_profile_yaml_warns_for_ignored_expression_guardrail_keys() {
+        let y = r#"
+message_structure: "ADT_A01"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+expression_guardrails:
+  max_complexity: 10
+  max_nesting_depth: 3
+  allow_field_comparisons: true
+"#;
+
+        let report = lint_profile_yaml(y);
+        let ignored_guardrail_paths = report
+            .issues
+            .iter()
+            .filter(|issue| issue.code == "unknown_expression_guardrail_key")
+            .filter_map(|issue| issue.path.as_deref())
+            .collect::<Vec<_>>();
+
+        assert!(
+            report.valid,
+            "ignored guardrail warnings should not fail profile lint: {report:?}"
+        );
+        assert_eq!(report.warning_count, 3, "unexpected warnings: {report:?}");
+        assert_eq!(
+            ignored_guardrail_paths,
+            vec![
+                "expression_guardrails.max_complexity",
+                "expression_guardrails.max_nesting_depth",
+                "expression_guardrails.allow_field_comparisons",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- warn when profile lint sees unsupported nested expression_guardrails keys before serde drops them
- add a regression test for stable warning code/path output
- refresh ripr badge receipt

## Validation
- cargo +1.95.0 test -p hl7v2 conformance::profile::tests::profile_lint_tests::test_lint_profile_yaml_warns_for_ignored_expression_guardrail_keys --all-features (failing first, then passing)
- cargo +1.95.0 test -p hl7v2 conformance::profile::tests::profile_lint_tests --all-features
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features