### PR TITLE
feat(json): add canonical JSON deserialization

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
-  "color": "red",
+  "color": "lightgrey",
   "label": "ripr+",
-  "message": "error",
+  "message": "needs test-efficiency",
   "schemaVersion": 1
 }

--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
-  "color": "lightgrey",
+  "color": "red",
   "label": "ripr+",
-  "message": "needs test-efficiency",
+  "message": "error",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13037",
+  "message": "1417",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "1417",
+  "message": "13142",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/README.md
+++ b/crates/hl7v2/README.md
@@ -15,6 +15,11 @@ let msg = parse(b"MSH|^~\\&|App||Fac||20250128||ADT^A01|123|P|2.5.1\rPID|1||PAT1
 assert_eq!(get(&msg, "PID.5.1"), Some("Doe"));
 ```
 
+The canonical JSON facade supports both directions. Use `to_json` or
+`to_json_string` to export a message, and `from_json` or `from_json_string` to
+reconstruct a message from that same representation. Reverse conversion
+returns `hl7v2::JsonError` for malformed structure or invalid delimiters.
+
 ## Features
 
 | Feature | Description |

--- a/crates/hl7v2/src/lib.rs
+++ b/crates/hl7v2/src/lib.rs
@@ -97,8 +97,8 @@ pub use transport::mllp::{
     is_mllp_framed, unwrap_mllp, unwrap_mllp_owned, wrap_mllp,
 };
 pub use writer::{
-    to_json, to_json_string, to_json_string_pretty, write, write_batch, write_file_batch,
-    write_mllp,
+    JsonError, from_json, from_json_string, to_json, to_json_string, to_json_string_pretty, write,
+    write_batch, write_file_batch, write_mllp,
 };
 
 #[cfg(feature = "normalize")]

--- a/crates/hl7v2/src/writer/json/mod.rs
+++ b/crates/hl7v2/src/writer/json/mod.rs
@@ -35,6 +35,274 @@
 use crate::model::*;
 use serde_json::json;
 
+/// Errors returned while converting the canonical JSON representation back to
+/// an HL7 message.
+#[derive(Debug, thiserror::Error)]
+pub enum JsonError {
+    /// The input was not valid JSON text.
+    #[error("invalid JSON syntax: {0}")]
+    Syntax(#[from] serde_json::Error),
+
+    /// A required JSON member was not present.
+    #[error("missing JSON member: {0}")]
+    Missing(String),
+
+    /// A JSON value had a different type than the canonical representation
+    /// requires.
+    #[error("invalid JSON at {path}: expected {expected}")]
+    InvalidType {
+        path: String,
+        expected: &'static str,
+    },
+
+    /// A JSON value could not be represented by the HL7 model.
+    #[error("invalid JSON at {path}: {message}")]
+    Invalid { path: String, message: String },
+}
+
+/// Convert the canonical JSON representation produced by [`to_json`] back to
+/// an HL7 message.
+///
+/// The representation uses numeric field keys (`"1"`, `"2"`, and so on),
+/// with MSH fields numbered according to their HL7 positions. Missing keys are
+/// reconstructed as empty fields. The `"__NULL__"` atom marker is converted
+/// back to [`Atom::Null`].
+///
+/// # Errors
+///
+/// Returns [`JsonError`] when required members are missing, values have the
+/// wrong type, or delimiters, segment IDs, or field numbers are invalid.
+pub fn from_json(value: &serde_json::Value) -> Result<Message, JsonError> {
+    let root = object(value, "message")?;
+    let meta = object(member(root, "meta", "message")?, "message.meta")?;
+    let delimiters = object(
+        member(meta, "delims", "message.meta")?,
+        "message.meta.delims",
+    )?;
+
+    let delims = Delims {
+        field: delimiter(delimiters, "field")?,
+        comp: delimiter(delimiters, "comp")?,
+        rep: delimiter(delimiters, "rep")?,
+        esc: delimiter(delimiters, "esc")?,
+        sub: delimiter(delimiters, "sub")?,
+    };
+    let delimiter_values = [
+        delims.field,
+        delims.comp,
+        delims.rep,
+        delims.esc,
+        delims.sub,
+    ];
+    if delimiter_values
+        .iter()
+        .enumerate()
+        .any(|(index, delimiter)| {
+            delimiter_values
+                .get(..index)
+                .is_some_and(|prefix| prefix.contains(delimiter))
+        })
+    {
+        return Err(invalid(
+            "message.meta.delims",
+            "delimiter characters must be distinct",
+        ));
+    }
+
+    let charsets = match meta.get("charsets") {
+        Some(value) => strings(value, "message.meta.charsets")?,
+        None => Vec::new(),
+    };
+
+    let segments = array(member(root, "segments", "message")?, "message.segments")?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| parse_segment(value, index))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Message {
+        delims,
+        segments,
+        charsets,
+    })
+}
+
+/// Parse JSON text containing the canonical representation produced by
+/// [`to_json`].
+///
+/// # Errors
+///
+/// Returns [`JsonError::Syntax`] for invalid JSON text or another
+/// [`JsonError`] when the decoded value is not a valid canonical message.
+pub fn from_json_string(input: &str) -> Result<Message, JsonError> {
+    let value = serde_json::from_str(input)?;
+    from_json(&value)
+}
+
+fn parse_segment(value: &serde_json::Value, segment_index: usize) -> Result<Segment, JsonError> {
+    let path = format!("message.segments[{segment_index}]");
+    let segment = object(value, &path)?;
+    let id_path = format!("{path}.id");
+    let id = string(member(segment, "id", &path)?, &id_path)?;
+    let id_bytes = id.as_bytes();
+    if id_bytes.len() != 3 || !id_bytes.iter().all(u8::is_ascii) {
+        return Err(invalid(
+            id_path,
+            "segment IDs must contain exactly three ASCII bytes",
+        ));
+    }
+    let id = id_bytes
+        .try_into()
+        .map_err(|_error| invalid(format!("{path}.id"), "segment ID must be three bytes"))?;
+
+    let fields_path = format!("{path}.fields");
+    let fields_object = object(member(segment, "fields", &path)?, &fields_path)?;
+    let mut indexed_fields = Vec::with_capacity(fields_object.len());
+    for (field_number, value) in fields_object {
+        let field_path = format!("{fields_path}.{field_number}");
+        let field_number = field_number.parse::<usize>().map_err(|_error| {
+            invalid(
+                field_path.clone(),
+                "field keys must be positive decimal integers",
+            )
+        })?;
+        let field_index = if id == *b"MSH" {
+            field_number.checked_sub(2)
+        } else {
+            field_number.checked_sub(1)
+        }
+        .ok_or_else(|| {
+            invalid(
+                field_path.clone(),
+                "field numbers must start at 2 for MSH and 1 for other segments",
+            )
+        })?;
+        indexed_fields.push((field_index, parse_field(value, &field_path)?));
+    }
+
+    let fields = match indexed_fields.iter().map(|(index, _)| *index).max() {
+        Some(max_index) => {
+            let field_count = max_index
+                .checked_add(1)
+                .ok_or_else(|| invalid(fields_path.clone(), "field index is too large"))?;
+            let mut fields = vec![Field::new(); field_count];
+            for (index, field) in indexed_fields {
+                let slot = fields.get_mut(index).ok_or_else(|| {
+                    invalid(fields_path.clone(), "field index is outside the message")
+                })?;
+                *slot = field;
+            }
+            fields
+        }
+        None => Vec::new(),
+    };
+
+    Ok(Segment { id, fields })
+}
+
+fn parse_field(value: &serde_json::Value, path: &str) -> Result<Field, JsonError> {
+    let reps = array(value, path)?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| parse_rep(value, &format!("{path}[{index}]")))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Field { reps })
+}
+
+fn parse_rep(value: &serde_json::Value, path: &str) -> Result<Rep, JsonError> {
+    let comps = array(value, path)?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| parse_comp(value, &format!("{path}[{index}]")))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Rep { comps })
+}
+
+fn parse_comp(value: &serde_json::Value, path: &str) -> Result<Comp, JsonError> {
+    let subs = array(value, path)?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let atom_path = format!("{path}[{index}]");
+            let atom = string(value, &atom_path)?;
+            Ok(if atom == "__NULL__" {
+                Atom::Null
+            } else {
+                Atom::Text(atom.to_owned())
+            })
+        })
+        .collect::<Result<Vec<_>, JsonError>>()?;
+    Ok(Comp { subs })
+}
+
+fn member<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    path: &str,
+) -> Result<&'a serde_json::Value, JsonError> {
+    object
+        .get(key)
+        .ok_or_else(|| JsonError::Missing(format!("{path}.{key}")))
+}
+
+fn object<'a>(
+    value: &'a serde_json::Value,
+    path: &str,
+) -> Result<&'a serde_json::Map<String, serde_json::Value>, JsonError> {
+    value.as_object().ok_or_else(|| JsonError::InvalidType {
+        path: path.to_owned(),
+        expected: "an object",
+    })
+}
+
+fn array<'a>(
+    value: &'a serde_json::Value,
+    path: &str,
+) -> Result<&'a Vec<serde_json::Value>, JsonError> {
+    value.as_array().ok_or_else(|| JsonError::InvalidType {
+        path: path.to_owned(),
+        expected: "an array",
+    })
+}
+
+fn strings(value: &serde_json::Value, path: &str) -> Result<Vec<String>, JsonError> {
+    array(value, path)?
+        .iter()
+        .enumerate()
+        .map(|(index, value)| string(value, &format!("{path}[{index}]")).map(str::to_owned))
+        .collect()
+}
+
+fn string<'a>(value: &'a serde_json::Value, path: &str) -> Result<&'a str, JsonError> {
+    value.as_str().ok_or_else(|| JsonError::InvalidType {
+        path: path.to_owned(),
+        expected: "a string",
+    })
+}
+
+fn delimiter(
+    object: &serde_json::Map<String, serde_json::Value>,
+    name: &str,
+) -> Result<char, JsonError> {
+    let path = format!("message.meta.delims.{name}");
+    let value = string(member(object, name, "message.meta.delims")?, &path)?;
+    let mut chars = value.chars();
+    let delimiter = chars
+        .next()
+        .ok_or_else(|| invalid(path.clone(), "delimiter must be one ASCII character"))?;
+    if chars.next().is_some() || !delimiter.is_ascii() || matches!(delimiter, '\r' | '\n') {
+        return Err(invalid(path, "delimiter must be one ASCII character"));
+    }
+    Ok(delimiter)
+}
+
+fn invalid(path: impl Into<String>, message: impl Into<String>) -> JsonError {
+    JsonError::Invalid {
+        path: path.into(),
+        message: message.into(),
+    }
+}
+
 /// Convert message to canonical JSON.
 ///
 /// # Arguments

--- a/crates/hl7v2/src/writer/json/tests.rs
+++ b/crates/hl7v2/src/writer/json/tests.rs
@@ -404,6 +404,117 @@ mod custom_delims_tests {
 }
 
 // ============================================================================
+// from_json Tests
+// ============================================================================
+
+#[cfg(test)]
+mod from_json_tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn roundtrips_canonical_json_with_sparse_fields_and_nested_atoms() -> Result<(), Box<dyn Error>>
+    {
+        let original = Message {
+            delims: Delims {
+                field: '*',
+                comp: ':',
+                rep: '+',
+                esc: '%',
+                sub: '#',
+            },
+            segments: vec![
+                Segment {
+                    id: *b"MSH",
+                    fields: vec![
+                        Field::from_text(":~%#"),
+                        Field::new(),
+                        Field::from_text("SENDER"),
+                    ],
+                },
+                Segment {
+                    id: *b"PID",
+                    fields: vec![
+                        Field::new(),
+                        Field {
+                            reps: vec![
+                                Rep {
+                                    comps: vec![Comp {
+                                        subs: vec![Atom::Text("Doe".to_owned()), Atom::Null],
+                                    }],
+                                },
+                                Rep {
+                                    comps: vec![Comp::from_text("John")],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            charsets: vec!["ASCII".to_owned(), "UTF-8".to_owned()],
+        };
+
+        let decoded = from_json(&to_json(&original))?;
+
+        if decoded == original {
+            Ok(())
+        } else {
+            Err(std::io::Error::other("canonical JSON roundtrip changed the message").into())
+        }
+    }
+
+    #[test]
+    fn from_json_string_decodes_canonical_output() -> Result<(), Box<dyn Error>> {
+        let original = Message::with_segments(vec![Segment {
+            id: *b"PID",
+            fields: vec![Field::from_text("123")],
+        }]);
+
+        let decoded = from_json_string(&to_json_string(&original))?;
+
+        if decoded == original {
+            Ok(())
+        } else {
+            Err(std::io::Error::other("JSON string roundtrip changed the message").into())
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_field_numbering() -> Result<(), Box<dyn Error>> {
+        let value = serde_json::json!({
+            "meta": {"delims": {"field": "|", "comp": "^", "rep": "~", "esc": "\\", "sub": "&"}},
+            "segments": [{"id": "MSH", "fields": {"1": [[ ["invalid"] ]]}}]
+        });
+
+        match from_json(&value) {
+            Ok(_) => Err(std::io::Error::other("invalid MSH field numbering was accepted").into()),
+            Err(_) => Ok(()),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_delimiters_and_atom_types() -> Result<(), Box<dyn Error>> {
+        let invalid_delims = serde_json::json!({
+            "meta": {"delims": {"field": "|", "comp": "|", "rep": "~", "esc": "\\", "sub": "&"}},
+            "segments": []
+        });
+        if from_json(&invalid_delims).is_ok() {
+            return Err(std::io::Error::other("duplicate delimiters were accepted").into());
+        }
+
+        let invalid_atom = serde_json::json!({
+            "meta": {"delims": {"field": "|", "comp": "^", "rep": "~", "esc": "\\", "sub": "&"}},
+            "segments": [{"id": "PID", "fields": {"1": [[[42]]]}}]
+        });
+        if from_json(&invalid_atom).is_ok() {
+            return Err(std::io::Error::other("non-string atom was accepted").into());
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
 // Segment ID Tests
 // ============================================================================
 

--- a/crates/hl7v2/src/writer/mod.rs
+++ b/crates/hl7v2/src/writer/mod.rs
@@ -35,7 +35,9 @@ use crate::model::*;
 
 pub mod json;
 
-pub use json::{to_json, to_json_string, to_json_string_pretty};
+pub use json::{
+    JsonError, from_json, from_json_string, to_json, to_json_string, to_json_string_pretty,
+};
 
 /// Write HL7 message to bytes.
 ///

--- a/crates/hl7v2/tests/json_facade.rs
+++ b/crates/hl7v2/tests/json_facade.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "json")]
 
-use hl7v2::{Comp, Delims, Field, Message, Rep, Segment, parse, to_json, to_json_string_pretty};
+use hl7v2::{
+    Comp, Delims, Field, Message, Rep, Segment, from_json, from_json_string, parse, to_json,
+    to_json_string, to_json_string_pretty,
+};
 use std::error::Error;
 use std::fmt::Debug;
 
@@ -105,6 +108,34 @@ fn json_facade_preserves_msh_field_numbering() -> Result<(), Box<dyn Error>> {
     require_eq(fields.get("2"), Some(&msh2), "MSH-2 encoding characters")?;
     require_eq(fields.get("3"), Some(&msh3), "MSH-3 sending application")?;
     require_eq(fields.get("10"), Some(&msh10), "MSH-10 control id")?;
+
+    Ok(())
+}
+
+#[test]
+fn json_facade_roundtrips_through_root_exports() -> Result<(), Box<dyn Error>> {
+    let original = Message {
+        delims: Delims::default(),
+        segments: vec![Segment {
+            id: *b"PID",
+            fields: vec![Field {
+                reps: vec![Rep {
+                    comps: vec![Comp {
+                        subs: vec![hl7v2::Atom::Text("Doe".to_owned()), hl7v2::Atom::Null],
+                    }],
+                }],
+            }],
+        }],
+        charsets: vec!["UTF-8".to_owned()],
+    };
+
+    let value = to_json(&original);
+    require_eq(from_json(&value)?, original.clone(), "value roundtrip")?;
+    require_eq(
+        from_json_string(&to_json_string(&original))?,
+        original,
+        "string roundtrip",
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## What this does

The live `hl7v2` JSON facade can export messages but cannot reconstruct them. This adds the missing reverse path for callers that store or receive the existing canonical JSON representation.

**Change:** `from_json` and `from_json_string` rebuild messages from the current `to_json` shape, including delimiters, charsets, segment order, sparse MSH/non-MSH field numbering, nested repetitions/components/subcomponents, and the `__NULL__` marker. Existing JSON output is unchanged, and malformed inputs return `JsonError` without panics.

## Verification

| Check | Result |
| --- | --- |
| JSON writer contract tests | 358 library tests passed, including roundtrip and malformed-input cases |
| Public JSON facade | 4 integration tests passed |
| `cargo fmt --all -- --check` | clean |
| Clippy | JSON library and JSON+profile test targets passed with `-D warnings` |

## Review map

- `crates/hl7v2/src/writer/json/mod.rs`: parses the canonical JSON structure with typed path-aware errors and reconstructs sparse field vectors safely.
- `crates/hl7v2/src/lib.rs` and `writer/mod.rs`: expose the new conversion functions and `JsonError` at the public facade.
- `crates/hl7v2/src/writer/json/tests.rs`: covers nested roundtrips, MSH numbering, delimiters, null atoms, and invalid inputs.
- `crates/hl7v2/tests/json_facade.rs`: proves both root-level APIs are usable by downstream callers.

The server endpoint and JSON schema redesign remain separate follow-up work.

Closes #159