### PR TITLE
fix: show profile segment flags in text explain

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12607",
+  "message": "12627",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -2312,11 +2312,6 @@ fn format_profile_explain_report(
         ReportFormat::Json => Ok(serde_json::to_string_pretty(report)?),
         ReportFormat::Yaml => Ok(serde_yaml::to_string(report)?),
         ReportFormat::Text => {
-            let segment_ids = report
-                .segments
-                .iter()
-                .map(|segment| segment.id.clone())
-                .collect::<Vec<_>>();
             let required_paths = report
                 .required_fields
                 .iter()
@@ -2337,7 +2332,7 @@ fn format_profile_explain_report(
             lines.push(format!(
                 "  Segments: {} ({})",
                 report.summary.segment_count,
-                format_string_list(&segment_ids)
+                format_profile_explain_segment_list(&report.segments)
             ));
             lines.push(format!(
                 "  Required fields: {} ({})",
@@ -2404,6 +2399,32 @@ fn format_profile_explain_report(
             Ok(lines.join("\n"))
         }
     }
+}
+
+fn format_profile_explain_segment_list(segments: &[ProfileExplainSegment]) -> String {
+    if segments.is_empty() {
+        return "<none>".to_string();
+    }
+
+    segments
+        .iter()
+        .map(|segment| {
+            let mut flags = Vec::new();
+            if segment.required {
+                flags.push("required");
+            }
+            if segment.repetition {
+                flags.push("repeating");
+            }
+
+            if flags.is_empty() {
+                segment.id.clone()
+            } else {
+                format!("{} ({})", segment.id, flags.join(", "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn format_string_list(values: &[String]) -> String {

--- a/crates/hl7v2-cli/src/tests.rs
+++ b/crates/hl7v2-cli/src/tests.rs
@@ -485,6 +485,35 @@ segments:
             assert_eq!(json["segments"][1]["required"], false);
             assert_eq!(json["segments"][1]["repetition"], true);
         }
+
+        #[test]
+        fn test_profile_explain_text_reports_segment_flags() {
+            let profile_yaml = r#"
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: MSH
+    required: true
+  - id: OBX
+    repetition: true
+"#;
+            let profile = hl7v2::load_profile_checked(profile_yaml).expect("profile should load");
+            let lint = hl7v2::lint_profile_yaml(profile_yaml);
+            let report = crate::build_profile_explain_report(
+                &PathBuf::from("profile.yaml"),
+                profile_yaml,
+                &profile,
+                &lint,
+            );
+            let output =
+                crate::format_profile_explain_report(&report, &crate::ReportFormat::Text, 1)
+                    .expect("profile explain should format as text");
+
+            assert!(
+                output.contains("Segments: 2 (MSH (required), OBX (repeating))"),
+                "text profile explain output should annotate segment flags:\n{output}"
+            );
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- annotate `profile explain --format text` segment lists with profile `required` and `repetition` flags
- keep JSON/YAML machine output unchanged; this only brings the human operator view up to parity
- refresh `badges/ripr.json`

## Validation
- failing-first: `cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli profile_explain_command::test_profile_explain_text_reports_segment_flags --all-features` failed before the formatter change because text output printed `Segments: 2 (MSH, OBX)`
- `cargo +1.95.0 test -p hl7v2-cli --bin hl7v2-cli profile_explain_command::test_profile_explain_text_reports_segment_flags --all-features`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `git diff --check`
- `cargo +1.95.0 clippy -p hl7v2-cli --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 test -p hl7v2-cli --all-features`
- pre-push gate completed successfully before the remote rejected a duplicate ref created by the timed-out first push