### PR TITLE
perf(server): borrow health response version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loopback (`127.0.0.1:8080`). Explicit network binds, including container
   deployment settings, remain unchanged; set `BIND_ADDRESS`, `server.host`, or
   `--host` when remote access is required.
+- Health responses now borrow the compile-time server version instead of
+  allocating a new string for each health request.
 
 ### Fixed
 

--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
-  "color": "red",
+  "color": "lightgrey",
   "label": "ripr+",
-  "message": "error",
+  "message": "needs test-efficiency",
   "schemaVersion": 1
 }

--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
-  "color": "lightgrey",
+  "color": "red",
   "label": "ripr+",
-  "message": "needs test-efficiency",
+  "message": "error",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "1415",
+  "message": "13037",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13038",
+  "message": "1415",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/src/handlers.rs
+++ b/crates/hl7v2-server/src/handlers.rs
@@ -74,7 +74,7 @@ pub async fn health_handler(State(state): State<Arc<AppState>>) -> impl IntoResp
 
     let response = HealthResponse {
         status: HealthStatus::Healthy,
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version: env!("CARGO_PKG_VERSION"),
         uptime_seconds: uptime,
     };
 

--- a/crates/hl7v2-server/src/models/core.rs
+++ b/crates/hl7v2-server/src/models/core.rs
@@ -12,12 +12,12 @@ use super::{
 };
 
 /// Health check response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct HealthResponse {
     /// Service status
     pub status: HealthStatus,
     /// Service version
-    pub version: String,
+    pub version: &'static str,
     /// Uptime in seconds
     pub uptime_seconds: u64,
 }

--- a/crates/hl7v2-server/tests/health_endpoints_test.rs
+++ b/crates/hl7v2-server/tests/health_endpoints_test.rs
@@ -96,6 +96,33 @@ async fn test_health_endpoint_contains_status() {
 }
 
 #[tokio::test]
+async fn test_health_endpoint_contains_version() {
+    let app = common::create_test_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(
+        body_str.contains(env!("CARGO_PKG_VERSION")),
+        "Health response should contain the server package version"
+    );
+}
+
+#[tokio::test]
 async fn test_health_endpoint_contains_uptime() {
     let app = common::create_test_router();
 


### PR DESCRIPTION
## What this does

The health handler previously allocated a `String` from the compile-time package version for every request. `HealthResponse.version` now borrows that compile-time value instead.

The HTTP/JSON/OpenAPI response remains unchanged. This changes the public Rust model field from `String` to `&'static str` and removes `Deserialize` from `HealthResponse`, because the response-only model now borrows a compile-time value. Current repository consumers are producer-side only; callers deserializing the JSON contract should use the documented wire schema or their own owned DTO.

## Verification

- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass
- `cargo metadata --locked --no-deps --format-version 1` — pass
- `cargo test --locked -p hl7v2-server --test health_endpoints_test` — pass (12 tests)
- Hosted checks — pending

Refs #166