### PR TITLE
docs(kubernetes): reconcile deployment guidance with checked-in manifests

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -167,7 +167,7 @@ spec:
 Apply changes:
 
 ```bash
-kubectl apply -f infrastructure/k8s/deployment.yaml
+kubectl apply -n hl7v2-system -f infrastructure/k8s/deployment.yaml
 ```
 
 ### Horizontal Pod Autoscaling

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -92,10 +92,13 @@ the local Compose values in `infrastructure/docker/sidecar.env.example`.
 
 ### Basic Deployment
 
-Apply the manifests:
+Create the namespace and the ConfigMaps referenced by the checked-in deployment
+bundle before applying it. The repository provides the deployment resource
+bundle, but not environment-specific profile or server configuration data.
 
 ```bash
-kubectl apply -f infrastructure/k8s/deployment.yaml
+kubectl create namespace hl7v2-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n hl7v2-system -f infrastructure/k8s/deployment.yaml
 ```
 
 `infrastructure/k8s/deployment.yaml` is a version-tagged example aligned to the
@@ -113,15 +116,17 @@ deployment smoke receipt after the rendered manifest is applied.
 
 ### With Ingress
 
-```bash
-kubectl apply -f infrastructure/k8s/ingress.yaml
-```
+The repository does not include an Ingress manifest. Configure an Ingress
+resource for your cluster and route it to the `hl7v2-server` Service on port
+`80`; keep controller-specific TLS and hostname settings in your deployment
+repository.
 
 ### Full Stack with Monitoring
 
 ```bash
-# Apply all manifests
-kubectl apply -f infrastructure/k8s/
+# Apply the checked-in deployment bundle (Deployment, Service, ServiceAccount,
+# HPA, and PDB)
+kubectl apply -n hl7v2-system -f infrastructure/k8s/deployment.yaml
 
 # Verify deployment
 kubectl get pods -n hl7v2-system
@@ -167,40 +172,13 @@ kubectl apply -f infrastructure/k8s/deployment.yaml
 
 ### Horizontal Pod Autoscaling
 
-Create HPA:
-
-```yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: hl7v2-server-hpa
-  namespace: hl7v2-system
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: hl7v2-server
-  minReplicas: 2
-  maxReplicas: 10
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
-```
-
-Apply:
+The checked-in `infrastructure/k8s/deployment.yaml` already includes an HPA
+targeting `hl7v2-server` with 3–10 replicas and CPU/memory targets. Adjust that
+resource in the deployment bundle or your rendered deployment overlay, then
+reapply:
 
 ```bash
-kubectl apply -f hpa.yaml
+kubectl apply -n hl7v2-system -f infrastructure/k8s/deployment.yaml
 ```
 
 ## Nix Deployment

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ hl7v2-cli ack <input.hl7> --code AE > error_ack.hl7
 - **Compression**: Gzip compression for responses
 - **OpenAPI 3.1 spec**: Complete API documentation at `api/openapi/hl7v2-api-v1.yaml`
 - **Docker ready**: Containerized deployment with Nix-built images
-- **Kubernetes ready**: Helm charts and manifests in `infrastructure/k8s/`
+- **Kubernetes ready**: Versioned deployment manifests in `infrastructure/k8s/`
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for production deployment guide.
 

--- a/infrastructure/grafana/README.md
+++ b/infrastructure/grafana/README.md
@@ -140,7 +140,7 @@ helm install prometheus prometheus-community/kube-prometheus-stack \
 #### Step 2: Deploy HL7v2 Server ServiceMonitor
 
 ```yaml
-# infrastructure/k8s/servicemonitor.yaml
+# Save this manifest as target/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -161,7 +161,7 @@ spec:
 Apply:
 
 ```bash
-kubectl apply -f infrastructure/k8s/servicemonitor.yaml
+kubectl apply -f target/servicemonitor.yaml
 ```
 
 #### Step 3: Import Dashboards


### PR DESCRIPTION
# Summary

Closes the current documentation drift tracked in #203 by aligning Kubernetes guidance with the files and resources actually present in the repository.

This PR:
- removes the nonexistent `infrastructure/k8s/ingress.yaml` command and documents the Ingress boundary;
- applies the checked-in `deployment.yaml` bundle instead of the whole directory, avoiding accidental application of the digest template;
- documents namespace handling and the environment-specific ConfigMaps referenced by the bundle;
- removes the duplicate HPA example because the HPA is already included in `deployment.yaml`;
- changes the Grafana guide to treat the ServiceMonitor as a user-created local manifest;
- removes the unsupported README claim that the repository contains Helm charts.

## Claim boundary

This is documentation-only. It does not add Kubernetes resources, create Helm charts, provide environment-specific ConfigMaps, or claim that an Ingress/ServiceMonitor is supplied by the repository. `deployment.yaml` remains a version-tagged example; production provenance still requires the digest-pinned rendering and deployment receipt described in `DEPLOYMENT.md`.

## Verification

Exact head: `03ff0f00b4773f0b30c06149d1bb262d9a2a7d3c`

| Check | Result |
| --- | --- |
| canonical source review | pass: deployment bundle, digest template, deployment guide, Grafana guide, and README reconciled |
| PR Gate | pass |
| CI Policy | pass |
| CI | pass: formatting, lints, policy checks, tests, docs, and MSRV |
| Security Dependency Audit | fail, unrelated: inherited advisories tracked by #923/#924 |
| local cargo gates | not run; docs-only hosted CI is the authoritative current proof for this branch |

## Assumptions

- The checked-in `deployment.yaml` remains an example bundle; environment-specific ConfigMaps and Ingress/TLS resources are intentionally supplied by operators.
- `target/servicemonitor.yaml` is an example local path; operators may choose another path.
- This change does not alter runtime behavior.

## Review map

- `DEPLOYMENT.md`: deployment commands, namespace/configuration prerequisites, Ingress boundary, bundle scope, and HPA guidance.
- `infrastructure/grafana/README.md`: user-created ServiceMonitor path and apply command.
- `README.md`: Kubernetes support claim reconciled with the checked-in manifests.