### PR TITLE
docs(security): clarify TLS termination support

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,7 +19,7 @@ This document provides a transparent view of which features are fully implemente
 
 ### 🚀 Connectivity
 - ✅ **MLLP Over TCP**: Fully implemented async client and server.
-- ✅ **TLS Support**: Secure framing using `rustls`.
+- 🟡 **TLS/HTTPS Termination**: `hl7v2-server` serves HTTP/gRPC without terminating TLS; deploy it behind a trusted TLS reverse proxy. MLLP is provided over plain TCP, and native TLS-wrapped MLLP is not currently part of the transport surface. Remote profile loading uses HTTPS separately.
 - ✅ **HTTP REST API**: Axum-based JSON endpoints for parse, validate, ACK, and normalize.
 - 🟡 **gRPC Service**: v1.5.0 unary RPCs have contract tests. Current `main` serves gRPC with `hl7v2 serve --mode grpc`, implements `ParseStream` as one request message into one response message, `GenerateAck`, `Normalize`, `ProfileLint`, `ProfileExplain`, and `ProfileTest` for inline profile evidence, `ValidateRedacted` with opt-in v2 validation, redaction receipt, and configured quarantine output evidence, `CreateEvidenceBundle` for configured-root evidence bundle creation, `ReplayEvidenceBundle` for configured-root evidence replay, `CorpusSummarize` for inline corpus summary evidence, `CorpusFingerprint` for inline corpus fingerprint evidence, and `CorpusDiff` for inline before/after corpus diff evidence with opt-in v2 provenance.
 


### PR DESCRIPTION
# Summary

Correct the implementation status table so the TLS claim matches the current product surface and deployment guidance.

## Assumptions

Current origin/main has no native TLS acceptor in hl7v2-server and no TLS-wrapped MLLP transport. DEPLOYMENT.md already defines TLS termination at a trusted reverse proxy, while remote profile HTTPS is a separate reqwest capability.

## Checklist

- [ ] I agree to the Contributor License Agreement.
- [ ] Full xtask gate was not run; this is a documentation-only change.
- [ ] Lint, no-panic, and file-policy checks were not run; no source files or policy surfaces changed.

## CI Economics

| Field | Value |
| --- | --- |
| Default PR LEM impact | +0 LEM locally; docs-only hosted validation |
| Workflows touched | None |
| Branch protection | Unchanged |
| Failure mode caught | Stale documentation could imply native TLS support that is not present |
| Cheaper signal? | Local diff, formatting, link, and source-boundary checks are sufficient for this docs seam |
| Rollback path | Revert the single docs/STATUS.md line |

## Commands Run

- cargo fmt --all -- --check
- cargo run --locked -p xtask -- check-doc-links
- git diff --check
- Source search for native TLS transport symbols in hl7v2 transport and hl7v2-server