### PR TITLE
fix: decode formatted text line breaks

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12741",
+  "message": "12758",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/escape.rs
+++ b/crates/hl7v2/src/escape.rs
@@ -11,6 +11,7 @@
 //! - `\R\` - Repetition separator
 //! - `\E\` - Escape character
 //! - `\T\` - Subcomponent separator
+//! - `\.br\` - Formatted text line break
 //!
 //! # Example
 //!
@@ -66,6 +67,8 @@ pub fn escape_text(text: &str, delims: &Delims) -> String {
         delims.rep,
         delims.esc,
         delims.sub,
+        '\n',
+        '\r',
     ];
 
     let first_idx = match text.find(&delims_arr[..]) {
@@ -79,7 +82,8 @@ pub fn escape_text(text: &str, delims: &Delims) -> String {
     // Bulk copy the clean prefix
     result.push_str(&text[..first_idx]);
 
-    for ch in text[first_idx..].chars() {
+    let mut chars = text[first_idx..].chars().peekable();
+    while let Some(ch) = chars.next() {
         match ch {
             c if c == delims.field => {
                 result.push(delims.esc);
@@ -104,6 +108,19 @@ pub fn escape_text(text: &str, delims: &Delims) -> String {
             c if c == delims.sub => {
                 result.push(delims.esc);
                 result.push('T');
+                result.push(delims.esc);
+            }
+            '\n' => {
+                result.push(delims.esc);
+                result.push_str(".br");
+                result.push(delims.esc);
+            }
+            '\r' => {
+                if chars.peek().copied() == Some('\n') {
+                    chars.next();
+                }
+                result.push(delims.esc);
+                result.push_str(".br");
                 result.push(delims.esc);
             }
             _ => result.push(ch),
@@ -203,6 +220,9 @@ pub fn unescape_text(text: &str, delims: &Delims) -> Result<String, Error> {
                 "T" => {
                     result.push(delims.sub);
                 }
+                ".br" => {
+                    result.push('\n');
+                }
                 _ => {
                     // Unknown escape sequences are passed through
                     result.push(delims.esc);
@@ -227,7 +247,7 @@ pub fn unescape_text(text: &str, delims: &Delims) -> Result<String, Error> {
 ///
 /// # Returns
 ///
-/// `true` if the text contains any delimiter characters
+/// `true` if the text contains any delimiter or formatted line-break characters
 pub fn needs_escaping(text: &str, delims: &Delims) -> bool {
     text.contains(
         &[
@@ -236,6 +256,8 @@ pub fn needs_escaping(text: &str, delims: &Delims) -> bool {
             delims.rep,
             delims.esc,
             delims.sub,
+            '\n',
+            '\r',
         ][..],
     )
 }

--- a/crates/hl7v2/src/escape/tests.rs
+++ b/crates/hl7v2/src/escape/tests.rs
@@ -127,6 +127,13 @@ fn test_unescape_multiple_sequences() {
 }
 
 #[test]
+fn test_unescape_formatted_text_line_break() {
+    let delims = Delims::default();
+    let unescaped = unescape_text("Line one\\.br\\Line two", &delims).unwrap();
+    assert_eq!(unescaped, "Line one\nLine two");
+}
+
+#[test]
 fn test_unescape_no_special_chars() {
     let delims = Delims::default();
     let unescaped = unescape_text("normal text", &delims).unwrap();
@@ -422,9 +429,17 @@ fn test_unescape_unicode() {
 #[test]
 fn test_escape_newlines() {
     let delims = Delims::default();
-    // Newlines are not delimiters, should not be escaped
+    // Newlines cannot be emitted literally inside an HL7 field.
     let escaped = escape_text("line1\nline2\rline3", &delims);
-    assert_eq!(escaped, "line1\nline2\rline3");
+    assert_eq!(escaped, "line1\\.br\\line2\\.br\\line3");
+}
+
+#[test]
+fn test_needs_escaping_line_breaks() {
+    let delims = Delims::default();
+
+    assert!(needs_escaping("line1\nline2", &delims));
+    assert!(needs_escaping("line1\rline2", &delims));
 }
 
 #[test]

--- a/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
+++ b/crates/hl7v2/src/parser/comprehensive_tests/unit_tests.rs
@@ -18,7 +18,7 @@
 )]
 
 use crate::model::*;
-use crate::{get, get_presence, parse, parse_batch, parse_file_batch, parse_mllp};
+use crate::{get, get_presence, parse, parse_batch, parse_file_batch, parse_mllp, write};
 
 // =============================================================================
 // Basic Message Parsing Tests
@@ -224,6 +224,37 @@ fn test_escape_special_chars() {
     assert!(
         value.contains('|'),
         "Should contain unescaped field separator"
+    );
+}
+
+#[test]
+fn test_vendor_oru_text_unescapes_formatted_line_break() {
+    let hl7 =
+        include_bytes!("../../../../../test_data/dirty-real-world/after/vendor-oru-null-text.hl7");
+    let normalized = String::from_utf8_lossy(hl7).replace('\n', "\r");
+    let message = parse(normalized.as_bytes()).unwrap();
+    let value = get(&message, "OBX.5").unwrap();
+
+    assert_eq!(value, "Line one\nLine two with escaped delimiters | ^ &");
+    assert!(!value.contains("\\.br\\"));
+}
+
+#[test]
+fn test_vendor_oru_formatted_line_break_roundtrips() {
+    let hl7 =
+        include_bytes!("../../../../../test_data/dirty-real-world/after/vendor-oru-null-text.hl7");
+    let normalized = String::from_utf8_lossy(hl7).replace('\n', "\r");
+    let message = parse(normalized.as_bytes()).unwrap();
+
+    let serialized = write(&message);
+    let serialized_text = String::from_utf8(serialized).unwrap();
+    assert!(serialized_text.contains("\\.br\\"));
+    assert!(!serialized_text.contains("Line one\nLine two"));
+
+    let reparsed = parse(serialized_text.as_bytes()).unwrap();
+    assert_eq!(
+        get(&reparsed, "OBX.5"),
+        Some("Line one\nLine two with escaped delimiters | ^ &")
     );
 }
 


### PR DESCRIPTION
## Summary
- decode HL7 formatted-text \.br\ escapes to line breaks during parse/query
- serialize literal CR/LF field text back as \.br\, including CRLF as one break
- add fixture-backed parser round-trip coverage for vendor ORU text plus escape helper regressions

## Failing-first evidence
- cargo +1.95.0 test -p hl7v2 test_unescape_formatted_text_line_break --all-features failed before the fix: literal \.br\ was returned
- cargo +1.95.0 test -p hl7v2 test_escape_newlines --all-features failed before the fix: raw line breaks were emitted
- cargo +1.95.0 test -p hl7v2 test_vendor_oru_text_unescapes_formatted_line_break --all-features failed before the fix: fixture text retained \.br\

## Validation
- cargo +1.95.0 fmt --check
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check
- cargo +1.95.0 test -p hl7v2 --all-features line_break
- cargo +1.95.0 test -p hl7v2 --all-features test_escape_newlines
- cargo +1.95.0 clippy -p hl7v2 --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p hl7v2 --all-features