### PR TITLE
fix: warn on ignored profile segment keys

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12693",
+  "message": "12710",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/lint.rs
+++ b/crates/hl7v2/src/conformance/profile/lint.rs
@@ -18,6 +18,7 @@ pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
 
     let mut issues = Vec::new();
     lint_unknown_profile_keys(&root, &mut issues);
+    lint_unknown_segment_keys(&root, &mut issues);
     lint_unknown_expression_guardrail_keys(&root, &mut issues);
 
     let profile = match serde_yaml::from_value::<Profile>(root) {
@@ -339,6 +340,37 @@ fn lint_unknown_expression_guardrail_keys(
                 Some(format!("expression_guardrails.{key}")),
                 format!("expression_guardrails key '{key}' is ignored by the profile loader"),
             ));
+        }
+    }
+}
+
+fn lint_unknown_segment_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileLintIssue>) {
+    let Some(mapping) = root.as_mapping() else {
+        return;
+    };
+    let segments_key = serde_yaml::Value::String("segments".to_string());
+    let Some(segments) = mapping
+        .get(&segments_key)
+        .and_then(serde_yaml::Value::as_sequence)
+    else {
+        return;
+    };
+
+    let known_keys = ["id", "required", "repetition"];
+
+    for (index, segment) in segments.iter().enumerate() {
+        let Some(segment_mapping) = segment.as_mapping() else {
+            continue;
+        };
+
+        for key in segment_mapping.keys().filter_map(serde_yaml::Value::as_str) {
+            if !known_keys.contains(&key) {
+                issues.push(ProfileLintIssue::warning(
+                    "unknown_segment_key",
+                    Some(format!("segments[{index}].{key}")),
+                    format!("segment key '{key}' is ignored by the profile loader"),
+                ));
+            }
         }
     }
 }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -1335,6 +1335,33 @@ description: "profile metadata"
     }
 
     #[test]
+    fn test_lint_profile_yaml_warns_for_ignored_segment_keys() {
+        let y = r#"
+message_structure: "ADT_A01"
+version: "2.5.1"
+segments:
+  - id: "PID"
+    required: true
+    max_uses: 1
+"#;
+
+        let report = lint_profile_yaml(y);
+
+        assert!(report.valid, "warnings should not fail profile lint");
+        assert_eq!(report.warning_count, 1, "unexpected warnings: {report:?}");
+        assert_eq!(report.issues[0].code, "unknown_segment_key");
+        assert_eq!(report.issues[0].severity, ProfileLintSeverity::Warning);
+        assert_eq!(
+            report.issues[0].path.as_deref(),
+            Some("segments[0].max_uses")
+        );
+        assert!(
+            report.issues[0].message.contains("ignored"),
+            "warning should explain that max_uses is ignored: {report:?}"
+        );
+    }
+
+    #[test]
     fn test_lint_profile_yaml_warns_for_ignored_expression_guardrail_keys() {
         let y = r#"
 message_structure: "ADT_A01"


### PR DESCRIPTION
## Summary

- warn when profile segment entries include ignored keys such as `max_uses`
- add a profile lint regression test for `segments[0].max_uses`
- refresh generated `ripr` badge count

## Failing-first evidence

- `cargo +1.95.0 test -p hl7v2 test_lint_profile_yaml_warns_for_ignored_segment_keys --all-features` failed before the fix with `warning_count: 0`

## Validation

- `cargo +1.95.0 test -p hl7v2 test_lint_profile_yaml_warns_for_ignored_segment_keys --all-features`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `git diff --check`
- `cargo +1.95.0 test -p hl7v2 profile_lint_tests --all-features`
- `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 test -p hl7v2 --all-features`