### PR TITLE
fix(mllp): bound streaming frame buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added gRPC profile lint parity with shared profile lint reports and opt-in
   v2 provenance.
 
+### Changed
+
+- Changed `MllpFrameIterator::extend` to return a typed error when input would
+  exceed its default 10 MiB buffer limit. Callers that previously appended
+  without handling a result must now handle or propagate `MllpError`.
+
 ### Fixed
 
 - Corrected the README CLI feature list to document supported first-use

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13030",
+  "message": "13037",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/transport/mllp/errors.rs
+++ b/crates/hl7v2/src/transport/mllp/errors.rs
@@ -23,6 +23,15 @@ pub enum MllpError {
     /// Connection timeout.
     #[error("Connection timeout")]
     Timeout,
+
+    /// The streaming frame buffer would exceed its configured limit.
+    #[error("MLLP buffer limit exceeded: attempted {attempted_size} bytes, maximum {max_size}")]
+    BufferLimitExceeded {
+        /// Maximum number of bytes allowed in the streaming buffer.
+        max_size: usize,
+        /// Number of bytes that would have been buffered.
+        attempted_size: usize,
+    },
 }
 
 impl From<std::io::Error> for MllpError {

--- a/crates/hl7v2/src/transport/mllp/streaming.rs
+++ b/crates/hl7v2/src/transport/mllp/streaming.rs
@@ -1,22 +1,46 @@
 use crate::model::Error;
 
-use super::{find_complete_mllp_message, unwrap_mllp_owned};
+use super::{MllpError, find_complete_mllp_message, unwrap_mllp_owned};
+
+/// Default maximum size of the buffered MLLP input (10 MiB).
+const DEFAULT_MAX_BUFFER_SIZE: usize = 10 * 1024 * 1024;
 
 /// An MLLP frame iterator for streaming scenarios.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MllpFrameIterator {
     buffer: Vec<u8>,
+    max_buffer_size: usize,
 }
 
 impl MllpFrameIterator {
     /// Create a new MLLP frame iterator.
     pub fn new() -> Self {
-        Self { buffer: Vec::new() }
+        Self::with_max_buffer_size(DEFAULT_MAX_BUFFER_SIZE)
     }
 
-    /// Add bytes to the internal buffer.
-    pub fn extend(&mut self, bytes: &[u8]) {
+    /// Create a new MLLP frame iterator with a custom buffer limit.
+    pub fn with_max_buffer_size(max_buffer_size: usize) -> Self {
+        Self {
+            buffer: Vec::new(),
+            max_buffer_size,
+        }
+    }
+
+    /// Add bytes to the internal buffer without exceeding its configured limit.
+    ///
+    /// If the bytes would exceed the limit, the buffer is unchanged and the
+    /// caller can recover by consuming a frame or calling [`Self::clear`].
+    pub fn extend(&mut self, bytes: &[u8]) -> Result<(), MllpError> {
+        let attempted_size = self.buffer.len().saturating_add(bytes.len());
+        if attempted_size > self.max_buffer_size {
+            return Err(MllpError::BufferLimitExceeded {
+                max_size: self.max_buffer_size,
+                attempted_size,
+            });
+        }
+
         self.buffer.extend_from_slice(bytes);
+        Ok(())
     }
 
     /// Try to extract the next complete MLLP frame.
@@ -37,8 +61,19 @@ impl MllpFrameIterator {
         self.buffer.len()
     }
 
+    /// Get the configured maximum buffer size.
+    pub fn max_buffer_size(&self) -> usize {
+        self.max_buffer_size
+    }
+
     /// Clear the internal buffer.
     pub fn clear(&mut self) {
         self.buffer.clear();
+    }
+}
+
+impl Default for MllpFrameIterator {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/hl7v2/src/transport/mllp/tests.rs
+++ b/crates/hl7v2/src/transport/mllp/tests.rs
@@ -250,6 +250,7 @@ fn test_frame_iterator_new() {
 fn test_frame_iterator_default() {
     let iter = MllpFrameIterator::default();
     assert_eq!(iter.buffer_len(), 0);
+    assert_eq!(iter.max_buffer_size(), 10 * 1024 * 1024);
 }
 
 #[test]
@@ -259,7 +260,7 @@ fn test_frame_iterator_single_message() {
     let hl7 = b"MSH|^~\\&|TEST\r";
     let framed = wrap_mllp(hl7);
 
-    iter.extend(&framed);
+    assert!(iter.extend(&framed).is_ok());
 
     let msg = iter.next_message().unwrap().unwrap();
     assert_eq!(&msg, hl7);
@@ -278,8 +279,8 @@ fn test_frame_iterator_multiple_messages() {
     let framed_2 = wrap_mllp(hl7_2);
 
     // Add both messages
-    iter.extend(&framed_1);
-    iter.extend(&framed_2);
+    assert!(iter.extend(&framed_1).is_ok());
+    assert!(iter.extend(&framed_2).is_ok());
 
     // Extract first message
     let msg_1 = iter.next_message().unwrap().unwrap();
@@ -301,11 +302,11 @@ fn test_frame_iterator_partial_message() {
     let framed = wrap_mllp(hl7);
 
     // Add partial message
-    iter.extend(&framed[..5]);
+    assert!(iter.extend(&framed[..5]).is_ok());
     assert!(iter.next_message().is_none());
 
     // Add the rest
-    iter.extend(&framed[5..]);
+    assert!(iter.extend(&framed[5..]).is_ok());
 
     // Now we can extract
     let msg = iter.next_message().unwrap().unwrap();
@@ -321,7 +322,7 @@ fn test_frame_iterator_byte_by_byte() {
 
     // Add byte by byte
     for byte in &framed {
-        iter.extend(&[*byte]);
+        assert!(iter.extend(&[*byte]).is_ok());
         if iter.buffer_len() < framed.len() {
             assert!(iter.next_message().is_none());
         }
@@ -336,7 +337,7 @@ fn test_frame_iterator_byte_by_byte() {
 fn test_frame_iterator_clear() {
     let mut iter = MllpFrameIterator::new();
 
-    iter.extend(b"some data");
+    assert!(iter.extend(b"some data").is_ok());
     assert!(iter.buffer_len() > 0);
 
     iter.clear();
@@ -349,11 +350,31 @@ fn test_frame_iterator_buffer_len() {
 
     assert_eq!(iter.buffer_len(), 0);
 
-    iter.extend(b"test");
+    assert!(iter.extend(b"test").is_ok());
     assert_eq!(iter.buffer_len(), 4);
 
-    iter.extend(b"more");
+    assert!(iter.extend(b"more").is_ok());
     assert_eq!(iter.buffer_len(), 8);
+}
+
+#[test]
+fn test_frame_iterator_rejects_input_beyond_limit_without_mutating_buffer() {
+    let mut iter = MllpFrameIterator::with_max_buffer_size(4);
+
+    assert!(iter.extend(b"123").is_ok());
+    let error = iter.extend(b"45");
+
+    assert_eq!(
+        error,
+        Err(MllpError::BufferLimitExceeded {
+            max_size: 4,
+            attempted_size: 5,
+        })
+    );
+    assert_eq!(iter.buffer_len(), 3);
+
+    assert!(iter.extend(b"4").is_ok());
+    assert_eq!(iter.buffer_len(), 4);
 }
 
 #[test]
@@ -363,7 +384,7 @@ fn test_frame_iterator_next_frame() {
     let hl7 = b"MSH|^~\\&|TEST\r";
     let framed = wrap_mllp(hl7);
 
-    iter.extend(&framed);
+    assert!(iter.extend(&framed).is_ok());
 
     let frame = iter.next_frame().unwrap();
     assert_eq!(frame, framed);
@@ -456,7 +477,7 @@ fn test_frame_iterator_concatenated_messages() {
     let mut combined = framed_1.clone();
     combined.extend_from_slice(&framed_2);
 
-    iter.extend(&combined);
+    assert!(iter.extend(&combined).is_ok());
 
     // Extract first message
     let msg_1 = iter.next_message().unwrap().unwrap();
@@ -488,7 +509,7 @@ fn test_frame_iterator_large_message() {
     let content: Vec<u8> = (0..50000).map(|i| (i % 256) as u8).collect();
     let framed = wrap_mllp(&content);
 
-    iter.extend(&framed);
+    assert!(iter.extend(&framed).is_ok());
 
     let msg = iter.next_message().unwrap().unwrap();
     assert_eq!(msg.as_slice(), content.as_slice());


### PR DESCRIPTION
## What this does

`MllpFrameIterator::extend` previously appended input without a bound, allowing an incomplete MLLP frame to grow memory indefinitely. This is a robustness and denial-of-service risk for callers that feed untrusted streams.

**Fix:** `MllpFrameIterator::new()` now applies a 10 MiB buffer limit, callers can select a limit, and `extend` returns `MllpError::BufferLimitExceeded` without mutating the buffer when input would exceed it. Complete-frame parsing and the existing default construction path remain available.

## Compatibility

The public `extend` method now returns `Result<(), MllpError>`. Callers must handle or propagate the new overflow error. The Unreleased changelog records this migration requirement.

## Verification

| Check | Result |
| --- | --- |
| MLLP transport tests | 49 passed, including configured-limit rejection and recovery |
| `cargo test --locked -p hl7v2 --lib` | 689 passed |
| strict Clippy | `cargo clippy --locked -p hl7v2 --lib --tests -- -D warnings` clean |
| format and diff hygiene | `cargo fmt --all`, `git diff --check` clean |

## Review map

- `MllpFrameIterator::extend`: rejects growth beyond the configured limit and preserves buffered bytes on failure.
- `MllpError::BufferLimitExceeded`: carries the configured maximum and attempted size for caller diagnostics.
- MLLP tests: cover the default limit, successful existing paths, overflow rejection, buffer preservation, and recovery.

## Out of scope

The broader #222 query, observability, and other transport findings remain separate slices.
