### PR TITLE
fix(server): warn on permissive CORS policy

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -481,6 +481,21 @@ spec:
 
 ### Security Best Practices
 
+#### CORS policy
+
+The server currently permits any origin, method, and header when
+`HL7V2_CORS_ALLOWED_ORIGINS` is unset or set to `*`. Startup emits a warning
+when this permissive policy is active. For browser clients in a trusted
+deployment, set an explicit comma-separated origin allowlist instead:
+
+```bash
+export HL7V2_CORS_ALLOWED_ORIGINS="https://app.example,https://ops.example"
+```
+
+CORS is a browser policy, not authentication. Keep API-key authentication,
+network policy, and TLS termination configured separately; an origin allowlist
+does not protect non-browser clients or replace `X-API-Key`.
+
 ✅ **DO**:
 - Use API key authentication in production
 - Deploy behind HTTPS/TLS reverse proxy
@@ -488,13 +503,14 @@ spec:
 - Use network policies to restrict access
 - Enable audit logging
 - Rotate API keys regularly
+- Set `HL7V2_CORS_ALLOWED_ORIGINS` to explicit trusted origins when browser access is required
 - Monitor for security events
 
 ❌ **DON'T**:
 - Expose server directly to public internet
 - Use HTTP in production
 - Share API keys across environments
-- Disable CORS without good reason
+- Leave the permissive CORS default enabled for an internet-facing browser client without reviewing the warning
 - Run as root user
 
 ## Performance Tuning

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ hl7v2-cli ack <input.hl7> --code AE > error_ack.hl7
 - **Prometheus metrics**: Request counts, latencies, error rates
 - **Redacted structured logs**: Evidence workflow logs hash message control IDs and bundle IDs while avoiding raw HL7, profile YAML, redaction policy TOML, and configured filesystem roots by default
 - **Concurrency limiting**: Built-in backpressure (100 concurrent requests default)
-- **CORS support**: Configurable allowed origins, with permissive local default
+- **CORS support**: Configurable allowed origins; the permissive local default emits a startup warning and can be narrowed with `HL7V2_CORS_ALLOWED_ORIGINS`
 - **Compression**: Gzip compression for responses
 - **OpenAPI 3.1 spec**: Complete API documentation at `api/openapi/hl7v2-api-v1.yaml`
 - **Docker ready**: Containerized deployment with Nix-built images

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13239",
+  "message": "13242",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -53,6 +53,20 @@ are not metric labels.
 The server reuses the same evidence contracts as the CLI and `hl7v2` library
 instead of defining a server-only report language.
 
+### CORS and authentication
+
+When `HL7V2_CORS_ALLOWED_ORIGINS` is unset, the server allows any origin,
+method, and header for browser requests and emits a startup warning. Set the
+variable to a comma-separated list of trusted origins to narrow that policy:
+
+```bash
+HL7V2_CORS_ALLOWED_ORIGINS="https://app.example,https://ops.example" \\
+  hl7v2-server
+```
+
+CORS does not authenticate requests. Configure `HL7V2_API_KEY`, network
+controls, and TLS termination independently.
+
 ## Public Rust API boundary
 
 The supported Rust integration surface is the root-level API: `Server`,

--- a/crates/hl7v2-server/src/main.rs
+++ b/crates/hl7v2-server/src/main.rs
@@ -1,6 +1,6 @@
 //! HL7v2 HTTP/REST API server binary.
 
-use hl7v2_server::{Server, ServerConfig};
+use hl7v2_server::{CorsAllowedOrigins, Server, ServerConfig};
 use std::net::SocketAddr;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     log_bind_security_warning(&config.bind_address);
     tracing::info!("CORS allowed origins: {:?}", config.cors_allowed_origins);
+    log_cors_security_warning(&config.cors_allowed_origins);
 
     // Create and run server
     let server = Server::new(config)?;
