### PR TITLE
fix: expose profile segment flags in explain reports

### DIFF
--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -1221,6 +1221,17 @@ components:
           type: array
           items:
             type: object
+            required:
+              - id
+              - required
+              - repetition
+            properties:
+              id:
+                type: string
+              required:
+                type: boolean
+              repetition:
+                type: boolean
         required_fields:
           type: array
           items:

--- a/api/proto/hl7v2/v1/hl7v2.proto
+++ b/api/proto/hl7v2/v1/hl7v2.proto
@@ -378,6 +378,8 @@ message ProfileExplainSummary {
 
 message ProfileExplainSegment {
   string id = 1;
+  bool required = 2;
+  bool repetition = 3;
 }
 
 message ProfileExplainRequiredField {

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12788",
+  "message": "12607",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -176,6 +176,8 @@ struct ProfileExplainSummary {
 #[derive(serde::Serialize)]
 struct ProfileExplainSegment {
     id: String,
+    required: bool,
+    repetition: bool,
 }
 
 #[derive(serde::Serialize)]
@@ -1690,6 +1692,8 @@ fn build_profile_explain_report(
             .iter()
             .map(|segment| ProfileExplainSegment {
                 id: segment.id.clone(),
+                required: segment.required,
+                repetition: segment.repetition,
             })
             .collect(),
         required_fields,

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -450,6 +450,43 @@ constraints:
         }
     }
 
+    mod profile_explain_command {
+        use super::*;
+
+        #[test]
+        fn test_profile_explain_json_reports_segment_flags() {
+            let profile_yaml = r#"
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+    required: true
+  - id: OBX
+    repetition: true
+"#;
+            let profile = hl7v2::load_profile_checked(profile_yaml).expect("profile should load");
+            let lint = hl7v2::lint_profile_yaml(profile_yaml);
+            let report = crate::build_profile_explain_report(
+                &PathBuf::from("profile.yaml"),
+                profile_yaml,
+                &profile,
+                &lint,
+            );
+            let output =
+                crate::format_profile_explain_report(&report, &crate::ReportFormat::Json, 1)
+                    .expect("profile explain should format as JSON");
+            let json: serde_json::Value =
+                serde_json::from_str(&output).expect("profile explain JSON should parse");
+
+            assert_eq!(json["segments"][0]["id"], "MSH");
+            assert_eq!(json["segments"][0]["required"], true);
+            assert_eq!(json["segments"][0]["repetition"], false);
+            assert_eq!(json["segments"][1]["id"], "OBX");
+            assert_eq!(json["segments"][1]["required"], false);
+            assert_eq!(json["segments"][1]["repetition"], true);
+        }
+    }
+
     // =========================================================================
     // ACK Generation Tests
     // =========================================================================

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -1221,6 +1221,17 @@ components:
           type: array
           items:
             type: object
+            required:
+              - id
+              - required
+              - repetition
+            properties:
+              id:
+                type: string
+              required:
+                type: boolean
+              repetition:
+                type: boolean
         required_fields:
           type: array
           items:

--- a/crates/hl7v2-server/proto/hl7v2/v1/hl7v2.proto
+++ b/crates/hl7v2-server/proto/hl7v2/v1/hl7v2.proto
@@ -378,6 +378,8 @@ message ProfileExplainSummary {
 
 message ProfileExplainSegment {
   string id = 1;
+  bool required = 2;
+  bool repetition = 3;
 }
 
 message ProfileExplainRequiredField {

--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -1533,6 +1533,8 @@ fn proto_profile_explain_segment_from_rust(
 ) -> ProfileExplainSegment {
     ProfileExplainSegment {
         id: segment.id.clone(),
+        required: segment.required,
+        repetition: segment.repetition,
     }
 }
 

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -111,7 +111,9 @@ message_structure: "ADT_A01"
 version: "2.5"
 segments:
   - id: "MSH"
+    required: true
   - id: "PID"
+    repetition: true
 constraints:
   - path: "PID.3"
     required: true
@@ -790,7 +792,11 @@ unknown_top_level: "ignored"
         assert_eq!(summary.required_field_count, 1);
         assert_eq!(summary.field_constraint_count, 1);
         assert_eq!(report.segments[0].id, "MSH");
+        assert!(report.segments[0].required);
+        assert!(!report.segments[0].repetition);
         assert_eq!(report.segments[1].id, "PID");
+        assert!(!report.segments[1].required);
+        assert!(report.segments[1].repetition);
         assert_eq!(report.required_fields[0].path, "PID.3");
         assert!(!report.required_fields[0].conditional);
         assert_eq!(report.field_constraints[0].path, "PID.3");

--- a/crates/hl7v2-server/tests/profile_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/profile_endpoint_test.rs
@@ -121,6 +121,9 @@ async fn test_profile_explain_schema_version_2_explains_inline_profile() {
     assert_eq!(body["message_structure"], "ADT_A01");
     assert_eq!(body["version"], "2.5.1");
     assert_eq!(body["summary"]["segment_count"], 4);
+    assert_eq!(body["segments"][0]["id"], "MSH");
+    assert_eq!(body["segments"][0]["required"], true);
+    assert_eq!(body["segments"][0]["repetition"], false);
     assert_eq!(body["lint"]["valid"], true);
     assert_eq!(body["profile_sha256"].as_str().unwrap().len(), 64);
     assert!(!body_text.contains("ADT^A01 test profile"));

--- a/crates/hl7v2/src/conformance/profile/lint.rs
+++ b/crates/hl7v2/src/conformance/profile/lint.rs
@@ -137,6 +137,8 @@ pub fn explain_profile(
             .iter()
             .map(|segment| ProfileExplainSegment {
                 id: segment.id.clone(),
+                required: segment.required,
+                repetition: segment.repetition,
             })
             .collect(),
         required_fields,

--- a/crates/hl7v2/src/conformance/profile/types.rs
+++ b/crates/hl7v2/src/conformance/profile/types.rs
@@ -534,6 +534,12 @@ pub struct ProfileExplainSummary {
 pub struct ProfileExplainSegment {
     /// Segment identifier, such as `MSH` or `PID`.
     pub id: String,
+    /// Whether this profile marks the segment as required.
+    #[serde(default)]
+    pub required: bool,
+    /// Whether this profile marks the segment as repeating.
+    #[serde(default)]
+    pub repetition: bool,
 }
 
 /// A required field recorded in a profile explain report.

--- a/crates/hl7v2/tests/conformance_facade.rs
+++ b/crates/hl7v2/tests/conformance_facade.rs
@@ -6,8 +6,8 @@ use hl7v2::conformance::datatype::datetime::{
     parse_hl7_ts_with_precision,
 };
 use hl7v2::{
-    ProfileFixtureExpectation, ProfileTestCaseReport, ProfileTestReport, Severity,
-    ValidationReport, explain_profile, lint_profile_yaml, load_profile_checked, parse,
+    ProfileExplainSegment, ProfileFixtureExpectation, ProfileTestCaseReport, ProfileTestReport,
+    Severity, ValidationReport, explain_profile, lint_profile_yaml, load_profile_checked, parse,
     run_profile_fixture_tests, validate,
 };
 use std::error::Error;
@@ -356,7 +356,9 @@ version: "2.5"
 message_type: "ADT^A01"
 segments:
   - id: "MSH"
+    required: true
   - id: "PID"
+    repetition: true
 constraints:
   - path: "PID.3"
     required: true
@@ -372,6 +374,23 @@ valuesets:
     require_eq(report.profile.as_str(), "profiles/adt.yaml", "profile")?;
     require_eq(report.message_structure.as_str(), "ADT_A01", "structure")?;
     require_eq(report.summary.segment_count, 2, "segment count")?;
+    let msh_segment = report
+        .segments
+        .first()
+        .ok_or_else(|| std::io::Error::other("expected MSH segment"))?;
+    let pid_segment = report
+        .segments
+        .get(1)
+        .ok_or_else(|| std::io::Error::other("expected PID segment"))?;
+    require_eq(msh_segment.id.as_str(), "MSH", "first segment id")?;
+    require(msh_segment.required, "MSH should be required")?;
+    require(!msh_segment.repetition, "MSH should not be repeating")?;
+    require_eq(pid_segment.id.as_str(), "PID", "second segment id")?;
+    require(
+        !pid_segment.required,
+        "PID should not be required by default",
+    )?;
+    require(pid_segment.repetition, "PID should be repeating")?;
     require_eq(
         report.summary.required_field_count,
         1,
@@ -391,6 +410,23 @@ valuesets:
     require_eq(v2.schema_version.as_str(), "2", "schema version")?;
     require_eq(v2.tool_name.as_str(), "test-surface", "tool name")?;
     require_eq(v2.tool_version.as_str(), "0.0.0", "tool version")?;
+
+    Ok(())
+}
+
+#[test]
+fn profile_explain_segment_deserializes_legacy_id_only_shape() -> Result<(), Box<dyn Error>> {
+    let segment: ProfileExplainSegment = serde_json::from_str(r#"{"id":"MSH"}"#)?;
+
+    require_eq(segment.id.as_str(), "MSH", "segment id")?;
+    require(
+        !segment.required,
+        "legacy segment explain records should default required to false",
+    )?;
+    require(
+        !segment.repetition,
+        "legacy segment explain records should default repetition to false",
+    )?;
 
     Ok(())
 }

--- a/fixtures/evidence/profile-explain-report-v2.json
+++ b/fixtures/evidence/profile-explain-report-v2.json
@@ -23,8 +23,8 @@
     "hl7_table_count": 0
   },
   "segments": [
-    {"id": "MSH"},
-    {"id": "PID"}
+    {"id": "MSH", "required": false, "repetition": false},
+    {"id": "PID", "required": false, "repetition": false}
   ],
   "required_fields": [
     {"path": "PID.3", "conditional": false}

--- a/fixtures/evidence/profile-explain-report.json
+++ b/fixtures/evidence/profile-explain-report.json
@@ -20,8 +20,8 @@
     "hl7_table_count": 0
   },
   "segments": [
-    {"id": "MSH"},
-    {"id": "PID"}
+    {"id": "MSH", "required": false, "repetition": false},
+    {"id": "PID", "required": false, "repetition": false}
   ],
   "required_fields": [
     {"path": "PID.3", "conditional": false}

--- a/schemas/evidence/profile-explain-report-v1.schema.json
+++ b/schemas/evidence/profile-explain-report-v1.schema.json
@@ -106,7 +106,11 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["id"],
-      "properties": {"id": {"type": "string"}}
+      "properties": {
+        "id": {"type": "string"},
+        "required": {"type": "boolean"},
+        "repetition": {"type": "boolean"}
+      }
     },
     "required_field": {
       "type": "object",

--- a/schemas/evidence/profile-explain-report-v2.schema.json
+++ b/schemas/evidence/profile-explain-report-v2.schema.json
@@ -116,7 +116,9 @@
       "additionalProperties": false,
       "required": ["id"],
       "properties": {
-        "id": {"type": "string"}
+        "id": {"type": "string"},
+        "required": {"type": "boolean"},
+        "repetition": {"type": "boolean"}
       }
     },
     "required_field": {


### PR DESCRIPTION
## Summary
- carry profile segment `required` and `repetition` flags through profile explain reports
- update Rust, CLI, REST/OpenAPI, gRPC/proto, evidence schemas, and golden fixtures
- keep legacy id-only segment explain JSON deserializable with false defaults

## Validation
- failing-first: `cargo +1.95.0 test -p hl7v2 --test conformance_facade profile_facade_explains_profile_contract_shape --all-features` failed before the implementation with missing `required`/`repetition` fields
- `cargo +1.95.0 test -p hl7v2 --test conformance_facade --all-features`
- `cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli profile_explain_command::test_profile_explain_json_reports_segment_flags --all-features`
- `cargo +1.95.0 test -p hl7v2-server --test profile_endpoint_test test_profile_explain_schema_version_2_explains_inline_profile --all-features`
- `cargo +1.95.0 test -p hl7v2-server --test grpc_contract_tests test_grpc_profile_explain_reports_contract_shape --all-features`
- `cargo +1.95.0 test -p hl7v2-server --test proto_packaging_test --all-features`
- `cargo +1.95.0 test -p hl7v2-cli --test integration_tests evidence_golden_fixtures::test_profile_reports_match_golden_fixtures --all-features`
- `cargo +1.95.0 test -p hl7v2 -p hl7v2-cli -p hl7v2-server --all-features`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `git diff --check`
- `cargo +1.95.0 clippy -p hl7v2 -p hl7v2-cli -p hl7v2-server --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 run -p xtask -- evidence-schema-check`