### PR TITLE
perf(server): avoid common status label allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "criterion",
  "futures",
  "hl7v2",
+ "hl7v2-server",
  "rand 0.10.2",
  "serde_json",
  "tokio",

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13142",
+  "message": "13222",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-bench/Cargo.toml
+++ b/crates/hl7v2-bench/Cargo.toml
@@ -23,6 +23,7 @@ hl7v2 = { version = "1.5.0", path = "../hl7v2", features = [
     "network",
     "synthetic",
 ] }
+hl7v2-server = { version = "1.5.0", path = "../hl7v2-server" }
 
 # Async runtime for network benchmarks
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "net", "io-util", "sync"] }
@@ -76,4 +77,8 @@ harness = false
 
 [[bench]]
 name = "template"
+harness = false
+
+[[bench]]
+name = "metrics"
 harness = false

--- a/crates/hl7v2-bench/benches/metrics.rs
+++ b/crates/hl7v2-bench/benches/metrics.rs
@@ -1,0 +1,27 @@
+//! Benchmarks for HTTP metrics label recording.
+//!
+//! The common-status benchmark exercises the middleware's static status-label
+//! path. The custom-status benchmark documents the owned fallback retained for
+//! caller-provided or otherwise uncommon status values.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use hl7v2_server::metrics::{init_metrics_recorder, record_request};
+use std::hint::black_box;
+
+fn bench_request_labels(c: &mut Criterion) {
+    let _handle = init_metrics_recorder();
+    let mut group = c.benchmark_group("request_labels");
+
+    group.bench_function("common_status", |b| {
+        b.iter(|| record_request(black_box("/hl7/parse"), black_box("200"), 0.001));
+    });
+
+    group.bench_function("custom_status", |b| {
+        b.iter(|| record_request(black_box("/hl7/parse"), black_box("599"), 0.001));
+    });
+
+    group.finish();
+}
+
+criterion_group!(metrics_benches, bench_request_labels);
+criterion_main!(metrics_benches);

--- a/crates/hl7v2-server/src/metrics.rs
+++ b/crates/hl7v2-server/src/metrics.rs
@@ -37,6 +37,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use metrics::Label;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use std::sync::{Arc, OnceLock};
 
