### PR TITLE
docs(nix): mark cli as released

### DIFF
--- a/NIX_USAGE.md
+++ b/NIX_USAGE.md
@@ -109,7 +109,7 @@ nix build .#checks.x86_64-linux.test    # Tests
 
 - **`packages.default`**: Main Rust package with all binaries
   - `hl7v2-server` - HTTP/REST API server
-  - `hl7v2-cli` - Command-line interface (future)
+  - `hl7v2-cli` - Command-line interface
 - **`packages.docker`**: Layered Docker image optimized for caching
 
 ### Development Shells


### PR DESCRIPTION
## What this does

`NIX_USAGE.md` incorrectly labels the released `hl7v2-cli` package as “future,” which can hide an available command-line surface from Nix users.

**Fix:** mark `hl7v2-cli` as the current command-line interface in the Flake Outputs section. No Nix configuration, package behavior, or commands change.

## Verification

| Check | Result |
| --- | --- |
| `git diff --check` | clean |
| `NIX_USAGE.md` and `flake.nix` review | package documentation matches the current CLI/default package surface |
| Nix flake evaluation | not run, `nix` is unavailable on the Windows host |

## Review map

- `NIX_USAGE.md:112`: removes the stale “future” qualifier from the released CLI entry.