@@ -59,6 +60,18 @@ fn bind_address_is_unspecified(bind_address: &str) -> bool {
         .parse::<SocketAddr>()
         .map(|address| address.ip().is_unspecified())
         .unwrap_or(false)
+}
+
+fn log_cors_security_warning(origins: &CorsAllowedOrigins) {
+    if cors_policy_is_permissive(origins) {
+        tracing::warn!(
+            "CORS allows any origin, method, and header; set HL7V2_CORS_ALLOWED_ORIGINS to a comma-separated allowlist for browser clients"
+        );
+    }
+}
+
+fn cors_policy_is_permissive(origins: &CorsAllowedOrigins) -> bool {
+    matches!(origins, CorsAllowedOrigins::Any)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -178,5 +191,17 @@ mod tests {
         assert!(bind_address_is_unspecified("[::]:8080"));
         assert!(!bind_address_is_unspecified("127.0.0.1:8080"));
         assert!(!bind_address_is_unspecified("not-an-address"));
+    }
+
+    #[test]
+    fn cors_security_warning_only_matches_permissive_policy()
+    -> Result<(), Box<dyn std::error::Error>> {
+        if !cors_policy_is_permissive(&CorsAllowedOrigins::Any) {
+            return Err("Any CORS policy should be treated as permissive".into());
+        }
+        if cors_policy_is_permissive(&CorsAllowedOrigins::list(["https://app.example"])) {
+            return Err("an explicit CORS origin list should not be treated as permissive".into());
+        }
+        Ok(())
     }
 }

--- a/docs/API_GUIDE.md
+++ b/docs/API_GUIDE.md
@@ -20,6 +20,11 @@ public for load-balancer and orchestration probes.
 -H "X-API-Key: your-secret-api-key"
 ```
 
+For browser clients, `HL7V2_CORS_ALLOWED_ORIGINS` controls the allowed origin
+list. If it is unset, the server keeps its permissive compatibility default and
+logs a startup warning. Set it to a comma-separated list of trusted origins;
+this policy does not replace API-key authentication.
+
 ---
 
 ## Endpoints


### PR DESCRIPTION
# Summary

`hl7v2-server` currently permits any CORS origin, method, and header when the CORS origin variable is unset, but operators receive no startup signal that this permissive policy is active. This PR makes that compatibility behavior visible and documents how to configure an explicit origin allowlist.

**Fix:** Emit a warning for `CorsAllowedOrigins::Any`, preserve the existing default and explicit-list behavior, and document that CORS does not replace API-key authentication or network/TLS controls.

## Assumptions

- The permissive default remains unchanged in this bounded compatibility slice.
- `HL7V2_CORS_ALLOWED_ORIGINS` is the operator-facing configuration path for browser origin policy.

## Checklist

- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [ ] `cargo run -p xtask -- gate --check` passes locally.
- [ ] `cargo run -p xtask -- check-lint-policy` passes.
- [ ] `cargo run -p xtask -- check-no-panic-family` passes.
- [ ] `cargo run -p xtask -- check-file-policy` passes.

## CI Economics

| Field                  | Value |
| ---------------------- | ----- |
| Default PR LEM impact  | No workflow changes; normal server checks |
| Workflows touched      | None |
| Branch protection      | Unchanged |
| Failure mode caught    | Missing operator visibility for permissive browser policy |
| Cheaper signal?        | Focused unit selection plus existing server checks |
| Rollback path           | Revert `948a5c6` |

## Commands Run

```text
cargo fmt --all -- --check                         PASS
git diff --check                                   PASS
cargo check --locked --offline -p hl7v2-server --bin hl7v2-server  PASS
cargo test --locked --offline -p hl7v2-server --bin hl7v2-server cors_security_warning_only_matches_permissive_policy  NOT VERIFIED: timed out without diagnostics under host Cargo contention
cargo test --locked --offline -p hl7v2-server --bin hl7v2-server --no-run  NOT VERIFIED: timed out without diagnostics under host Cargo contention
```
