### PR TITLE
perf(profile): borrow default user agent

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
-  "color": "red",
+  "color": "lightgrey",
   "label": "ripr+",
-  "message": "error",
+  "message": "needs test-efficiency",
   "schemaVersion": 1
 }

--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
-  "color": "lightgrey",
+  "color": "red",
   "label": "ripr+",
-  "message": "needs test-efficiency",
+  "message": "error",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "13286",
+  "message": "1417",
   "schemaVersion": 1
 }

--- a/badges/ripr.json
+++ b/badges/ripr.json
@@ -1,6 +1,6 @@
 {
   "color": "orange",
   "label": "ripr",
-  "message": "1417",
+  "message": "13288",
   "schemaVersion": 1
 }

--- a/crates/hl7v2/src/conformance/profile/loader.rs
+++ b/crates/hl7v2/src/conformance/profile/loader.rs
@@ -8,6 +8,7 @@
     reason = "Pre-existing profile loader panic-family debt moved from hl7v2-prof; cleanup is separate from this behavior-preserving module collapse."
 )]
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,6 +24,9 @@ const DEFAULT_CACHE_SIZE: usize = 100;
 
 /// Default request timeout in seconds
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Default User-Agent sent for remote profile requests.
+const DEFAULT_USER_AGENT: &str = concat!("hl7v2-rs/", env!("CARGO_PKG_VERSION"));
 
 /// Cache entry containing the profile and its ETag.
 #[derive(Debug)]
@@ -151,7 +155,7 @@ pub struct LoadResult {
 pub struct ProfileLoaderBuilder {
     cache_size: usize,
     timeout: Duration,
-    user_agent: String,
+    user_agent: Cow<'static, str>,
 }
 
 impl Default for ProfileLoaderBuilder {
@@ -159,7 +163,7 @@ impl Default for ProfileLoaderBuilder {
         Self {
             cache_size: DEFAULT_CACHE_SIZE,
             timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
-            user_agent: format!("hl7v2-rs/{}", env!("CARGO_PKG_VERSION")),
+            user_agent: Cow::Borrowed(DEFAULT_USER_AGENT),
         }
     }
 }
@@ -184,7 +188,7 @@ impl ProfileLoaderBuilder {
 
     /// Set the User-Agent header for remote profile requests.
     pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
-        self.user_agent = user_agent.into();
+        self.user_agent = Cow::Owned(user_agent.into());
         self
     }
 
@@ -192,7 +196,7 @@ impl ProfileLoaderBuilder {
     pub fn build(self) -> ProfileLoader {
         let client = reqwest::Client::builder()
             .timeout(self.timeout)
-            .user_agent(self.user_agent)
+            .user_agent(self.user_agent.as_ref())
             .build()
             .unwrap_or_default();
 
@@ -502,6 +506,22 @@ mod tests {
                 .build()
                 .unwrap_or_default(),
             timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+        }
+    }
+
+    #[test]
+    fn default_user_agent_is_borrowed_and_custom_value_is_owned()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let default_builder = ProfileLoaderBuilder::default();
+        match default_builder.user_agent {
+            Cow::Borrowed(value) if value == DEFAULT_USER_AGENT => {}
+            _ => return Err("default User-Agent should use the static value".into()),
+        }
+
+        let custom_builder = ProfileLoaderBuilder::default().user_agent("custom-agent");
+        match custom_builder.user_agent {
+            Cow::Owned(value) if value == "custom-agent" => Ok(()),
+            _ => Err("custom User-Agent should remain owned".into()),
         }
     }
 


### PR DESCRIPTION
## Summary\n\nRemoves the builder-time allocation for the default profile-loader User-Agent.\n\n- Stores hl7v2-rs/<version> as a borrowed compile-time value.\n- Keeps caller-provided User-Agent values owned through the existing setter.\n- Passes the borrowed value to reqwest without changing the public builder API or wire behavior.\n- Adds a focused regression test for default-borrowed/custom-owned behavior.\n\n## Assumptions\n\nThis is a behavior-preserving internal representation change. It establishes that the default builder path no longer formats a new String; it does not claim an end-to-end throughput or allocation reduction for remote profile loading.\n\n## Checklist\n\n- [ ] I agree to the [Contributor License Agreement](../CLA.md) for this contribution.\n- [ ] cargo run -p xtask -- gate --check passes locally.\n- [ ] cargo run -p xtask -- check-lint-policy passes.\n- [ ] cargo run -p xtask -- check-no-panic-family passes.\n- [ ] cargo run -p xtask -- check-file-policy passes.\n\n## CI Economics\n\n| Field                  | Value |\n| ---------------------- | ----- |\n| Default PR LEM impact  | Standard Rust/profile lane; one-file behavior-preserving performance slice |\n| Workflows touched      | none |\n| Branch protection      | unchanged |\n| Failure mode caught    | default User-Agent regressions or accidental loss of custom User-Agent ownership |\n| Cheaper signal?        | focused loader tests and strict package Clippy run locally |\n| Rollback path          | revert commit 67770e7 |\n\n## Commands Run\n\n`	ext\ncargo fmt --all\ncargo test --locked -p hl7v2 --features profile --lib default_user_agent\ncargo test --locked -p hl7v2 --features profile --lib conformance::profile::loader::tests\ncargo clippy --locked -p hl7v2 --features profile --lib -- -D warnings\ncargo fmt --all -- --check\ngit diff --check\n`\n\nThe proof establishes the default/custom ownership contract and preserves the profile-loader test module. It does not establish broader allocation counts or throughput improvements.