### PR TITLE
fix(monitoring): expand Prometheus environment label

### DIFF
--- a/infrastructure/grafana/README.md
+++ b/infrastructure/grafana/README.md
@@ -53,6 +53,8 @@ The easiest way to get started with monitoring:
 Set `PROMETHEUS_IMAGE` and `GRAFANA_IMAGE` to versioned or digest-pinned
 image references before running this stack. The placeholders intentionally fail
 if unset so the monitoring example does not drift back to floating tags.
+Use a Prometheus 3.x image for the `ENVIRONMENT` external-label expansion shown
+below.
 
 ```yaml
 # docker-compose.yml (monitoring stack)
@@ -61,6 +63,8 @@ version: '3.8'
 services:
   prometheus:
     image: "${PROMETHEUS_IMAGE:?set PROMETHEUS_IMAGE to a versioned or digest-pinned prom/prometheus image}"
+    environment:
+      ENVIRONMENT: "${ENVIRONMENT:-production}"
     volumes:
       - ./infrastructure/grafana/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./infrastructure/grafana/alerts:/etc/prometheus/alerts

--- a/infrastructure/grafana/prometheus.yml
+++ b/infrastructure/grafana/prometheus.yml
@@ -5,7 +5,7 @@ global:
   evaluation_interval: 15s
   external_labels:
     cluster: 'hl7v2-production'
-    environment: '{{ env }}'
+    environment: '${ENVIRONMENT}'
 
 # Alertmanager configuration (optional)
 alerting:


### PR DESCRIPTION
## What this does

The monitoring Prometheus config currently uses the literal Jinja expression `{{ env }}` for its external environment label, so deployments do not receive a meaningful environment value. The canonical monitoring Compose example also did not pass an environment value into the Prometheus container.

**Fix:** use Prometheus-supported `${ENVIRONMENT}` expansion and pass `ENVIRONMENT` from Compose with a `production` default. The example now documents the Prometheus 3.x requirement for this expansion.

## Verification

| Check | Result |
| --- | --- |
| Prometheus YAML parse | pass |
| monitoring environment wiring assertions | pass |
| stale-template search | pass |
| `cargo run --locked --offline -q -p xtask -- check-doc-links` | 237 Markdown files and 724 local links checked |
| `git diff --check` | pass |
| containerized `promtool check config` | not run, Docker Desktop Linux daemon unavailable |

## Review map

- `infrastructure/grafana/prometheus.yml`: external environment labels use the supported `${ENVIRONMENT}` reference.
- `infrastructure/grafana/README.md`: the documented Compose stack supplies the environment value and states the Prometheus 3.x requirement.

Fixes #147