### PR TITLE
docs(readme): document workspace support crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,15 @@ hl7v2-python
   PyO3 binding backend; builds the public hl7v2 Python distribution
 ```
 
+The workspace also contains internal support surfaces used to develop and
+verify the public crates:
+
+- `hl7v2-bench`: Criterion benchmarks for parsing, transport, queries, JSON,
+  and related performance work.
+- `hl7v2-e2e-tests`: black-box end-to-end coverage for workspace behavior.
+- `hl7v2-test-utils`: shared test fixtures and helpers.
+- `xtask`: repository-local setup, validation, policy, and evidence commands.
+
 Retired compatibility crate names should not gain new behavior. See
 [ADR-015](docs/adr/0015-collapse-public-crate-surface.md) and
 [the module map](docs/architecture/module-map.md) for the migration policy.


### PR DESCRIPTION
## What this does

The README architecture map explains the public library, server, CLI, and Python binding crates but omits the internal workspace surfaces contributors use for verification and maintenance. That makes the repository structure harder to discover from the front door.

**Change:** document `hl7v2-bench`, `hl7v2-e2e-tests`, `hl7v2-test-utils`, and `xtask` with their current responsibilities. Existing public architecture and setup guidance remain unchanged.

Closes #217.

## Verification

| Check | Result |
| --- | --- |
| workspace metadata cross-check | all four names match current `Cargo.toml` members and crate manifests |
| `cargo run --offline -q -p xtask -- check-doc-links` | 237 Markdown files and 724 local links checked |
| `git diff --check` | clean |

## Review map

- `README.md` architecture section: adds the contributor-facing map for internal benchmark, end-to-end, test utility, and repository-tooling surfaces.
