### PR TITLE
docs(readme): replace unsupported interactive claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the README CLI feature list to document supported first-use
+  diagnostics instead of the unsupported interactive REPL claim.
 - Reduced profile-cache read contention while preserving LRU hit promotion and
   bounded eviction behavior during concurrent loads.
 - Reduced repeated profile-regex compilation contention with bounded shared

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ hl7v2-cli ack <input.hl7> --code AE > error_ack.hl7
 
 - **Unified command interface**: parse, normalize, validate, lint profiles, acknowledge, generate, summarize corpora
 - **Input/output formats**: Raw HL7, JSON, MLLP framing
-- **Interactive mode**: Command-line REPL for exploratory use
+- **First-use diagnostics**: `hl7v2-cli doctor` checks a sample, profile, and optional server URL
 - **File I/O**: Read from files or stdin, write to files or stdout
 
 ### HTTP/REST API Server (`hl7v2-server`)


### PR DESCRIPTION
# Summary

Correct the README CLI feature list to match the current `hl7v2-cli` implementation. The README no longer claims an unsupported interactive REPL; it now points users to the supported `hl7v2-cli doctor` first-use diagnostics command. The Unreleased changelog records the correction.

Refs #217

## Assumptions

- The remaining README defect in #217 is the interactive/REPL claim; the historical crate-count, `--report`, and deployment findings were reconciled against current main and are not widened here.
- `hl7v2-cli doctor` is the supported first-use diagnostic surface, as documented and implemented in `crates/hl7v2-cli/src/cli.rs`.
- This PR does not close the broader #217 issue because other historical findings require separate current-source verification.

## Checklist

- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [ ] `cargo run -p xtask -- gate --check` passes locally. (Not run; docs-only slice.)
- [ ] `cargo run -p xtask -- check-lint-policy` passes. (Not run; no source changes.)
- [ ] `cargo run -p xtask -- check-no-panic-family` passes. (Not run; no source changes.)
- [ ] `cargo run -p xtask -- check-file-policy` passes. (Not run; no source changes.)

## CI Economics

| Field | Value |
| --- | --- |
| Default PR LEM impact | +0 LEM intended; documentation/changelog only |
| Workflows touched | None |
| Branch protection | Unchanged |
| Failure mode caught | Stale user-facing CLI capability claims and broken local documentation links |
| Cheaper signal? | Local link validation is sufficient for this bounded docs surface; hosted Docs Gate remains the merge signal |
| Rollback path | Revert this two-file documentation commit |

## Commands Run

```text
cargo run --locked -p xtask -- check-doc-links
git diff --check
```

`check-doc-links` passed for 237 Markdown files and 724 local links. The supported `doctor` command was verified against `crates/hl7v2-cli/src/cli.rs` and existing current guides; a full CLI build was not claimed because the first isolated build attempt timed out without diagnostics.

## Claim Boundary

This PR establishes that the README no longer advertises an unsupported interactive REPL and instead names the implemented first-use diagnostics command. It does not claim that all historical #217 documentation findings are resolved, nor does it change CLI behavior, command interfaces, deployment behavior, or release readiness.