### PR TITLE
fix: validate required profile segments

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12776",
+  "message": "12788",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/loading.rs
+++ b/crates/hl7v2/src/conformance/profile/loading.rs
@@ -169,13 +169,15 @@ fn merge_profiles(parent: Profile, child: Profile) -> Profile {
     }
 }
 
-/// Merge segment specifications, removing duplicates by ID
+/// Merge segment specifications, with child specs overriding parent specs by ID
 fn merge_segment_specs(parent: Vec<SegmentSpec>, child: Vec<SegmentSpec>) -> Vec<SegmentSpec> {
     let mut result: Vec<SegmentSpec> = parent;
 
-    // Add child segments that don't already exist in parent
+    // Add child segments, replacing any with the same ID.
     for child_segment in child {
-        if !result.iter().any(|s| s.id == child_segment.id) {
+        if let Some(pos) = result.iter().position(|s| s.id == child_segment.id) {
+            result[pos] = child_segment;
+        } else {
             result.push(child_segment);
         }
     }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -40,6 +40,36 @@ constraints:
     }
 
     #[test]
+    fn test_required_segment_specs_report_missing_segments() {
+        let y = r#"
+message_structure: "oru_required_segments"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "PID"
+    required: true
+  - id: "PV1"
+    required: false
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r\
+OBX|1|ST|STATUS^Status||Final\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected only missing required PID segment: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "MISSING_REQUIRED_SEGMENT");
+        assert_eq!(probs[0].path.as_deref(), Some("PID"));
+    }
+
+    #[test]
     fn test_cross_field_equals() {
         let y = r#"
 message_structure: "xfield"
@@ -963,7 +993,10 @@ custom_rules:
 
 #[cfg(test)]
 mod profile_load_error_tests {
-    use super::super::{ProfileLoadError, load_profile_checked, load_profile_with_inheritance};
+    use super::super::{
+        ProfileLoadError, load_profile_checked, load_profile_with_inheritance, validate,
+    };
+    use crate::parse;
 
     #[test]
     fn test_load_profile_checked_valid() {
@@ -1081,6 +1114,42 @@ segments:
             Err(ProfileLoadError::InheritanceCycle(ref cycle))
                 if cycle == "base -> loop -> base"
         ));
+    }
+
+    #[test]
+    fn test_load_profile_with_inheritance_child_segment_flags_override_parent() {
+        let child = r#"
+message_structure: "CHILD"
+version: "2.5.1"
+parent: "base"
+segments:
+  - id: "PID"
+    required: true
+"#;
+
+        let profile = load_profile_with_inheritance(child, |name| match name {
+            "base" => load_profile_checked(
+                r#"
+message_structure: "BASE"
+version: "2.5.1"
+segments:
+  - id: "PID"
+"#,
+            ),
+            other => Err(ProfileLoadError::ParentNotFound(other.to_string())),
+        })
+        .unwrap();
+
+        let message =
+            parse(b"MSH|^~\\&|LAB|FAC|EHR|FAC|20250101000000||ORU^R01|MSG1|P|2.5.1\r").unwrap();
+        let issues = validate(&message, &profile);
+
+        assert!(
+            issues.iter().any(|issue| {
+                issue.code == "MISSING_REQUIRED_SEGMENT" && issue.path.as_deref() == Some("PID")
+            }),
+            "expected child required segment flag to survive inheritance: {issues:?}"
+        );
     }
 }
 

--- a/crates/hl7v2/src/conformance/profile/types.rs
+++ b/crates/hl7v2/src/conformance/profile/types.rs
@@ -136,6 +136,12 @@ pub struct Profile {
 pub struct SegmentSpec {
     /// Segment identifier (for example, `MSH`).
     pub id: String,
+    /// Whether this segment must appear in messages validated by this profile.
+    #[serde(default)]
+    pub required: bool,
+    /// Whether this profile permits repeated occurrences of this segment.
+    #[serde(default)]
+    pub repetition: bool,
 }
 
 /// Constraint on a field path

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -6,6 +6,8 @@ use super::*;
 pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
     let mut issues = Vec::new();
 
+    validate_required_segments(msg, profile, &mut issues);
+
     // Validate constraints (including conditional ones)
     for constraint in &profile.constraints {
         if should_validate_constraint(msg, constraint) {
@@ -79,6 +81,27 @@ pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
     }
 
     issues
+}
+
+fn validate_required_segments(msg: &Message, profile: &Profile, issues: &mut Vec<Issue>) {
+    for segment in &profile.segments {
+        if !segment.required {
+            continue;
+        }
+        if msg
+            .segments
+            .iter()
+            .any(|actual| actual.id_str() == segment.id)
+        {
+            continue;
+        }
+
+        issues.push(Issue::error(
+            "MISSING_REQUIRED_SEGMENT",
+            Some(segment.id.clone()),
+            format!("Required segment {} is missing", segment.id),
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/schemas/profile/profile-v1.schema.json
+++ b/schemas/profile/profile-v1.schema.json
@@ -26,6 +26,13 @@
       "type": "string",
       "description": "Human-readable description of this profile"
     },
+    "segments": {
+      "type": "array",
+      "description": "Segment declarations for validation",
+      "items": {
+        "$ref": "#/definitions/segment"
+      }
+    },
     "constraints": {
       "type": "array",
       "description": "Field-level constraints for validation",
@@ -52,6 +59,29 @@
     }
   },
   "definitions": {
+    "segment": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "HL7 segment identifier",
+          "pattern": "^[A-Z][A-Z0-9]{2}$",
+          "examples": ["MSH", "PID", "OBX"]
+        },
+        "required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the segment must appear in messages validated by this profile"
+        },
+        "repetition": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the profile permits repeated occurrences of this segment"
+        }
+      },
+      "additionalProperties": true
+    },
     "constraint": {
       "type": "object",
       "required": ["path"],


### PR DESCRIPTION
## Summary
- deserialize profile segment required/repetition flags and validate missing required segments
- make child segment specs override parent specs during profile inheritance
- add regression tests and update the profile v1 schema segment contract

## Validation
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 conformance::profile::tests --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features