### PR TITLE
ci(nightly): pin cargo-fuzz version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
           shared-key: fuzz-nightly
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install cargo-fuzz --version 0.13.2 --locked
 
       - name: Run fuzz test - ${{ matrix.target }}
         run: |


### PR DESCRIPTION
## What this does

Pins the remaining unversioned nightly CI tool installation: `cargo-fuzz` now installs version `0.13.2` with its published lockfile. The other tools in this workflow (`cargo-mutants`, `cargo-audit`, and `cargo-deny`) were already pinned and are unchanged.

## Security and reproducibility boundary

This changes the toolchain input for the nightly fuzzing lane only. It prevents a mutable crates.io latest release from changing the command behavior between nightly runs. It does not change fuzz targets, fuzz duration, failure handling, or application runtime behavior.

## Verification

| Check | Result |
| --- | --- |
| crates.io package inspection | `cargo-fuzz` current release verified as `0.13.2` |
| `actionlint` for all workflow files | pass |
| `git diff --check` | pass |
| `cargo metadata --locked --no-deps` | pass |

Refs #177