### PR TITLE
perf(ack): avoid redundant message type clone

### DIFF
--- a/crates/hl7v2/src/ack.rs
+++ b/crates/hl7v2/src/ack.rs
@@ -220,7 +220,7 @@ fn create_ack_msh_segment(original: &Message) -> Result<Segment, Error> {
                     subs: vec![Atom::Text("ACK".to_string())],
                 },
                 Comp {
-                    subs: vec![Atom::Text(message_type.clone())],
+                    subs: vec![Atom::Text(message_type)],
                 },
             ],
         }],


### PR DESCRIPTION
# Summary

ACK MSH construction clones the owned `message_type` immediately before moving it into the only output field that uses it. That creates an unnecessary allocation/copy on the ACK path without changing the wire format or public API.

This PR moves `message_type` directly into the ACK component. Default-string handling, borrowed metadata APIs, and allocation benchmarking remain separate because they need independent design or profiler evidence.

## Assumptions

- `message_type` has no use after the ACK MSH-9 component is built, so moving it preserves behavior exactly.
- This is a narrow behavior-preserving optimization and does not claim a measured end-to-end throughput improvement.

## Verification

| Check | Result |
| --- | --- |
| ACK behavior tests | 5 tests passed, including routing metadata, missing fields, ACK codes, and optional ERR handling |
| Strict package Clippy | `cargo clippy --locked -p hl7v2 --features ack --lib -- -D warnings` passed |
| Formatting and diff checks | `cargo fmt --all -- --check` and `git diff --check` passed |

## Checklist

- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.
- [ ] `cargo run -p xtask -- gate --check` passes locally.
- [ ] `cargo run -p xtask -- check-lint-policy` passes.
- [ ] `cargo run -p xtask -- check-no-panic-family` passes.
- [ ] `cargo run -p xtask -- check-file-policy` passes.

## CI Economics

| Field | Value |
| --- | --- |
| Default PR LEM impact | Minimal: one Rust expression and existing focused tests |
| Workflows touched | None |
| Branch protection | Unchanged |
| Failure mode caught | ACK routing or code-generation regression while removing the redundant clone |
| Cheaper signal? | Existing ACK tests are the sufficient local behavior signal; no new workflow lane is needed |
| Rollback path | Revert `cb1b720` |

## Commands Run

```text
cargo test --locked -p hl7v2 --features ack --lib ack
cargo clippy --locked -p hl7v2 --features ack --lib -- -D warnings
cargo fmt --all -- --check
git diff --check
```
