### PR TITLE
fix: honor profile hl7 table references

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12727",
+  "message": "12741",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-cli/src/main.rs
+++ b/crates/hl7v2-cli/src/main.rs
@@ -1733,10 +1733,9 @@ fn build_profile_explain_report(
             .valuesets
             .iter()
             .map(|valueset| {
-                let table_code_count = table_code_counts
-                    .get(valueset.name.as_str())
-                    .copied()
-                    .unwrap_or(0);
+                let table_id =
+                    valueset_hl7_table_id(valueset.name.as_str(), valueset.hl7_table.as_deref());
+                let table_code_count = table_code_counts.get(table_id).copied().unwrap_or(0);
                 let source = if !valueset.codes.is_empty() {
                     "inline"
                 } else if table_code_count > 0 {
@@ -1816,6 +1815,12 @@ fn build_profile_explain_report(
                 .collect(),
         },
     }
+}
+
+fn valueset_hl7_table_id<'a>(name: &'a str, hl7_table: Option<&'a str>) -> &'a str {
+    hl7_table
+        .filter(|table_id| !table_id.trim().is_empty())
+        .unwrap_or(name)
 }
 
 fn profile_lint_issue_is_ignored_or_unsupported(issue: &ProfileLintIssue) -> bool {

--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -928,6 +928,55 @@ hl7_tables:
     }
 
     #[test]
+    fn test_profile_explain_json_reports_explicit_hl7_table_reference() {
+        let dir = create_temp_dir();
+        let profile_file = create_temp_profile(
+            &dir,
+            "profile.yaml",
+            r#"
+message_structure: ADT_A01
+version: "2.5.1"
+segments:
+  - id: PID
+valuesets:
+  - path: PID.8
+    name: Administrative Sex
+    hl7_table: HL70001
+hl7_tables:
+  - id: HL70001
+    name: Administrative Sex
+    version: "2.5.1"
+    codes:
+      - value: M
+        description: Male
+      - value: F
+        description: Female
+"#,
+        );
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "explain",
+                profile_file.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute profile explain");
+
+        assert!(output.status.success());
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("profile explain output should be JSON");
+        assert_eq!(report["value_sets"][0]["name"], "Administrative Sex");
+        assert_eq!(report["value_sets"][0]["source"], "hl7_table");
+        assert_eq!(report["value_sets"][0]["inline_code_count"], 0);
+        assert_eq!(report["value_sets"][0]["table_code_count"], 2);
+        assert_eq!(report["lint"]["valid"], true);
+    }
+
+    #[test]
     fn test_profile_explain_json_schema_version_2_adds_provenance() {
         let dir = create_temp_dir();
         let profile_file = create_temp_profile(&dir, "profile.yaml", PID3_REQUIRED_PROFILE);

--- a/crates/hl7v2/src/conformance/profile/lint.rs
+++ b/crates/hl7v2/src/conformance/profile/lint.rs
@@ -180,10 +180,8 @@ pub fn explain_profile(
             .valuesets
             .iter()
             .map(|valueset| {
-                let table_code_count = table_code_counts
-                    .get(valueset.name.as_str())
-                    .copied()
-                    .unwrap_or(0);
+                let table_id = valueset_hl7_table_id(valueset);
+                let table_code_count = table_code_counts.get(table_id).copied().unwrap_or(0);
                 let source = if !valueset.codes.is_empty() {
                     "inline"
                 } else if table_code_count > 0 {
@@ -275,6 +273,14 @@ fn compute_profile_sha256(value: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(value.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+fn valueset_hl7_table_id(valueset: &ValueSet) -> &str {
+    valueset
+        .hl7_table
+        .as_deref()
+        .filter(|table_id| !table_id.trim().is_empty())
+        .unwrap_or(valueset.name.as_str())
 }
 
 fn lint_unknown_profile_keys(root: &serde_yaml::Value, issues: &mut Vec<ProfileLintIssue>) {
@@ -556,12 +562,13 @@ fn lint_value_sets(profile: &Profile, issues: &mut Vec<ProfileLintIssue>) {
             ));
         }
 
-        if valueset.codes.is_empty() && !table_ids.contains(valueset.name.as_str()) {
+        let table_id = valueset_hl7_table_id(valueset);
+        if valueset.codes.is_empty() && !table_ids.contains(table_id) {
             issues.push(ProfileLintIssue::warning(
                 "empty_valueset_without_table",
                 Some(format!("valuesets[{index}]")),
                 format!(
-                    "value set '{}' has no inline codes and does not reference an hl7_tables id",
+                    "value set '{}' has no inline codes and does not reference an existing hl7_tables id",
                     valueset.name
                 ),
             ));

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -531,6 +531,42 @@ OBX|1|NM|WBC^White Blood Count||7.2|10^9/L|4.0-11.0|N~BAD|||F\r",
     }
 
     #[test]
+    fn test_hl7_table_valueset_uses_explicit_table_id_when_name_is_display_label() {
+        let y = r#"
+message_structure: "adt_table_reference"
+version: "2.5.1"
+segments:
+  - id: "PID"
+valuesets:
+  - path: "PID.8"
+    name: "Administrative Sex"
+    hl7_table: "HL70001"
+hl7_tables:
+  - id: "HL70001"
+    name: "Administrative Sex"
+    version: "2.5.1"
+    codes:
+      - value: "M"
+        description: "Male"
+        status: "A"
+      - value: "F"
+        description: "Female"
+        status: "A"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|ADT|FAC|EHR|FAC|20250101000000||ADT^A01|MSG1|P|2.5.1\r\
+PID|1||123^^^HOSP^MR||Doe^Jane||19800101|X\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(probs.len(), 1, "expected table reference issue: {probs:?}");
+        assert_eq!(probs[0].code, "VALUE_NOT_IN_HL7_TABLE");
+        assert_eq!(probs[0].path.as_deref(), Some("PID.8"));
+    }
+
+    #[test]
     fn test_advanced_datatype_checks_later_repetitions() {
         let y = r#"
 message_structure: "oru_repetitions"

--- a/crates/hl7v2/src/conformance/profile/types.rs
+++ b/crates/hl7v2/src/conformance/profile/types.rs
@@ -202,8 +202,11 @@ pub struct LengthConstraint {
 pub struct ValueSet {
     /// Field path where this value set applies.
     pub path: String,
-    /// Name of the value set.
+    /// Name of the value set. For table-backed sets, this may be a display label.
     pub name: String,
+    /// HL7 table ID used when `name` is not the table identifier.
+    #[serde(default)]
+    pub hl7_table: Option<String>,
     /// Codes can be defined inline OR reference an HL7 table by name
     #[serde(default)]
     pub codes: Vec<String>,

--- a/crates/hl7v2/src/conformance/profile/validation.rs
+++ b/crates/hl7v2/src/conformance/profile/validation.rs
@@ -756,7 +756,7 @@ fn validate_advanced_data_type(
 
 /// Validate HL7 tables with precedence support
 fn validate_hl7_tables_with_precedence(msg: &Message, profile: &Profile, issues: &mut Vec<Issue>) {
-    // Create a mapping of value set names to HL7 tables
+    // Create a mapping of HL7 table IDs to table definitions.
     let mut table_map: std::collections::HashMap<&str, &HL7Table> =
         std::collections::HashMap::new();
     for table in &profile.hl7_tables {
@@ -765,7 +765,7 @@ fn validate_hl7_tables_with_precedence(msg: &Message, profile: &Profile, issues:
 
     // Validate value sets with table precedence
     for valueset in &profile.valuesets {
-        if let Some(table_id) = table_map.get(valueset.name.as_str()) {
+        if let Some(table_id) = table_map.get(valueset_hl7_table_id(valueset)) {
             if let Some(value) = path_text_values(msg, &valueset.path)
                 .into_iter()
                 .filter(|value| !value.is_empty())
@@ -789,6 +789,14 @@ fn validate_hl7_tables_with_precedence(msg: &Message, profile: &Profile, issues:
             }
         }
     }
+}
+
+fn valueset_hl7_table_id(valueset: &ValueSet) -> &str {
+    valueset
+        .hl7_table
+        .as_deref()
+        .filter(|table_id| !table_id.trim().is_empty())
+        .unwrap_or(valueset.name.as_str())
 }
 
 /// Validate that a field value does not exceed the maximum length


### PR DESCRIPTION
Summary
- Add valuesets[].hl7_table as an explicit profile input for table-backed value sets.
- Resolve HL7 table validation and profile explain table counts by hl7_table when present, with the old name lookup retained as fallback.
- Add regression coverage for display-label value-set names referencing HL7 table IDs.

Validation
- failing-first: cargo +1.95.0 test -p hl7v2 test_hl7_table_valueset_uses_explicit_table_id_when_name_is_display_label --all-features
- failing-first: cargo +1.95.0 test -p hl7v2-cli test_profile_explain_json_reports_explicit_hl7_table_reference --test integration_tests
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 test_hl7_table_valueset_uses_explicit_table_id_when_name_is_display_label --all-features
- cargo +1.95.0 test -p hl7v2 test_hl7_table_valueset_checks_later_repetitions --all-features
- cargo +1.95.0 test -p hl7v2-cli test_profile_explain_json_reports_explicit_hl7_table_reference --test integration_tests
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests