### PR TITLE
fix: warn on ignored profile constraint keys

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12710",
+  "message": "12727",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/lint.rs
+++ b/crates/hl7v2/src/conformance/profile/lint.rs
@@ -19,6 +19,7 @@ pub fn lint_profile_yaml(yaml: &str) -> ProfileLintReport {
     let mut issues = Vec::new();
     lint_unknown_profile_keys(&root, &mut issues);
     lint_unknown_segment_keys(&root, &mut issues);
+    lint_unknown_constraint_keys(&root, &mut issues);
     lint_unknown_expression_guardrail_keys(&root, &mut issues);
 
     let profile = match serde_yaml::from_value::<Profile>(root) {
@@ -369,6 +370,40 @@ fn lint_unknown_segment_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileL
                     "unknown_segment_key",
                     Some(format!("segments[{index}].{key}")),
                     format!("segment key '{key}' is ignored by the profile loader"),
+                ));
+            }
+        }
+    }
+}
+
+fn lint_unknown_constraint_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileLintIssue>) {
+    let Some(mapping) = root.as_mapping() else {
+        return;
+    };
+    let constraints_key = serde_yaml::Value::String("constraints".to_string());
+    let Some(constraints) = mapping
+        .get(&constraints_key)
+        .and_then(serde_yaml::Value::as_sequence)
+    else {
+        return;
+    };
+
+    let known_keys = ["path", "required", "components", "in", "when", "pattern"];
+
+    for (index, constraint) in constraints.iter().enumerate() {
+        let Some(constraint_mapping) = constraint.as_mapping() else {
+            continue;
+        };
+
+        for key in constraint_mapping
+            .keys()
+            .filter_map(serde_yaml::Value::as_str)
+        {
+            if !known_keys.contains(&key) {
+                issues.push(ProfileLintIssue::warning(
+                    "unknown_constraint_key",
+                    Some(format!("constraints[{index}].{key}")),
+                    format!("constraint key '{key}' is ignored by the profile loader"),
                 ));
             }
         }

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -1362,6 +1362,35 @@ segments:
     }
 
     #[test]
+    fn test_lint_profile_yaml_warns_for_ignored_constraint_keys() {
+        let y = r#"
+message_structure: "ADT_A01"
+version: "2.5.1"
+segments:
+  - id: "PID"
+constraints:
+  - path: "PID.3"
+    required: true
+    datatype: "CX"
+"#;
+
+        let report = lint_profile_yaml(y);
+
+        assert!(report.valid, "warnings should not fail profile lint");
+        assert_eq!(report.warning_count, 1, "unexpected warnings: {report:?}");
+        assert_eq!(report.issues[0].code, "unknown_constraint_key");
+        assert_eq!(report.issues[0].severity, ProfileLintSeverity::Warning);
+        assert_eq!(
+            report.issues[0].path.as_deref(),
+            Some("constraints[0].datatype")
+        );
+        assert!(
+            report.issues[0].message.contains("ignored"),
+            "warning should explain that datatype is ignored: {report:?}"
+        );
+    }
+
+    #[test]
     fn test_lint_profile_yaml_warns_for_ignored_expression_guardrail_keys() {
         let y = r#"
 message_structure: "ADT_A01"


### PR DESCRIPTION
## Summary

- warn when profile constraint entries include ignored keys such as `datatype`
- add a profile lint regression test for `constraints[0].datatype`
- refresh generated `ripr` badge count

## Failing-first evidence

- `cargo +1.95.0 test -p hl7v2 test_lint_profile_yaml_warns_for_ignored_constraint_keys --all-features` failed before the fix with `warning_count: 0`

## Validation

- `cargo +1.95.0 test -p hl7v2 test_lint_profile_yaml_warns_for_ignored_constraint_keys --all-features`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 run -p xtask -- badges --check`
- `git diff --check`
- `cargo +1.95.0 test -p hl7v2 profile_lint_tests --all-features`
- `cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 test -p hl7v2 --all-features`