### PR TITLE
fix: enforce profile segment repetition

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12627",
+  "message": "12664",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -3341,7 +3341,7 @@ version: "2.5"
 segments:
   - id: "MSH"
   - id: "NK1"
-    max_uses: 2
+    repetition: true
   - id: "NTE"
 "#,
         );

--- a/crates/hl7v2-server/tests/bundle_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/bundle_endpoint_test.rs
@@ -261,7 +261,7 @@ version: "2.5"
 segments:
   - id: "MSH"
   - id: "NK1"
-    max_uses: 2
+    repetition: true
   - id: "NTE"
 "#,
         "redaction_policy": r#"

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -1173,7 +1173,7 @@ segments:
     required: true
   - id: "NK1"
     required: true
-    max_uses: 2
+    repetition: true
 "#;
         let policy = r#"
 [[rules]]

--- a/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
+++ b/crates/hl7v2-server/tests/validate_redacted_endpoint_test.rs
@@ -245,7 +245,7 @@ segments:
     required: true
   - id: "NK1"
     required: true
-    max_uses: 2
+    repetition: true
 "#;
     let policy = r#"
 [[rules]]
@@ -292,7 +292,7 @@ segments:
     required: true
   - id: "NK1"
     required: true
-    max_uses: 2
+    repetition: true
 "#;
     let policy = r#"
 [[rules]]

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -70,6 +70,35 @@ OBX|1|ST|STATUS^Status||Final\r",
     }
 
     #[test]