@@ -163,24 +164,113 @@ fn describe_metrics() {
 pub fn record_request(endpoint: &str, status: &str, duration_seconds: f64) {
     record_request_with_shared_labels(
         Arc::<str>::from(endpoint),
-        Arc::<str>::from(status),
+        status_label(status),
         duration_seconds,
     );
 }
 
-fn record_request_with_shared_labels(endpoint: Arc<str>, status: Arc<str>, duration_seconds: f64) {
+fn record_request_with_shared_labels(endpoint: Arc<str>, status: Label, duration_seconds: f64) {
     metrics::counter!(
         "hl7v2_requests_total",
-        "endpoint" => Arc::clone(&endpoint),
-        "status" => status
+        vec![Label::new("endpoint", Arc::clone(&endpoint)), status]
     )
     .increment(1);
 
     metrics::histogram!(
         "hl7v2_request_duration_seconds",
-        "endpoint" => endpoint
+        vec![Label::new("endpoint", endpoint)]
     )
     .record(duration_seconds);
+}
+
+fn status_label(status: &str) -> Label {
+    if status.len() == 3
+        && !status.starts_with('0')
+        && let Ok(code) = status.parse::<u16>()
+        && let Some(label) = static_status_label_for_code(code)
+    {
+        return label;
+    }
+
+    Label::new("status", Arc::<str>::from(status))
+}
+
+fn static_status_label_for_code(code: u16) -> Option<Label> {
+    let status = match code {
+        100 => "100",
+        101 => "101",
+        102 => "102",
+        103 => "103",
+        200 => "200",
+        201 => "201",
+        202 => "202",
+        203 => "203",
+        204 => "204",
+        205 => "205",
+        206 => "206",
+        207 => "207",
+        208 => "208",
+        226 => "226",
+        300 => "300",
+        301 => "301",
+        302 => "302",
+        303 => "303",
+        304 => "304",
+        305 => "305",
+        307 => "307",
+        308 => "308",
+        400 => "400",
+        401 => "401",
+        402 => "402",
+        403 => "403",
+        404 => "404",
+        405 => "405",
+        406 => "406",
+        407 => "407",
+        408 => "408",
+        409 => "409",
+        410 => "410",
+        411 => "411",
+        412 => "412",
+        413 => "413",
+        414 => "414",
+        415 => "415",
+        416 => "416",
+        417 => "417",
+        418 => "418",
+        421 => "421",
+        422 => "422",
+        423 => "423",
+        424 => "424",
+        425 => "425",
+        426 => "426",
+        428 => "428",
+        429 => "429",
+        431 => "431",
+        451 => "451",
+        500 => "500",
+        501 => "501",
+        502 => "502",
+        503 => "503",
+        504 => "504",
+        505 => "505",
+        506 => "506",
+        507 => "507",
+        508 => "508",
+        510 => "510",
+        511 => "511",
+        _ => return None,
+    };
+
+    Some(Label::from_static_parts("status", status))
+}
+
+fn status_label_for_code(status: StatusCode) -> Label {
+    if let Some(label) = static_status_label_for_code(status.as_u16()) {
+        return label;
+    }
+
+    Label::new("status", Arc::<str>::from(status.as_u16().to_string()))
 }
 
 /// Record a successfully parsed HL7 message for an evidence workflow.
@@ -293,7 +383,7 @@ pub mod middleware {
 
         // Record metrics
         let duration = start.elapsed();
-        let status = Arc::<str>::from(response.status().as_u16().to_string());
+        let status = status_label_for_code(response.status());
 
         record_request_with_shared_labels(path, status, duration.as_secs_f64());
 
@@ -324,6 +414,21 @@ mod tests {
         // Test recording a request
         record_request("/hl7/parse", "200", 0.05);
         // No panic means success
+    }
+
+    #[test]
+    fn status_labels_preserve_common_and_custom_values() -> Result<(), String> {
+        for (input, expected) in [("200", "200"), ("599", "599"), ("0200", "0200")] {
+            let (_, value) = status_label(input).into_parts();
+            if value.as_ref() != expected {
+                return Err(format!(
+                    "status label value was {:?}, expected {expected}",
+                    value.as_ref()
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
# Summary

The `hl7v2-server` request-metrics path now uses static `metrics::Label` values for standard HTTP status codes while retaining shared `Arc<str>` storage for dynamic endpoint labels and an owned fallback for uncommon status values. A dedicated Criterion target measures common-status and custom-status recording paths. This preserves metric names, label keys, values, cardinality, and the public `record_request` signature.

Closes #205.

## Assumptions

- `metrics` 0.24.6 requires non-static request labels to use owned or shared storage, so this PR does not claim zero allocations per request.
- The benchmark target is a repeatable measurement surface; runtime benchmark results were not completed locally because the Windows release build exceeded the bounded timeout.

## Checklist

- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [ ] `cargo run -p xtask -- gate --check` passes locally.
- [ ] `cargo run -p xtask -- check-lint-policy` passes.
- [ ] `cargo run -p xtask -- check-no-panic-family` passes.
- [ ] `cargo run -p xtask -- check-file-policy` passes.

## CI Economics

| Field                  | Value |
| ---------------------- | ----- |
| Default PR LEM impact  | No workflow changes; benchmark compile surface added to the existing internal bench crate |
| Workflows touched      | None |
| Branch protection      | Unchanged |
| Failure mode caught    | Prevents avoidable status-label ownership work from the request-metrics path |
| Cheaper signal?        | Focused server compile, Clippy, and the dedicated Criterion target |
| Rollback path          | Revert this commit and the benchmark registration |

## Commands Run

```text
cargo fmt --all -- --check                         pass
cargo check --locked -p hl7v2-server --lib         pass
cargo check --offline -p hl7v2-bench --bench metrics pass
cargo clippy --offline -p hl7v2-server --lib -- -D warnings pass
git diff --check                                    pass
cargo test --offline -p hl7v2-server --lib metrics::tests -- --test-threads=1 not run: 5-minute timeout
cargo bench --offline -p hl7v2-bench --bench metrics -- --warm-up-time 1 --measurement-time 2 --sample-size 10 not run: 5-minute release-build timeout
```
