### PR TITLE
fix(devex): use canonical hooks in nix shell

### DIFF
--- a/NIX_USAGE.md
+++ b/NIX_USAGE.md
@@ -167,9 +167,10 @@ Darwin builds include necessary Apple SDK frameworks.
 
 ## Repository Hooks
 
-When the tracked `.githooks/` directory is present, `nix develop` configures
-`core.hooksPath` to use it. The hooks delegate to the repository's `xtask`
-workflow, so Nix and non-Nix development use the same behavior:
+When the tracked `.githooks/` directory is present, `nix develop` enables
+Git's worktree configuration and sets the current worktree's `core.hooksPath`
+to use it. The hooks delegate to the repository's `xtask` workflow, so Nix and
+non-Nix development use the same behavior:
 
 1. **Pre-commit**: `cargo run -p xtask -- hook-pre-commit`
 2. **Pre-push**: `cargo run -p xtask -- hook-pre-push`

--- a/NIX_USAGE.md
+++ b/NIX_USAGE.md
@@ -35,7 +35,7 @@ This provides:
 - **Utilities**: jq, yq, just, watchexec
 
 The shell also:
-- Sets up git pre-commit hooks automatically
+- Configures the tracked `.githooks/` workflow automatically when the repository hooks are present
 - Displays helpful command reference
 - Configures Rust environment variables
 
@@ -165,16 +165,18 @@ The flake supports:
 
 Darwin builds include necessary Apple SDK frameworks.
 
-## Pre-Commit Hooks
+## Repository Hooks
 
-The development shell automatically installs git pre-commit hooks that run:
+When the tracked `.githooks/` directory is present, `nix develop` configures
+`core.hooksPath` to use it. The hooks delegate to the repository's `xtask`
+workflow, so Nix and non-Nix development use the same behavior:
 
-1. **Format check**: `cargo fmt --all -- --check`
-2. **Linting**: `cargo clippy --all-targets --all-features -- -D warnings`
-3. **Tests**: `cargo test --all`
-4. **Schema validation**: Validates YAML profiles against JSON schema (if available)
+1. **Pre-commit**: `cargo run -p xtask -- hook-pre-commit`
+2. **Pre-push**: `cargo run -p xtask -- hook-pre-push`
 
-Hooks are installed on first `nix develop` entry.
+The pre-commit command only runs when staged Rust or Cargo files are present,
+and it restages files after lint fixes. Run `just setup` (or
+`cargo run -p xtask -- setup`) to configure the same hook path explicitly.
 
 ## CI/CD Integration
 

--- a/flake.nix
+++ b/flake.nix
@@ -136,10 +136,15 @@
             # This keeps Nix and non-Nix development on one hook workflow and
             # also works in linked worktrees where .git is a file.
             if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" &&
-              [ -f "$REPO_ROOT/.githooks/pre-commit" ]; then
-              git -C "$REPO_ROOT" config core.hooksPath .githooks
-              chmod +x "$REPO_ROOT"/.githooks/pre-commit "$REPO_ROOT"/.githooks/pre-push 2>/dev/null || true
-              echo "✅ Using repository hooks from .githooks"
+              [ -f "$REPO_ROOT/.githooks/pre-commit" ] &&
+              [ -f "$REPO_ROOT/.githooks/pre-push" ]; then
+              if chmod +x "$REPO_ROOT"/.githooks/pre-commit "$REPO_ROOT"/.githooks/pre-push &&
+                git -C "$REPO_ROOT" config extensions.worktreeConfig true &&
+                git -C "$REPO_ROOT" config --worktree core.hooksPath .githooks; then
+                echo "✅ Using repository hooks from .githooks"
+              else
+                echo "⚠️ Could not configure repository hooks from .githooks" >&2
+              fi
             fi
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -132,33 +132,13 @@
             echo "  kubectl apply -f infrastructure/k8s/ - Deploy to Kubernetes"
             echo ""
 
-            # Set up pre-commit hooks
-            if [ ! -f .git/hooks/pre-commit ]; then
-              echo "Setting up pre-commit hooks..."
-              cat > .git/hooks/pre-commit << 'EOF'
-#!/usr/bin/env bash
-set -e
-
-echo "Running pre-commit checks..."
-
-# Format check
-cargo fmt --all -- --check
-
-# Clippy
-cargo clippy --all-targets --all-features -- -D warnings
-
-# Tests
-cargo test --all
-
-# Schema validation (if schema exists)
-if command -v ajv &> /dev/null && [ -f schemas/profile/profile-v1.schema.json ]; then
-  ajv validate -s schemas/profile/profile-v1.schema.json -d 'examples/profiles/*.yaml' || true
-fi
-
-echo "✅ Pre-commit checks passed!"
-EOF
-              chmod +x .git/hooks/pre-commit
-              echo "✅ Pre-commit hooks installed"
+            # Use the tracked repository hooks, which delegate to xtask.
+            # This keeps Nix and non-Nix development on one hook workflow and
+            # also works in linked worktrees where .git is a file.
+            if git rev-parse --git-dir >/dev/null 2>&1 && [ -f .githooks/pre-commit ]; then
+              git config core.hooksPath .githooks
+              chmod +x .githooks/pre-commit .githooks/pre-push 2>/dev/null || true
+              echo "✅ Using repository hooks from .githooks"
             fi
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -135,9 +135,10 @@
             # Use the tracked repository hooks, which delegate to xtask.
             # This keeps Nix and non-Nix development on one hook workflow and
             # also works in linked worktrees where .git is a file.
-            if git rev-parse --git-dir >/dev/null 2>&1 && [ -f .githooks/pre-commit ]; then
-              git config core.hooksPath .githooks
-              chmod +x .githooks/pre-commit .githooks/pre-push 2>/dev/null || true
+            if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" &&
+              [ -f "$REPO_ROOT/.githooks/pre-commit" ]; then
+              git -C "$REPO_ROOT" config core.hooksPath .githooks
+              chmod +x "$REPO_ROOT"/.githooks/pre-commit "$REPO_ROOT"/.githooks/pre-push 2>/dev/null || true
               echo "✅ Using repository hooks from .githooks"
             fi
           '';


### PR DESCRIPTION
## What this does

Entering the Nix development shell currently writes a second full-test hook under `.git/hooks`, which bypasses the tracked `.githooks` workflow and behaves differently in linked worktrees.

**Fix:** Configure `core.hooksPath` to `.githooks` when the tracked hooks are present. Nix users now use the same xtask-backed pre-commit and pre-push hooks as non-Nix users, while the existing hook policy and runtime code remain unchanged.

## Verification

| Check | Result |
| --- | --- |
| `git diff --check` | clean |
| Extracted flake shellHook with `bash -n` | pass |
| Hook static assertions | pass: no duplicate `.git/hooks` writer or full-test hook; canonical path and tracked hooks present |
| `cargo metadata --locked --no-deps` | pass |
| Nix evaluation | not run, `nix` is unavailable on the Windows host |

## Review map

- `flake.nix:135-142`: selects the tracked `.githooks` path and supports linked worktrees without generating a duplicate hook.
- `NIX_USAGE.md:168-184`: documents the canonical hook commands and staged-file behavior.

Closes #246.