### PR TITLE
perf(server): share request metric labels

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12956",
+  "message": "12961",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/src/metrics.rs
+++ b/crates/hl7v2-server/src/metrics.rs
@@ -172,7 +172,7 @@ fn record_request_with_shared_labels(endpoint: Arc<str>, status: Arc<str>, durat
     metrics::counter!(
         "hl7v2_requests_total",
         "endpoint" => Arc::clone(&endpoint),
-        "status" => Arc::clone(&status)
+        "status" => status
     )
     .increment(1);
 

--- a/crates/hl7v2-server/src/metrics.rs
+++ b/crates/hl7v2-server/src/metrics.rs
@@ -161,12 +161,24 @@ fn describe_metrics() {
 /// * `status` - The HTTP status code (e.g., "200", "400")
 /// * `duration_seconds` - Request duration in seconds
 pub fn record_request(endpoint: &str, status: &str, duration_seconds: f64) {
-    metrics::counter!("hl7v2_requests_total", "endpoint" => endpoint.to_string(), "status" => status.to_string())
-        .increment(1);
+    record_request_with_shared_labels(
+        Arc::<str>::from(endpoint),
+        Arc::<str>::from(status),
+        duration_seconds,
+    );
+}
+
+fn record_request_with_shared_labels(endpoint: Arc<str>, status: Arc<str>, duration_seconds: f64) {
+    metrics::counter!(
+        "hl7v2_requests_total",
+        "endpoint" => Arc::clone(&endpoint),
+        "status" => Arc::clone(&status)
+    )
+    .increment(1);
 
     metrics::histogram!(
         "hl7v2_request_duration_seconds",
-        "endpoint" => endpoint.to_string()
+        "endpoint" => endpoint
     )
     .record(duration_seconds);
 }
@@ -274,16 +286,16 @@ pub mod middleware {
     /// Metrics middleware that records request metrics
     pub async fn metrics_middleware(request: Request, next: Next) -> Response {
         let start = Instant::now();
-        let path = request.uri().path().to_string();
+        let path = Arc::<str>::from(request.uri().path());
 
         // Process the request
         let response = next.run(request).await;
 
         // Record metrics
         let duration = start.elapsed();
-        let status = response.status().as_u16().to_string();
+        let status = Arc::<str>::from(response.status().as_u16().to_string());
 
-        record_request(&path, &status, duration.as_secs_f64());
+        record_request_with_shared_labels(path, status, duration.as_secs_f64());
 
         response
     }


### PR DESCRIPTION
# Summary

Reduce duplicate request-metric label storage in `hl7v2-server` by constructing each dynamic endpoint/status label once as `Arc<str>` and sharing it across the counter and histogram emissions. The public `record_request` API and metric names/label values remain unchanged.

Related to #205.

## Assumptions

- The current `metrics` 0.24 API requires dynamic label values to be owned or shared for the recorder's `'static` storage; a non-static `&str` replacement would not compile.
- This slice targets duplicate label copies, not a claim of zero allocations or a benchmarked throughput improvement.

## Checklist

- [x] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [ ] `cargo run -p xtask -- gate --check` passes locally.
- [ ] `cargo run -p xtask -- check-lint-policy` passes.
- [ ] `cargo run -p xtask -- check-no-panic-family` passes.
- [ ] `cargo run -p xtask -- check-file-policy` passes.

## CI Economics

| Field                  | Value |
| ---------------------- | ----- |
| Default PR LEM impact  | Unchanged; no workflow changes |
| Workflows touched      | None |
| Branch protection      | Unchanged |
| Failure mode caught    | Preserves request metric rendering while reducing duplicate dynamic label copies |
| Cheaper signal?        | Focused server tests and strict Clippy run locally; hosted required checks remain authoritative |
| Rollback path          | Revert the two commits |

## Commands Run

```bash
cargo test --locked -p hl7v2-server --lib
cargo clippy --locked -p hl7v2-server --lib --tests -- -D warnings
cargo fmt --all -- --check
git diff --check
cargo run --locked -p xtask -- badges --check
```

## Claim Boundary

- The change preserves the existing metric names, label keys, label values, and public function signature.
- Local proof establishes 92 server-library tests pass, the changed code is warning-free under strict Clippy, and the committed badge is current.
- The change shares the endpoint value between the counter and histogram and shares the status value between counter labels; it does not establish zero allocations per request.
- No benchmark, allocator-count measurement, full workspace test, or hosted-check result is claimed here; hosted CI is required for those broader checks.