### PR TITLE
fix(server): protect metrics when api key configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the REST `/metrics` endpoint to require `X-API-Key` when API-key
+  authentication is configured; `/health` and `/ready` remain public probes.
 - Changed `MllpFrameIterator::extend` to return a typed error when input would
   exceed its default 10 MiB buffer limit. Callers that previously appended
   without handling a result must now handle or propagate `MllpError`.

--- a/api/openapi/hl7v2-api-v1.yaml
+++ b/api/openapi/hl7v2-api-v1.yaml
@@ -19,9 +19,9 @@ info:
     X-API-Key: <your-api-key>
     ```
 
-    Health, readiness, metrics, and API documentation endpoints are public by
-    design so load balancers, scrapers, and local operators can inspect service
-    state without application credentials.
+    Health, readiness, and API documentation endpoints are public by design so
+    load balancers and local operators can inspect service state. Metrics
+    require the X-API-Key header when the server is configured with an API key.
 
     ## Rate Limiting
 
@@ -87,7 +87,7 @@ paths:
   /metrics:
     get:
       summary: Prometheus metrics
-      description: Returns metrics in Prometheus text format
+      description: Returns metrics in Prometheus text format. Requires the X-API-Key header when API-key authentication is configured.
       tags: [health]
       operationId: getMetrics
       responses:
@@ -97,6 +97,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        '401':
+          description: Missing or invalid API key when authentication is configured
 
   /hl7/parse:
     post:

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13222",
+  "message": "13239",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
@@ -124,7 +124,7 @@ async fn test_auth_invalid_api_key_fails() {
 }
 
 #[tokio::test]
-async fn test_health_public_metrics_requires_api_key() {
+async fn test_health_public_metrics_requires_api_key() -> Result<(), Box<dyn std::error::Error>> {
     let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
     let state = Arc::new(AppState {
         start_time: Instant::now(),
@@ -166,11 +166,9 @@ async fn test_health_public_metrics_requires_api_key() {
                     8080,
                 ))))
                 .uri("/metrics")
-                .body(axum::body::Body::empty())
-                .unwrap(),
+                .body(axum::body::Body::empty())?,
         )
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     let response = app
@@ -182,10 +180,10 @@ async fn test_health_public_metrics_requires_api_key() {
                 ))))
                 .uri("/metrics")
                 .header("X-API-Key", "secret-key")
-                .body(axum::body::Body::empty())
-                .unwrap(),
+                .body(axum::body::Body::empty())?,
         )
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(response.status(), StatusCode::OK);
+
+    Ok(())
 }

--- a/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
+++ b/crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs
@@ -124,7 +124,7 @@ async fn test_auth_invalid_api_key_fails() {
 }
 
 #[tokio::test]
-async fn test_health_metrics_public() {
+async fn test_health_public_metrics_requires_api_key() {
     let metrics_handle = hl7v2_server::metrics::init_metrics_recorder();
     let state = Arc::new(AppState {
         start_time: Instant::now(),
@@ -156,7 +156,23 @@ async fn test_health_metrics_public() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Metrics should be public (standard for internal scraping)
+    // Metrics should require the configured API key.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/metrics")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
     let response = app
         .oneshot(
             Request::builder()
@@ -165,6 +181,7 @@ async fn test_health_metrics_public() {
                     8080,
                 ))))
                 .uri("/metrics")
+                .header("X-API-Key", "secret-key")
                 .body(axum::body::Body::empty())
                 .unwrap(),
         )

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -19,7 +19,8 @@ Useful release-candidate workflows include:
 - `POST /hl7/bundle` for server-created redacted evidence bundles under a
   configured bundle output root.
 - `POST /hl7/ack-policy` for policy-driven ACK/NAK decisions.
-- `/metrics` for Prometheus metrics.
+- `/metrics` for Prometheus metrics; it requires `X-API-Key` when
+  `HL7V2_API_KEY` is configured, while `/health` and `/ready` remain public.
 
 The gRPC service implements `Parse`, `ParseStream`, `Validate`, `ProfileLint`,
 `ProfileExplain`, `ProfileTest`, `ValidateRedacted`, `CreateEvidenceBundle`,

--- a/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
+++ b/crates/hl7v2-server/openapi/hl7v2-api-v1.yaml
@@ -19,9 +19,9 @@ info:
     X-API-Key: <your-api-key>
     ```
 
