### PR TITLE
fix(server): reject invalid CORS origins

### DIFF
--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13242",
+  "message": "13252",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13252",
+  "message": "13286",
   "schemaVersion": 1
 }

--- a/crates/hl7v2-server/README.md
+++ b/crates/hl7v2-server/README.md
@@ -65,7 +65,9 @@ HL7V2_CORS_ALLOWED_ORIGINS="https://app.example,https://ops.example" \\
 ```
 
 CORS does not authenticate requests. Configure `HL7V2_API_KEY`, network
-controls, and TLS termination independently.
+controls, and TLS termination independently. Invalid configured origins are
+rejected as configuration errors; a manually constructed invalid state fails
+closed by disabling CORS rather than panicking.
 
 ## Public Rust API boundary
 

--- a/crates/hl7v2-server/src/routes.rs
+++ b/crates/hl7v2-server/src/routes.rs
@@ -123,14 +123,19 @@ fn build_cors_layer(origins: &CorsAllowedOrigins) -> CorsLayer {
     match origins {
         CorsAllowedOrigins::Any => layer.allow_origin(Any),
         CorsAllowedOrigins::List(origins) => {
-            let origins = origins
+            let parsed_origins = origins
                 .iter()
-                .map(|origin| {
-                    HeaderValue::from_str(origin)
-                        .expect("CORS allowed origin must be a valid header value")
-                })
-                .collect::<Vec<_>>();
-            layer.allow_origin(AllowOrigin::list(origins))
+                .map(|origin| HeaderValue::from_str(origin))
+                .collect::<Result<Vec<_>, _>>();
+            match parsed_origins {
+                Ok(origins) => layer.allow_origin(AllowOrigin::list(origins)),
+                Err(_) => {
+                    tracing::error!(
+                        "CORS allowlist contains an invalid origin; refusing to enable CORS"
+                    );
+                    CorsLayer::new()
+                }
+            }
         }
     }
 }

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -8,6 +8,7 @@ use crate::{
     grpc::{Hl7ServiceImpl, proto::hl7_service_server::Hl7ServiceServer},
     routes::build_router_with_body_limit,
 };
+use axum::http::HeaderValue;
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
@@ -333,6 +334,20 @@ impl ServerConfig {
             return Err(crate::Error::Config(
                 "max_message_size must be greater than zero".to_string(),
             ));
+        }
+        if let CorsAllowedOrigins::List(origins) = &self.cors_allowed_origins {
+            for (index, origin) in origins.iter().enumerate() {
+                if origin.is_empty() {
+                    return Err(crate::Error::Config(format!(
+                        "CORS origin at index {index} must not be empty"
+                    )));
+                }
+                HeaderValue::from_str(origin).map_err(|error| {
+                    crate::Error::Config(format!(
+                        "CORS origin at index {index} is invalid: {error}"
+                    ))
+                })?;
+            }
         }
         Ok(())
     }
@@ -882,6 +897,22 @@ mod tests {
                 "https://ops.example".to_string()
             ])
         );
+    }
+
+    #[test]
+    fn server_config_rejects_invalid_cors_origin()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let invalid_origin = format!("https://app.example,{}", '\u{0001}');
+        let error =
+            match ServerConfig::from_sources(None, None, None, Some(invalid_origin), None, None) {
+                Ok(_) => return Err("invalid CORS origin should be rejected".into()),
+                Err(error) => error,
+            };
+
+        if !error.to_string().contains("CORS origin") {
+            return Err(format!("unexpected configuration error: {error}").into());
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -418,11 +418,28 @@ fn is_valid_cors_origin(origin: &str) -> bool {
         return false;
     };
 
-    !scheme.is_empty()
-        && !authority.host().is_empty()
-        && !authority.as_str().contains('@')
-        && uri.path().is_empty()
-        && uri.query().is_none()
+    let host = authority.host();
+    let valid_port = match authority.as_str().strip_prefix(host) {
+        Some("") => true,
+        Some(port) => port
+            .strip_prefix(':')
+            .is_some_and(|port| !port.is_empty() && port.parse::<u16>().is_ok()),
+        None => false,
+    };
+
+    if scheme.is_empty() || host.is_empty() || authority.as_str().contains('@') || !valid_port {
+        return false;
+    }
+
+    let Some((_, rest)) = origin.split_once("://") else {
+        return false;
+    };
+    let mut components = rest.splitn(2, ['/', '?', '#']);
+    let Some(raw_authority) = components.next() else {
+        return false;
+    };
+
+    raw_authority == authority.as_str() && components.next().is_none()
 }
 
 fn split_profile_paths(paths: OsString) -> Vec<String> {

--- a/crates/hl7v2-server/src/server.rs
+++ b/crates/hl7v2-server/src/server.rs
@@ -8,7 +8,7 @@ use crate::{
     grpc::{Hl7ServiceImpl, proto::hl7_service_server::Hl7ServiceServer},
     routes::build_router_with_body_limit,
 };
-use axum::http::HeaderValue;
+use axum::http::{HeaderValue, Uri};
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
@@ -342,6 +342,11 @@ impl ServerConfig {
                         "CORS origin at index {index} must not be empty"
                     )));
                 }
+                if !is_valid_cors_origin(origin) {
+                    return Err(crate::Error::Config(format!(
+                        "CORS origin at index {index} is invalid"
+                    )));
+                }
                 HeaderValue::from_str(origin).map_err(|error| {
                     crate::Error::Config(format!(
                         "CORS origin at index {index} is invalid: {error}"
@@ -400,6 +405,24 @@ impl ServerConfig {
 
         checks
     }
+}
+
+fn is_valid_cors_origin(origin: &str) -> bool {
+    let Ok(uri) = origin.parse::<Uri>() else {
+        return false;
+    };
+    let Some(scheme) = uri.scheme_str() else {
+        return false;
+    };
+    let Some(authority) = uri.authority() else {
+        return false;
+    };
+
+    !scheme.is_empty()
+        && !authority.host().is_empty()
+        && !authority.as_str().contains('@')
+        && uri.path().is_empty()
+        && uri.query().is_none()
 }
 
 fn split_profile_paths(paths: OsString) -> Vec<String> {
@@ -902,15 +925,28 @@ mod tests {
     #[test]
     fn server_config_rejects_invalid_cors_origin()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
-        let invalid_origin = format!("https://app.example,{}", '\u{0001}');
-        let error =
-            match ServerConfig::from_sources(None, None, None, Some(invalid_origin), None, None) {
+        let invalid_origins = [
+            "https://app.example/path".to_string(),
+            "not an origin".to_string(),
+            "https://app.example:bad".to_string(),
+            format!("https://app.example,{}", '\u{0001}'),
+        ];
+        for invalid_origin in invalid_origins {
+            let error = match ServerConfig::from_sources(
+                None,
+                None,
+                None,
+                Some(invalid_origin),
+                None,
+                None,
+            ) {
                 Ok(_) => return Err("invalid CORS origin should be rejected".into()),
                 Err(error) => error,
             };
 
-        if !error.to_string().contains("CORS origin") {
-            return Err(format!("unexpected configuration error: {error}").into());
+            if !error.to_string().contains("CORS origin") {
+                return Err(format!("unexpected configuration error: {error}").into());
+            }
         }
         Ok(())
     }

--- a/crates/hl7v2-server/tests/http_runtime_contract_test.rs
+++ b/crates/hl7v2-server/tests/http_runtime_contract_test.rs
@@ -459,3 +459,33 @@ async fn test_cors_uses_configured_origin_list() {
             .is_none()
     );
 }
+
+#[tokio::test]
+async fn test_invalid_cors_origin_fails_closed_without_router_panic() {
+    let app = test_router(
+        None,
+        CorsAllowedOrigins::List(vec!["https://app.example".to_string(), "\u{1}".to_string()]),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .extension(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                    [127, 0, 0, 1],
+                    8080,
+                ))))
+                .uri("/health")
+                .header("Origin", "https://app.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .is_none()
+    );
+}


### PR DESCRIPTION
# Summary

Closes the next CORS hardening slice for #195. Explicit CORS origins are now validated as configuration, so malformed values fail before server startup. Router construction no longer panics if a manually constructed public `AppState` contains an invalid origin; it logs an error and disables CORS for that state.

The permissive default, valid explicit allowlists, API-key authentication, and TLS boundaries are unchanged.

## Assumptions

- `HL7V2_CORS_ALLOWED_ORIGINS` remains a comma-separated list; malformed explicit values are configuration errors.
- `CorsAllowedOrigins` and `AppState` remain public, so the router retains a defensive fail-closed path for callers that bypass `ServerConfig` validation.

## Checklist

- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [x] `cargo run -p xtask -- gate --check --only fmt` passes locally.
- [x] `cargo run -p xtask -- check-doc-links` passes locally.
- [x] `cargo clippy --locked --offline -p hl7v2-server --tests -- -D warnings` passes locally.

## CI Economics

| Field                  | Value |
| ---------------------- | ----- |
| Default PR LEM impact  | +0 workflow impact; one focused server regression test |
| Workflows touched      | None |
| Branch protection       | Unchanged |
| Failure mode caught    | Malformed CORS configuration and panic-shaped router construction |
| Cheaper signal?        | Focused configuration and runtime tests cover the changed seam; hosted full checks remain the merge proof |
| Rollback path           | Revert commit `adb4e10` |

## Commands Run

```text
cargo fmt --all -- --check
git diff --check
cargo check --locked --offline -p hl7v2-server --tests
cargo test --locked --offline -p hl7v2-server --lib server_config_rejects_invalid_cors_origin
cargo test --locked --offline -p hl7v2-server --test http_runtime_contract_test test_invalid_cors_origin_fails_closed_without_router_panic
cargo clippy --locked --offline -p hl7v2-server --tests -- -D warnings
cargo run --locked --offline -q -p xtask -- gate --check --only fmt
cargo run --locked --offline -q -p xtask -- check-doc-links
cargo run --locked --offline -q -p xtask -- badges --check
```

The gate reported two stale/surplus pre-existing no-panic baseline entries in `crates/hl7v2-e2e-tests/tests/e2e/security_tests.rs`; no new entry was introduced by this PR.
