### PR TITLE
fix: accept profile table code aliases

### DIFF
--- a/crates/hl7v2-cli/tests/integration_tests.rs
+++ b/crates/hl7v2-cli/tests/integration_tests.rs
@@ -977,6 +977,36 @@ hl7_tables:
     }
 
     #[test]
+    fn test_profile_explain_json_accepts_public_example_table_entries() {
+        let profile_file = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../examples/profiles/ADT_A01.yaml");
+
+        let mut cmd = cli_command();
+        let output = cmd
+            .args([
+                "profile",
+                "explain",
+                profile_file.to_str().unwrap(),
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("Failed to execute profile explain");
+
+        assert!(
+            output.status.success(),
+            "profile explain failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let report: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("profile explain output should be JSON");
+        assert_eq!(report["message_structure"], "ADT_A01");
+        assert_eq!(report["summary"]["hl7_table_count"], 3);
+        assert_eq!(report["value_sets"][0]["source"], "hl7_table");
+        assert_eq!(report["value_sets"][0]["table_code_count"], 4);
+    }
+
+    #[test]
     fn test_profile_explain_json_schema_version_2_adds_provenance() {
         let dir = create_temp_dir();
         let profile_file = create_temp_profile(&dir, "profile.yaml", PID3_REQUIRED_PROFILE);

--- a/crates/hl7v2/src/conformance/profile/tests.rs
+++ b/crates/hl7v2/src/conformance/profile/tests.rs
@@ -567,6 +567,40 @@ PID|1||123^^^HOSP^MR||Doe^Jane||19800101|X\r",
     }
 
     #[test]
+    fn test_hl7_table_entries_accept_code_display_aliases() {
+        let y = r#"
+message_structure: "adt_table_entry_aliases"
+version: "2.5.1"
+segments:
+  - id: "PID"
+valuesets:
+  - path: "PID.8"
+    name: "Administrative Sex"
+    hl7_table: "HL70001"
+hl7_tables:
+  - id: "HL70001"
+    name: "Administrative Sex"
+    version: "2.5.1"
+    codes:
+      - code: "M"
+        display: "Male"
+      - code: "F"
+        display: "Female"
+"#;
+        let msg = parse(
+            b"MSH|^~\\&|ADT|FAC|EHR|FAC|20250101000000||ADT^A01|MSG1|P|2.5.1\r\
+PID|1||123^^^HOSP^MR||Doe^Jane||19800101|X\r",
+        )
+        .unwrap();
+        let p: Profile = load_profile(y).unwrap();
+        let probs = validate(&msg, &p);
+
+        assert_eq!(probs.len(), 1, "expected table alias issue: {probs:?}");
+        assert_eq!(probs[0].code, "VALUE_NOT_IN_HL7_TABLE");
+        assert_eq!(probs[0].path.as_deref(), Some("PID.8"));
+    }
+
+    #[test]
     fn test_advanced_datatype_checks_later_repetitions() {
         let y = r#"
 message_structure: "oru_repetitions"

--- a/crates/hl7v2/src/conformance/profile/types.rs
+++ b/crates/hl7v2/src/conformance/profile/types.rs
@@ -301,8 +301,10 @@ pub struct HL7Table {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HL7TableEntry {
     /// Code value.
+    #[serde(alias = "code")]
     pub value: String,
     /// Code description.
+    #[serde(alias = "display")]
     pub description: String,
     /// Entry status (`A` active, `D` deprecated, `R` restricted).
     #[serde(default)]


### PR DESCRIPTION
Summary
- Accept code/display as profile HL7 table entry aliases for value/description.
- Preserve the existing value/description profile shape and output serialization.
- Add regression coverage for table-backed validation and for the public ADT example profile explain path.

Validation
- failing-first: cargo +1.95.0 test -p hl7v2 test_hl7_table_entries_accept_code_display_aliases --all-features
- failing-first: cargo +1.95.0 test -p hl7v2-cli test_profile_explain_json_accepts_public_example_table_entries --test integration_tests (same loader failure; initial run timed out during compile)
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 test_hl7_table_entries_accept_code_display_aliases --all-features
- cargo +1.95.0 test -p hl7v2-cli test_profile_explain_json_accepts_public_example_table_entries --test integration_tests
- cargo +1.95.0 test -p hl7v2 test_hl7_table_valueset_uses_explicit_table_id_when_name_is_display_label --all-features
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features
- cargo +1.95.0 clippy -p hl7v2-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2-cli --test integration_tests