### PR TITLE
ci(publish): verify token before publish plan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,16 +42,6 @@ jobs:
         with:
           shared-key: publish-crates-io
 
-      - name: Show publish plan
-        env:
-          PUBLISH_FROM: ${{ github.event.inputs.from }}
-        run: |
-          if [ -n "$PUBLISH_FROM" ]; then
-            cargo run -p xtask -- publish-plan --from "$PUBLISH_FROM"
-          else
-            cargo run -p xtask -- publish-plan
-          fi
-
       - name: Verify crates.io token
         if: github.event.inputs.execute == 'true'
         env:
@@ -60,6 +50,16 @@ jobs:
           if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
             echo "::error::CARGO_REGISTRY_TOKEN secret is not configured."
             exit 1
+          fi
+
+      - name: Show publish plan
+        env:
+          PUBLISH_FROM: ${{ github.event.inputs.from }}
+        run: |
+          if [ -n "$PUBLISH_FROM" ]; then
+            cargo run -p xtask -- publish-plan --from "$PUBLISH_FROM"
+          else
+            cargo run -p xtask -- publish-plan
           fi
 
       - name: Publish crates


### PR DESCRIPTION
## What this does

The crates.io publish workflow now verifies the execute-time registry token before generating the publish plan. A missing token fails fast during an actual publish run, while dry-run dispatches still print the plan without requiring credentials.

**Fix:** reorder the existing verification and plan steps without changing either execute condition or the publish commands.

## Verification

| Check | Result |
| --- | --- |
| `actionlint .github/workflows/publish.yml` | pass |
| workflow structural assertions | verify step precedes plan; execute gate unchanged |
| `git diff --check` | pass |

## Review map

- `.github/workflows/publish.yml`: execute-only token validation runs before publish-plan; dry-run and publish behavior remain otherwise unchanged.

Fixes #151