+    fn test_segment_repetition_flag_rejects_extra_occurrence() {
+        let y = r#"
+message_structure: "adt_single_pid"
+version: "2.5.1"
+segments:
+  - id: "MSH"
+    required: true
+  - id: "PID"
+    repetition: false
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|APP|FAC|EHR|FAC|20250101000000||ADT^A01|MSG1|P|2.5.1\r\
+PID|1||111^^^HOSP^MR||One^Patient||19800101|F\r\
+PID|2||222^^^HOSP^MR||Two^Patient||19820101|M\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(
+            probs.len(),
+            1,
+            "expected repeated PID segment to violate profile: {probs:?}"
+        );
+        assert_eq!(probs[0].code, "SEGMENT_REPETITION_NOT_ALLOWED");
+        assert_eq!(probs[0].path.as_deref(), Some("PID[2]"));
+    }
+
+    #[test]
     fn test_cross_field_equals() {
         let y = r#"
 message_structure: "xfield"

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -6,7 +6,7 @@ use super::*;
 pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
     let mut issues = Vec::new();
 
-    validate_required_segments(msg, profile, &mut issues);
+    validate_segment_specs(msg, profile, &mut issues);
 
     // Validate constraints (including conditional ones)
     for constraint in &profile.constraints {
@@ -83,24 +83,35 @@ pub fn validate(msg: &Message, profile: &Profile) -> Vec<Issue> {
     issues
 }
 
-fn validate_required_segments(msg: &Message, profile: &Profile, issues: &mut Vec<Issue>) {
+fn validate_segment_specs(msg: &Message, profile: &Profile, issues: &mut Vec<Issue>) {
     for segment in &profile.segments {
-        if !segment.required {
-            continue;
-        }
-        if msg
+        let mut occurrence_count = 0;
+
+        for _ in msg
             .segments
             .iter()
-            .any(|actual| actual.id_str() == segment.id)
+            .filter(|actual| actual.id_str() == segment.id)
         {
-            continue;
+            occurrence_count += 1;
+            if occurrence_count > 1 && !segment.repetition {
+                issues.push(Issue::error(
+                    "SEGMENT_REPETITION_NOT_ALLOWED",
+                    Some(format!("{}[{occurrence_count}]", segment.id)),
+                    format!(
+                        "Segment {} repeats but the profile does not permit repetition",
+                        segment.id
+                    ),
+                ));
+            }
         }
 
-        issues.push(Issue::error(
-            "MISSING_REQUIRED_SEGMENT",
-            Some(segment.id.clone()),
-            format!("Required segment {} is missing", segment.id),
-        ));
+        if segment.required && occurrence_count == 0 {
+            issues.push(Issue::error(
+                "MISSING_REQUIRED_SEGMENT",
+                Some(segment.id.clone()),
+                format!("Required segment {} is missing", segment.id),
+            ));
+        }
     }
 }
 
@@ -113,6 +124,10 @@ struct RepetitionSemanticsCase {
 
 #[cfg(test)]
 const PROFILE_REPETITION_SEMANTICS: &[RepetitionSemanticsCase] = &[
+    RepetitionSemanticsCase {
+        validation_path: "segments.repetition",
+        collector: "segment_occurrence_count",
+    },
     RepetitionSemanticsCase {
         validation_path: "constraints.required",
         collector: "required_path_has_value",
@@ -1685,8 +1700,10 @@ mod repetition_semantics_tests {
             "required_path_has_value",
             "field_component_counts",
             "check_rule_condition",
+            "segment_occurrence_count",
         ];
         const EXPECTED_PATHS: &[&str] = &[
+            "segments.repetition",
             "constraints.required",
             "constraints.when",
             "constraints.in",

--- a/crates/hl7v2/src/conformance/validation.rs
+++ b/crates/hl7v2/src/conformance/validation.rs
@@ -311,6 +311,16 @@ fn message_type(message: &Message) -> String {
 }
 
 fn segment_index_for_path(message: &Message, path: &str) -> Option<usize> {
+    if let Some((segment, segment_repetition)) = segment_occurrence_for_path(path) {
+        return message
+            .segments
+            .iter()
+            .enumerate()
+            .filter(|(_index, actual)| actual.id_str() == segment)
+            .nth(segment_repetition.checked_sub(1)?)
+            .map(|(index, _segment)| index);
+    }
+
     let located = crate::query::path::parse_located_path(path).ok()?;
     let segment_repetition = located.segment_repetition.unwrap_or(1);
 
@@ -321,6 +331,35 @@ fn segment_index_for_path(message: &Message, path: &str) -> Option<usize> {
         .filter(|(_index, segment)| segment.id_str() == located.path.segment)
         .nth(segment_repetition.checked_sub(1)?)
         .map(|(index, _segment)| index)
+}
+
+fn segment_occurrence_for_path(path: &str) -> Option<(String, usize)> {
+    let path = path.trim();
+    if path.is_empty() || path.contains('.') || path.contains('-') {
+        return None;
+    }
+
+    let (segment, repetition) = if let Some(start) = path.find('[') {
+        if !path.ends_with(']') {
+            return None;
+        }
+        let segment = &path[..start];
+        let repetition = &path[start + 1..path.len().checked_sub(1)?];
+        (segment, repetition.parse::<usize>().ok()?)
+    } else {
+        (path, 1)
+    };
+
+    if segment.is_empty()
+        || repetition == 0
+        || !segment
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        return None;
+    }
+
+    Some((segment.to_ascii_uppercase(), repetition))
 }
 
 fn field_index_for_path(path: &str) -> Option<usize> {
@@ -1385,6 +1424,11 @@ OBX|3|ST|CODE3^Third||\r",
                     Some("OBX[3]-5".to_string()),
                     "Third OBX observation value is required".to_string(),
                 ),
+                Issue::error(
+                    "SEGMENT_REPETITION_NOT_ALLOWED",
+                    Some("OBX[3]".to_string()),
+                    "Third OBX segment is not allowed by the profile".to_string(),
+                ),
             ],
         );
 
@@ -1394,6 +1438,9 @@ OBX|3|ST|CODE3^Third||\r",
         assert_eq!(report.issues[1].path.as_deref(), Some("OBX[3]-5"));
         assert_eq!(report.issues[1].segment_index, Some(4));
         assert_eq!(report.issues[1].field_index, Some(5));
+        assert_eq!(report.issues[2].path.as_deref(), Some("OBX[3]"));
+        assert_eq!(report.issues[2].segment_index, Some(4));
+        assert_eq!(report.issues[2].field_index, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- enforce `segments[].repetition: false` during profile validation
- report repeated non-repeating segments with `SEGMENT_REPETITION_NOT_ALLOWED` at paths like `PID[2]`
- teach validation reports to infer `segment_index` for segment-only occurrence paths such as `OBX[3]`
- update the profile repetition-semantics audit matrix and refresh `badges/ripr.json`

## Validation
- failing-first: `cargo +1.95.0 test -p hl7v2 test_segment_repetition_flag_rejects_extra_occurrence --all-features` failed before the fix because repeated `PID` produced no issue
- `cargo +1.95.0 test -p hl7v2 test_segment_repetition_flag_rejects_extra_occurrence --all-features`
- `cargo +1.95.0 test -p hl7v2 profile_repetition_semantics_matrix_is_explicit --all-features`
- `cargo +1.95.0 test -p hl7v2 validation_report_infers_indices_from_diagnostic_paths --all-features`
- `cargo +1.95.0 test -p hl7v2 --all-features`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `git diff --check`
- `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings`