### PR TITLE
ci(security): pin semgrep container image

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,7 +68,9 @@ jobs:
     name: SAST (Semgrep)
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      # Keep the release tag for readability and the digest for reproducibility.
+      # Refresh both values together when updating Semgrep.
+      image: returntocorp/semgrep:1.172.0@sha256:65dcd4408adda7c183a6b4550cb1e9b19f7f627a6fbb7e0559bd466bedc44d7b
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## What this does

Pins the Semgrep SAST container in `.github/workflows/security.yml` to the current release `1.172.0` and its immutable OCI index digest. The workflow no longer follows the mutable `latest` tag, so security scan behavior and SARIF generation are reproducible until the tag and digest are intentionally refreshed together.

## Security boundary

This changes the CI supply-chain input used by the required Semgrep security lane. It does not change application runtime behavior, permissions, secrets, or scanned source content.

## Verification

| Check | Result |
| --- | --- |
| Docker registry manifest inspection | `1.172.0` resolves to the pinned digest `sha256:65dcd440...` |
| `actionlint` for all workflow files | pass |
| `git diff --check` | pass |
| `cargo metadata --locked --no-deps` | pass |

## Maintenance

Future Semgrep updates should change the human-readable tag and digest together after verifying the new registry manifest.

Refs #178