-    Health, readiness, metrics, and API documentation endpoints are public by
-    design so load balancers, scrapers, and local operators can inspect service
-    state without application credentials.
+    Health, readiness, and API documentation endpoints are public by design so
+    load balancers and local operators can inspect service state. Metrics
+    require the X-API-Key header when the server is configured with an API key.
 
     ## Rate Limiting
 
@@ -87,7 +87,7 @@ paths:
   /metrics:
     get:
       summary: Prometheus metrics
-      description: Returns metrics in Prometheus text format
+      description: Returns metrics in Prometheus text format. Requires the X-API-Key header when API-key authentication is configured.
       tags: [health]
       operationId: getMetrics
       responses:
@@ -97,6 +97,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        '401':
+          description: Missing or invalid API key when authentication is configured
 
   /hl7/parse:
     post:

--- a/crates/hl7v2-server/src/main.rs
+++ b/crates/hl7v2-server/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         tracing::warn!(
             bind_address = %config.bind_address,
-            "API key authentication is disabled; /hl7 routes are publicly accessible"
+            "API key authentication is disabled; /hl7 and /metrics routes are publicly accessible"
         );
     }
     log_bind_security_warning(&config.bind_address);
@@ -91,7 +91,7 @@ where
 }
 
 fn usage() -> &'static str {
