### PR TITLE
security(config): clarify api key placeholder

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,8 @@
 [server]
 host = "127.0.0.1"
 port = 8080
-# api_key = "secret-key"
+# Generate a unique key before enabling API-key authentication.
+# api_key = "CHANGE_ME_TO_A_SECURE_RANDOM_STRING"
 # bundle_output_root = "bundles"
 # max_message_size = 52428800 # 50 MiB application-level HL7 message limit
 


### PR DESCRIPTION
## What this does

The repository configuration example currently shows the ambiguous commented value api_key = "secret-key". Users copying it can mistake a predictable placeholder for a suitable credential.

**Change:** Replace that value with explicit guidance to generate a unique key and a clearly non-secret CHANGE_ME placeholder. Runtime authentication, config loading, and defaults are unchanged.

## Verification

| Check | Result |
| --- | --- |
| git diff --check | clean |
| cargo metadata --locked --no-deps | pass |
| TOML parse via Python tomllib | pass |
| cargo test -p hl7v2-cli config_example_matches_loader_shape --locked | timed out after 120 seconds under concurrent workspace Cargo builds; not counted as pass |

## Review map

- config.example.toml:6-7: makes the example credential guidance explicit without adding a secret.

Resolves only the example-config placeholder subfinding from #195. Runtime defaults, endpoint exposure, CORS, and TLS remain outside this PR.