### PR TITLE
perf(writer): preallocate serialized message buffers

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "12961",
+  "message": "13030",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/writer/mod.rs
+++ b/crates/hl7v2/src/writer/mod.rs
@@ -59,8 +59,14 @@ pub use json::{to_json, to_json_string, to_json_string_pretty};
 /// let bytes = write(&message);
 /// ```
 pub fn write(msg: &Message) -> Vec<u8> {
-    let mut buf = Vec::new();
+    let mut buf = Vec::with_capacity(message_capacity(msg));
 
+    write_message_into(msg, &mut buf);
+
+    buf
+}
+
+fn write_message_into(msg: &Message, buf: &mut Vec<u8>) {
     // Write segments
     for segment in &msg.segments {
         // Write segment ID
@@ -81,21 +87,19 @@ pub fn write(msg: &Message) -> Vec<u8> {
             for field in segment.fields.iter().skip(1) {
                 // Skip the encoding characters field
                 buf.push(msg.delims.field as u8);
-                write_field(&mut buf, field, &msg.delims);
+                write_field(buf, field, &msg.delims);
             }
         } else {
             // Write fields
             for field in &segment.fields {
                 buf.push(msg.delims.field as u8);
-                write_field(&mut buf, field, &msg.delims);
+                write_field(buf, field, &msg.delims);
             }
         }
 
         // End segment with carriage return
         buf.push(b'\r');
     }
-
-    buf
 }
 
 /// Write HL7 message with MLLP framing.
@@ -135,8 +139,14 @@ pub fn write_mllp(msg: &Message) -> Vec<u8> {
 ///
 /// The serialized HL7 batch bytes
 pub fn write_batch(batch: &Batch) -> Vec<u8> {
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(batch_capacity(batch));
 
+    write_batch_into(batch, &mut result);
+
+    result
+}
+
+fn write_batch_into(batch: &Batch, result: &mut Vec<u8>) {
     // Write BHS if present
     if let Some(header) = &batch.header {
         result.extend_from_slice(&header.id);
@@ -147,13 +157,13 @@ pub fn write_batch(batch: &Batch) -> Vec<u8> {
             &Delims::default()
         };
         result.push(delims.field as u8);
-        write_segment_fields(header, &mut result, delims);
+        write_segment_fields(header, result, delims);
         result.push(b'\r');
     }
 
     // Write all messages
     for message in &batch.messages {
-        result.extend(write(message));
+        write_message_into(message, result);
     }
 
     // Write BTS if present
@@ -165,11 +175,9 @@ pub fn write_batch(batch: &Batch) -> Vec<u8> {
             &Delims::default()
         };
         result.push(delims.field as u8);
-        write_segment_fields(trailer, &mut result, delims);
+        write_segment_fields(trailer, result, delims);
         result.push(b'\r');
     }
-
-    result
 }
 
 /// Write file batch to bytes.