-    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server], [ack], and [quarantine] settings\n  BIND_ADDRESS                Override bind address (default: 127.0.0.1:8080)\n  HL7V2_API_KEY               API key for protected /hl7/* routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_MAX_MESSAGE_SIZE      Maximum decoded HL7 message size in bytes (default: 50 MiB)\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes\n  HL7V2_BUNDLE_OUTPUT_ROOT    Existing writable directory for server-generated evidence bundles\n  RUST_LOG                    tracing filter, for example hl7v2_server=info,tower_http=debug\n  RUST_LOG_FORMAT             set to json for JSON logs; any other value uses text logs"
+    "Usage: hl7v2-server [--print-config]\n\nOptions:\n  --print-config  Print sanitized effective server configuration as JSON and exit\n  -h, --help      Print help\n\nEnvironment:\n  HL7V2_CONFIG                Optional TOML/YAML config file with [server], [ack], and [quarantine] settings\n  BIND_ADDRESS                Override bind address (default: 127.0.0.1:8080)\n  HL7V2_API_KEY               API key for protected /hl7/* and /metrics routes\n  HL7V2_CORS_ALLOWED_ORIGINS  Comma-separated CORS origins, or * for any\n  HL7V2_MAX_MESSAGE_SIZE      Maximum decoded HL7 message size in bytes (default: 50 MiB)\n  HL7V2_PROFILE_PATHS         Profile files that must load before readiness passes\n  HL7V2_BUNDLE_OUTPUT_ROOT    Existing writable directory for server-generated evidence bundles\n  RUST_LOG                    tracing filter, for example hl7v2_server=info,tower_http=debug\n  RUST_LOG_FORMAT             set to json for JSON logs; any other value uses text logs"
 }
 
 fn init_tracing() {

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -70,6 +70,17 @@ pub(crate) fn build_router_with_body_limit(state: Arc<AppState>, max_body_size: 
         ));
     }
 
+    // Metrics can expose operational details, so apply the same API-key
+    // protection when authentication is configured. Health and readiness
+    // remain public for load-balancer and orchestration probes.
+    let mut metrics_routes = Router::new().route("/metrics", get(metrics_handler));
+    if state.api_key.is_some() {
+        metrics_routes = metrics_routes.route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ));
+    }
+
     let cors_layer = build_cors_layer(&state.cors_allowed_origins);
 
     // Main router
@@ -89,7 +100,7 @@ pub(crate) fn build_router_with_body_limit(state: Arc<AppState>, max_body_size: 
         )
         .route("/health", get(health_handler))
         .route("/ready", get(ready_handler))
-        .route("/metrics", get(metrics_handler))
+        .merge(metrics_routes)
         .nest("/hl7", api_routes)
         // Keep the extractor limit for its 413 rejection behavior and also
         // wrap every request body so raw-body consumers cannot bypass it.
@@ -189,6 +200,38 @@ mod tests {
         let status = response.status();
         let body = response.into_body().collect().await.unwrap().to_bytes();
         (status, body.to_vec())
+    }
+
+    async fn request_metrics(app: Router, api_key: Option<&str>) -> StatusCode {
+        let mut request = Request::builder()
+            .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                8080,
+            ))))
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+
+        if let Some(key) = api_key {
+            request
+                .headers_mut()
+                .insert("X-API-Key", axum::http::HeaderValue::from_str(key).unwrap());
+        }
+
+        app.oneshot(request).await.unwrap().status()
+    }
+
+    async fn request_public_probe(app: Router, uri: &str) -> StatusCode {
+        let request = Request::builder()
+            .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                8080,
+            ))))
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+
+        app.oneshot(request).await.unwrap().status()
     }
 
     #[tokio::test]
@@ -379,5 +422,40 @@ mod tests {
         assert_eq!(response_data.metadata.version, "2.5");
         assert_eq!(response_data.metadata.sending_application, "SendingApp");
         assert!(response_data.message.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint_rejects_missing_api_key() {
+        let (app, _) = build_test_router_with_api_key("server::metrics-auth::missing-key");
+
+        assert_eq!(request_metrics(app, None).await, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint_rejects_invalid_api_key() {
+        let (app, _) = build_test_router_with_api_key("server::metrics-auth::invalid-key");
+
+        assert_eq!(
+            request_metrics(app, Some("not-the-configured-key")).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metrics_endpoint_accepts_valid_deterministic_api_key() {
+        let (app, key) = build_test_router_with_api_key("server::metrics-auth::valid-key");
+
+        assert_eq!(request_metrics(app, Some(&key)).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_health_and_ready_remain_public_when_api_key_is_configured() {
+        let (app, _) = build_test_router_with_api_key("server::metrics-auth::public-probes");
+
+        assert_eq!(
+            request_public_probe(app.clone(), "/health").await,
+            StatusCode::OK
+        );
+        assert_eq!(request_public_probe(app, "/ready").await, StatusCode::OK);
     }
 }

--- a/crates/hl7v2-server/tests/http_runtime_contract_test.rs
+++ b/crates/hl7v2-server/tests/http_runtime_contract_test.rs
@@ -351,8 +351,25 @@ async fn test_new_hl7_routes_require_api_key_when_configured() {
 }
 
 #[tokio::test]
-async fn test_metrics_stays_public_when_api_key_is_configured() {
+async fn test_metrics_requires_api_key_when_configured() {
     let app = test_router(Some("secret-key"), CorsAllowedOrigins::default());
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
     let response = app
         .oneshot(
             Request::builder()
@@ -361,6 +378,7 @@ async fn test_metrics_stays_public_when_api_key_is_configured() {
                     8080,
                 ))))
                 .uri("/metrics")
+                .header("X-API-Key", "secret-key")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -12,7 +12,9 @@ By default, the server runs on `http://localhost:8080`. All API paths are relati
 
 ## Authentication
 
-If `HL7V2_API_KEY` is configured on the server, all requests to `/hl7/*` routes must include the `X-API-Key` header.
+If `HL7V2_API_KEY` is configured on the server, requests to `/hl7/*` and
+`/metrics` must include the `X-API-Key` header. `/health` and `/ready` remain
+public for load-balancer and orchestration probes.
 
 ```bash
 -H "X-API-Key: your-secret-api-key"
@@ -478,6 +480,8 @@ curl http://localhost:8080/ready
 **Prometheus Metrics:**
 ```bash
 curl http://localhost:8080/metrics
+# When HL7V2_API_KEY is configured:
+curl -H "X-API-Key: your-secret-api-key" http://localhost:8080/metrics
 # Returns: hl7v2_requests_total{endpoint="/hl7/parse",status="200"} 42 ...
 ```
 


### PR DESCRIPTION
## Summary

Part of #195. Protect the REST `/metrics` endpoint with the existing constant-time `X-API-Key` middleware whenever API-key authentication is configured.

- `/health` and `/ready` remain public for orchestration probes.
- Updated route and runtime contract tests for missing, invalid, and valid credentials.
- Synchronized OpenAPI, API guide, server README, and changelog contract text.

## Proof

- `cargo test --locked -p hl7v2-server --tests` — pass
- `cargo clippy --locked -p hl7v2-server --lib --tests -- -D warnings` — pass
- `cargo test --locked -p hl7v2-server --test proto_packaging_test` — pass
- `cargo run --offline -q -p xtask -- check-doc-links` — pass (237 Markdown files, 724 local links)
- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass

## Claim boundary

This PR protects metrics access when the existing API-key feature is enabled. It does not change bind defaults, TLS, CORS, API-key storage, or health/readiness exposure. Hosted checks are not yet observed on this PR head.