### PR TITLE
fix(validation): reject impossible calendar dates

### DIFF
--- a/crates/hl7v2/src/conformance/datatype.rs
+++ b/crates/hl7v2/src/conformance/datatype.rs
@@ -559,21 +559,13 @@ pub fn matches_format(value: &str, format: &str, datatype: &str) -> bool {
             if !has_exact_digits(year, 4) {
                 return false;
             }
-            // Check month (2 digits)
-            let Some(month) = parse_fixed_u32(month, 2) else {
-                return false;
-            };
-            if !(1..=12).contains(&month) {
+            if !has_exact_digits(month, 2) || !has_exact_digits(day, 2) {
                 return false;
             }
-            // Check day (2 digits)
-            let Some(day) = parse_fixed_u32(day, 2) else {
-                return false;
-            };
-            if !(1..=31).contains(&day) {
-                return false;
-            }
-            true
+
+            // Reuse the canonical HL7 date parser so month lengths and leap
+            // years are validated instead of accepting every day through 31.
+            hl7v2_datetime::is_valid_hl7_date(&format!("{year}{month}{day}"))
         }
         ("TM", "HH:MM:SS") => {
             // Check if value matches HH:MM:SS format
@@ -999,6 +991,10 @@ mod tests {
         // Day out of range
         assert!(!matches_format("2025-01-32", "YYYY-MM-DD", "DT"));
         assert!(!matches_format("2025-01-00", "YYYY-MM-DD", "DT"));
+        // Calendar-invalid dates
+        assert!(!matches_format("2025-02-29", "YYYY-MM-DD", "DT"));
+        assert!(!matches_format("2025-04-31", "YYYY-MM-DD", "DT"));
+        assert!(matches_format("2024-02-29", "YYYY-MM-DD", "DT"));
     }
 
     #[test]


### PR DESCRIPTION
## What this does

`matches_format` accepts `YYYY-MM-DD` values by checking only numeric month and day ranges, so impossible dates such as `2025-02-29` and `2025-04-31` pass format validation.

**Fix:** retain the existing shape checks, then delegate calendar validity to the canonical HL7 date parser. Valid leap-day input remains accepted; the other #206 allocation, schema, and error-model findings remain separate.

## Verification

| Check | Result |
| --- | --- |
| baseline regression witness | unpatched `origin/main` fails on `2025-02-29` |
| focused date tests | patched: 2 passed |
| datatype library suite | 107 passed |
| package Clippy, formatting, diff hygiene | pass |

## Review map

- `crates/hl7v2/src/conformance/datatype.rs`: `DT` format matching now reuses canonical calendar validation and covers leap-year/month-length boundaries.

Related to #206