@@ -182,20 +190,26 @@ pub fn write_batch(batch: &Batch) -> Vec<u8> {
 ///
 /// The serialized HL7 file batch bytes
 pub fn write_file_batch(file_batch: &FileBatch) -> Vec<u8> {
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(file_batch_capacity(file_batch));
 
+    write_file_batch_into(file_batch, &mut result);
+
+    result
+}
+
+fn write_file_batch_into(file_batch: &FileBatch, result: &mut Vec<u8>) {
     // Write FHS if present
     if let Some(header) = &file_batch.header {
         result.extend_from_slice(&header.id);
         let delims = get_delimiters_from_file_batch(file_batch);
         result.push(delims.field as u8);
-        write_segment_fields(header, &mut result, &delims);
+        write_segment_fields(header, result, &delims);
         result.push(b'\r');
     }
 
     // Write all batches
     for batch in &file_batch.batches {
-        result.extend(write_batch(batch));
+        write_batch_into(batch, result);
     }
 
     // Write FTS if present
@@ -203,16 +217,156 @@ pub fn write_file_batch(file_batch: &FileBatch) -> Vec<u8> {
         result.extend_from_slice(&trailer.id);
         let delims = get_delimiters_from_file_batch(file_batch);
         result.push(delims.field as u8);
-        write_segment_fields(trailer, &mut result, &delims);
+        write_segment_fields(trailer, result, &delims);
         result.push(b'\r');
     }
-
-    result
 }
 
 // ============================================================================
 // Internal helper functions
 // ============================================================================
+
+fn message_capacity(msg: &Message) -> usize {
+    msg.segments.iter().fold(0usize, |capacity, segment| {
+        capacity.saturating_add(segment_capacity(
+            segment,
+            &msg.delims,
+            segment.id == *b"MSH",
+        ))
+    })
+}
+
+fn batch_capacity(batch: &Batch) -> usize {
+    let default_delims = Delims::default();
+    let delims = batch
+        .messages
+        .first()
+        .map_or(&default_delims, |message| &message.delims);
+    let mut capacity: usize = 0;
+
+    if let Some(header) = &batch.header {
+        capacity = capacity.saturating_add(segment_fields_capacity(header, delims));
+    }
+    for message in &batch.messages {
+        capacity = capacity.saturating_add(message_capacity(message));
+    }
+    if let Some(trailer) = &batch.trailer {
+        capacity = capacity.saturating_add(segment_fields_capacity(trailer, delims));
+    }
+
+    capacity
+}
+
+fn file_batch_capacity(file_batch: &FileBatch) -> usize {
+    let delims = get_delimiters_from_file_batch(file_batch);
+    let mut capacity: usize = 0;
+
+    if let Some(header) = &file_batch.header {
+        capacity = capacity.saturating_add(segment_fields_capacity(header, &delims));
+    }
+    for batch in &file_batch.batches {
+        capacity = capacity.saturating_add(batch_capacity(batch));
+    }
+    if let Some(trailer) = &file_batch.trailer {
+        capacity = capacity.saturating_add(segment_fields_capacity(trailer, &delims));
+    }
+
+    capacity
+}
+
+fn segment_capacity(segment: &Segment, delims: &Delims, is_msh: bool) -> usize {
+    let mut capacity = segment.id.len();
+    if is_msh {
+        capacity = capacity.saturating_add(5);
+        for field in segment.fields.iter().skip(1) {
+            capacity = capacity
+                .saturating_add(1)
+                .saturating_add(field_capacity(field, delims));
+        }
+    } else {
+        for field in &segment.fields {
+            capacity = capacity
+                .saturating_add(1)
+                .saturating_add(field_capacity(field, delims));
+        }
+    }
+    capacity.saturating_add(1)
+}
+
+fn segment_fields_capacity(segment: &Segment, delims: &Delims) -> usize {
+    let fields_capacity =
+        segment
+            .fields
+            .iter()
+            .enumerate()
+            .fold(0usize, |capacity, (index, field)| {
+                capacity
+                    .saturating_add(if index > 0 { 1 } else { 0 })
+                    .saturating_add(field_capacity(field, delims))
+            });
+    segment
+        .id
+        .len()
+        .saturating_add(1)
+        .saturating_add(fields_capacity)
+        .saturating_add(1)
+}
+
+fn field_capacity(field: &Field, delims: &Delims) -> usize {
+    field
+        .reps
+        .iter()
+        .enumerate()
+        .fold(0usize, |capacity, (index, repetition)| {
+            capacity
+                .saturating_add(if index > 0 { 1 } else { 0 })
+                .saturating_add(rep_capacity(repetition, delims))
+        })
+}
+
+fn rep_capacity(rep: &Rep, delims: &Delims) -> usize {
+    rep.comps
+        .iter()
+        .enumerate()
+        .fold(0usize, |capacity, (index, component)| {
+            capacity
+                .saturating_add(if index > 0 { 1 } else { 0 })
+                .saturating_add(comp_capacity(component, delims))
+        })
+}
+
+fn comp_capacity(comp: &Comp, delims: &Delims) -> usize {
+    comp.subs
+        .iter()
+        .enumerate()
+        .fold(0usize, |capacity, (index, atom)| {
+            capacity
+                .saturating_add(if index > 0 { 1 } else { 0 })
+                .saturating_add(atom_capacity(atom, delims))
+        })
+}
+
+fn atom_capacity(atom: &Atom, delims: &Delims) -> usize {
+    match atom {
+        Atom::Text(text) => text.chars().fold(0usize, |capacity, character| {
+            let character_capacity = if [
+                delims.field,
+                delims.comp,
+                delims.rep,
+                delims.esc,
+                delims.sub,
+            ]
+            .contains(&character)
+            {
+                delims.esc.len_utf8().saturating_mul(2).saturating_add(1)
+            } else {
+                character.len_utf8()
+            };
+            capacity.saturating_add(character_capacity)
+        }),
+        Atom::Null => 2,
+    }
+}
 
 /// Write a field to bytes (with escaping)
 fn write_field(output: &mut Vec<u8>, field: &Field, delims: &Delims) {

--- a/crates/hl7v2/src/writer/tests.rs
+++ b/crates/hl7v2/src/writer/tests.rs
@@ -1081,4 +1081,47 @@ fn test_write_allocation_efficiency() {
 
     // Verify the output is reasonable (not excessively large due to over-allocation)
     assert!(bytes.len() < 1000);
+    assert_eq!(bytes.capacity(), bytes.len());
+}
+
+#[test]
+fn test_write_batch_capacity_covers_nested_serialization() {
+    let message = Message {
+        delims: Delims::default(),
+        segments: vec![Segment {
+            id: *b"MSH",
+            fields: vec![Field::from_text("^~\\&"), Field::from_text("value|é")],
+        }],
+        charsets: vec![],
+    };
+    let batch = Batch {
+        header: Some(Segment {
+            id: *b"BHS",
+            fields: vec![Field::from_text("header")],
+        }),
+        messages: vec![message.clone()],
+        trailer: Some(Segment {
+            id: *b"BTS",
+            fields: vec![Field::from_text("1")],
+        }),
+    };
+    let file_batch = FileBatch {
+        header: Some(Segment {
+            id: *b"FHS",
+            fields: vec![Field::from_text("file")],
+        }),
+        batches: vec![batch.clone()],
+        trailer: Some(Segment {
+            id: *b"FTS",
+            fields: vec![Field::from_text("1")],
+        }),
+    };
+
+    let message_bytes = write(&message);
+    let batch_bytes = write_batch(&batch);
+    let file_batch_bytes = write_file_batch(&file_batch);
+
+    assert_eq!(message_bytes.capacity(), message_bytes.len());
+    assert_eq!(batch_bytes.capacity(), batch_bytes.len());
+    assert_eq!(file_batch_bytes.capacity(), file_batch_bytes.len());
 }


### PR DESCRIPTION
# Summary

Fixes #204.

Preallocate the actual serialized byte capacity for `hl7v2::writer::write`, `write_batch`, and `write_file_batch`. The capacity walk follows the writer's nested message/segment/field/repetition/component/subcomponent structure and accounts for HL7 escaping, including Unicode text. Batch and file-batch serialization now write nested messages directly into the destination buffer instead of allocating a temporary `Vec<u8>` per message/batch.

The source-of-truth correction is that the current implementation lives in `crates/hl7v2/src/writer/`, not a standalone `hl7v2-writer` crate.

## Assumptions

- The existing serialization algorithm and output bytes are the contract; this PR changes only buffer sizing and destination reuse.
- `Vec::with_capacity` is used with an exact serialized-size calculation for the current writer behavior.
- No benchmark-backed latency or throughput improvement is claimed in this PR.

## Checklist

- [x] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [ ] `cargo run -p xtask -- gate --check` passes locally.
- [ ] `cargo run -p xtask -- check-lint-policy` passes.
- [ ] `cargo run -p xtask -- check-no-panic-family` passes.
- [ ] `cargo run -p xtask -- check-file-policy` passes.

## CI Economics

| Field                  | Value |
| ---------------------- | ----- |
| Default PR LEM impact  | Unchanged; no workflow changes |
| Workflows touched      | None |
| Branch protection      | Unchanged |
| Failure mode caught    | Detects writer output regressions and capacity-accounting errors across nested serialization |
| Cheaper signal?        | Focused writer tests plus the full `hl7v2` library suite and strict Clippy run locally; hosted checks remain authoritative |
| Rollback path          | Revert commit `9dbe50c` |

## Commands Run

```bash
cargo test --locked -p hl7v2 --lib
cargo test --locked -p hl7v2 --lib writer::tests::test_write_
cargo clippy --locked -p hl7v2 --lib --tests -- -D warnings
cargo fmt --all -- --check
git diff --check
cargo run --locked -p xtask -- badges --check
```

## Claim Boundary

- The public writer APIs, serialized bytes, delimiters, escaping, and MLLP behavior are preserved by the existing and focused tests.
- Local proof establishes 688 `hl7v2` library tests pass, 44 focused writer tests pass, strict Clippy passes, formatting passes, and the generated badge is current.
- New regression coverage verifies returned capacity equals serialized length for a message, batch, and file batch containing escaped Unicode text.
- This PR establishes exact preallocation and removes nested temporary writer buffers; it does not establish a measured wall-clock, allocator-count, or throughput improvement.
- Hosted checks are required for full repository acceptance and are not claimed until they complete on the exact PR head.