### PR TITLE
fix: map gRPC segment occurrence locations

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12664",
+  "message": "12693",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/src/grpc.rs
+++ b/crates/hl7v2-server/src/grpc.rs
@@ -705,7 +705,43 @@ fn proto_location_from_issue_path(path: &str) -> Location {
         };
     }
 
+    if let Some(location) = proto_segment_occurrence_location_from_issue_path(path) {
+        return location;
+    }
+
     proto_location_from_legacy_issue_path(path)
+}
+
+fn proto_segment_occurrence_location_from_issue_path(path: &str) -> Option<Location> {
+    let path = path.trim();
+    if path.is_empty() || path.contains('.') || path.contains('-') {
+        return None;
+    }
+
+    let has_repetition_selector = path.contains('[');
+    let (segment, repetition) = if has_repetition_selector {
+        let without_closing_bracket = path.strip_suffix(']')?;
+        let (segment, repetition) = without_closing_bracket.split_once('[')?;
+        let repetition = repetition.parse::<usize>().ok()?;
+        (segment, repetition)
+    } else {
+        (path, 0)
+    };
+
+    if segment.is_empty()
+        || (has_repetition_selector && repetition == 0)
+        || !segment.chars().all(|ch| ch.is_ascii_alphanumeric())
+    {
+        return None;
+    }
+
+    Some(Location {
+        segment: segment.to_ascii_uppercase(),
+        field: 0,
+        component: 0,
+        repetition: usize_to_i32(repetition),
+        byte_offset: 0,
+    })
 }
 
 fn proto_location_from_legacy_issue_path(path: &str) -> Location {

--- a/crates/hl7v2-server/tests/grpc_contract_tests.rs
+++ b/crates/hl7v2-server/tests/grpc_contract_tests.rs
@@ -657,6 +657,49 @@ constraints:
     }
 
     #[tokio::test]
+    async fn test_grpc_validate_maps_segment_occurrence_path_to_location() {
+        let service = service();
+        let profile = r#"
+message_structure: "ADT_A01"
+version: "2.5"
+segments:
+  - id: "MSH"
+  - id: "PID"
+    repetition: false
+"#;
+        let message = b"MSH|^~\\&|SENDAPP|SENDFAC|RECVAPP|RECVFAC|202605030101||ADT^A01|CTRL123|P|2.5\rPID|1||123456^^^HOSP^MR||Doe^John||19700101|M\rPID|2||987654^^^HOSP^MR||Doe^Jane||19750101|F\r";
+
+        let request = Request::new(ValidateRequest {
+            message: message.to_vec(),
+            profile: profile.to_string(),
+            mllp_framed: false,
+            options: None,
+            report_schema_version: 2,
+        });
+
+        let response = service.validate(request).await.expect("RPC should succeed");
+        let inner = response.into_inner();
+
+        assert!(!inner.valid);
+        assert_eq!(inner.errors.len(), 1);
+        assert_eq!(inner.errors[0].code, "SEGMENT_REPETITION_NOT_ALLOWED");
+
+        let location = inner.errors[0]
+            .location
+            .as_ref()
+            .expect("Segment occurrence issue location should exist");
+        assert_eq!(location.segment, "PID");
+        assert_eq!(location.field, 0);
+        assert_eq!(location.repetition, 2);
+        assert_eq!(location.component, 0);
+
+        let report_v2 = inner
+            .validation_report_v2
+            .expect("Validation report v2 should exist");
+        assert_eq!(report_v2.issues[0].path.as_deref(), Some("PID[2]"));
+    }
+
+    #[tokio::test]
     async fn test_grpc_profile_lint_accepts_valid_profile() {
         let service = service();
         let response = service


### PR DESCRIPTION
Fixes gRPC diagnostic location mapping for segment-only occurrence paths such as `PID[2]`.

Problem:
- Core validation reports now use segment-only occurrence paths for non-repeating segment violations, e.g. `SEGMENT_REPETITION_NOT_ALLOWED` at `PID[2]`.
- The gRPC mapper only parsed field paths with `parse_located_path`; `PID[2]` fell through to legacy dot parsing and surfaced as segment `PID[2]`, repetition `0`.

Change:
- Add a narrow segment-occurrence path parser before the legacy fallback.
- Preserve existing field/repetition/component location parsing.
- Add a gRPC contract regression proving `PID[2]` maps to segment `PID`, repetition `2`, field `0`, component `0`.
- Refresh `badges/ripr.json` after `xtask badges --check` reported it stale.

Falling-first evidence:
- `cargo +1.95.0 test -p hl7v2-server --test grpc_contract_tests test_grpc_validate_maps_segment_occurrence_path_to_location --all-features` failed before the fix with `left: "PID[2]"`, `right: "PID"`.

Validation:
- `cargo +1.95.0 test -p hl7v2-server --test grpc_contract_tests test_grpc_validate_maps_segment_occurrence_path_to_location --all-features`
- `cargo +1.95.0 test -p hl7v2-server --test grpc_contract_tests test_grpc_validate_maps_diagnostic_path_to_location --all-features`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `git diff --check`
- `cargo +1.95.0 clippy -p hl7v2-server --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 test -p hl7v2-server --all-features`